### PR TITLE
fix: open chat file links in Monaco

### DIFF
--- a/site/src/content/docs/features/parallel-agents.mdx
+++ b/site/src/content/docs/features/parallel-agents.mdx
@@ -70,6 +70,8 @@ Each agent session has a lifecycle:
 
 Press **Escape** to stop a running agent at any time.
 
+When an agent mentions a workspace file such as `README.md` or `src/main.rs` in the chat transcript, click it to open that file in Claudette's editor tab. Web links in the transcript still open in your default browser.
+
 ## Workspace Context Menu
 
 Use the opener in the workspace header to launch the current worktree in a detected editor, file manager, terminal, or IDE. The primary button uses the detected app's native icon and opens the first preferred app; the chevron shows the app list and a copy-path action. JetBrains IDEs such as IntelliJ IDEA, PyCharm, PhpStorm, WebStorm, DataGrip, DataSpell, GoLand, CLion, Rider, RubyMine, RustRover, Aqua, Fleet, and Writerside are detected from the standard app install plus JetBrains Toolbox launcher scripts.

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -5,6 +5,26 @@
   position: relative;
 }
 
+.panel :global(.cc-file-path-link) {
+  color: var(--text-primary);
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  line-height: inherit;
+  text-decoration: underline;
+  text-decoration-color: rgba(var(--accent-primary-rgb), 0.35);
+  text-underline-offset: 2px;
+  cursor: pointer;
+  word-break: break-all;
+}
+
+.panel :global(.cc-file-path-link:hover) {
+  color: var(--accent-primary);
+  text-decoration-color: currentColor;
+}
+
 /* Filler shown while a workspace's sessions are still loading from the
    backend (typical window: 50-150ms on a sidebar click, longer on first
    launch). Holds the content area open with the theme background so the
@@ -829,6 +849,10 @@
   overflow-wrap: anywhere;
   white-space: pre-wrap;
   color: var(--accent-primary);
+}
+
+.inlineEditPathButton {
+  text-align: left;
 }
 
 .changeStats {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -90,6 +90,14 @@ import { QueuedMessagesPopover } from "./QueuedMessagesPopover";
 import { shouldAutoDispatchQueuedMessage } from "./queuedMessageEditing";
 
 const EMPTY_QUEUED_MESSAGES: QueuedMessage[] = [];
+const chatScrollState = globalThis as typeof globalThis & {
+  __CLAUDETTE_CHAT_SCROLL_TOP__?: Map<string, number>;
+  __CLAUDETTE_CHAT_SCROLL_RESTORING__?: Set<string>;
+};
+const chatScrollTopBySession =
+  chatScrollState.__CLAUDETTE_CHAT_SCROLL_TOP__ ??= new Map<string, number>();
+const restoringChatScrollSessions =
+  chatScrollState.__CLAUDETTE_CHAT_SCROLL_RESTORING__ ??= new Set<string>();
 
 export function ChatPanel() {
   const { t } = useTranslation("chat");
@@ -370,8 +378,13 @@ export function ChatPanel() {
   );
 
   // Sticky scroll: auto-follow when at bottom, stop when user scrolls up.
-  const { isAtBottom, scrollToBottom, handleContentChanged, suppressNextAutoScrollRef } =
-    useStickyScroll(messagesContainerRef);
+  const {
+    isAtBottom,
+    scrollToBottom,
+    restoreScrollPosition,
+    handleContentChanged,
+    suppressNextAutoScrollRef,
+  } = useStickyScroll(messagesContainerRef);
   usePreventScrollBounce(messagesContainerRef);
 
   // Memoize context value to avoid re-rendering StreamingMessage on every parent render.
@@ -563,10 +576,65 @@ export function ChatPanel() {
     };
   }, [activeSessionId, selectedWorkspaceId, setChatMessages, setChatPagination, hydrateCompletedTurns]);
 
-  // Scroll to bottom unconditionally on session switch.
+  // Preserve the chat position while Monaco/diff views temporarily unmount
+  // this panel. Without this, opening a file link snaps long chats to bottom.
   useEffect(() => {
-    if (activeSessionId) scrollToBottom();
-  }, [activeSessionId, scrollToBottom]);
+    if (!activeSessionId) return;
+    const savedScrollTop = chatScrollTopBySession.get(activeSessionId);
+    if (savedScrollTop == null) {
+      restoringChatScrollSessions.delete(activeSessionId);
+      scrollToBottom();
+      return;
+    }
+    restoringChatScrollSessions.add(activeSessionId);
+    let cancelled = false;
+    let frameId: number | null = null;
+    let attempts = 0;
+    const restore = () => {
+      if (cancelled) return;
+      restoreScrollPosition(savedScrollTop);
+      attempts += 1;
+      const container = messagesContainerRef.current;
+      const maxScrollTop = container
+        ? Math.max(0, container.scrollHeight - container.clientHeight)
+        : 0;
+      const expectedTop = Math.min(savedScrollTop, maxScrollTop);
+      if (
+        attempts < 8 &&
+        container &&
+        Math.abs(container.scrollTop - expectedTop) > 1
+      ) {
+        frameId = requestAnimationFrame(restore);
+      } else {
+        restoringChatScrollSessions.delete(activeSessionId);
+      }
+    };
+    frameId = requestAnimationFrame(restore);
+    return () => {
+      cancelled = true;
+      restoringChatScrollSessions.delete(activeSessionId);
+      if (frameId !== null) cancelAnimationFrame(frameId);
+    };
+  }, [activeSessionId, restoreScrollPosition, scrollToBottom]);
+
+  useEffect(() => {
+    if (!activeSessionId) return;
+    const container = messagesContainerRef.current;
+    return () => {
+      if (container && !restoringChatScrollSessions.has(activeSessionId)) {
+        chatScrollTopBySession.set(activeSessionId, container.scrollTop);
+        restoringChatScrollSessions.add(activeSessionId);
+      }
+    };
+  }, [activeSessionId]);
+
+  const rememberChatScrollPosition = useCallback(() => {
+    if (!activeSessionId) return;
+    const container = messagesContainerRef.current;
+    if (!container) return;
+    chatScrollTopBySession.set(activeSessionId, container.scrollTop);
+    restoringChatScrollSessions.add(activeSessionId);
+  }, [activeSessionId]);
 
   // Load older messages when the user scrolls to the top of the message list.
   const hasMoreRef = useRef(false);
@@ -595,6 +663,15 @@ export function ChatPanel() {
     if (!container) return;
 
     const onScroll = () => {
+      if (
+        activeSessionIdRef.current &&
+        !restoringChatScrollSessions.has(activeSessionIdRef.current)
+      ) {
+        chatScrollTopBySession.set(
+          activeSessionIdRef.current,
+          container.scrollTop,
+        );
+      }
       if (
         container.scrollTop < 200 &&
         hasMoreRef.current &&
@@ -1444,6 +1521,7 @@ export function ChatPanel() {
                   onForkTurn={isRemote ? undefined : handleFork}
                   onAttachmentContextMenu={openAttachmentMenu}
                   onAttachmentClick={openLightbox}
+                  onOpenFileLink={rememberChatScrollPosition}
                   searchQuery={searchQuery}
                   globalOffset={globalOffset}
                   toolDisplayMode={toolDisplayMode}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1466,6 +1466,7 @@ export function ChatPanel() {
                     hasStreaming || hasPendingTypewriter ? (
                       <StreamingMessage
                         sessionId={activeSessionId}
+                        workspaceId={selectedWorkspaceId}
                         isStreaming={isRunning ?? false}
                         searchQuery={searchQuery}
                       />

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -90,14 +90,6 @@ import { QueuedMessagesPopover } from "./QueuedMessagesPopover";
 import { shouldAutoDispatchQueuedMessage } from "./queuedMessageEditing";
 
 const EMPTY_QUEUED_MESSAGES: QueuedMessage[] = [];
-const chatScrollState = globalThis as typeof globalThis & {
-  __CLAUDETTE_CHAT_SCROLL_TOP__?: Map<string, number>;
-  __CLAUDETTE_CHAT_SCROLL_RESTORING__?: Set<string>;
-};
-const chatScrollTopBySession =
-  chatScrollState.__CLAUDETTE_CHAT_SCROLL_TOP__ ??= new Map<string, number>();
-const restoringChatScrollSessions =
-  chatScrollState.__CLAUDETTE_CHAT_SCROLL_RESTORING__ ??= new Set<string>();
 
 export function ChatPanel() {
   const { t } = useTranslation("chat");
@@ -109,6 +101,13 @@ export function ChatPanel() {
     s.selectedWorkspaceId
       ? s.selectedSessionIdByWorkspaceId[s.selectedWorkspaceId] ?? null
       : null,
+  );
+  const activeSessionIdsKey = useAppStore((s) =>
+    selectedWorkspaceId
+      ? (s.sessionsByWorkspace[selectedWorkspaceId] ?? [])
+          .map((session) => session.id)
+          .join("\0")
+      : "",
   );
   const workspaces = useAppStore((s) => s.workspaces);
   const repositories = useAppStore((s) => s.repositories);
@@ -135,6 +134,8 @@ export function ChatPanel() {
   const setSlashCommandsCache = useAppStore((s) => s.setSlashCommands);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const processingRef = useRef<HTMLDivElement>(null);
+  const chatScrollTopBySessionRef = useRef(new Map<string, number>());
+  const restoringChatScrollSessionsRef = useRef(new Set<string>());
   const [error, setError] = useState<string | null>(null);
   const [isSteeringQueued, setIsSteeringQueued] = useState(false);
   const [pendingSteerContent, setPendingSteerContent] = useState<string | null>(null);
@@ -393,6 +394,22 @@ export function ChatPanel() {
     [handleContentChanged, suppressNextAutoScrollRef],
   );
 
+  useEffect(() => {
+    const activeSessionIds = new Set(
+      activeSessionIdsKey ? activeSessionIdsKey.split("\0") : [],
+    );
+    for (const sessionId of chatScrollTopBySessionRef.current.keys()) {
+      if (!activeSessionIds.has(sessionId)) {
+        chatScrollTopBySessionRef.current.delete(sessionId);
+      }
+    }
+    for (const sessionId of restoringChatScrollSessionsRef.current.keys()) {
+      if (!activeSessionIds.has(sessionId)) {
+        restoringChatScrollSessionsRef.current.delete(sessionId);
+      }
+    }
+  }, [activeSessionIdsKey]);
+
   // Elapsed timer for running agent.
   const promptStartTime = useAppStore(
     (s) => (selectedWorkspaceId ? s.promptStartTime[selectedWorkspaceId] ?? null : null)
@@ -576,17 +593,17 @@ export function ChatPanel() {
     };
   }, [activeSessionId, selectedWorkspaceId, setChatMessages, setChatPagination, hydrateCompletedTurns]);
 
-  // Preserve the chat position while Monaco/diff views temporarily unmount
-  // this panel. Without this, opening a file link snaps long chats to bottom.
+  // Preserve chat position while moving between chat, Monaco, and diff views.
+  // Without this, opening a file link can snap long chats back to bottom.
   useEffect(() => {
     if (!activeSessionId) return;
-    const savedScrollTop = chatScrollTopBySession.get(activeSessionId);
+    const savedScrollTop = chatScrollTopBySessionRef.current.get(activeSessionId);
     if (savedScrollTop == null) {
-      restoringChatScrollSessions.delete(activeSessionId);
+      restoringChatScrollSessionsRef.current.delete(activeSessionId);
       scrollToBottom();
       return;
     }
-    restoringChatScrollSessions.add(activeSessionId);
+    restoringChatScrollSessionsRef.current.add(activeSessionId);
     let cancelled = false;
     let frameId: number | null = null;
     let attempts = 0;
@@ -606,13 +623,13 @@ export function ChatPanel() {
       ) {
         frameId = requestAnimationFrame(restore);
       } else {
-        restoringChatScrollSessions.delete(activeSessionId);
+        restoringChatScrollSessionsRef.current.delete(activeSessionId);
       }
     };
     frameId = requestAnimationFrame(restore);
     return () => {
       cancelled = true;
-      restoringChatScrollSessions.delete(activeSessionId);
+      restoringChatScrollSessionsRef.current.delete(activeSessionId);
       if (frameId !== null) cancelAnimationFrame(frameId);
     };
   }, [activeSessionId, restoreScrollPosition, scrollToBottom]);
@@ -621,9 +638,12 @@ export function ChatPanel() {
     if (!activeSessionId) return;
     const container = messagesContainerRef.current;
     return () => {
-      if (container && !restoringChatScrollSessions.has(activeSessionId)) {
-        chatScrollTopBySession.set(activeSessionId, container.scrollTop);
-        restoringChatScrollSessions.add(activeSessionId);
+      if (
+        container &&
+        !restoringChatScrollSessionsRef.current.has(activeSessionId)
+      ) {
+        chatScrollTopBySessionRef.current.set(activeSessionId, container.scrollTop);
+        restoringChatScrollSessionsRef.current.add(activeSessionId);
       }
     };
   }, [activeSessionId]);
@@ -632,8 +652,8 @@ export function ChatPanel() {
     if (!activeSessionId) return;
     const container = messagesContainerRef.current;
     if (!container) return;
-    chatScrollTopBySession.set(activeSessionId, container.scrollTop);
-    restoringChatScrollSessions.add(activeSessionId);
+    chatScrollTopBySessionRef.current.set(activeSessionId, container.scrollTop);
+    restoringChatScrollSessionsRef.current.add(activeSessionId);
   }, [activeSessionId]);
 
   // Load older messages when the user scrolls to the top of the message list.
@@ -665,9 +685,9 @@ export function ChatPanel() {
     const onScroll = () => {
       if (
         activeSessionIdRef.current &&
-        !restoringChatScrollSessions.has(activeSessionIdRef.current)
+        !restoringChatScrollSessionsRef.current.has(activeSessionIdRef.current)
       ) {
-        chatScrollTopBySession.set(
+        chatScrollTopBySessionRef.current.set(
           activeSessionIdRef.current,
           container.scrollTop,
         );

--- a/src/ui/src/components/chat/EditChangeSummary.tsx
+++ b/src/ui/src/components/chat/EditChangeSummary.tsx
@@ -19,10 +19,12 @@ export function InlineEditSummary({
   summary,
   searchQuery,
   worktreePath,
+  onOpenFile,
 }: {
   summary: EditSummary;
   searchQuery: string;
   worktreePath?: string | null;
+  onOpenFile?: (filePath: string) => void;
 }) {
   const file = summary.files[0];
   if (!file) return null;
@@ -32,20 +34,34 @@ export function InlineEditSummary({
   // the +/- totals match the surface, instead of misattributing the
   // aggregate churn to just `files[0]`.
   const isMulti = summary.files.length > 1;
+  const relativePath = relativizePath(file.filePath, worktreePath);
+  const pathContent = (
+    <HighlightedPlainText
+      text={relativePath}
+      query={searchQuery}
+    />
+  );
   return (
     <span className={styles.inlineEditSummary}>
       <Pencil size={12} aria-hidden="true" className={styles.inlineEditIcon} />
       <span className={styles.inlineEditVerb}>Editing</span>
-      <span className={styles.inlineEditPath}>
-        {isMulti ? (
-          `${summary.files.length} files`
-        ) : (
-          <HighlightedPlainText
-            text={relativizePath(file.filePath, worktreePath)}
-            query={searchQuery}
-          />
-        )}
-      </span>
+      {isMulti || !onOpenFile ? (
+        <span className={styles.inlineEditPath}>
+          {isMulti ? `${summary.files.length} files` : pathContent}
+        </span>
+      ) : (
+        <button
+          type="button"
+          className={`${styles.inlineEditPath} ${styles.inlineEditPathButton} cc-file-path-link`}
+          title={relativePath}
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenFile(file.filePath);
+          }}
+        >
+          {pathContent}
+        </button>
+      )}
       <ChangeStats added={summary.added} removed={summary.removed} />
     </span>
   );

--- a/src/ui/src/components/chat/HighlightedMessageMarkdown.tsx
+++ b/src/ui/src/components/chat/HighlightedMessageMarkdown.tsx
@@ -23,11 +23,13 @@ const SEARCH_MARK_CLASS = "cc-search-match";
 interface Props {
   content: string;
   query: string;
+  onOpenFile?: (path: string) => boolean;
 }
 
 export const HighlightedMessageMarkdown = memo(function HighlightedMessageMarkdown({
   content,
   query,
+  onOpenFile,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -47,7 +49,7 @@ export const HighlightedMessageMarkdown = memo(function HighlightedMessageMarkdo
 
   return (
     <div ref={containerRef} className="cc-highlight-wrap">
-      <MessageMarkdown content={content} />
+      <MessageMarkdown content={content} onOpenFile={onOpenFile} />
     </div>
   );
 });

--- a/src/ui/src/components/chat/HighlightedMessageMarkdown.tsx
+++ b/src/ui/src/components/chat/HighlightedMessageMarkdown.tsx
@@ -24,12 +24,14 @@ interface Props {
   content: string;
   query: string;
   onOpenFile?: (path: string) => boolean;
+  resolveFilePath?: (path: string) => string | null;
 }
 
 export const HighlightedMessageMarkdown = memo(function HighlightedMessageMarkdown({
   content,
   query,
   onOpenFile,
+  resolveFilePath,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -49,7 +51,11 @@ export const HighlightedMessageMarkdown = memo(function HighlightedMessageMarkdo
 
   return (
     <div ref={containerRef} className="cc-highlight-wrap">
-      <MessageMarkdown content={content} onOpenFile={onOpenFile} />
+      <MessageMarkdown
+        content={content}
+        onOpenFile={onOpenFile}
+        resolveFilePath={resolveFilePath}
+      />
     </div>
   );
 });

--- a/src/ui/src/components/chat/MessageMarkdown.module.css
+++ b/src/ui/src/components/chat/MessageMarkdown.module.css
@@ -297,9 +297,14 @@
    away from the prose around it. The path text itself is monospace (matching
    how Claude usually writes paths) so the click target reads as
    path-shaped rather than as a generic link. */
-.body :where(:global(a.cc-file-path-link)) {
-  font-family: var(--font-mono, ui-monospace, monospace);
+.body :where(:global(.cc-file-path-link)) {
   color: var(--text-primary);
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  line-height: inherit;
   text-decoration: underline;
   text-decoration-color: rgba(var(--accent-primary-rgb), 0.35);
   text-underline-offset: 2px;
@@ -307,7 +312,7 @@
   word-break: break-all;
 }
 
-.body :where(:global(a.cc-file-path-link:hover)) {
+.body :where(:global(.cc-file-path-link:hover)) {
   color: var(--accent-primary);
   text-decoration-color: currentColor;
 }

--- a/src/ui/src/components/chat/MessageMarkdown.tsx
+++ b/src/ui/src/components/chat/MessageMarkdown.tsx
@@ -39,9 +39,11 @@ const COMPONENTS: Components = {
 export const MessageMarkdown = memo(function MessageMarkdown({
   content,
   onOpenFile,
+  resolveFilePath,
 }: {
   content: string;
   onOpenFile?: (path: string) => boolean;
+  resolveFilePath?: (path: string) => string | null;
 }) {
   const preprocessed = useMemo(() => preprocessContent(content), [content]);
   const body = (
@@ -56,9 +58,14 @@ export const MessageMarkdown = memo(function MessageMarkdown({
       </Markdown>
     </div>
   );
-  if (!onOpenFile) return body;
+  if (!onOpenFile && !resolveFilePath) return body;
   return (
-    <MarkdownFileOpenContext.Provider value={{ openFile: onOpenFile }}>
+    <MarkdownFileOpenContext.Provider
+      value={{
+        openFile: onOpenFile ?? (() => false),
+        resolveFilePath,
+      }}
+    >
       {body}
     </MarkdownFileOpenContext.Provider>
   );

--- a/src/ui/src/components/chat/MessageMarkdown.tsx
+++ b/src/ui/src/components/chat/MessageMarkdown.tsx
@@ -4,6 +4,7 @@ import type { Components } from "react-markdown";
 import {
   preprocessContent,
   MARKDOWN_COMPONENTS,
+  MarkdownFileOpenContext,
   REHYPE_PLUGINS,
   REMARK_PLUGINS,
   safeUrlTransform,
@@ -37,11 +38,13 @@ const COMPONENTS: Components = {
  */
 export const MessageMarkdown = memo(function MessageMarkdown({
   content,
+  onOpenFile,
 }: {
   content: string;
+  onOpenFile?: (path: string) => boolean;
 }) {
   const preprocessed = useMemo(() => preprocessContent(content), [content]);
-  return (
+  const body = (
     <div className={styles.body}>
       <Markdown
         remarkPlugins={REMARK_PLUGINS}
@@ -52,5 +55,11 @@ export const MessageMarkdown = memo(function MessageMarkdown({
         {preprocessed}
       </Markdown>
     </div>
+  );
+  if (!onOpenFile) return body;
+  return (
+    <MarkdownFileOpenContext.Provider value={{ openFile: onOpenFile }}>
+      {body}
+    </MarkdownFileOpenContext.Provider>
   );
 });

--- a/src/ui/src/components/chat/MessagesWithTurns.test.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.test.tsx
@@ -10,6 +10,8 @@ import { MessagesWithTurns } from "./MessagesWithTurns";
 
 const serviceMocks = vi.hoisted(() => ({
   invoke: vi.fn(() => Promise.resolve()),
+  listWorkspaceFiles: vi.fn(() => Promise.resolve([])),
+  openUrl: vi.fn(() => Promise.resolve()),
   loadAttachmentData: vi.fn(),
   getClaudeAuthStatus: vi.fn(() =>
     Promise.resolve({
@@ -108,6 +110,9 @@ async function render(node: React.ReactNode): Promise<HTMLElement> {
 
 beforeEach(() => {
   serviceMocks.invoke.mockClear();
+  serviceMocks.listWorkspaceFiles.mockClear();
+  serviceMocks.listWorkspaceFiles.mockResolvedValue([]);
+  serviceMocks.openUrl.mockClear();
   serviceMocks.claudeAuthLogin.mockClear();
   serviceMocks.getClaudeAuthStatus.mockClear();
   serviceMocks.getClaudeAuthStatus.mockResolvedValue({
@@ -324,9 +329,11 @@ describe("MessagesWithTurns edit summaries", () => {
 
     const state = useAppStore.getState();
     expect(state.fileTabsByWorkspace[WORKSPACE_ID]).toBeUndefined();
-    expect(serviceMocks.invoke).toHaveBeenCalledWith("open_in_editor", {
-      path: "~/Downloads/report.md",
-    });
+    expect(serviceMocks.invoke).not.toHaveBeenCalledWith(
+      "open_in_editor",
+      expect.anything(),
+    );
+    expect(serviceMocks.openUrl).not.toHaveBeenCalled();
   });
 
   it("opens localhost file URLs from agent output in Monaco without navigating", async () => {

--- a/src/ui/src/components/chat/MessagesWithTurns.test.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.test.tsx
@@ -267,6 +267,12 @@ describe("MessagesWithTurns edit summaries", () => {
   });
 
   it("opens agent-mentioned file names in the Monaco file tab", async () => {
+    serviceMocks.listWorkspaceFiles.mockResolvedValue([
+      { path: "README.md", is_directory: false },
+    ] as never);
+    useAppStore.setState({
+      fileTreeRefreshNonceByWorkspace: { [WORKSPACE_ID]: 1 },
+    });
     const messages = [
       message("user-1", "User", "what changed?"),
       message("assistant-1", "Assistant", "I updated README.md for you."),
@@ -282,6 +288,9 @@ describe("MessagesWithTurns edit summaries", () => {
         toolDisplayMode="grouped"
       />,
     );
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     const link = Array.from(container.querySelectorAll("button")).find(
       (item) => item.textContent === "README.md",
@@ -297,6 +306,39 @@ describe("MessagesWithTurns edit summaries", () => {
     const state = useAppStore.getState();
     expect(state.fileTabsByWorkspace[WORKSPACE_ID]).toEqual(["README.md"]);
     expect(state.activeFileTabByWorkspace[WORKSPACE_ID]).toBe("README.md");
+  });
+
+  it("does not link unresolved agent-mentioned file names", async () => {
+    serviceMocks.listWorkspaceFiles.mockResolvedValue([
+      { path: "CHANGELOG.md", is_directory: false },
+    ] as never);
+    useAppStore.setState({
+      fileTreeRefreshNonceByWorkspace: { [WORKSPACE_ID]: 2 },
+    });
+    const messages = [
+      message("user-1", "User", "what changed?"),
+      message("assistant-1", "Assistant", "I updated README.md for you."),
+    ];
+
+    const container = await render(
+      <MessagesWithTurns
+        messages={messages}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        isRunning={false}
+        searchQuery=""
+        toolDisplayMode="grouped"
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const link = Array.from(container.querySelectorAll("button")).find(
+      (item) => item.textContent === "README.md",
+    );
+    expect(link).toBeUndefined();
+    expect(container.textContent).toContain("README.md");
   });
 
   it("opens resolved at-sign file mentions in user messages", async () => {
@@ -388,7 +430,7 @@ describe("MessagesWithTurns edit summaries", () => {
     const link = Array.from(container.querySelectorAll("button")).find(
       (item) => item.textContent === "~/Downloads/report.md",
     );
-    expect(link).toBeTruthy();
+    expect(link).toBeUndefined();
 
     await act(async () => {
       link?.dispatchEvent(
@@ -406,9 +448,13 @@ describe("MessagesWithTurns edit summaries", () => {
   });
 
   it("opens localhost file URLs from agent output in Monaco without navigating", async () => {
+    serviceMocks.listWorkspaceFiles.mockResolvedValue([
+      { path: "README.md", is_directory: false },
+    ] as never);
     const worktreePath =
       "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger";
     useAppStore.setState({
+      fileTreeRefreshNonceByWorkspace: { [WORKSPACE_ID]: 3 },
       workspaces: [
         {
           ...useAppStore.getState().workspaces[0],
@@ -435,6 +481,9 @@ describe("MessagesWithTurns edit summaries", () => {
         toolDisplayMode="grouped"
       />,
     );
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     const fileButton = Array.from(container.querySelectorAll("button")).find(
       (item) => item.textContent?.includes("README.md"),
@@ -460,9 +509,14 @@ describe("MessagesWithTurns edit summaries", () => {
   });
 
   it("opens multiple file links from one agent message without dropping prior tabs", async () => {
+    serviceMocks.listWorkspaceFiles.mockResolvedValue([
+      { path: "README.md", is_directory: false },
+      { path: "simple-wave.svg", is_directory: false },
+    ] as never);
     const worktreePath =
       "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger";
     useAppStore.setState({
+      fileTreeRefreshNonceByWorkspace: { [WORKSPACE_ID]: 4 },
       workspaces: [
         {
           ...useAppStore.getState().workspaces[0],
@@ -488,6 +542,9 @@ describe("MessagesWithTurns edit summaries", () => {
         toolDisplayMode="grouped"
       />,
     );
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     const readmeButton = Array.from(container.querySelectorAll("button")).find(
       (item) => item.textContent === "README.md:8",

--- a/src/ui/src/components/chat/MessagesWithTurns.test.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.test.tsx
@@ -365,6 +365,11 @@ describe("MessagesWithTurns edit summaries", () => {
     const state = useAppStore.getState();
     expect(state.fileTabsByWorkspace[WORKSPACE_ID]).toEqual(["CLAUDETTE_TEST.md"]);
     expect(state.activeFileTabByWorkspace[WORKSPACE_ID]).toBe("CLAUDETTE_TEST.md");
+    expect(state.fileRevealTargetByWorkspace[WORKSPACE_ID]).toMatchObject({
+      path: "CLAUDETTE_TEST.md",
+      startLine: 1,
+      endLine: 1,
+    });
   });
 
   it("renders Claude CLI slash-login failures as a sign-in callout", async () => {

--- a/src/ui/src/components/chat/MessagesWithTurns.test.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.test.tsx
@@ -278,7 +278,7 @@ describe("MessagesWithTurns edit summaries", () => {
       />,
     );
 
-    const link = Array.from(container.querySelectorAll("a")).find(
+    const link = Array.from(container.querySelectorAll("button")).find(
       (item) => item.textContent === "README.md",
     );
     expect(link).toBeTruthy();
@@ -311,7 +311,7 @@ describe("MessagesWithTurns edit summaries", () => {
       />,
     );
 
-    const link = Array.from(container.querySelectorAll("a")).find(
+    const link = Array.from(container.querySelectorAll("button")).find(
       (item) => item.textContent === "~/Downloads/report.md",
     );
     expect(link).toBeTruthy();
@@ -327,6 +327,44 @@ describe("MessagesWithTurns edit summaries", () => {
     expect(serviceMocks.invoke).toHaveBeenCalledWith("open_in_editor", {
       path: "~/Downloads/report.md",
     });
+  });
+
+  it("opens localhost file URLs from agent output in Monaco without navigating", async () => {
+    const messages = [
+      message("user-1", "User", "where did you write?"),
+      message(
+        "assistant-1",
+        "Assistant",
+        "Wrote http://localhost:14254/repo/CLAUDETTE_TEST.md:1",
+      ),
+    ];
+
+    const container = await render(
+      <MessagesWithTurns
+        messages={messages}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        isRunning={false}
+        searchQuery=""
+        toolDisplayMode="grouped"
+      />,
+    );
+
+    const fileButton = Array.from(container.querySelectorAll("button")).find(
+      (item) => item.textContent?.includes("CLAUDETTE_TEST.md"),
+    );
+    expect(fileButton).toBeTruthy();
+    expect(container.querySelector('a[href^="http://localhost:14254/repo"]')).toBeNull();
+
+    await act(async () => {
+      fileButton?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    const state = useAppStore.getState();
+    expect(state.fileTabsByWorkspace[WORKSPACE_ID]).toEqual(["CLAUDETTE_TEST.md"]);
+    expect(state.activeFileTabByWorkspace[WORKSPACE_ID]).toBe("CLAUDETTE_TEST.md");
   });
 
   it("renders Claude CLI slash-login failures as a sign-in callout", async () => {

--- a/src/ui/src/components/chat/MessagesWithTurns.test.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.test.tsx
@@ -9,6 +9,7 @@ import type { ChatMessage } from "../../types/chat";
 import { MessagesWithTurns } from "./MessagesWithTurns";
 
 const serviceMocks = vi.hoisted(() => ({
+  invoke: vi.fn(() => Promise.resolve()),
   loadAttachmentData: vi.fn(),
   getClaudeAuthStatus: vi.fn(() =>
     Promise.resolve({
@@ -27,6 +28,10 @@ const serviceMocks = vi.hoisted(() => ({
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: serviceMocks.invoke,
 }));
 
 vi.mock("../../services/tauri", async (importOriginal) => {
@@ -102,6 +107,7 @@ async function render(node: React.ReactNode): Promise<HTMLElement> {
 }
 
 beforeEach(() => {
+  serviceMocks.invoke.mockClear();
   serviceMocks.claudeAuthLogin.mockClear();
   serviceMocks.getClaudeAuthStatus.mockClear();
   serviceMocks.getClaudeAuthStatus.mockResolvedValue({
@@ -139,6 +145,8 @@ beforeEach(() => {
     resolvedClaudeAuthFailureMessageId: null,
     diffFiles: [],
     diffMergeBase: "base-sha",
+    fileTabsByWorkspace: {},
+    activeFileTabByWorkspace: {},
   });
 });
 
@@ -284,6 +292,41 @@ describe("MessagesWithTurns edit summaries", () => {
     const state = useAppStore.getState();
     expect(state.fileTabsByWorkspace[WORKSPACE_ID]).toEqual(["README.md"]);
     expect(state.activeFileTabByWorkspace[WORKSPACE_ID]).toBe("README.md");
+  });
+
+  it("does not open home-relative file links as Monaco tabs", async () => {
+    const messages = [
+      message("user-1", "User", "where is it?"),
+      message("assistant-1", "Assistant", "Saved to ~/Downloads/report.md."),
+    ];
+
+    const container = await render(
+      <MessagesWithTurns
+        messages={messages}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        isRunning={false}
+        searchQuery=""
+        toolDisplayMode="grouped"
+      />,
+    );
+
+    const link = Array.from(container.querySelectorAll("a")).find(
+      (item) => item.textContent === "~/Downloads/report.md",
+    );
+    expect(link).toBeTruthy();
+
+    await act(async () => {
+      link?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    const state = useAppStore.getState();
+    expect(state.fileTabsByWorkspace[WORKSPACE_ID]).toBeUndefined();
+    expect(serviceMocks.invoke).toHaveBeenCalledWith("open_in_editor", {
+      path: "~/Downloads/report.md",
+    });
   });
 
   it("renders Claude CLI slash-login failures as a sign-in callout", async () => {

--- a/src/ui/src/components/chat/MessagesWithTurns.test.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.test.tsx
@@ -337,12 +337,22 @@ describe("MessagesWithTurns edit summaries", () => {
   });
 
   it("opens localhost file URLs from agent output in Monaco without navigating", async () => {
+    const worktreePath =
+      "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger";
+    useAppStore.setState({
+      workspaces: [
+        {
+          ...useAppStore.getState().workspaces[0],
+          worktree_path: worktreePath,
+        },
+      ],
+    });
     const messages = [
       message("user-1", "User", "where did you write?"),
       message(
         "assistant-1",
         "Assistant",
-        "Wrote http://localhost:14254/repo/CLAUDETTE_TEST.md:1",
+        `Wrote http://localhost:14254${worktreePath}/README.md:8`,
       ),
     ];
 
@@ -358,10 +368,11 @@ describe("MessagesWithTurns edit summaries", () => {
     );
 
     const fileButton = Array.from(container.querySelectorAll("button")).find(
-      (item) => item.textContent?.includes("CLAUDETTE_TEST.md"),
+      (item) => item.textContent?.includes("README.md"),
     );
     expect(fileButton).toBeTruthy();
-    expect(container.querySelector('a[href^="http://localhost:14254/repo"]')).toBeNull();
+    expect(fileButton?.textContent).toBe("README.md:8");
+    expect(container.querySelector('a[href^="http://localhost:14254"]')).toBeNull();
 
     await act(async () => {
       fileButton?.dispatchEvent(
@@ -370,12 +381,72 @@ describe("MessagesWithTurns edit summaries", () => {
     });
 
     const state = useAppStore.getState();
-    expect(state.fileTabsByWorkspace[WORKSPACE_ID]).toEqual(["CLAUDETTE_TEST.md"]);
-    expect(state.activeFileTabByWorkspace[WORKSPACE_ID]).toBe("CLAUDETTE_TEST.md");
+    expect(state.fileTabsByWorkspace[WORKSPACE_ID]).toEqual(["README.md"]);
+    expect(state.activeFileTabByWorkspace[WORKSPACE_ID]).toBe("README.md");
     expect(state.fileRevealTargetByWorkspace[WORKSPACE_ID]).toMatchObject({
-      path: "CLAUDETTE_TEST.md",
-      startLine: 1,
-      endLine: 1,
+      path: "README.md",
+      startLine: 8,
+      endLine: 8,
+    });
+  });
+
+  it("reopens a chat file link after its Monaco tab was closed", async () => {
+    const worktreePath =
+      "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger";
+    useAppStore.setState({
+      workspaces: [
+        {
+          ...useAppStore.getState().workspaces[0],
+          worktree_path: worktreePath,
+        },
+      ],
+    });
+    const messages = [
+      message(
+        "assistant-1",
+        "Assistant",
+        `See http://localhost:14254${worktreePath}/README.md:8`,
+      ),
+    ];
+
+    const container = await render(
+      <MessagesWithTurns
+        messages={messages}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        isRunning={false}
+        searchQuery=""
+        toolDisplayMode="grouped"
+      />,
+    );
+
+    const fileButton = Array.from(container.querySelectorAll("button")).find(
+      (item) => item.textContent === "README.md:8",
+    );
+    expect(fileButton).toBeTruthy();
+
+    await act(async () => {
+      fileButton?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+    useAppStore.getState().closeFileTab(WORKSPACE_ID, "README.md");
+    expect(useAppStore.getState().fileTabsByWorkspace[WORKSPACE_ID]).toEqual([]);
+    expect(useAppStore.getState().activeFileTabByWorkspace[WORKSPACE_ID]).toBeNull();
+
+    await act(async () => {
+      fileButton?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    const state = useAppStore.getState();
+    expect(state.fileTabsByWorkspace[WORKSPACE_ID]).toEqual(["README.md"]);
+    expect(state.activeFileTabByWorkspace[WORKSPACE_ID]).toBe("README.md");
+    expect(state.fileRevealTargetByWorkspace[WORKSPACE_ID]).toMatchObject({
+      path: "README.md",
+      startLine: 8,
+      endLine: 8,
     });
   });
 

--- a/src/ui/src/components/chat/MessagesWithTurns.test.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.test.tsx
@@ -253,6 +253,39 @@ describe("MessagesWithTurns edit summaries", () => {
     });
   });
 
+  it("opens agent-mentioned file names in the Monaco file tab", async () => {
+    const messages = [
+      message("user-1", "User", "what changed?"),
+      message("assistant-1", "Assistant", "I updated README.md for you."),
+    ];
+
+    const container = await render(
+      <MessagesWithTurns
+        messages={messages}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        isRunning={false}
+        searchQuery=""
+        toolDisplayMode="grouped"
+      />,
+    );
+
+    const link = Array.from(container.querySelectorAll("a")).find(
+      (item) => item.textContent === "README.md",
+    );
+    expect(link).toBeTruthy();
+
+    await act(async () => {
+      link?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    const state = useAppStore.getState();
+    expect(state.fileTabsByWorkspace[WORKSPACE_ID]).toEqual(["README.md"]);
+    expect(state.activeFileTabByWorkspace[WORKSPACE_ID]).toBe("README.md");
+  });
+
   it("renders Claude CLI slash-login failures as a sign-in callout", async () => {
     const messages = [
       message("user-1", "User", "ping"),

--- a/src/ui/src/components/chat/MessagesWithTurns.test.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.test.tsx
@@ -299,6 +299,75 @@ describe("MessagesWithTurns edit summaries", () => {
     expect(state.activeFileTabByWorkspace[WORKSPACE_ID]).toBe("README.md");
   });
 
+  it("opens resolved at-sign file mentions in user messages", async () => {
+    serviceMocks.listWorkspaceFiles.mockResolvedValue([
+      { path: "README.md", is_directory: false },
+    ] as never);
+    useAppStore.setState({
+      fileTreeRefreshNonceByWorkspace: { [WORKSPACE_ID]: 1 },
+    });
+    const messages = [
+      message("user-1", "User", "make a simple edit to @README.md"),
+    ];
+
+    const container = await render(
+      <MessagesWithTurns
+        messages={messages}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        isRunning={false}
+        searchQuery=""
+        toolDisplayMode="grouped"
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const link = Array.from(container.querySelectorAll("button")).find(
+      (item) => item.textContent === "@README.md",
+    );
+    expect(link).toBeTruthy();
+
+    await act(async () => {
+      link?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    const state = useAppStore.getState();
+    expect(state.fileTabsByWorkspace[WORKSPACE_ID]).toEqual(["README.md"]);
+    expect(state.activeFileTabByWorkspace[WORKSPACE_ID]).toBe("README.md");
+  });
+
+  it("does not link unresolved at-sign mentions in user messages", async () => {
+    serviceMocks.listWorkspaceFiles.mockResolvedValue([
+      { path: "README.md", is_directory: false },
+    ] as never);
+    useAppStore.setState({
+      fileTreeRefreshNonceByWorkspace: { [WORKSPACE_ID]: 2 },
+    });
+    const messages = [
+      message("user-1", "User", "ask @alice about dev@example.com"),
+    ];
+
+    const container = await render(
+      <MessagesWithTurns
+        messages={messages}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        isRunning={false}
+        searchQuery=""
+        toolDisplayMode="grouped"
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("button.cc-file-path-link")).toBeNull();
+  });
+
   it("does not open home-relative file links as Monaco tabs", async () => {
     const messages = [
       message("user-1", "User", "where is it?"),
@@ -387,6 +456,67 @@ describe("MessagesWithTurns edit summaries", () => {
       path: "README.md",
       startLine: 8,
       endLine: 8,
+    });
+  });
+
+  it("opens multiple file links from one agent message without dropping prior tabs", async () => {
+    const worktreePath =
+      "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger";
+    useAppStore.setState({
+      workspaces: [
+        {
+          ...useAppStore.getState().workspaces[0],
+          worktree_path: worktreePath,
+        },
+      ],
+    });
+    const messages = [
+      message(
+        "assistant-1",
+        "Assistant",
+        `Edited http://localhost:14254${worktreePath}/README.md:8 and http://localhost:14254${worktreePath}/simple-wave.svg:1`,
+      ),
+    ];
+
+    const container = await render(
+      <MessagesWithTurns
+        messages={messages}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        isRunning={false}
+        searchQuery=""
+        toolDisplayMode="grouped"
+      />,
+    );
+
+    const readmeButton = Array.from(container.querySelectorAll("button")).find(
+      (item) => item.textContent === "README.md:8",
+    );
+    const svgButton = Array.from(container.querySelectorAll("button")).find(
+      (item) => item.textContent === "simple-wave.svg:1",
+    );
+    expect(readmeButton).toBeTruthy();
+    expect(svgButton).toBeTruthy();
+
+    await act(async () => {
+      readmeButton?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+      svgButton?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    const state = useAppStore.getState();
+    expect(state.fileTabsByWorkspace[WORKSPACE_ID]).toEqual([
+      "README.md",
+      "simple-wave.svg",
+    ]);
+    expect(state.activeFileTabByWorkspace[WORKSPACE_ID]).toBe("simple-wave.svg");
+    expect(state.fileRevealTargetByWorkspace[WORKSPACE_ID]).toMatchObject({
+      path: "simple-wave.svg",
+      startLine: 1,
+      endLine: 1,
     });
   });
 

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -59,6 +59,7 @@ import { ChatAuthFailureCallout } from "../auth/ChatAuthFailureCallout";
 import { cleanClaudeAuthError, isClaudeAuthError } from "../auth/claudeAuth";
 import { monacoFileLinkTarget } from "./chatFileLinks";
 import { useWorkspaceFileIndex } from "./useWorkspaceFileIndex";
+import { detectFileReferences } from "../../utils/filePathLinks";
 import {
   EMPTY_ACTIVITIES,
   EMPTY_ATTACHMENTS,
@@ -86,6 +87,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   liveTaskProgressNode,
   streamingThinkingNode,
   streamingMessageNode,
+  onOpenFileLink,
 }: {
   messages: ChatMessage[];
   /** The enclosing workspace id — forwarded into rollback data so the modal
@@ -125,6 +127,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   liveTaskProgressNode?: React.ReactNode;
   streamingThinkingNode?: React.ReactNode;
   streamingMessageNode?: React.ReactNode;
+  onOpenFileLink?: () => void;
 }) {
   const { t } = useTranslation("chat");
   const completedTurns = useAppStore(
@@ -479,10 +482,11 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     (filePath: string) => {
       const target = monacoFileLinkTarget(filePath, worktreePath);
       if (!target) return false;
+      onOpenFileLink?.();
       openFileTab(workspaceId, target.path, target.revealTarget);
       return true;
     },
-    [openFileTab, workspaceId, worktreePath],
+    [onOpenFileLink, openFileTab, workspaceId, worktreePath],
   );
 
   // Per-turn rollback data, keyed by turn.id. Completed turns are only
@@ -942,12 +946,14 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                     // searchability wins over the easter egg.
                     <HighlightedPlainText text={msg.content} query={searchQuery} />
                   ) : (
-                    renderUltrathinkText(msg.content, {
+                    renderFileLinkedPlainText(msg.content, {
                       animated: false,
                       styles: {
                         ultrathinkChar: styles.ultrathinkChar,
                         ultrathinkCharAnimated: styles.ultrathinkCharAnimated,
                       },
+                      resolveFilePath: fileIndex.resolve,
+                      openFile: openFileInMonaco,
                     })
                   )}
                 </div>
@@ -965,3 +971,55 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     </>
   );
 });
+
+function renderFileLinkedPlainText(
+  text: string,
+  options: {
+    animated: boolean;
+    styles: Parameters<typeof renderUltrathinkText>[1]["styles"];
+    resolveFilePath: (path: string) => string | null;
+    openFile: (path: string) => boolean;
+  },
+): React.ReactNode {
+  const matches = detectFileReferences(text).flatMap((match) => {
+    const isMention = match.text?.startsWith("@") === true;
+    const resolvedPath = isMention ? options.resolveFilePath(match.path) : match.path;
+    return resolvedPath ? [{ ...match, resolvedPath }] : [];
+  });
+  if (matches.length === 0) {
+    return renderUltrathinkText(text, options);
+  }
+
+  const nodes: React.ReactNode[] = [];
+  let cursor = 0;
+  for (const match of matches) {
+    if (match.start > cursor) {
+      nodes.push(
+        <React.Fragment key={`text-${cursor}`}>
+          {renderUltrathinkText(text.slice(cursor, match.start), options)}
+        </React.Fragment>,
+      );
+    }
+    const label = match.text ?? match.path;
+    nodes.push(
+      <button
+        type="button"
+        className="cc-file-path-link"
+        title={match.resolvedPath}
+        key={`file-${match.start}-${match.end}`}
+        onClick={() => options.openFile(match.resolvedPath)}
+      >
+        {label}
+      </button>,
+    );
+    cursor = match.end;
+  }
+  if (cursor < text.length) {
+    nodes.push(
+      <React.Fragment key={`text-${cursor}`}>
+        {renderUltrathinkText(text.slice(cursor), options)}
+      </React.Fragment>,
+    );
+  }
+  return nodes;
+}

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -477,8 +477,17 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   const openFileInMonaco = useCallback(
     (filePath: string) => {
       const rel = relativizePath(filePath, worktreePath);
-      if (/^([a-zA-Z]:[\\/]|[\\/])/.test(rel)) return;
-      openFileTab(workspaceId, rel);
+      if (
+        /^([a-zA-Z]:[\\/]|[\\/])/.test(rel) ||
+        rel === "." ||
+        rel === ".." ||
+        rel.startsWith("../") ||
+        rel.startsWith("..\\")
+      ) {
+        return false;
+      }
+      openFileTab(workspaceId, rel.replace(/^\.[\\/]/, ""));
+      return true;
     },
     [openFileTab, workspaceId, worktreePath],
   );
@@ -927,7 +936,11 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                     // setup-script output, and other multi-line system notes
                     // preserve headings, lists, and code blocks instead of
                     // collapsing newlines into a single paragraph.
-                    <HighlightedMessageMarkdown content={msg.content} query={searchQuery} />
+                    <HighlightedMessageMarkdown
+                      content={msg.content}
+                      query={searchQuery}
+                      onOpenFile={openFileInMonaco}
+                    />
                   ) : searchQuery ? (
                     // While the search bar is open, render user messages as plain
                     // highlighted text so matches inside them get marked. The

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -8,7 +8,6 @@ import type { ChatMessage, ChatAttachment } from "../../types/chat";
 import { roleClassKey, shouldRenderAsMarkdown } from "./messageRendering";
 import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
 import { HighlightedPlainText } from "./HighlightedPlainText";
-import { relativizePath } from "../../hooks/toolSummary";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { collapsedToolGroupKey } from "./collapsedToolGroupKey";
 import { CompactionDivider } from "./CompactionDivider";
@@ -58,6 +57,7 @@ import {
 } from "./toolActivityGroups";
 import { ChatAuthFailureCallout } from "../auth/ChatAuthFailureCallout";
 import { cleanClaudeAuthError, isClaudeAuthError } from "../auth/claudeAuth";
+import { monacoFileLinkPath } from "./chatFileLinks";
 import {
   EMPTY_ACTIVITIES,
   EMPTY_ATTACHMENTS,
@@ -469,24 +469,15 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   // Activity-derived edits use absolute paths (the agent's full path
   // including the worktree prefix); the file-tab store keys by repo-
   // relative path, so strip the worktree prefix when present.
-  // `relativizePath` handles both `/` and `\` so this works on Windows
-  // worktrees too. If the result still looks absolute (POSIX `/...`
-  // or Windows `C:\...` / `C:/...`), the file isn't reachable via the
-  // current worktree — bail rather than passing a bad key into the
-  // file-tab store.
+  // The helper handles both `/` and `\` so this works on Windows
+  // worktrees too. If the result still looks absolute or home-relative,
+  // the file isn't reachable via the current worktree — bail rather than
+  // passing a bad key into the file-tab store.
   const openFileInMonaco = useCallback(
     (filePath: string) => {
-      const rel = relativizePath(filePath, worktreePath);
-      if (
-        /^([a-zA-Z]:[\\/]|[\\/])/.test(rel) ||
-        rel === "." ||
-        rel === ".." ||
-        rel.startsWith("../") ||
-        rel.startsWith("..\\")
-      ) {
-        return false;
-      }
-      openFileTab(workspaceId, rel.replace(/^\.[\\/]/, ""));
+      const rel = monacoFileLinkPath(filePath, worktreePath);
+      if (!rel) return false;
+      openFileTab(workspaceId, rel);
       return true;
     },
     [openFileTab, workspaceId, worktreePath],

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -58,6 +58,7 @@ import {
 import { ChatAuthFailureCallout } from "../auth/ChatAuthFailureCallout";
 import { cleanClaudeAuthError, isClaudeAuthError } from "../auth/claudeAuth";
 import { monacoFileLinkTarget } from "./chatFileLinks";
+import { useWorkspaceFileIndex } from "./useWorkspaceFileIndex";
 import {
   EMPTY_ACTIVITIES,
   EMPTY_ATTACHMENTS,
@@ -156,6 +157,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   const worktreePath = useAppStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.worktree_path,
   );
+  const fileIndex = useWorkspaceFileIndex(workspaceId);
   const liveToolActivities = useAppStore(
     (s) => s.toolActivities[sessionId] ?? EMPTY_ACTIVITIES,
   );
@@ -931,6 +933,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                       content={msg.content}
                       query={searchQuery}
                       onOpenFile={openFileInMonaco}
+                      resolveFilePath={fileIndex.resolve}
                     />
                   ) : searchQuery ? (
                     // While the search bar is open, render user messages as plain

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -982,8 +982,7 @@ function renderFileLinkedPlainText(
   },
 ): React.ReactNode {
   const matches = detectFileReferences(text).flatMap((match) => {
-    const isMention = match.text?.startsWith("@") === true;
-    const resolvedPath = isMention ? options.resolveFilePath(match.path) : match.path;
+    const resolvedPath = options.resolveFilePath(match.path);
     return resolvedPath ? [{ ...match, resolvedPath }] : [];
   });
   if (matches.length === 0) {

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -57,7 +57,7 @@ import {
 } from "./toolActivityGroups";
 import { ChatAuthFailureCallout } from "../auth/ChatAuthFailureCallout";
 import { cleanClaudeAuthError, isClaudeAuthError } from "../auth/claudeAuth";
-import { monacoFileLinkPath } from "./chatFileLinks";
+import { monacoFileLinkTarget } from "./chatFileLinks";
 import {
   EMPTY_ACTIVITIES,
   EMPTY_ATTACHMENTS,
@@ -475,9 +475,9 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   // passing a bad key into the file-tab store.
   const openFileInMonaco = useCallback(
     (filePath: string) => {
-      const rel = monacoFileLinkPath(filePath, worktreePath);
-      if (!rel) return false;
-      openFileTab(workspaceId, rel);
+      const target = monacoFileLinkTarget(filePath, worktreePath);
+      if (!target) return false;
+      openFileTab(workspaceId, target.path, target.revealTarget);
       return true;
     },
     [openFileTab, workspaceId, worktreePath],

--- a/src/ui/src/components/chat/StreamingMessage.tsx
+++ b/src/ui/src/components/chat/StreamingMessage.tsx
@@ -5,6 +5,7 @@ import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
 import { StreamingContext } from "./StreamingContext";
 import { ScrollContext } from "./ScrollContext";
 import { monacoFileLinkTarget } from "./chatFileLinks";
+import { useWorkspaceFileIndex } from "./useWorkspaceFileIndex";
 import styles from "./ChatPanel.module.css";
 import caretStyles from "./caret.module.css";
 
@@ -35,6 +36,7 @@ export const StreamingMessage = memo(function StreamingMessage({
   const worktreePath = useAppStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.worktree_path,
   );
+  const fileIndex = useWorkspaceFileIndex(workspaceId);
   const { handleContentChanged } = useContext(ScrollContext);
 
   const fullText = streaming || pendingText;
@@ -78,6 +80,7 @@ export const StreamingMessage = memo(function StreamingMessage({
             content={displayed}
             query={searchQuery}
             onOpenFile={openFileInMonaco}
+            resolveFilePath={fileIndex.resolve}
           />
         </StreamingContext.Provider>
         {showCaret && <span className={caretStyles.caret} aria-hidden="true" />}

--- a/src/ui/src/components/chat/StreamingMessage.tsx
+++ b/src/ui/src/components/chat/StreamingMessage.tsx
@@ -1,10 +1,10 @@
 import { memo, useCallback, useContext, useEffect } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import { useTypewriter } from "../../hooks/useTypewriter";
-import { relativizePath } from "../../hooks/toolSummary";
 import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
 import { StreamingContext } from "./StreamingContext";
 import { ScrollContext } from "./ScrollContext";
+import { monacoFileLinkPath } from "./chatFileLinks";
 import styles from "./ChatPanel.module.css";
 import caretStyles from "./caret.module.css";
 
@@ -56,17 +56,9 @@ export const StreamingMessage = memo(function StreamingMessage({
 
   const openFileInMonaco = useCallback(
     (filePath: string) => {
-      const rel = relativizePath(filePath, worktreePath);
-      if (
-        /^([a-zA-Z]:[\\/]|[\\/])/.test(rel) ||
-        rel === "." ||
-        rel === ".." ||
-        rel.startsWith("../") ||
-        rel.startsWith("..\\")
-      ) {
-        return false;
-      }
-      openFileTab(workspaceId, rel.replace(/^\.[\\/]/, ""));
+      const rel = monacoFileLinkPath(filePath, worktreePath);
+      if (!rel) return false;
+      openFileTab(workspaceId, rel);
       return true;
     },
     [openFileTab, workspaceId, worktreePath],

--- a/src/ui/src/components/chat/StreamingMessage.tsx
+++ b/src/ui/src/components/chat/StreamingMessage.tsx
@@ -4,7 +4,7 @@ import { useTypewriter } from "../../hooks/useTypewriter";
 import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
 import { StreamingContext } from "./StreamingContext";
 import { ScrollContext } from "./ScrollContext";
-import { monacoFileLinkPath } from "./chatFileLinks";
+import { monacoFileLinkTarget } from "./chatFileLinks";
 import styles from "./ChatPanel.module.css";
 import caretStyles from "./caret.module.css";
 
@@ -56,9 +56,9 @@ export const StreamingMessage = memo(function StreamingMessage({
 
   const openFileInMonaco = useCallback(
     (filePath: string) => {
-      const rel = monacoFileLinkPath(filePath, worktreePath);
-      if (!rel) return false;
-      openFileTab(workspaceId, rel);
+      const target = monacoFileLinkTarget(filePath, worktreePath);
+      if (!target) return false;
+      openFileTab(workspaceId, target.path, target.revealTarget);
       return true;
     },
     [openFileTab, workspaceId, worktreePath],

--- a/src/ui/src/components/chat/StreamingMessage.tsx
+++ b/src/ui/src/components/chat/StreamingMessage.tsx
@@ -1,6 +1,7 @@
-import { memo, useContext, useEffect } from "react";
+import { memo, useCallback, useContext, useEffect } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import { useTypewriter } from "../../hooks/useTypewriter";
+import { relativizePath } from "../../hooks/toolSummary";
 import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
 import { StreamingContext } from "./StreamingContext";
 import { ScrollContext } from "./ScrollContext";
@@ -16,10 +17,12 @@ import caretStyles from "./caret.module.css";
  */
 export const StreamingMessage = memo(function StreamingMessage({
   sessionId,
+  workspaceId,
   isStreaming,
   searchQuery,
 }: {
   sessionId: string;
+  workspaceId: string;
   isStreaming: boolean;
   searchQuery: string;
 }) {
@@ -28,6 +31,10 @@ export const StreamingMessage = memo(function StreamingMessage({
     (s) => s.pendingTypewriter[sessionId]?.text ?? "",
   );
   const finishTypewriterDrain = useAppStore((s) => s.finishTypewriterDrain);
+  const openFileTab = useAppStore((s) => s.openFileTab);
+  const worktreePath = useAppStore(
+    (s) => s.workspaces.find((w) => w.id === workspaceId)?.worktree_path,
+  );
   const { handleContentChanged } = useContext(ScrollContext);
 
   const fullText = streaming || pendingText;
@@ -47,6 +54,24 @@ export const StreamingMessage = memo(function StreamingMessage({
     }
   }, [showCaret, streaming, pendingText, sessionId, finishTypewriterDrain]);
 
+  const openFileInMonaco = useCallback(
+    (filePath: string) => {
+      const rel = relativizePath(filePath, worktreePath);
+      if (
+        /^([a-zA-Z]:[\\/]|[\\/])/.test(rel) ||
+        rel === "." ||
+        rel === ".." ||
+        rel.startsWith("../") ||
+        rel.startsWith("..\\")
+      ) {
+        return false;
+      }
+      openFileTab(workspaceId, rel.replace(/^\.[\\/]/, ""));
+      return true;
+    },
+    [openFileTab, workspaceId, worktreePath],
+  );
+
   if (!displayed) return null;
 
   return (
@@ -57,7 +82,11 @@ export const StreamingMessage = memo(function StreamingMessage({
     >
       <div className={styles.content}>
         <StreamingContext.Provider value={isStreaming || pendingText.length > 0}>
-          <HighlightedMessageMarkdown content={displayed} query={searchQuery} />
+          <HighlightedMessageMarkdown
+            content={displayed}
+            query={searchQuery}
+            onOpenFile={openFileInMonaco}
+          />
         </StreamingContext.Provider>
         {showCaret && <span className={caretStyles.caret} aria-hidden="true" />}
       </div>

--- a/src/ui/src/components/chat/ToolActivityRow.test.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.test.tsx
@@ -59,6 +59,14 @@ beforeEach(() => {
   useAppStore.setState({
     expandedToolUseIds: {},
     extendedToolCallOutput: true,
+    selectedWorkspaceId: "workspace-1",
+    diffFiles: [],
+    diffStagedFiles: null,
+    diffSelectedFile: null,
+    diffSelectedLayer: null,
+    diffTabsByWorkspace: {},
+    fileTabsByWorkspace: {},
+    activeFileTabByWorkspace: {},
   });
 });
 
@@ -323,5 +331,42 @@ describe("ToolActivityRow", () => {
     expect(container.querySelector("pre")?.textContent).toContain(
       "diff --git a/src/app.ts b/src/app.ts",
     );
+  });
+
+  it("opens an inline edit summary in the diff viewer when a diff is available", async () => {
+    useAppStore.setState({
+      diffFiles: [
+        { path: "README.md", status: "Modified", additions: 2, deletions: 0 },
+      ],
+    });
+    const container = await render(
+      <ToolActivityRow
+        activity={activity("Edit", {
+          inputJson: JSON.stringify({
+            file_path: "/repo/README.md",
+            old_string: "old",
+            new_string: "new\nagain",
+          }),
+        })}
+        searchQuery=""
+        worktreePath="/repo"
+      />,
+    );
+
+    const fileButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("README.md"),
+    );
+    expect(fileButton).toBeTruthy();
+
+    await act(async () => {
+      fileButton?.click();
+    });
+
+    const state = useAppStore.getState();
+    expect(state.diffSelectedFile).toBe("README.md");
+    expect(state.diffTabsByWorkspace["workspace-1"]).toEqual([
+      { path: "README.md", layer: null },
+    ]);
+    expect(state.fileTabsByWorkspace["workspace-1"]).toBeUndefined();
   });
 });

--- a/src/ui/src/components/chat/ToolActivityRow.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useReducer, type MouseEvent } from "react";
+import { useCallback, useEffect, useMemo, useReducer, type MouseEvent } from "react";
 import { ChevronRight, WandSparkles } from "lucide-react";
 import type { ToolActivity } from "../../stores/useAppStore";
 import { useAppStore } from "../../stores/useAppStore";
@@ -15,6 +15,7 @@ import {
 } from "./editActivitySummary";
 import { resolveToolSummary } from "./toolMetadata";
 import { isSkillActivity, skillActivationName } from "./toolActivityGroups";
+import type { DiffLayer } from "../../types/diff";
 
 interface ToolActivityRowProps {
   activity: ToolActivity;
@@ -94,6 +95,12 @@ function GenericToolActivityRow({
   const expanded = useAppStore((s) => !!s.expandedToolUseIds[activity.toolUseId]);
   const toggleToolUseExpanded = useAppStore((s) => s.toggleToolUseExpanded);
   const extendedToolCallOutput = useAppStore((s) => s.extendedToolCallOutput);
+  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const diffFiles = useAppStore((s) => s.diffFiles);
+  const diffStagedFiles = useAppStore((s) => s.diffStagedFiles);
+  const openDiffTab = useAppStore((s) => s.openDiffTab);
+  const openFileTab = useAppStore((s) => s.openFileTab);
+  const setDiffSelectedCommitHash = useAppStore((s) => s.setDiffSelectedCommitHash);
   const editSummary = summarizeToolActivityEdit(activity);
   const summary = activitySummaryText(activity);
   const details = useMemo(() => toolDetails(activity), [activity]);
@@ -114,6 +121,29 @@ function GenericToolActivityRow({
       cancelled = true;
     };
   }, [cachedHtml, details.content, details.lang, expanded, extendedToolCallOutput]);
+
+  const openEditedFile = useCallback(
+    (filePath: string) => {
+      if (!selectedWorkspaceId) return;
+      const relativePath = relativizePath(filePath, worktreePath).replace(/\\/g, "/");
+      const diffTarget = findDiffTarget(relativePath, diffFiles, diffStagedFiles);
+      if (diffTarget) {
+        openDiffTab(selectedWorkspaceId, diffTarget.path, diffTarget.layer);
+        setDiffSelectedCommitHash(null);
+        return;
+      }
+      openFileTab(selectedWorkspaceId, relativePath);
+    },
+    [
+      diffFiles,
+      diffStagedFiles,
+      openDiffTab,
+      openFileTab,
+      selectedWorkspaceId,
+      setDiffSelectedCommitHash,
+      worktreePath,
+    ],
+  );
 
   const label = `${expanded ? "Collapse" : "Expand"} ${activity.toolName} input details`;
 
@@ -142,6 +172,7 @@ function GenericToolActivityRow({
             summary={editSummary}
             searchQuery={searchQuery}
             worktreePath={worktreePath}
+            onOpenFile={openEditedFile}
           />
         ) : (
           <span
@@ -188,6 +219,27 @@ function activitySummaryText(activity: ToolActivity): string {
     extractToolSummary(activity.toolName, activity.inputJson) ||
     ""
   );
+}
+
+function findDiffTarget(
+  path: string,
+  diffFiles: ReturnType<typeof useAppStore.getState>["diffFiles"],
+  diffStagedFiles: ReturnType<typeof useAppStore.getState>["diffStagedFiles"],
+): { path: string; layer: DiffLayer | null } | null {
+  if (diffStagedFiles) {
+    const layered: Array<[DiffLayer, typeof diffFiles]> = [
+      ["unstaged", diffStagedFiles.unstaged],
+      ["staged", diffStagedFiles.staged],
+      ["untracked", diffStagedFiles.untracked],
+      ["committed", diffStagedFiles.committed],
+    ];
+    for (const [layer, files] of layered) {
+      const file = files.find((item) => item.path === path);
+      if (file) return { path: file.path, layer };
+    }
+  }
+  const file = diffFiles.find((item) => item.path === path);
+  return file ? { path: file.path, layer: null } : null;
 }
 
 function toolDetails(activity: ToolActivity): ToolDetails {

--- a/src/ui/src/components/chat/chatFileLinks.test.ts
+++ b/src/ui/src/components/chat/chatFileLinks.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { monacoFileLinkPath } from "./chatFileLinks";
+
+describe("monacoFileLinkPath", () => {
+  it("keeps workspace-relative files for Monaco", () => {
+    expect(monacoFileLinkPath("README.md", "/repo")).toBe("README.md");
+    expect(monacoFileLinkPath("./src/main.rs", "/repo")).toBe("src/main.rs");
+  });
+
+  it("relativizes absolute paths inside the worktree", () => {
+    expect(monacoFileLinkPath("/repo/src/main.rs", "/repo")).toBe("src/main.rs");
+  });
+
+  it("rejects absolute and home-relative paths so native fallback can handle them", () => {
+    expect(monacoFileLinkPath("/tmp/report.md", "/repo")).toBeNull();
+    expect(monacoFileLinkPath("C:\\Users\\me\\report.md", "/repo")).toBeNull();
+    expect(monacoFileLinkPath("~/Downloads/report.md", "/repo")).toBeNull();
+    expect(monacoFileLinkPath("~\\Downloads\\report.md", "/repo")).toBeNull();
+    expect(monacoFileLinkPath("~", "/repo")).toBeNull();
+  });
+
+  it("rejects parent-directory traversal", () => {
+    expect(monacoFileLinkPath("../README.md", "/repo")).toBeNull();
+    expect(monacoFileLinkPath("..\\README.md", "/repo")).toBeNull();
+  });
+});

--- a/src/ui/src/components/chat/chatFileLinks.test.ts
+++ b/src/ui/src/components/chat/chatFileLinks.test.ts
@@ -10,6 +10,9 @@ describe("monacoFileLinkPath", () => {
 
   it("relativizes absolute paths inside the worktree", () => {
     expect(monacoFileLinkPath("/repo/src/main.rs", "/repo")).toBe("src/main.rs");
+    expect(monacoFileLinkPath("C:\\repo\\src\\main.rs", "C:\\repo")).toBe(
+      "src/main.rs",
+    );
   });
 
   it("preserves line and range targets separately from the file tab path", () => {

--- a/src/ui/src/components/chat/chatFileLinks.test.ts
+++ b/src/ui/src/components/chat/chatFileLinks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { monacoFileLinkPath } from "./chatFileLinks";
+import { monacoFileLinkPath, monacoFileLinkTarget } from "./chatFileLinks";
 
 describe("monacoFileLinkPath", () => {
   it("keeps workspace-relative files for Monaco", () => {
@@ -10,6 +10,18 @@ describe("monacoFileLinkPath", () => {
 
   it("relativizes absolute paths inside the worktree", () => {
     expect(monacoFileLinkPath("/repo/src/main.rs", "/repo")).toBe("src/main.rs");
+  });
+
+  it("preserves line and range targets separately from the file tab path", () => {
+    expect(monacoFileLinkTarget("/repo/src/main.rs:7:2-9:4", "/repo")).toEqual({
+      path: "src/main.rs",
+      revealTarget: {
+        startLine: 7,
+        startColumn: 2,
+        endLine: 9,
+        endColumn: 4,
+      },
+    });
   });
 
   it("rejects absolute and home-relative paths so native fallback can handle them", () => {

--- a/src/ui/src/components/chat/chatFileLinks.ts
+++ b/src/ui/src/components/chat/chatFileLinks.ts
@@ -1,10 +1,31 @@
 import { relativizePath } from "../../hooks/toolSummary";
+import { parseFilePathTarget } from "../../utils/filePathLinks";
+
+export interface MonacoFileRevealTarget {
+  startLine: number;
+  startColumn?: number;
+  endLine: number;
+  endColumn?: number;
+}
+
+export interface MonacoFileLinkTarget {
+  path: string;
+  revealTarget?: MonacoFileRevealTarget;
+}
 
 export function monacoFileLinkPath(
   filePath: string,
   worktreePath: string | null | undefined,
 ): string | null {
-  const rel = relativizePath(filePath, worktreePath);
+  return monacoFileLinkTarget(filePath, worktreePath)?.path ?? null;
+}
+
+export function monacoFileLinkTarget(
+  filePath: string,
+  worktreePath: string | null | undefined,
+): MonacoFileLinkTarget | null {
+  const parsed = parseFilePathTarget(filePath);
+  const rel = relativizePath(parsed.path, worktreePath);
   if (
     /^([a-zA-Z]:[\\/]|[\\/])/.test(rel) ||
     rel === "~" ||
@@ -17,5 +38,15 @@ export function monacoFileLinkPath(
   ) {
     return null;
   }
-  return rel.replace(/^\.[\\/]/, "");
+  const path = rel.replace(/^\.[\\/]/, "");
+  const revealTarget =
+    typeof parsed.startLine === "number"
+      ? {
+          startLine: parsed.startLine,
+          startColumn: parsed.startColumn,
+          endLine: parsed.endLine ?? parsed.startLine,
+          endColumn: parsed.endColumn,
+        }
+      : undefined;
+  return revealTarget ? { path, revealTarget } : { path };
 }

--- a/src/ui/src/components/chat/chatFileLinks.ts
+++ b/src/ui/src/components/chat/chatFileLinks.ts
@@ -1,0 +1,21 @@
+import { relativizePath } from "../../hooks/toolSummary";
+
+export function monacoFileLinkPath(
+  filePath: string,
+  worktreePath: string | null | undefined,
+): string | null {
+  const rel = relativizePath(filePath, worktreePath);
+  if (
+    /^([a-zA-Z]:[\\/]|[\\/])/.test(rel) ||
+    rel === "~" ||
+    rel.startsWith("~/") ||
+    rel.startsWith("~\\") ||
+    rel === "." ||
+    rel === ".." ||
+    rel.startsWith("../") ||
+    rel.startsWith("..\\")
+  ) {
+    return null;
+  }
+  return rel.replace(/^\.[\\/]/, "");
+}

--- a/src/ui/src/components/chat/chatFileLinks.ts
+++ b/src/ui/src/components/chat/chatFileLinks.ts
@@ -38,7 +38,7 @@ export function monacoFileLinkTarget(
   ) {
     return null;
   }
-  const path = rel.replace(/^\.[\\/]/, "");
+  const path = rel.replace(/^\.[\\/]/, "").replace(/\\/g, "/");
   const revealTarget =
     typeof parsed.startLine === "number"
       ? {

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
@@ -86,4 +86,19 @@ describe("useWorkspaceFileIndex", () => {
 
     expect(serviceMocks.listWorkspaceFiles).toHaveBeenCalledTimes(1);
   });
+
+  it("reloads the index when the workspace file tree refreshes", async () => {
+    await render("ws-c");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    useAppStore.setState({ fileTreeRefreshNonceByWorkspace: { "ws-c": 1 } });
+    await render("ws-c");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(serviceMocks.listWorkspaceFiles).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
@@ -101,4 +101,26 @@ describe("useWorkspaceFileIndex", () => {
 
     expect(serviceMocks.listWorkspaceFiles).toHaveBeenCalledTimes(2);
   });
+
+  it("does not cache rejected workspace file loads", async () => {
+    serviceMocks.listWorkspaceFiles
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce([
+        { path: "README.md", is_directory: false },
+      ]);
+
+    await render("ws-d");
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(latestResolve?.("README.md")).toBeNull();
+
+    await render("ws-d");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(serviceMocks.listWorkspaceFiles).toHaveBeenCalledTimes(2);
+    expect(latestResolve?.("README.md")).toBe("README.md");
+  });
 });

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
@@ -69,6 +69,7 @@ describe("useWorkspaceFileIndex", () => {
 
     expect(serviceMocks.listWorkspaceFiles).toHaveBeenCalledTimes(1);
     expect(latestResolve?.("Cargo.toml")).toBe("Cargo.toml");
+    expect(latestResolve?.("@Cargo.toml")).toBe("Cargo.toml");
     expect(latestResolve?.("./README.md")).toBe("README.md");
     expect(latestResolve?.("src/main.rs")).toBe("src/main.rs");
     expect(latestResolve?.("./README.md:7")).toBe("README.md:7");

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useWorkspaceFileIndex } from "./useWorkspaceFileIndex";
+import { useAppStore } from "../../stores/useAppStore";
+
+const serviceMocks = vi.hoisted(() => ({
+  listWorkspaceFiles: vi.fn(),
+}));
+
+vi.mock("../../services/tauri", () => ({
+  listWorkspaceFiles: serviceMocks.listWorkspaceFiles,
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const roots: Root[] = [];
+const containers: HTMLElement[] = [];
+let latestResolve: ((path: string) => string | null) | null = null;
+
+function Harness({ workspaceId }: { workspaceId: string }) {
+  const index = useWorkspaceFileIndex(workspaceId);
+  useEffect(() => {
+    latestResolve = index.resolve;
+  }, [index.resolve]);
+  return null;
+}
+
+async function render(workspaceId: string): Promise<void> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  containers.push(container);
+  await act(async () => {
+    root.render(<Harness workspaceId={workspaceId} />);
+  });
+}
+
+beforeEach(() => {
+  latestResolve = null;
+  serviceMocks.listWorkspaceFiles.mockReset();
+  serviceMocks.listWorkspaceFiles.mockResolvedValue([
+    { path: "Cargo.toml", is_directory: false },
+    { path: "README.md", is_directory: false },
+    { path: "src/main.rs", is_directory: false },
+    { path: "examples/main.rs", is_directory: false },
+    { path: "src", is_directory: true },
+  ]);
+  useAppStore.setState({ fileTreeRefreshNonceByWorkspace: {} });
+});
+
+afterEach(async () => {
+  for (const root of roots.splice(0).reverse()) {
+    await act(async () => root.unmount());
+  }
+  for (const container of containers.splice(0)) container.remove();
+});
+
+describe("useWorkspaceFileIndex", () => {
+  it("resolves exact paths and unique basenames with one workspace file load", async () => {
+    await render("ws-a");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(serviceMocks.listWorkspaceFiles).toHaveBeenCalledTimes(1);
+    expect(latestResolve?.("Cargo.toml")).toBe("Cargo.toml");
+    expect(latestResolve?.("./README.md")).toBe("README.md");
+    expect(latestResolve?.("src/main.rs")).toBe("src/main.rs");
+    expect(latestResolve?.("./README.md:7")).toBe("README.md:7");
+    expect(latestResolve?.("Cargo.toml:2:3-4:5")).toBe("Cargo.toml:2:3-4:5");
+    expect(latestResolve?.("main.rs")).toBeNull();
+    expect(latestResolve?.("src")).toBeNull();
+  });
+
+  it("shares the cached load across multiple consumers for the same workspace", async () => {
+    await render("ws-b");
+    await render("ws-b");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(serviceMocks.listWorkspaceFiles).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.ts
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.ts
@@ -66,7 +66,7 @@ export function useWorkspaceFileIndex(
     if (!data) return EMPTY_INDEX;
     return {
       resolve(rawPath: string) {
-        const parsed = parseFilePathTarget(rawPath.trim());
+        const parsed = parseFilePathTarget(rawPath.trim().replace(/^@/, ""));
         const normalized = parsed.path.replace(/\\/g, "/").replace(/^\.\//, "");
         if (!normalized || normalized.startsWith("../")) return null;
         const lineSuffix = formatLineSuffix(parsed);

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.ts
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.ts
@@ -49,6 +49,10 @@ export function useWorkspaceFileIndex(
         if (!cancelled) setData(next);
       })
       .catch((err) => {
+        const current = dataCache.get(workspaceId);
+        if (current?.promise === promise) {
+          dataCache.delete(workspaceId);
+        }
         if (cancelled) return;
         console.error("Failed to load workspace file index:", err);
         setData(null);

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.ts
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.ts
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useState } from "react";
+import { listWorkspaceFiles } from "../../services/tauri";
+import { useAppStore } from "../../stores/useAppStore";
+import { parseFilePathTarget } from "../../utils/filePathLinks";
+
+export interface WorkspaceFileIndex {
+  resolve: (path: string) => string | null;
+}
+
+const EMPTY_INDEX: WorkspaceFileIndex = { resolve: () => null };
+
+interface FileIndexData {
+  paths: Set<string>;
+  uniqueBasenames: Map<string, string | null>;
+}
+
+const dataCache = new Map<string, Promise<FileIndexData>>();
+
+export function useWorkspaceFileIndex(
+  workspaceId: string | null | undefined,
+): WorkspaceFileIndex {
+  const refreshNonce = useAppStore((s) =>
+    workspaceId ? (s.fileTreeRefreshNonceByWorkspace[workspaceId] ?? 0) : 0,
+  );
+  const [data, setData] = useState<FileIndexData | null>(null);
+
+  useEffect(() => {
+    if (!workspaceId) {
+      setData(null);
+      return;
+    }
+    let cancelled = false;
+    const cacheKey = `${workspaceId}:${refreshNonce}`;
+    let promise = dataCache.get(cacheKey);
+    if (!promise) {
+      promise = listWorkspaceFiles(workspaceId).then(buildFileIndex);
+      dataCache.set(cacheKey, promise);
+    }
+    promise
+      .then((next) => {
+        if (!cancelled) setData(next);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("Failed to load workspace file index:", err);
+        setData(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, refreshNonce]);
+
+  return useMemo(() => {
+    if (!data) return EMPTY_INDEX;
+    return {
+      resolve(rawPath: string) {
+        const parsed = parseFilePathTarget(rawPath.trim());
+        const normalized = parsed.path.replace(/\\/g, "/").replace(/^\.\//, "");
+        if (!normalized || normalized.startsWith("../")) return null;
+        const lineSuffix = formatLineSuffix(parsed);
+        if (data.paths.has(normalized)) return `${normalized}${lineSuffix}`;
+        if (normalized.includes("/")) return null;
+        const basenamePath = data.uniqueBasenames.get(normalized.toLowerCase());
+        return basenamePath ? `${basenamePath}${lineSuffix}` : null;
+      },
+    };
+  }, [data]);
+}
+
+function formatLineSuffix(parsed: ReturnType<typeof parseFilePathTarget>): string {
+  if (typeof parsed.startLine !== "number") return "";
+  let suffix = `:${parsed.startLine}`;
+  if (typeof parsed.startColumn === "number") {
+    suffix += `:${parsed.startColumn}`;
+  }
+  if (
+    typeof parsed.endLine === "number" &&
+    (parsed.endLine !== parsed.startLine ||
+      typeof parsed.endColumn === "number")
+  ) {
+    suffix += `-${parsed.endLine}`;
+    if (typeof parsed.endColumn === "number") {
+      suffix += `:${parsed.endColumn}`;
+    }
+  }
+  return suffix;
+}
+
+function buildFileIndex(
+  entries: Awaited<ReturnType<typeof listWorkspaceFiles>>,
+): FileIndexData {
+  const paths = new Set<string>();
+  const uniqueBasenames = new Map<string, string | null>();
+  for (const entry of entries) {
+    if (entry.is_directory) continue;
+    const path = entry.path.replace(/\\/g, "/");
+    paths.add(path);
+    const basename = path.split("/").pop()?.toLowerCase();
+    if (!basename) continue;
+    if (!uniqueBasenames.has(basename)) {
+      uniqueBasenames.set(basename, path);
+    } else if (uniqueBasenames.get(basename) !== path) {
+      uniqueBasenames.set(basename, null);
+    }
+  }
+  return { paths, uniqueBasenames };
+}

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.ts
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.ts
@@ -14,7 +14,13 @@ interface FileIndexData {
   uniqueBasenames: Map<string, string | null>;
 }
 
-const dataCache = new Map<string, Promise<FileIndexData>>();
+interface FileIndexCacheEntry {
+  refreshNonce: number;
+  promise: Promise<FileIndexData>;
+}
+
+const MAX_CACHED_WORKSPACES = 20;
+const dataCache = new Map<string, FileIndexCacheEntry>();
 
 export function useWorkspaceFileIndex(
   workspaceId: string | null | undefined,
@@ -30,11 +36,13 @@ export function useWorkspaceFileIndex(
       return;
     }
     let cancelled = false;
-    const cacheKey = `${workspaceId}:${refreshNonce}`;
-    let promise = dataCache.get(cacheKey);
+    const cached = dataCache.get(workspaceId);
+    let promise =
+      cached?.refreshNonce === refreshNonce ? cached.promise : undefined;
     if (!promise) {
       promise = listWorkspaceFiles(workspaceId).then(buildFileIndex);
-      dataCache.set(cacheKey, promise);
+      dataCache.set(workspaceId, { refreshNonce, promise });
+      trimFileIndexCache();
     }
     promise
       .then((next) => {
@@ -65,6 +73,14 @@ export function useWorkspaceFileIndex(
       },
     };
   }, [data]);
+}
+
+function trimFileIndexCache(): void {
+  while (dataCache.size > MAX_CACHED_WORKSPACES) {
+    const oldestKey = dataCache.keys().next().value;
+    if (!oldestKey) return;
+    dataCache.delete(oldestKey);
+  }
 }
 
 function formatLineSuffix(parsed: ReturnType<typeof parseFilePathTarget>): string {

--- a/src/ui/src/components/file-viewer/FileViewer.test.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAppStore } from "../../stores/useAppStore";
+import {
+  fileBufferKey,
+  makeUnloadedBuffer,
+} from "../../stores/slices/fileTreeSlice";
+import { FileViewer } from "./FileViewer";
+
+const serviceMocks = vi.hoisted(() => ({
+  loadDiffFiles: vi.fn(),
+  readWorkspaceFileBytes: vi.fn(),
+  readWorkspaceFileForViewer: vi.fn(),
+  writeWorkspaceFile: vi.fn(),
+}));
+
+vi.mock("../../services/tauri", () => serviceMocks);
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("../chat/SessionTabs", () => ({
+  SessionTabs: () => <div data-testid="session-tabs" />,
+}));
+vi.mock("./MonacoEditor", () => ({
+  MonacoEditor: () => <div data-testid="monaco-editor" />,
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const WS = "workspace-1";
+const FILE = "README.md";
+
+const roots: Root[] = [];
+const containers: HTMLElement[] = [];
+
+async function render(node: ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  containers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return container;
+}
+
+function seedOpenFile(closeNonce = 0) {
+  useAppStore.setState({
+    selectedWorkspaceId: WS,
+    fileTabsByWorkspace: { [WS]: [FILE] },
+    activeFileTabByWorkspace: { [WS]: FILE },
+    fileRevealTargetByWorkspace: {},
+    fileBuffers: {
+      [fileBufferKey(WS, FILE)]: makeUnloadedBuffer(),
+    },
+    requestCloseFileTabNonceByWorkspace: { [WS]: closeNonce },
+  });
+}
+
+beforeEach(() => {
+  serviceMocks.loadDiffFiles.mockReset();
+  serviceMocks.readWorkspaceFileBytes.mockReset();
+  serviceMocks.readWorkspaceFileForViewer.mockReset();
+  serviceMocks.writeWorkspaceFile.mockReset();
+  serviceMocks.readWorkspaceFileForViewer.mockResolvedValue({
+    content: "# README",
+    is_binary: false,
+    size_bytes: 8,
+    truncated: false,
+  });
+  useAppStore.setState({
+    selectedWorkspaceId: null,
+    fileTabsByWorkspace: {},
+    activeFileTabByWorkspace: {},
+    fileRevealTargetByWorkspace: {},
+    fileBuffers: {},
+    requestCloseFileTabNonceByWorkspace: {},
+  });
+});
+
+afterEach(async () => {
+  for (const root of roots.splice(0).reverse()) {
+    await act(async () => root.unmount());
+  }
+  for (const container of containers.splice(0)) container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("FileViewer close nonce handling", () => {
+  it("does not consume a stale close nonce when reopening a file tab", async () => {
+    seedOpenFile(1);
+
+    await render(<FileViewer />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const state = useAppStore.getState();
+    expect(state.fileTabsByWorkspace[WS]).toEqual([FILE]);
+    expect(state.activeFileTabByWorkspace[WS]).toBe(FILE);
+  });
+
+  it("closes the mounted file when the close nonce increments", async () => {
+    seedOpenFile(1);
+
+    await render(<FileViewer />);
+    await act(async () => {
+      useAppStore.setState({
+        requestCloseFileTabNonceByWorkspace: { [WS]: 2 },
+      });
+    });
+
+    const state = useAppStore.getState();
+    expect(state.fileTabsByWorkspace[WS]).toEqual([]);
+    expect(state.activeFileTabByWorkspace[WS]).toBeNull();
+  });
+});

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -372,17 +372,21 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
   // its own close button uses, so the unsaved-changes prompt fires
   // identically whether the user clicks × or hits the keystroke.
   //
-  // Handled-nonce tracking matches the FilesPanel pattern: a Map
-  // keyed by workspace, seeded at 0 so a bump that arrived while
-  // this viewer was mounting (rare but possible if `Cmd+W` fired
-  // mid-route to a fresh file tab) is still consumed.
+  // Handled-nonce tracking is keyed by workspace and initializes from the
+  // current value. A nonce is a "new close request" signal, not persistent
+  // desired state; consuming an old value would immediately close every file
+  // reopened after the first Cmd+W/tab-close request in that workspace.
   const closeFileTabNonce = useAppStore(
     (s) => s.requestCloseFileTabNonceByWorkspace[workspaceId] ?? 0,
   );
   const handledCloseNonces = useRef<Map<string, number>>(new Map());
   useEffect(() => {
-    if (closeFileTabNonce === 0) return;
     const handled = handledCloseNonces.current.get(workspaceId) ?? 0;
+    if (!handledCloseNonces.current.has(workspaceId)) {
+      handledCloseNonces.current.set(workspaceId, closeFileTabNonce);
+      return;
+    }
+    if (closeFileTabNonce === 0) return;
     if (closeFileTabNonce === handled) return;
     handledCloseNonces.current.set(workspaceId, closeFileTabNonce);
     requestCloseFileTab();

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -85,6 +85,7 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
   const setDiffFiles = useAppStore((s) => s.setDiffFiles);
   const setFileTabPreview = useAppStore((s) => s.setFileTabPreview);
   const closeFileTab = useAppStore((s) => s.closeFileTab);
+  const clearFileRevealTarget = useAppStore((s) => s.clearFileRevealTarget);
   const requestFileTreeRefresh = useAppStore((s) => s.requestFileTreeRefresh);
   const addToast = useAppStore((s) => s.addToast);
   const keybindings = useAppStore((s) => s.keybindings);
@@ -189,6 +190,12 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
       setFileBufferContent(workspaceId, path, next);
     },
     [workspaceId, path, setFileBufferContent],
+  );
+  const handleRevealTargetApplied = useCallback(
+    (nonce: number) => {
+      clearFileRevealTarget(workspaceId, nonce);
+    },
+    [clearFileRevealTarget, workspaceId],
   );
 
   const copySource = useCallback((): string | null => {
@@ -509,6 +516,7 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
               value={bufferState.buffer}
               filename={path}
               revealTarget={revealTarget}
+              onRevealTargetApplied={handleRevealTargetApplied}
               readOnly={editDisabled}
               onChange={handleBufferChange}
               onSave={handleSave}

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -74,6 +74,10 @@ interface FileViewerInnerProps {
 function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
   const bufferKey = fileBufferKey(workspaceId, path);
   const bufferState = useAppStore((s) => s.fileBuffers[bufferKey]);
+  const revealTarget = useAppStore((s) => {
+    const target = s.fileRevealTargetByWorkspace[workspaceId];
+    return target?.path === path ? target : null;
+  });
   const setFileBufferLoaded = useAppStore((s) => s.setFileBufferLoaded);
   const setFileBufferLoadError = useAppStore((s) => s.setFileBufferLoadError);
   const setFileBufferContent = useAppStore((s) => s.setFileBufferContent);
@@ -504,6 +508,7 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
               // `executeEdits` (preserves cursor + undo).
               value={bufferState.buffer}
               filename={path}
+              revealTarget={revealTarget}
               readOnly={editDisabled}
               onChange={handleBufferChange}
               onSave={handleSave}

--- a/src/ui/src/components/file-viewer/MonacoEditor.module.css
+++ b/src/ui/src/components/file-viewer/MonacoEditor.module.css
@@ -34,6 +34,10 @@
   border-radius: var(--radius-sm) !important;
 }
 
+.host :global(.claudette-reveal-line) {
+  background: rgba(var(--accent-primary-rgb), 0.16);
+}
+
 /* Git gutter — colored bars in Monaco's line-numbers gutter. Decorations
    are applied via `linesDecorationsClassName`; Monaco renders the class
    on a thin strip immediately right of the line numbers. */

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -36,6 +36,7 @@ interface MonacoEditorProps {
   readOnly: boolean;
   /** Optional one-shot reveal target from chat file links. */
   revealTarget?: FileRevealTarget | null;
+  onRevealTargetApplied?: (nonce: number) => void;
   /** Fired on every document change. The parent compares against the
    *  baseline to update the per-tab dirty flag. The `@monaco-editor/react`
    *  wrapper internally suppresses this callback while it's applying a
@@ -52,6 +53,7 @@ export const MonacoEditor = memo(function MonacoEditor({
   value,
   filename,
   revealTarget,
+  onRevealTargetApplied,
   readOnly,
   onChange,
   onSave,
@@ -148,7 +150,8 @@ export const MonacoEditor = memo(function MonacoEditor({
         },
       },
     ]);
-  }, [revealTarget]);
+    onRevealTargetApplied?.(revealTarget.nonce);
+  }, [onRevealTargetApplied, revealTarget]);
 
   // Define the 'claudette' theme before the editor instance is created so
   // the theme prop resolves immediately and there's no flash of vs-dark.

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -142,7 +142,7 @@ export const MonacoEditor = memo(function MonacoEditor({
           isWholeLine: true,
           className: "claudette-reveal-line",
           overviewRuler: {
-            color: "rgba(255, 203, 107, 0.65)",
+            color: "rgba(var(--accent-primary-rgb), 0.65)",
             position: monacoInstance.editor.OverviewRulerLane.Center,
           },
         },

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -5,6 +5,7 @@ import { applyMonacoTheme, initMonacoThemeSync } from "./monacoTheme";
 import { DEFAULT_MONO_STACK } from "../../styles/fonts";
 import { useAppStore } from "../../stores/useAppStore";
 import { executeCloseTab, executeNewTab } from "../../hotkeys/contextActions";
+import type { FileRevealTarget } from "../../stores/slices/fileTreeSlice";
 import {
   useGitGutter,
   type DecorationsCollection,
@@ -33,6 +34,8 @@ interface MonacoEditorProps {
   /** Read-only mode. Toggled at runtime via `updateOptions` so flipping
    *  view/edit doesn't lose cursor position or undo stack. */
   readOnly: boolean;
+  /** Optional one-shot reveal target from chat file links. */
+  revealTarget?: FileRevealTarget | null;
   /** Fired on every document change. The parent compares against the
    *  baseline to update the per-tab dirty flag. The `@monaco-editor/react`
    *  wrapper internally suppresses this callback while it's applying a
@@ -48,6 +51,7 @@ export const MonacoEditor = memo(function MonacoEditor({
   workspaceId,
   value,
   filename,
+  revealTarget,
   readOnly,
   onChange,
   onSave,
@@ -74,6 +78,7 @@ export const MonacoEditor = memo(function MonacoEditor({
   // `[]`-deps effect inside the hook would run *before* the lazy-loaded
   // editor mounts, so the collection has to be initialized here.
   const gutterCollectionRef = useRef<DecorationsCollection | null>(null);
+  const revealCollectionRef = useRef<DecorationsCollection | null>(null);
 
   // Mirror the editor's text into React state so the git-gutter hook can
   // recompute on every change. Seeded from `value`; user typing updates
@@ -106,10 +111,44 @@ export const MonacoEditor = memo(function MonacoEditor({
     () => () => {
       cleanupThemeSyncRef.current?.();
       gutterCollectionRef.current?.clear();
+      revealCollectionRef.current?.clear();
       gutterCollectionRef.current = null;
+      revealCollectionRef.current = null;
     },
     [],
   );
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    const monacoInstance = monacoRef.current;
+    if (!editor || !monacoInstance || !revealTarget) return;
+    const model = editor.getModel();
+    const lineCount = model?.getLineCount() ?? revealTarget.startLine;
+    const startLine = clampLine(revealTarget.startLine, lineCount);
+    const endLine = clampLine(revealTarget.endLine, lineCount);
+    const rangeEndLine = Math.max(startLine, endLine);
+    const range = new monacoInstance.Range(
+      startLine,
+      revealTarget.startColumn ?? 1,
+      rangeEndLine,
+      revealTarget.endColumn ?? model?.getLineMaxColumn(rangeEndLine) ?? 1,
+    );
+    editor.setSelection(range);
+    editor.revealRangeInCenter(range);
+    revealCollectionRef.current?.set([
+      {
+        range,
+        options: {
+          isWholeLine: true,
+          className: "claudette-reveal-line",
+          overviewRuler: {
+            color: "rgba(255, 203, 107, 0.65)",
+            position: monacoInstance.editor.OverviewRulerLane.Center,
+          },
+        },
+      },
+    ]);
+  }, [revealTarget]);
 
   // Define the 'claudette' theme before the editor instance is created so
   // the theme prop resolves immediately and there's no flash of vs-dark.
@@ -126,6 +165,7 @@ export const MonacoEditor = memo(function MonacoEditor({
     // switches via `key={path}`, so a fresh collection is created per
     // file.
     gutterCollectionRef.current = editor.createDecorationsCollection();
+    revealCollectionRef.current = editor.createDecorationsCollection();
     // Start live theme sync: re-derives the Monaco theme whenever the
     // Claudette theme changes (data-theme attribute or inline CSS vars).
     cleanupThemeSyncRef.current = initMonacoThemeSync(monacoInstance);
@@ -207,3 +247,7 @@ export const MonacoEditor = memo(function MonacoEditor({
     </div>
   );
 });
+
+function clampLine(line: number, lineCount: number): number {
+  return Math.max(1, Math.min(line, Math.max(1, lineCount)));
+}

--- a/src/ui/src/components/layout/AppLayout.module.css
+++ b/src/ui/src/components/layout/AppLayout.module.css
@@ -78,8 +78,23 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  position: relative;
   background: var(--app-bg);
   contain: layout style;
+}
+
+.contentPanel {
+  position: absolute;
+  inset: 0;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.contentPanelHidden {
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .terminal {

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -131,13 +131,32 @@ export function AppLayout() {
           <div className={styles.center}>
             <div className={styles.content}>
               {selectedWorkspaceId ? (
-                showFileViewer ? (
-                  <FileViewer />
-                ) : showDiff ? (
-                  <DiffViewer />
-                ) : (
-                  <ChatPanel />
-                )
+                <>
+                  <div
+                    className={`${styles.contentPanel} ${
+                      showFileViewer ? "" : styles.contentPanelHidden
+                    }`}
+                    aria-hidden={!showFileViewer}
+                  >
+                    {showFileViewer && <FileViewer />}
+                  </div>
+                  <div
+                    className={`${styles.contentPanel} ${
+                      showDiff ? "" : styles.contentPanelHidden
+                    }`}
+                    aria-hidden={!showDiff}
+                  >
+                    {showDiff && <DiffViewer />}
+                  </div>
+                  <div
+                    className={`${styles.contentPanel} ${
+                      !showFileViewer && !showDiff ? "" : styles.contentPanelHidden
+                    }`}
+                    aria-hidden={showFileViewer || showDiff}
+                  >
+                    <ChatPanel />
+                  </div>
+                </>
               ) : (
                 <Dashboard />
               )}

--- a/src/ui/src/hooks/useStickyScroll.test.tsx
+++ b/src/ui/src/hooks/useStickyScroll.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment happy-dom
+
+import { act, useEffect, useRef, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useStickyScroll } from "./useStickyScroll";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+type StickyScrollApi = ReturnType<typeof useStickyScroll>;
+
+async function render(node: ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return container;
+}
+
+function configureScrollMetrics(
+  el: HTMLElement,
+  metrics: { scrollTop?: number; scrollHeight: number; clientHeight: number },
+) {
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => (el as HTMLElement & { _scrollTop?: number })._scrollTop ?? 0,
+    set: (value: number) => {
+      (el as HTMLElement & { _scrollTop?: number })._scrollTop = value;
+    },
+  });
+  if (metrics.scrollTop != null) el.scrollTop = metrics.scrollTop;
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    value: metrics.scrollHeight,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    value: metrics.clientHeight,
+  });
+}
+
+function installDomObservers() {
+  globalThis.ResizeObserver = vi.fn().mockImplementation(function () {
+    return {
+      observe: () => undefined,
+      unobserve: () => undefined,
+      disconnect: () => undefined,
+    };
+  }) as unknown as typeof globalThis.ResizeObserver;
+  globalThis.MutationObserver = vi.fn().mockImplementation(function () {
+    return {
+      observe: () => undefined,
+      disconnect: () => undefined,
+      takeRecords: () => [],
+    };
+  }) as unknown as typeof globalThis.MutationObserver;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    cb(0);
+    return 1;
+  }) as typeof globalThis.requestAnimationFrame;
+}
+
+function Harness({
+  metrics,
+  onReady,
+}: {
+  metrics: { scrollTop?: number; scrollHeight: number; clientHeight: number };
+  onReady: (api: StickyScrollApi, el: HTMLDivElement) => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const stickyScroll = useStickyScroll(ref);
+  useEffect(() => {
+    if (ref.current) onReady(stickyScroll, ref.current);
+  }, [onReady, stickyScroll]);
+  return (
+    <div
+      ref={(el) => {
+        ref.current = el;
+        if (el) configureScrollMetrics(el, metrics);
+      }}
+    />
+  );
+}
+
+beforeEach(() => {
+  installDomObservers();
+});
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+  vi.restoreAllMocks();
+});
+
+describe("useStickyScroll", () => {
+  it("restores a saved chat scroll position without snapping to bottom", async () => {
+    let api!: StickyScrollApi;
+    let target!: HTMLDivElement;
+    await render(
+      <Harness
+        metrics={{ scrollHeight: 1000, clientHeight: 400 }}
+        onReady={(nextApi, nextTarget) => {
+          api = nextApi;
+          target = nextTarget;
+        }}
+      />,
+    );
+
+    await act(async () => {
+      api.restoreScrollPosition(250);
+    });
+
+    expect(target.scrollTop).toBe(250);
+    expect(api.isAtBottom).toBe(false);
+  });
+
+  it("clamps restored positions to the available scroll range", async () => {
+    let api!: StickyScrollApi;
+    let target!: HTMLDivElement;
+    await render(
+      <Harness
+        metrics={{ scrollHeight: 1000, clientHeight: 400 }}
+        onReady={(nextApi, nextTarget) => {
+          api = nextApi;
+          target = nextTarget;
+        }}
+      />,
+    );
+
+    await act(async () => {
+      api.restoreScrollPosition(5000);
+    });
+
+    expect(target.scrollTop).toBe(600);
+    expect(api.isAtBottom).toBe(true);
+  });
+});

--- a/src/ui/src/hooks/useStickyScroll.ts
+++ b/src/ui/src/hooks/useStickyScroll.ts
@@ -144,5 +144,29 @@ export function useStickyScroll(
     });
   }, [containerRef]);
 
-  return { isAtBottom, scrollToBottom, handleContentChanged, suppressNextAutoScrollRef } as const;
+  /** Restore a saved scrollTop without re-enabling auto-follow. */
+  const restoreScrollPosition = useCallback(
+    (scrollTop: number) => {
+      const el = containerRef.current;
+      if (!el) return;
+      const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+      const nextScrollTop = Math.max(0, Math.min(scrollTop, maxScrollTop));
+      programmaticScrollRef.current = true;
+      el.scrollTop = nextScrollTop;
+      const atBottom =
+        nextScrollTop + el.clientHeight >=
+        el.scrollHeight - thresholdRef.current;
+      isAtBottomRef.current = atBottom;
+      setIsAtBottom(atBottom);
+    },
+    [containerRef],
+  );
+
+  return {
+    isAtBottom,
+    scrollToBottom,
+    restoreScrollPosition,
+    handleContentChanged,
+    suppressNextAutoScrollRef,
+  } as const;
 }

--- a/src/ui/src/stores/slices/fileTreeSlice.ts
+++ b/src/ui/src/stores/slices/fileTreeSlice.ts
@@ -209,6 +209,7 @@ export interface FileTreeSlice {
     path: string,
     revealTarget?: Omit<FileRevealTarget, "path" | "nonce">,
   ) => void;
+  clearFileRevealTarget: (workspaceId: string, nonce?: number) => void;
   /** Switch to an already-open tab (no-op if not in the workspace's tabs). */
   selectFileTab: (workspaceId: string, path: string) => void;
   /** Close a tab. Caller is responsible for any "discard unsaved?" prompt;
@@ -434,6 +435,18 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
             }
           : s.fileRevealTargetByWorkspace,
         fileBuffers: nextBuffers,
+      };
+    }),
+
+  clearFileRevealTarget: (workspaceId, nonce) =>
+    set((s) => {
+      const current = s.fileRevealTargetByWorkspace[workspaceId];
+      if (!current || (nonce !== undefined && current.nonce !== nonce)) return s;
+      return {
+        fileRevealTargetByWorkspace: {
+          ...s.fileRevealTargetByWorkspace,
+          [workspaceId]: null,
+        },
       };
     }),
 

--- a/src/ui/src/stores/slices/fileTreeSlice.ts
+++ b/src/ui/src/stores/slices/fileTreeSlice.ts
@@ -4,6 +4,15 @@ import type { UnifiedTabEntry } from "../../components/chat/sessionTabsLogic";
 
 export type FileViewerPreviewMode = "source" | "preview";
 
+export interface FileRevealTarget {
+  path: string;
+  startLine: number;
+  startColumn?: number;
+  endLine: number;
+  endColumn?: number;
+  nonce: number;
+}
+
 /** Per-tab buffer + UI state. Lives in the store keyed by `${wsId}:${path}`
  *  so that switching tabs preserves unsaved edits across the FileViewer's
  *  remounts. The tab strip drives selection; the FileViewer is just a view
@@ -160,6 +169,7 @@ export interface FileTreeSlice {
    *  active for that workspace; the workspace falls back to its diff or
    *  chat. */
   activeFileTabByWorkspace: Record<string, string | null>;
+  fileRevealTargetByWorkspace: Record<string, FileRevealTarget | null>;
 
   /** Per-`${wsId}:${path}` buffer + UI state for every open file tab. */
   fileBuffers: Record<string, FileBufferState>;
@@ -194,7 +204,11 @@ export interface FileTreeSlice {
    *  the new list. */
   setFileTabsForWorkspace: (workspaceId: string, paths: string[]) => void;
   /** Open a file tab and make it active. If already open, just selects it. */
-  openFileTab: (workspaceId: string, path: string) => void;
+  openFileTab: (
+    workspaceId: string,
+    path: string,
+    revealTarget?: Omit<FileRevealTarget, "path" | "nonce">,
+  ) => void;
   /** Switch to an already-open tab (no-op if not in the workspace's tabs). */
   selectFileTab: (workspaceId: string, path: string) => void;
   /** Close a tab. Caller is responsible for any "discard unsaved?" prompt;
@@ -317,6 +331,7 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
   requestCloseFileTabNonceByWorkspace: {},
   fileTabsByWorkspace: {},
   activeFileTabByWorkspace: {},
+  fileRevealTargetByWorkspace: {},
   fileBuffers: {},
   filePathUndoStackByWorkspace: {},
 
@@ -384,7 +399,7 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
       },
     })),
 
-  openFileTab: (workspaceId, path) =>
+  openFileTab: (workspaceId, path, revealTarget) =>
     set((s) => {
       const existing = s.fileTabsByWorkspace[workspaceId] ?? [];
       const alreadyOpen = existing.includes(path);
@@ -407,6 +422,17 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
           ...s.activeFileTabByWorkspace,
           [workspaceId]: path,
         },
+        fileRevealTargetByWorkspace: revealTarget
+          ? {
+              ...s.fileRevealTargetByWorkspace,
+              [workspaceId]: {
+                ...revealTarget,
+                path,
+                nonce:
+                  (s.fileRevealTargetByWorkspace[workspaceId]?.nonce ?? 0) + 1,
+              },
+            }
+          : s.fileRevealTargetByWorkspace,
         fileBuffers: nextBuffers,
       };
     }),

--- a/src/ui/src/stores/slices/fileTreeSlice.ts
+++ b/src/ui/src/stores/slices/fileTreeSlice.ts
@@ -496,6 +496,25 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
       }
       const key = fileBufferKey(workspaceId, path);
       const { [key]: _dropped, ...remainingBuffers } = s.fileBuffers;
+      const currentReveal = s.fileRevealTargetByWorkspace[workspaceId];
+      const nextReveal =
+        currentReveal?.path === path
+          ? {
+              ...s.fileRevealTargetByWorkspace,
+              [workspaceId]: null,
+            }
+          : s.fileRevealTargetByWorkspace;
+      const existingOrder = s.tabOrderByWorkspace[workspaceId] ?? [];
+      const nextOrder = existingOrder.filter(
+        (entry) => !(entry.kind === "file" && entry.path === path),
+      );
+      const nextTabOrder =
+        nextOrder.length === existingOrder.length
+          ? s.tabOrderByWorkspace
+          : {
+              ...s.tabOrderByWorkspace,
+              [workspaceId]: nextOrder,
+            };
       return {
         fileTabsByWorkspace: {
           ...s.fileTabsByWorkspace,
@@ -505,6 +524,8 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
           ...s.activeFileTabByWorkspace,
           [workspaceId]: nextActive,
         },
+        fileRevealTargetByWorkspace: nextReveal,
+        tabOrderByWorkspace: nextTabOrder,
         fileBuffers: remainingBuffers,
       };
     }),

--- a/src/ui/src/stores/useAppStore.fileTree.test.ts
+++ b/src/ui/src/stores/useAppStore.fileTree.test.ts
@@ -73,6 +73,23 @@ describe("file path store updates", () => {
     });
   });
 
+  it("clears a reveal target only when the consumed nonce still matches", () => {
+    useAppStore.getState().openFileTab(WS, "README.md", {
+      startLine: 4,
+      endLine: 4,
+    });
+    useAppStore.getState().clearFileRevealTarget(WS, 0);
+    expect(useAppStore.getState().fileRevealTargetByWorkspace[WS]).toEqual({
+      path: "README.md",
+      startLine: 4,
+      endLine: 4,
+      nonce: 1,
+    });
+
+    useAppStore.getState().clearFileRevealTarget(WS, 1);
+    expect(useAppStore.getState().fileRevealTargetByWorkspace[WS]).toBeNull();
+  });
+
   it("renames child file tabs when a folder is renamed", () => {
     openLoadedFile("src/components/Button.tsx");
     openLoadedFile("src/components/Card.tsx");

--- a/src/ui/src/stores/useAppStore.fileTree.test.ts
+++ b/src/ui/src/stores/useAppStore.fileTree.test.ts
@@ -145,6 +145,57 @@ describe("file path store updates", () => {
     expect(state.fileBuffers[`${WS}:c.ts`]).toBeUndefined();
   });
 
+  it("clears closed file metadata so the same file can reopen cleanly", () => {
+    useAppStore.setState({
+      tabOrderByWorkspace: {
+        [WS]: [
+          { kind: "session", sessionId: "session-1" },
+          { kind: "file", path: "README.md" },
+        ],
+      },
+    });
+    useAppStore.getState().openFileTab(WS, "README.md", {
+      startLine: 8,
+      endLine: 8,
+    });
+    useAppStore.getState().setFileBufferLoaded(WS, "README.md", {
+      baseline: "hello",
+      isBinary: false,
+      sizeBytes: 5,
+      truncated: false,
+      imageBytesB64: null,
+    });
+
+    useAppStore.getState().closeFileTab(WS, "README.md");
+
+    expect(useAppStore.getState().fileTabsByWorkspace[WS]).toEqual([]);
+    expect(useAppStore.getState().activeFileTabByWorkspace[WS]).toBeNull();
+    expect(useAppStore.getState().fileBuffers[`${WS}:README.md`]).toBeUndefined();
+    expect(useAppStore.getState().fileRevealTargetByWorkspace[WS]).toBeNull();
+    expect(useAppStore.getState().tabOrderByWorkspace[WS]).toEqual([
+      { kind: "session", sessionId: "session-1" },
+    ]);
+
+    useAppStore.getState().openFileTab(WS, "README.md", {
+      startLine: 8,
+      endLine: 8,
+    });
+
+    const state = useAppStore.getState();
+    expect(state.fileTabsByWorkspace[WS]).toEqual(["README.md"]);
+    expect(state.activeFileTabByWorkspace[WS]).toBe("README.md");
+    expect(state.fileBuffers[`${WS}:README.md`]).toMatchObject({
+      loaded: false,
+      buffer: "",
+      baseline: "",
+    });
+    expect(state.fileRevealTargetByWorkspace[WS]).toMatchObject({
+      path: "README.md",
+      startLine: 8,
+      endLine: 8,
+    });
+  });
+
   it("removes all child file tabs when a folder is deleted", () => {
     openLoadedFile("src/components/Button.tsx");
     openLoadedFile("src/components/Card.tsx");

--- a/src/ui/src/stores/useAppStore.fileTree.test.ts
+++ b/src/ui/src/stores/useAppStore.fileTree.test.ts
@@ -8,6 +8,7 @@ function reset() {
   useAppStore.setState({
     fileTabsByWorkspace: {},
     activeFileTabByWorkspace: {},
+    fileRevealTargetByWorkspace: {},
     fileBuffers: {},
     allFilesExpandedDirsByWorkspace: {},
     allFilesSelectedPathByWorkspace: {},
@@ -49,6 +50,27 @@ describe("file path store updates", () => {
     expect(state.tabOrderByWorkspace[WS]).toEqual([
       { kind: "file", path: "src/main.ts" },
     ]);
+  });
+
+  it("stores a one-shot reveal target when opening a file tab with a line range", () => {
+    useAppStore.getState().openFileTab(WS, "README.md", {
+      startLine: 4,
+      endLine: 8,
+      startColumn: 2,
+      endColumn: 5,
+    });
+
+    const state = useAppStore.getState();
+    expect(state.fileTabsByWorkspace[WS]).toEqual(["README.md"]);
+    expect(state.activeFileTabByWorkspace[WS]).toBe("README.md");
+    expect(state.fileRevealTargetByWorkspace[WS]).toEqual({
+      path: "README.md",
+      startLine: 4,
+      endLine: 8,
+      startColumn: 2,
+      endColumn: 5,
+      nonce: 1,
+    });
   });
 
   it("renames child file tabs when a folder is renamed", () => {

--- a/src/ui/src/utils/filePathLinks.test.ts
+++ b/src/ui/src/utils/filePathLinks.test.ts
@@ -119,6 +119,13 @@ describe("relative file references", () => {
         path: "src/ui/src/utils/markdown.ts",
       },
     ]);
+    expect(detectFileReferences("open ./src/main.rs")).toEqual([
+      {
+        start: 5,
+        end: 18,
+        path: "./src/main.rs",
+      },
+    ]);
   });
 
   it("does not mistake domain-like text for a workspace file", () => {
@@ -154,6 +161,7 @@ describe("localhost file URL decoding", () => {
 
   it("does not treat normal localhost app routes as file paths", () => {
     expect(decodeLocalhostFileUrl("http://localhost:14254/workspaces/current")).toBeNull();
+    expect(decodeLocalhostFileUrl("http://localhost:3000/index.html")).toBeNull();
   });
 
   it("does not decode non-localhost URLs as files", () => {

--- a/src/ui/src/utils/filePathLinks.test.ts
+++ b/src/ui/src/utils/filePathLinks.test.ts
@@ -3,11 +3,13 @@ import { describe, it, expect } from "vitest";
 import {
   decodeFilePathHref,
   decodeLocalhostFileUrl,
+  decodeLocalhostFileUrlTarget,
   detectFileReferences,
   detectFilePaths,
   encodeFilePathHref,
   FILE_PATH_SCHEME,
   isLikelyRelativeFileReference,
+  parseFilePathTarget,
   stripFileLineSuffix,
 } from "./filePathLinks";
 
@@ -137,6 +139,11 @@ describe("localhost file URL decoding", () => {
         "http://localhost:14254/Users/jamesbrink/project/CLAUDETTE_TEST.md:1",
       ),
     ).toBe("/Users/jamesbrink/project/CLAUDETTE_TEST.md");
+    expect(
+      decodeLocalhostFileUrlTarget(
+        "http://localhost:14254/Users/jamesbrink/project/CLAUDETTE_TEST.md:1",
+      ),
+    ).toBe("/Users/jamesbrink/project/CLAUDETTE_TEST.md:1");
   });
 
   it("decodes loopback Windows paths", () => {
@@ -158,6 +165,23 @@ describe("localhost file URL decoding", () => {
   it("strips line and column suffixes from file targets", () => {
     expect(stripFileLineSuffix("/tmp/file.ts:10")).toBe("/tmp/file.ts");
     expect(stripFileLineSuffix("/tmp/file.ts:10:2")).toBe("/tmp/file.ts");
+  });
+
+  it("parses line and range suffixes into file targets", () => {
+    expect(parseFilePathTarget("src/main.ts:10")).toEqual({
+      path: "src/main.ts",
+      startLine: 10,
+      endLine: 10,
+      startColumn: undefined,
+      endColumn: undefined,
+    });
+    expect(parseFilePathTarget("src/main.ts:10:2-12:8")).toEqual({
+      path: "src/main.ts",
+      startLine: 10,
+      startColumn: 2,
+      endLine: 12,
+      endColumn: 8,
+    });
   });
 });
 

--- a/src/ui/src/utils/filePathLinks.test.ts
+++ b/src/ui/src/utils/filePathLinks.test.ts
@@ -113,6 +113,15 @@ describe("relative file references", () => {
     ]);
   });
 
+  it("recognizes leading at-sign file mentions without accepting emails", () => {
+    expect(detectFileReferences("make a simple edit to @README.md")).toEqual([
+      { start: 22, end: 32, path: "README.md", text: "@README.md" },
+    ]);
+    expect(isLikelyRelativeFileReference("@README.md")).toBe(true);
+    expect(detectFileReferences("email dev@example.com")).toEqual([]);
+    expect(isLikelyRelativeFileReference("dev@example.com")).toBe(false);
+  });
+
   it("recognizes nested workspace-relative source paths", () => {
     expect(detectFileReferences("open src/ui/src/utils/markdown.ts")).toEqual([
       {
@@ -128,6 +137,24 @@ describe("relative file references", () => {
         path: "./src/main.rs",
       },
     ]);
+  });
+
+  it("keeps line and range suffixes on relative file references", () => {
+    expect(detectFileReferences("open src/main.rs:10")).toEqual([
+      {
+        start: 5,
+        end: 19,
+        path: "src/main.rs:10",
+      },
+    ]);
+    expect(detectFileReferences("see README.md:2:3-4:5")).toEqual([
+      {
+        start: 4,
+        end: 21,
+        path: "README.md:2:3-4:5",
+      },
+    ]);
+    expect(isLikelyRelativeFileReference("README.md:10")).toBe(true);
   });
 
   it("does not mistake domain-like text for a workspace file", () => {

--- a/src/ui/src/utils/filePathLinks.test.ts
+++ b/src/ui/src/utils/filePathLinks.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from "vitest";
 
 import {
   decodeFilePathHref,
+  detectFileReferences,
   detectFilePaths,
   encodeFilePathHref,
   FILE_PATH_SCHEME,
+  isLikelyRelativeFileReference,
 } from "./filePathLinks";
 
 describe("detectFilePaths — POSIX", () => {
@@ -92,6 +94,37 @@ describe("detectFilePaths — non-matches and false-positive guards", () => {
   it("ignores leading char that suggests middle-of-token", () => {
     // Preceded by a word char → not a path start
     expect(detectFilePaths("abc/def/ghi")).toEqual([]);
+  });
+});
+
+describe("relative file references", () => {
+  it("recognizes common bare filenames agents mention in prose", () => {
+    expect(detectFileReferences("Edit README.md next")).toEqual([
+      { start: 5, end: 14, path: "README.md" },
+    ]);
+    expect(detectFileReferences("Create CLAUDETTE_TEST.md")).toEqual([
+      { start: 7, end: 24, path: "CLAUDETTE_TEST.md" },
+    ]);
+  });
+
+  it("recognizes nested workspace-relative source paths", () => {
+    expect(detectFileReferences("open src/ui/src/utils/markdown.ts")).toEqual([
+      {
+        start: 5,
+        end: 33,
+        path: "src/ui/src/utils/markdown.ts",
+      },
+    ]);
+  });
+
+  it("does not mistake domain-like text for a workspace file", () => {
+    expect(detectFileReferences("visit example.com today")).toEqual([]);
+    expect(isLikelyRelativeFileReference("example.com")).toBe(false);
+  });
+
+  it("does not match relative file references inside URLs or emails", () => {
+    expect(detectFileReferences("https://example.com/README.md")).toEqual([]);
+    expect(detectFileReferences("email dev@example.com")).toEqual([]);
   });
 });
 

--- a/src/ui/src/utils/filePathLinks.test.ts
+++ b/src/ui/src/utils/filePathLinks.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect } from "vitest";
 
 import {
   decodeFilePathHref,
+  decodeLocalhostFileUrl,
   detectFileReferences,
   detectFilePaths,
   encodeFilePathHref,
   FILE_PATH_SCHEME,
   isLikelyRelativeFileReference,
+  stripFileLineSuffix,
 } from "./filePathLinks";
 
 describe("detectFilePaths — POSIX", () => {
@@ -125,6 +127,37 @@ describe("relative file references", () => {
   it("does not match relative file references inside URLs or emails", () => {
     expect(detectFileReferences("https://example.com/README.md")).toEqual([]);
     expect(detectFileReferences("email dev@example.com")).toEqual([]);
+  });
+});
+
+describe("localhost file URL decoding", () => {
+  it("decodes Codex-style localhost URLs to file paths and strips line suffixes", () => {
+    expect(
+      decodeLocalhostFileUrl(
+        "http://localhost:14254/Users/jamesbrink/project/CLAUDETTE_TEST.md:1",
+      ),
+    ).toBe("/Users/jamesbrink/project/CLAUDETTE_TEST.md");
+  });
+
+  it("decodes loopback Windows paths", () => {
+    expect(
+      decodeLocalhostFileUrl("http://127.0.0.1:14254/C:/Users/me/project/app.ts:12:3"),
+    ).toBe("C:/Users/me/project/app.ts");
+  });
+
+  it("does not treat normal localhost app routes as file paths", () => {
+    expect(decodeLocalhostFileUrl("http://localhost:14254/workspaces/current")).toBeNull();
+  });
+
+  it("does not decode non-localhost URLs as files", () => {
+    expect(
+      decodeLocalhostFileUrl("https://example.com/Users/me/project/app.ts:1"),
+    ).toBeNull();
+  });
+
+  it("strips line and column suffixes from file targets", () => {
+    expect(stripFileLineSuffix("/tmp/file.ts:10")).toBe("/tmp/file.ts");
+    expect(stripFileLineSuffix("/tmp/file.ts:10:2")).toBe("/tmp/file.ts");
   });
 });
 

--- a/src/ui/src/utils/filePathLinks.test.ts
+++ b/src/ui/src/utils/filePathLinks.test.ts
@@ -8,6 +8,8 @@ import {
   detectFilePaths,
   encodeFilePathHref,
   FILE_PATH_SCHEME,
+  formatFilePathDisplayLabel,
+  isExplicitFilePathTarget,
   isLikelyRelativeFileReference,
   parseFilePathTarget,
   stripFileLineSuffix,
@@ -153,6 +155,29 @@ describe("localhost file URL decoding", () => {
     ).toBe("/Users/jamesbrink/project/CLAUDETTE_TEST.md:1");
   });
 
+  it("decodes localhost SVG file URLs with line suffixes", () => {
+    expect(
+      decodeLocalhostFileUrlTarget(
+        "http://localhost:14254/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/simple-wave.svg:1",
+      ),
+    ).toBe(
+      "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/simple-wave.svg:1",
+    );
+  });
+
+  it("decodes explicit localhost file URLs without needing a known extension", () => {
+    expect(
+      decodeLocalhostFileUrlTarget(
+        "http://localhost:14254/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/generated.assetbundle:12",
+      ),
+    ).toBe(
+      "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/generated.assetbundle:12",
+    );
+    expect(isExplicitFilePathTarget("/Users/me/project/generated.assetbundle:12")).toBe(
+      true,
+    );
+  });
+
   it("decodes loopback Windows paths", () => {
     expect(
       decodeLocalhostFileUrl("http://127.0.0.1:14254/C:/Users/me/project/app.ts:12:3"),
@@ -190,6 +215,22 @@ describe("localhost file URL decoding", () => {
       endLine: 12,
       endColumn: 8,
     });
+  });
+
+  it("formats decoded file targets as compact inline file labels", () => {
+    expect(
+      formatFilePathDisplayLabel(
+        "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/README.md:8",
+      ),
+    ).toBe("README.md:8");
+    expect(
+      formatFilePathDisplayLabel(
+        "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/website/guide/quickstart.md:6",
+      ),
+    ).toBe("website/guide/quickstart.md:6");
+    expect(formatFilePathDisplayLabel("/tmp/report.md:2:4-5:8")).toBe(
+      "report.md:2:4-5:8",
+    );
   });
 });
 

--- a/src/ui/src/utils/filePathLinks.ts
+++ b/src/ui/src/utils/filePathLinks.ts
@@ -59,7 +59,11 @@ const RELATIVE_FILE_REGEX =
  * another path, hyphenated word). Mirrors the old lookbehind's character
  * class: word chars, colon, dot, both slash kinds, hyphen.
  */
-const FORBIDDEN_PREV_CHAR_REGEX = /[\w:.\\/@-]/;
+const FORBIDDEN_PREV_CHAR_REGEX = /[\w:.\\@-]/;
+
+function isForbiddenPreviousChar(char: string): boolean {
+  return char === "/" || FORBIDDEN_PREV_CHAR_REGEX.test(char);
+}
 
 /**
  * Sentence-final characters that tend to follow a path in prose but are
@@ -187,7 +191,7 @@ export function detectFilePaths(text: string): FilePathMatch[] {
     // Lookbehind-equivalent guard: skip matches that started in the
     // middle of another token. See PATH_REGEX comment for why this is
     // a JS check rather than a regex lookbehind.
-    if (m.index > 0 && FORBIDDEN_PREV_CHAR_REGEX.test(text[m.index - 1])) {
+    if (m.index > 0 && isForbiddenPreviousChar(text[m.index - 1])) {
       continue;
     }
     const raw = m[0];
@@ -240,7 +244,7 @@ export function detectFileReferences(text: string): FilePathMatch[] {
 
   for (const m of text.matchAll(RELATIVE_FILE_REGEX)) {
     if (m.index === undefined) continue;
-    if (m.index > 0 && FORBIDDEN_PREV_CHAR_REGEX.test(text[m.index - 1])) {
+    if (m.index > 0 && isForbiddenPreviousChar(text[m.index - 1])) {
       continue;
     }
     if (

--- a/src/ui/src/utils/filePathLinks.ts
+++ b/src/ui/src/utils/filePathLinks.ts
@@ -29,6 +29,14 @@ export interface FilePathMatch {
   path: string;
 }
 
+export interface FilePathTarget {
+  path: string;
+  startLine?: number;
+  startColumn?: number;
+  endLine?: number;
+  endColumn?: number;
+}
+
 /**
  * The path body uses `[^\s<>"|*?]` rather than a stricter set so:
  *  - paths with spaces would still split on whitespace (we don't try to
@@ -238,8 +246,25 @@ export function isLikelyRelativeFileReference(value: string): boolean {
   return KNOWN_FILE_EXTENSIONS.has(ext);
 }
 
+export function parseFilePathTarget(path: string): FilePathTarget {
+  const match = path.match(/:(\d+)(?::(\d+))?(?:-(\d+)(?::(\d+))?)?$/);
+  if (!match) return { path };
+  const startLine = Number.parseInt(match[1], 10);
+  const startColumn = match[2] ? Number.parseInt(match[2], 10) : undefined;
+  const endLine = match[3] ? Number.parseInt(match[3], 10) : startLine;
+  const endColumn = match[4] ? Number.parseInt(match[4], 10) : undefined;
+  if (!Number.isFinite(startLine) || startLine < 1) return { path };
+  return {
+    path: path.slice(0, match.index),
+    startLine,
+    startColumn,
+    endLine,
+    endColumn,
+  };
+}
+
 export function stripFileLineSuffix(path: string): string {
-  return path.replace(/:\d+(?::\d+)?$/, "");
+  return parseFilePathTarget(path).path;
 }
 
 export function isLikelyFilePathTarget(value: string): boolean {
@@ -261,6 +286,11 @@ export function isLikelyFilePathTarget(value: string): boolean {
 }
 
 export function decodeLocalhostFileUrl(href: string): string | null {
+  const target = decodeLocalhostFileUrlTarget(href);
+  return target ? stripFileLineSuffix(target) : null;
+}
+
+export function decodeLocalhostFileUrlTarget(href: string): string | null {
   let parsed: URL;
   try {
     parsed = new URL(href);
@@ -284,9 +314,8 @@ export function decodeLocalhostFileUrl(href: string): string | null {
   } catch {
     pathname = parsed.pathname;
   }
-  const withoutLine = stripFileLineSuffix(pathname);
   const candidate =
-    /^\/[A-Za-z]:[\\/]/.test(withoutLine) ? withoutLine.slice(1) : withoutLine;
+    /^\/[A-Za-z]:[\\/]/.test(pathname) ? pathname.slice(1) : pathname;
   return isLikelyFilePathTarget(candidate) ? candidate : null;
 }
 

--- a/src/ui/src/utils/filePathLinks.ts
+++ b/src/ui/src/utils/filePathLinks.ts
@@ -238,6 +238,58 @@ export function isLikelyRelativeFileReference(value: string): boolean {
   return KNOWN_FILE_EXTENSIONS.has(ext);
 }
 
+export function stripFileLineSuffix(path: string): string {
+  return path.replace(/:\d+(?::\d+)?$/, "");
+}
+
+export function isLikelyFilePathTarget(value: string): boolean {
+  const candidate = stripFileLineSuffix(value.trim().replace(TRAILING_PUNCT_REGEX, ""));
+  if (!candidate || candidate.length < MIN_PATH_LENGTH) return false;
+  if (isLikelyRelativeFileReference(candidate)) return true;
+
+  const normalized = candidate.replace(/\\/g, "/");
+  const absoluteish =
+    normalized.startsWith("/") ||
+    normalized.startsWith("~/") ||
+    /^[A-Za-z]:\//.test(normalized);
+  if (!absoluteish) return false;
+  const basename = normalized.split("/").pop()?.toLowerCase() ?? "";
+  if (KNOWN_FILENAMES.has(basename)) return true;
+  const dot = basename.lastIndexOf(".");
+  if (dot <= 0 || dot === basename.length - 1) return false;
+  return KNOWN_FILE_EXTENSIONS.has(basename.slice(dot + 1));
+}
+
+export function decodeLocalhostFileUrl(href: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(href);
+  } catch {
+    return null;
+  }
+  if (!/^https?:$/.test(parsed.protocol)) return null;
+  const hostname = parsed.hostname.toLowerCase();
+  if (
+    hostname !== "localhost" &&
+    hostname !== "127.0.0.1" &&
+    hostname !== "[::1]" &&
+    hostname !== "::1"
+  ) {
+    return null;
+  }
+
+  let pathname: string;
+  try {
+    pathname = decodeURI(parsed.pathname);
+  } catch {
+    pathname = parsed.pathname;
+  }
+  const withoutLine = stripFileLineSuffix(pathname);
+  const candidate =
+    /^\/[A-Za-z]:[\\/]/.test(withoutLine) ? withoutLine.slice(1) : withoutLine;
+  return isLikelyFilePathTarget(candidate) ? candidate : null;
+}
+
 export function detectFileReferences(text: string): FilePathMatch[] {
   const absoluteMatches = detectFilePaths(text);
   const matches: FilePathMatch[] = [...absoluteMatches];

--- a/src/ui/src/utils/filePathLinks.ts
+++ b/src/ui/src/utils/filePathLinks.ts
@@ -221,7 +221,7 @@ export function isLikelyRelativeFileReference(value: string): boolean {
   if (/^[\\/]|^[A-Za-z]:[\\/]/.test(candidate)) return false;
   if (candidate.includes("://") || candidate.includes("@")) return false;
 
-  const normalized = candidate.replace(/\\/g, "/");
+  const normalized = candidate.replace(/\\/g, "/").replace(/^\.\//, "");
   if (
     normalized === "." ||
     normalized === ".." ||
@@ -316,7 +316,20 @@ export function decodeLocalhostFileUrlTarget(href: string): string | null {
   }
   const candidate =
     /^\/[A-Za-z]:[\\/]/.test(pathname) ? pathname.slice(1) : pathname;
-  return isLikelyFilePathTarget(candidate) ? candidate : null;
+  if (!isLikelyFilePathTarget(candidate)) return null;
+  return isLikelyLocalhostFileTarget(candidate) ? candidate : null;
+}
+
+function isLikelyLocalhostFileTarget(candidate: string): boolean {
+  const parsed = parseFilePathTarget(candidate);
+  if (typeof parsed.startLine === "number") return true;
+  const normalized = parsed.path.replace(/\\/g, "/");
+  if (/^[A-Za-z]:\//.test(normalized) || /^\/\/[^/]+\/[^/]+/.test(normalized)) {
+    return true;
+  }
+  return /^\/(?:Users|home|tmp|var|private|Volumes|workspaces|workspace)\//.test(
+    normalized,
+  );
 }
 
 export function detectFileReferences(text: string): FilePathMatch[] {

--- a/src/ui/src/utils/filePathLinks.ts
+++ b/src/ui/src/utils/filePathLinks.ts
@@ -1,9 +1,9 @@
 /**
- * Detect absolute file paths inside a plain-text string so a markdown
+ * Detect file paths inside a plain-text string so a markdown
  * post-processor can wrap them in clickable links. The link target uses
  * a custom `claudettepath:` URI so the markdown `<a>` override knows to
- * route the click into a Tauri command instead of treating it as a web
- * URL — and so rehype-sanitize doesn't strip it as an unsafe protocol
+ * route the click into the workspace file opener instead of treating it as
+ * a web URL — and so rehype-sanitize doesn't strip it as an unsafe protocol
  * (we extend the allowed-scheme list in `markdown.ts`).
  *
  * Recognized:
@@ -11,13 +11,13 @@
  *  - POSIX home          `~/Downloads/foo.csv`
  *  - Windows drive       `C:\Users\foo\bar.csv`, `C:/Users/foo/bar.csv`
  *  - Windows UNC         `\\server\share\file.txt`
+ *  - Relative files      `README.md`, `src/main.rs`, `package.json`
  *
  * Deliberately ignored:
- *  - Bare relative paths (`foo/bar.csv`) — too ambiguous, false-positives
- *    with sentence fragments, and we have no anchor to resolve them
- *    against on the host side.
  *  - URLs (`https://...`) — the leading `://` lookbehind keeps the regex
  *    from matching the `/example.com/...` substring inside one.
+ *  - Domain-like prose (`example.com`) — common URL-ish hostnames are not
+ *    workspace files.
  */
 
 export interface FilePathMatch {
@@ -50,13 +50,16 @@ export interface FilePathMatch {
 const PATH_REGEX =
   /(?:[A-Za-z]:[\\/][^\s<>"|*?]+|\\\\[^\s<>"|*?\\/]+\\[^\s<>"|*?\\/]+(?:\\[^\s<>"|*?\\/]+)*|~?\/[^\s<>"|*?]+)/g;
 
+const RELATIVE_FILE_REGEX =
+  /(?:\.{1,2}[\\/])?(?:[A-Za-z0-9_$@.+-]+[\\/])*[A-Za-z0-9_$@.+-]+(?:\.[A-Za-z0-9][A-Za-z0-9+-]{0,15})+/g;
+
 /**
  * Characters that, if they sit immediately before a regex match, indicate
  * the match started in the middle of an existing token (URL scheme tail,
  * another path, hyphenated word). Mirrors the old lookbehind's character
  * class: word chars, colon, dot, both slash kinds, hyphen.
  */
-const FORBIDDEN_PREV_CHAR_REGEX = /[\w:.\\/-]/;
+const FORBIDDEN_PREV_CHAR_REGEX = /[\w:.\\/@-]/;
 
 /**
  * Sentence-final characters that tend to follow a path in prose but are
@@ -72,6 +75,110 @@ const TRAILING_PUNCT_REGEX = /[.,;:!?)\]'"`]+$/;
  *  enforcing the presence of an additional inner separator — that would
  *  reject legitimate two-segment paths like `/etc` or `~/foo`. */
 const MIN_PATH_LENGTH = 3;
+
+const COMMON_HOSTLIKE_EXTENSIONS = new Set([
+  "app",
+  "biz",
+  "co",
+  "com",
+  "dev",
+  "io",
+  "net",
+  "org",
+]);
+
+const KNOWN_FILE_EXTENSIONS = new Set([
+  "astro",
+  "bash",
+  "c",
+  "cc",
+  "cfg",
+  "clj",
+  "cljs",
+  "cmake",
+  "conf",
+  "cpp",
+  "cs",
+  "css",
+  "csv",
+  "cts",
+  "cu",
+  "cxx",
+  "dart",
+  "diff",
+  "dockerignore",
+  "env",
+  "erb",
+  "fish",
+  "go",
+  "graphql",
+  "h",
+  "hpp",
+  "hs",
+  "html",
+  "java",
+  "jl",
+  "js",
+  "json",
+  "jsx",
+  "kt",
+  "kts",
+  "less",
+  "lua",
+  "m",
+  "md",
+  "mdx",
+  "mjs",
+  "mm",
+  "mts",
+  "nix",
+  "patch",
+  "php",
+  "pl",
+  "plist",
+  "proto",
+  "py",
+  "r",
+  "rb",
+  "rs",
+  "sass",
+  "scala",
+  "scss",
+  "sh",
+  "sql",
+  "svelte",
+  "swift",
+  "toml",
+  "tsx",
+  "ts",
+  "txt",
+  "vue",
+  "xml",
+  "yaml",
+  "yml",
+  "zig",
+  "zsh",
+]);
+
+const KNOWN_FILENAMES = new Set([
+  ".env",
+  ".gitignore",
+  ".npmrc",
+  ".prettierrc",
+  "cargo.lock",
+  "cargo.toml",
+  "dockerfile",
+  "justfile",
+  "makefile",
+  "package-lock.json",
+  "package.json",
+  "pnpm-lock.yaml",
+  "readme",
+  "readme.md",
+  "tsconfig.json",
+  "vite.config.ts",
+  "yarn.lock",
+]);
 
 export function detectFilePaths(text: string): FilePathMatch[] {
   const matches: FilePathMatch[] = [];
@@ -93,6 +200,68 @@ export function detectFilePaths(text: string): FilePathMatch[] {
     });
   }
   return matches;
+}
+
+export function isLikelyRelativeFileReference(value: string): boolean {
+  const candidate = value.trim().replace(TRAILING_PUNCT_REGEX, "");
+  if (!candidate || candidate.length < MIN_PATH_LENGTH) return false;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(candidate)) return false;
+  if (/^[\\/]|^[A-Za-z]:[\\/]/.test(candidate)) return false;
+  if (candidate.includes("://") || candidate.includes("@")) return false;
+
+  const normalized = candidate.replace(/\\/g, "/");
+  if (
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.includes("/../")
+  ) {
+    return false;
+  }
+
+  const parts = normalized.split("/");
+  if (parts.some((part) => !part || part === "." || part === "..")) {
+    return false;
+  }
+
+  const basename = parts[parts.length - 1].toLowerCase();
+  if (KNOWN_FILENAMES.has(basename)) return true;
+
+  const dot = basename.lastIndexOf(".");
+  if (dot <= 0 || dot === basename.length - 1) return false;
+  const ext = basename.slice(dot + 1);
+  if (COMMON_HOSTLIKE_EXTENSIONS.has(ext) && parts.length === 1) return false;
+  return KNOWN_FILE_EXTENSIONS.has(ext);
+}
+
+export function detectFileReferences(text: string): FilePathMatch[] {
+  const absoluteMatches = detectFilePaths(text);
+  const matches: FilePathMatch[] = [...absoluteMatches];
+
+  for (const m of text.matchAll(RELATIVE_FILE_REGEX)) {
+    if (m.index === undefined) continue;
+    if (m.index > 0 && FORBIDDEN_PREV_CHAR_REGEX.test(text[m.index - 1])) {
+      continue;
+    }
+    if (
+      absoluteMatches.some(
+        (absolute) => m.index! >= absolute.start && m.index! < absolute.end,
+      )
+    ) {
+      continue;
+    }
+
+    const raw = m[0];
+    const stripped = raw.replace(TRAILING_PUNCT_REGEX, "");
+    if (!isLikelyRelativeFileReference(stripped)) continue;
+    matches.push({
+      start: m.index,
+      end: m.index + stripped.length,
+      path: stripped,
+    });
+  }
+
+  return matches.sort((a, b) => a.start - b.start);
 }
 
 /** URI scheme used by the markdown autolinker to mark its synthesized

--- a/src/ui/src/utils/filePathLinks.ts
+++ b/src/ui/src/utils/filePathLinks.ts
@@ -27,6 +27,8 @@ export interface FilePathMatch {
   end: number;
   /** The matched path with surrounding sentence punctuation stripped. */
   path: string;
+  /** Optional source text to display when it differs from the file target. */
+  text?: string;
 }
 
 export interface FilePathTarget {
@@ -59,7 +61,7 @@ const PATH_REGEX =
   /(?:[A-Za-z]:[\\/][^\s<>"|*?]+|\\\\[^\s<>"|*?\\/]+\\[^\s<>"|*?\\/]+(?:\\[^\s<>"|*?\\/]+)*|~?\/[^\s<>"|*?]+)/g;
 
 const RELATIVE_FILE_REGEX =
-  /(?:\.{1,2}[\\/])?(?:[A-Za-z0-9_$@.+-]+[\\/])*[A-Za-z0-9_$@.+-]+(?:\.[A-Za-z0-9][A-Za-z0-9+-]{0,15})+/g;
+  /@?(?:\.{1,2}[\\/])?(?:[A-Za-z0-9_$+.-]+[\\/])*[A-Za-z0-9_$+.-]+(?:\.[A-Za-z0-9][A-Za-z0-9+-]{0,15})+(?::\d+(?::\d+)?(?:-\d+(?::\d+)?)?)?/g;
 
 /**
  * Characters that, if they sit immediately before a regex match, indicate
@@ -216,7 +218,8 @@ export function detectFilePaths(text: string): FilePathMatch[] {
 }
 
 export function isLikelyRelativeFileReference(value: string): boolean {
-  const candidate = value.trim().replace(TRAILING_PUNCT_REGEX, "");
+  const rawCandidate = value.trim().replace(TRAILING_PUNCT_REGEX, "");
+  const candidate = parseFilePathTarget(stripMentionPrefix(rawCandidate)).path;
   if (!candidate || candidate.length < MIN_PATH_LENGTH) return false;
   if (/^[a-z][a-z0-9+.-]*:/i.test(candidate)) return false;
   if (/^[\\/]|^[A-Za-z]:[\\/]/.test(candidate)) return false;
@@ -245,6 +248,10 @@ export function isLikelyRelativeFileReference(value: string): boolean {
   const ext = basename.slice(dot + 1);
   if (COMMON_HOSTLIKE_EXTENSIONS.has(ext) && parts.length === 1) return false;
   return KNOWN_FILE_EXTENSIONS.has(ext);
+}
+
+function stripMentionPrefix(value: string): string {
+  return value.startsWith("@") ? value.slice(1) : value;
 }
 
 export function parseFilePathTarget(path: string): FilePathTarget {
@@ -401,10 +408,12 @@ export function detectFileReferences(text: string): FilePathMatch[] {
     const raw = m[0];
     const stripped = raw.replace(TRAILING_PUNCT_REGEX, "");
     if (!isLikelyRelativeFileReference(stripped)) continue;
+    const path = stripMentionPrefix(stripped);
     matches.push({
       start: m.index,
       end: m.index + stripped.length,
-      path: stripped,
+      path,
+      ...(path === stripped ? {} : { text: stripped }),
     });
   }
 

--- a/src/ui/src/utils/filePathLinks.ts
+++ b/src/ui/src/utils/filePathLinks.ts
@@ -159,6 +159,7 @@ const KNOWN_FILE_EXTENSIONS = new Set([
   "sh",
   "sql",
   "svelte",
+  "svg",
   "swift",
   "toml",
   "tsx",
@@ -267,6 +268,39 @@ export function stripFileLineSuffix(path: string): string {
   return parseFilePathTarget(path).path;
 }
 
+export function formatFilePathDisplayLabel(path: string): string {
+  const target = parseFilePathTarget(path);
+  const normalizedPath = target.path.replace(/\\/g, "/");
+  const workspaceRelativeMatch = normalizedPath.match(
+    /\/\.claudette\/workspaces\/[^/]+\/[^/]+\/(.+)$/,
+  );
+  const displayPath =
+    workspaceRelativeMatch?.[1] ??
+    normalizedPath.split("/").filter(Boolean).pop() ??
+    normalizedPath;
+  const rangeSuffix = formatFilePathRangeSuffix(target);
+  return `${displayPath}${rangeSuffix}`;
+}
+
+function formatFilePathRangeSuffix(target: FilePathTarget): string {
+  if (typeof target.startLine !== "number") return "";
+  let suffix = `:${target.startLine}`;
+  if (typeof target.startColumn === "number") {
+    suffix += `:${target.startColumn}`;
+  }
+  if (
+    typeof target.endLine === "number" &&
+    (target.endLine !== target.startLine ||
+      typeof target.endColumn === "number")
+  ) {
+    suffix += `-${target.endLine}`;
+    if (typeof target.endColumn === "number") {
+      suffix += `:${target.endColumn}`;
+    }
+  }
+  return suffix;
+}
+
 export function isLikelyFilePathTarget(value: string): boolean {
   const candidate = stripFileLineSuffix(value.trim().replace(TRAILING_PUNCT_REGEX, ""));
   if (!candidate || candidate.length < MIN_PATH_LENGTH) return false;
@@ -283,6 +317,21 @@ export function isLikelyFilePathTarget(value: string): boolean {
   const dot = basename.lastIndexOf(".");
   if (dot <= 0 || dot === basename.length - 1) return false;
   return KNOWN_FILE_EXTENSIONS.has(basename.slice(dot + 1));
+}
+
+export function isExplicitFilePathTarget(value: string): boolean {
+  const candidate = value.trim().replace(TRAILING_PUNCT_REGEX, "");
+  if (!candidate || candidate.length < MIN_PATH_LENGTH) return false;
+
+  const parsed = parseFilePathTarget(candidate);
+  const normalized = parsed.path.replace(/\\/g, "/");
+  if (!isKnownLocalPathRoot(normalized)) return false;
+
+  const basename = normalized.split("/").filter(Boolean).pop()?.toLowerCase();
+  if (!basename || basename === "." || basename === "..") return false;
+  if (KNOWN_FILENAMES.has(basename)) return true;
+  if (typeof parsed.startLine === "number") return true;
+  return basename.includes(".");
 }
 
 export function decodeLocalhostFileUrl(href: string): string | null {
@@ -316,19 +365,19 @@ export function decodeLocalhostFileUrlTarget(href: string): string | null {
   }
   const candidate =
     /^\/[A-Za-z]:[\\/]/.test(pathname) ? pathname.slice(1) : pathname;
-  if (!isLikelyFilePathTarget(candidate)) return null;
-  return isLikelyLocalhostFileTarget(candidate) ? candidate : null;
+  return isExplicitFilePathTarget(candidate) ? candidate : null;
 }
 
-function isLikelyLocalhostFileTarget(candidate: string): boolean {
-  const parsed = parseFilePathTarget(candidate);
-  if (typeof parsed.startLine === "number") return true;
-  const normalized = parsed.path.replace(/\\/g, "/");
-  if (/^[A-Za-z]:\//.test(normalized) || /^\/\/[^/]+\/[^/]+/.test(normalized)) {
+function isKnownLocalPathRoot(normalizedPath: string): boolean {
+  if (
+    normalizedPath.startsWith("~/") ||
+    /^[A-Za-z]:\//.test(normalizedPath) ||
+    /^\/\/[^/]+\/[^/]+/.test(normalizedPath)
+  ) {
     return true;
   }
   return /^\/(?:Users|home|tmp|var|private|Volumes|workspaces|workspace)\//.test(
-    normalized,
+    normalizedPath,
   );
 }
 

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -134,6 +134,43 @@ describe("MARKDOWN_COMPONENTS.code wiring", () => {
     const props = (el as unknown as { props: any }).props;
     expect(props.node).toBeUndefined();
   });
+
+  it("turns inline code into a file button when the context resolves it", async () => {
+    const openFile = vi.fn(() => true);
+    const resolveFilePath = vi.fn((path: string) =>
+      path === "Cargo.toml" ? "Cargo.toml" : null,
+    );
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile, resolveFilePath } },
+        createElement(HighlightedCode, { children: "Cargo.toml" }),
+      ),
+    );
+
+    const button = container.querySelector("button");
+    expect(button?.textContent).toBe("Cargo.toml");
+    expect(container.querySelector("code")).toBeNull();
+    button?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(resolveFilePath).toHaveBeenCalledWith("Cargo.toml");
+    expect(openFile).toHaveBeenCalledWith("Cargo.toml");
+  });
+
+  it("leaves inline code alone when the context cannot resolve it", async () => {
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile: vi.fn(), resolveFilePath: () => null } },
+        createElement(HighlightedCode, { children: "not-a-file" }),
+      ),
+    );
+
+    expect(container.querySelector("code")?.textContent).toBe("not-a-file");
+    expect(container.querySelector("button")).toBeNull();
+  });
 });
 
 describe("safeUrlTransform", () => {

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createElement } from "react";
 import type { ReactElement, ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import type { Components } from "react-markdown";
 
 const tauriMocks = vi.hoisted(() => ({
   invoke: vi.fn(() => Promise.resolve()),
@@ -233,8 +234,7 @@ describe("normalizeExternalHref", () => {
 });
 
 describe("MARKDOWN_COMPONENTS.a click handling", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const LinkOverride = MARKDOWN_COMPONENTS.a as (props: any) => ReactElement;
+  const LinkOverride = MARKDOWN_COMPONENTS.a as NonNullable<Components["a"]>;
 
   beforeEach(() => {
     tauriMocks.invoke.mockClear();
@@ -340,7 +340,9 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
       }),
     );
 
-    container.querySelector("a")?.dispatchEvent(
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("https://www.example.com/docs");
+    link?.dispatchEvent(
       new MouseEvent("click", { bubbles: true, cancelable: true }),
     );
 

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -9,17 +9,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { Components } from "react-markdown";
 
 const tauriMocks = vi.hoisted(() => ({
-  invoke: vi.fn(() => Promise.resolve()),
-  openInEditor: vi.fn(() => Promise.resolve()),
   openUrl: vi.fn(() => Promise.resolve()),
 }));
 
-vi.mock("@tauri-apps/api/core", () => ({
-  invoke: tauriMocks.invoke,
-}));
-
 vi.mock("../services/tauri", () => ({
-  openInEditor: tauriMocks.openInEditor,
   openUrl: tauriMocks.openUrl,
 }));
 
@@ -237,8 +230,6 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
   const LinkOverride = MARKDOWN_COMPONENTS.a as NonNullable<Components["a"]>;
 
   beforeEach(() => {
-    tauriMocks.invoke.mockClear();
-    tauriMocks.openInEditor.mockClear();
     tauriMocks.openUrl.mockClear();
   });
 
@@ -262,10 +253,10 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
     );
 
     expect(openFile).toHaveBeenCalledWith("README.md");
-    expect(tauriMocks.openInEditor).not.toHaveBeenCalled();
+    expect(tauriMocks.openUrl).not.toHaveBeenCalled();
   });
 
-  it("falls back to the native opener for absolute file paths outside Monaco", async () => {
+  it("does not open absolute file paths in a native app when Monaco cannot handle them", async () => {
     const openFile = vi.fn(() => false);
     const container = await render(
       createElement(
@@ -283,10 +274,10 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
     );
 
     expect(openFile).toHaveBeenCalledWith("/tmp/report.md");
-    expect(tauriMocks.openInEditor).toHaveBeenCalledWith("/tmp/report.md");
+    expect(tauriMocks.openUrl).not.toHaveBeenCalled();
   });
 
-  it("falls back to the native opener when the Monaco opener throws", async () => {
+  it("does not open absolute file paths in a native app when the Monaco opener throws", async () => {
     const openFile = vi.fn(() => {
       throw new Error("boom");
     });
@@ -306,7 +297,34 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
     );
 
     expect(openFile).toHaveBeenCalledWith("/tmp/report.md");
-    expect(tauriMocks.openInEditor).toHaveBeenCalledWith("/tmp/report.md");
+    expect(tauriMocks.openUrl).not.toHaveBeenCalled();
+  });
+
+  it("opens a localhost file URL in the browser when Monaco cannot handle it", async () => {
+    const openFile = vi.fn(() => false);
+    const href =
+      "http://localhost:14255/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/website/guide/quickstart.md:6";
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile } },
+        createElement(LinkOverride, {
+          href,
+          children: href,
+        }),
+      ),
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+    button?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(openFile).toHaveBeenCalledWith(
+      "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/website/guide/quickstart.md:6",
+    );
+    expect(tauriMocks.openUrl).toHaveBeenCalledWith(href);
   });
 
   it("routes localhost file URLs through the Monaco file opener without rendering a navigable href", async () => {
@@ -330,6 +348,21 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
     );
 
     expect(openFile).toHaveBeenCalledWith("/Users/me/project/CLAUDETTE_TEST.md:1");
+  });
+
+  it("blocks unsupported anchors from navigating the webview", async () => {
+    const container = await render(
+      createElement(LinkOverride, {
+        href: "/internal/app/path",
+        children: "internal",
+      }),
+    );
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+
+    container.querySelector("a")?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(tauriMocks.openUrl).not.toHaveBeenCalled();
   });
 
   it("opens scheme-less www links through open_url with an https URL", async () => {

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -9,6 +9,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 const tauriMocks = vi.hoisted(() => ({
   invoke: vi.fn(() => Promise.resolve()),
+  openInEditor: vi.fn(() => Promise.resolve()),
   openUrl: vi.fn(() => Promise.resolve()),
 }));
 
@@ -17,6 +18,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 vi.mock("../services/tauri", () => ({
+  openInEditor: tauriMocks.openInEditor,
   openUrl: tauriMocks.openUrl,
 }));
 
@@ -236,6 +238,7 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
 
   beforeEach(() => {
     tauriMocks.invoke.mockClear();
+    tauriMocks.openInEditor.mockClear();
     tauriMocks.openUrl.mockClear();
   });
 
@@ -259,7 +262,7 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
     );
 
     expect(openFile).toHaveBeenCalledWith("README.md");
-    expect(tauriMocks.invoke).not.toHaveBeenCalled();
+    expect(tauriMocks.openInEditor).not.toHaveBeenCalled();
   });
 
   it("falls back to the native opener for absolute file paths outside Monaco", async () => {
@@ -280,9 +283,30 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
     );
 
     expect(openFile).toHaveBeenCalledWith("/tmp/report.md");
-    expect(tauriMocks.invoke).toHaveBeenCalledWith("open_in_editor", {
-      path: "/tmp/report.md",
+    expect(tauriMocks.openInEditor).toHaveBeenCalledWith("/tmp/report.md");
+  });
+
+  it("falls back to the native opener when the Monaco opener throws", async () => {
+    const openFile = vi.fn(() => {
+      throw new Error("boom");
     });
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile } },
+        createElement(LinkOverride, {
+          href: "claudettepath:/tmp/report.md",
+          children: "/tmp/report.md",
+        }),
+      ),
+    );
+
+    container.querySelector("button")?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(openFile).toHaveBeenCalledWith("/tmp/report.md");
+    expect(tauriMocks.openInEditor).toHaveBeenCalledWith("/tmp/report.md");
   });
 
   it("routes localhost file URLs through the Monaco file opener without rendering a navigable href", async () => {

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -282,6 +282,32 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
     expect(openFile).toHaveBeenCalledWith("docs/README.md");
   });
 
+  it("routes bare file links only when the workspace index resolves them", async () => {
+    const openFile = vi.fn(() => true);
+    const resolveFilePath = vi.fn((path: string) =>
+      path === "README.md" ? "docs/README.md" : null,
+    );
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile, resolveFilePath } },
+        createElement(LinkOverride, {
+          href: "claudettepath:README.md",
+          children: "README.md",
+        }),
+      ),
+    );
+
+    const button = container.querySelector("button");
+    expect(button?.textContent).toBe("README.md");
+    button?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(resolveFilePath).toHaveBeenCalledWith("README.md");
+    expect(openFile).toHaveBeenCalledWith("docs/README.md");
+  });
+
   it("leaves unresolved at-sign mentions as plain text", async () => {
     const openFile = vi.fn(() => true);
     const container = await render(
@@ -297,6 +323,24 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
 
     expect(container.querySelector("button")).toBeNull();
     expect(container.textContent).toBe("@README.md");
+    expect(openFile).not.toHaveBeenCalled();
+  });
+
+  it("leaves unresolved bare file links as plain text when a resolver is available", async () => {
+    const openFile = vi.fn(() => true);
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile, resolveFilePath: () => null } },
+        createElement(LinkOverride, {
+          href: "claudettepath:README.md",
+          children: "README.md",
+        }),
+      ),
+    );
+
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.textContent).toBe("README.md");
     expect(openFile).not.toHaveBeenCalled();
   });
 
@@ -394,6 +438,41 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
     );
 
     expect(openFile).toHaveBeenCalledWith("/Users/me/project/CLAUDETTE_TEST.md:1");
+  });
+
+  it("routes localhost file URLs through the workspace-resolved display path when available", async () => {
+    const openFile = vi.fn(() => true);
+    const resolveFilePath = vi.fn((path: string) =>
+      path === "website/guide/quickstart.md:6"
+        ? "website/guide/quickstart.md:6"
+        : null,
+    );
+    const href =
+      "http://localhost:14255/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/website/guide/quickstart.md:6";
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile, resolveFilePath } },
+        createElement(LinkOverride, {
+          href,
+          children: href,
+        }),
+      ),
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+    expect(button?.textContent).toBe("website/guide/quickstart.md:6");
+    button?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(resolveFilePath).toHaveBeenCalledWith(
+      "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/website/guide/quickstart.md:6",
+    );
+    expect(resolveFilePath).toHaveBeenCalledWith("website/guide/quickstart.md:6");
+    expect(openFile).toHaveBeenCalledWith("website/guide/quickstart.md:6");
+    expect(tauriMocks.openUrl).not.toHaveBeenCalled();
   });
 
   it("routes localhost SVG file URLs through the Monaco file opener", async () => {

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -1,7 +1,24 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createElement } from "react";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+
+const tauriMocks = vi.hoisted(() => ({
+  invoke: vi.fn(() => Promise.resolve()),
+  openUrl: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: tauriMocks.invoke,
+}));
+
+vi.mock("../services/tauri", () => ({
+  openUrl: tauriMocks.openUrl,
+}));
 
 vi.mock("./highlight", () => ({
   getCachedHighlight: vi.fn(),
@@ -11,11 +28,40 @@ vi.mock("./highlight", () => ({
 import {
   EXTERNAL_SCHEMES,
   MARKDOWN_COMPONENTS,
+  MarkdownFileOpenContext,
+  normalizeExternalHref,
   SANITIZE_SCHEMA,
   HighlightedCode,
   safeUrlTransform,
 } from "./markdown";
 import { getCachedHighlight, highlightCode } from "./highlight";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function render(node: ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return container;
+}
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0)) {
+    await act(async () => root.unmount());
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
 
 describe("EXTERNAL_SCHEMES", () => {
   it("matches http URLs", () => {
@@ -121,6 +167,98 @@ describe("safeUrlTransform", () => {
     expect(SANITIZE_SCHEMA.attributes.source).toEqual(
       expect.arrayContaining(["srcSet", "media"]),
     );
+  });
+});
+
+describe("normalizeExternalHref", () => {
+  it("keeps explicit http, https, and mailto links", () => {
+    expect(normalizeExternalHref("https://example.com/path")).toBe(
+      "https://example.com/path",
+    );
+    expect(normalizeExternalHref("http://example.com")).toBe("http://example.com");
+    expect(normalizeExternalHref("mailto:user@example.com")).toBe(
+      "mailto:user@example.com",
+    );
+  });
+
+  it("upgrades www links that GFM can emit without a scheme", () => {
+    expect(normalizeExternalHref("www.example.com/docs")).toBe(
+      "https://www.example.com/docs",
+    );
+  });
+
+  it("rejects relative files and unsafe schemes", () => {
+    expect(normalizeExternalHref("README.md")).toBeNull();
+    expect(normalizeExternalHref("javascript:alert(1)")).toBeNull();
+  });
+});
+
+describe("MARKDOWN_COMPONENTS.a click handling", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const LinkOverride = MARKDOWN_COMPONENTS.a as (props: any) => ReactElement;
+
+  beforeEach(() => {
+    tauriMocks.invoke.mockClear();
+    tauriMocks.openUrl.mockClear();
+  });
+
+  it("routes claudettepath links through the Monaco file opener context", async () => {
+    const openFile = vi.fn(() => true);
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile } },
+        createElement(LinkOverride, {
+          href: "claudettepath:README.md",
+          children: "README.md",
+        }),
+      ),
+    );
+
+    container.querySelector("a")?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(openFile).toHaveBeenCalledWith("README.md");
+    expect(tauriMocks.invoke).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the native opener for absolute file paths outside Monaco", async () => {
+    const openFile = vi.fn(() => false);
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile } },
+        createElement(LinkOverride, {
+          href: "claudettepath:/tmp/report.md",
+          children: "/tmp/report.md",
+        }),
+      ),
+    );
+
+    container.querySelector("a")?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(openFile).toHaveBeenCalledWith("/tmp/report.md");
+    expect(tauriMocks.invoke).toHaveBeenCalledWith("open_in_editor", {
+      path: "/tmp/report.md",
+    });
+  });
+
+  it("opens scheme-less www links through open_url with an https URL", async () => {
+    const container = await render(
+      createElement(LinkOverride, {
+        href: "www.example.com/docs",
+        children: "www.example.com/docs",
+      }),
+    );
+
+    container.querySelector("a")?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(tauriMocks.openUrl).toHaveBeenCalledWith("https://www.example.com/docs");
   });
 });
 

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -268,7 +268,7 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
       new MouseEvent("click", { bubbles: true, cancelable: true }),
     );
 
-    expect(openFile).toHaveBeenCalledWith("/Users/me/project/CLAUDETTE_TEST.md");
+    expect(openFile).toHaveBeenCalledWith("/Users/me/project/CLAUDETTE_TEST.md:1");
   });
 
   it("opens scheme-less www links through open_url with an https URL", async () => {

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -215,7 +215,9 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
       ),
     );
 
-    container.querySelector("a")?.dispatchEvent(
+    const button = container.querySelector("button");
+    expect(button?.getAttribute("href")).toBeNull();
+    button?.dispatchEvent(
       new MouseEvent("click", { bubbles: true, cancelable: true }),
     );
 
@@ -236,7 +238,7 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
       ),
     );
 
-    container.querySelector("a")?.dispatchEvent(
+    container.querySelector("button")?.dispatchEvent(
       new MouseEvent("click", { bubbles: true, cancelable: true }),
     );
 
@@ -244,6 +246,29 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
     expect(tauriMocks.invoke).toHaveBeenCalledWith("open_in_editor", {
       path: "/tmp/report.md",
     });
+  });
+
+  it("routes localhost file URLs through the Monaco file opener without rendering a navigable href", async () => {
+    const openFile = vi.fn(() => true);
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile } },
+        createElement(LinkOverride, {
+          href: "http://localhost:14254/Users/me/project/CLAUDETTE_TEST.md:1",
+          children: "http://localhost:14254/Users/me/project/CLAUDETTE_TEST.md:1",
+        }),
+      ),
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+    expect(container.querySelector("a")).toBeNull();
+    button?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(openFile).toHaveBeenCalledWith("/Users/me/project/CLAUDETTE_TEST.md");
   });
 
   it("opens scheme-less www links through open_url with an https URL", async () => {

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -300,7 +300,7 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
     expect(tauriMocks.openUrl).not.toHaveBeenCalled();
   });
 
-  it("opens a localhost file URL in the browser when Monaco cannot handle it", async () => {
+  it("does not open localhost file URLs in the browser when Monaco cannot handle them", async () => {
     const openFile = vi.fn(() => false);
     const href =
       "http://localhost:14255/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/website/guide/quickstart.md:6";
@@ -317,6 +317,7 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
 
     const button = container.querySelector("button");
     expect(button).toBeTruthy();
+    expect(button?.textContent).toBe("website/guide/quickstart.md:6");
     button?.dispatchEvent(
       new MouseEvent("click", { bubbles: true, cancelable: true }),
     );
@@ -324,7 +325,7 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
     expect(openFile).toHaveBeenCalledWith(
       "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/website/guide/quickstart.md:6",
     );
-    expect(tauriMocks.openUrl).toHaveBeenCalledWith(href);
+    expect(tauriMocks.openUrl).not.toHaveBeenCalled();
   });
 
   it("routes localhost file URLs through the Monaco file opener without rendering a navigable href", async () => {
@@ -342,12 +343,96 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
 
     const button = container.querySelector("button");
     expect(button).toBeTruthy();
+    expect(button?.textContent).toBe("CLAUDETTE_TEST.md:1");
     expect(container.querySelector("a")).toBeNull();
     button?.dispatchEvent(
       new MouseEvent("click", { bubbles: true, cancelable: true }),
     );
 
     expect(openFile).toHaveBeenCalledWith("/Users/me/project/CLAUDETTE_TEST.md:1");
+  });
+
+  it("routes localhost SVG file URLs through the Monaco file opener", async () => {
+    const openFile = vi.fn(() => true);
+    const href =
+      "http://localhost:14254/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/simple-wave.svg:1";
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile } },
+        createElement(LinkOverride, {
+          href,
+          children: href,
+        }),
+      ),
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+    expect(button?.textContent).toBe("simple-wave.svg:1");
+    expect(container.querySelector("a")).toBeNull();
+    button?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(openFile).toHaveBeenCalledWith(
+      "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/simple-wave.svg:1",
+    );
+    expect(tauriMocks.openUrl).not.toHaveBeenCalled();
+  });
+
+  it("routes same-origin absolute file hrefs through Monaco instead of rendering an app-route anchor", async () => {
+    const openFile = vi.fn(() => true);
+    const href =
+      "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/README.md:8";
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile } },
+        createElement(LinkOverride, {
+          href,
+          children: "README.md",
+        }),
+      ),
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+    expect(button?.textContent).toBe("README.md:8");
+    expect(container.querySelector("a")).toBeNull();
+    button?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(openFile).toHaveBeenCalledWith(href);
+    expect(tauriMocks.openUrl).not.toHaveBeenCalled();
+  });
+
+  it("routes same-origin absolute file hrefs with unknown extensions through Monaco", async () => {
+    const openFile = vi.fn(() => true);
+    const href =
+      "/Users/jamesbrink/.claudette/workspaces/claudex/copper-ginger/generated.assetbundle:12";
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile } },
+        createElement(LinkOverride, {
+          href,
+          children: "generated.assetbundle",
+        }),
+      ),
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+    expect(button?.textContent).toBe("generated.assetbundle:12");
+    expect(container.querySelector("a")).toBeNull();
+    button?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(openFile).toHaveBeenCalledWith(href);
+    expect(tauriMocks.openUrl).not.toHaveBeenCalled();
   });
 
   it("blocks unsupported anchors from navigating the webview", async () => {

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -160,11 +160,11 @@ describe("MARKDOWN_COMPONENTS.code wiring", () => {
       createElement(
         MarkdownFileOpenContext.Provider,
         { value: { openFile: vi.fn(), resolveFilePath: () => null } },
-        createElement(HighlightedCode, { children: "not-a-file" }),
+        createElement(HighlightedCode, { children: "foo.ts" }),
       ),
     );
 
-    expect(container.querySelector("code")?.textContent).toBe("not-a-file");
+    expect(container.querySelector("code")?.textContent).toBe("foo.ts");
     expect(container.querySelector("button")).toBeNull();
   });
 });
@@ -254,6 +254,50 @@ describe("MARKDOWN_COMPONENTS.a click handling", () => {
 
     expect(openFile).toHaveBeenCalledWith("README.md");
     expect(tauriMocks.openUrl).not.toHaveBeenCalled();
+  });
+
+  it("routes at-sign file mentions only when the workspace index resolves them", async () => {
+    const openFile = vi.fn(() => true);
+    const resolveFilePath = vi.fn((path: string) =>
+      path === "README.md" ? "docs/README.md" : null,
+    );
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile, resolveFilePath } },
+        createElement(LinkOverride, {
+          href: "claudettepath:README.md",
+          children: "@README.md",
+        }),
+      ),
+    );
+
+    const button = container.querySelector("button");
+    expect(button?.textContent).toBe("@README.md");
+    button?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    expect(resolveFilePath).toHaveBeenCalledWith("README.md");
+    expect(openFile).toHaveBeenCalledWith("docs/README.md");
+  });
+
+  it("leaves unresolved at-sign mentions as plain text", async () => {
+    const openFile = vi.fn(() => true);
+    const container = await render(
+      createElement(
+        MarkdownFileOpenContext.Provider,
+        { value: { openFile, resolveFilePath: () => null } },
+        createElement(LinkOverride, {
+          href: "claudettepath:README.md",
+          children: "@README.md",
+        }),
+      ),
+    );
+
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.textContent).toBe("@README.md");
+    expect(openFile).not.toHaveBeenCalled();
   });
 
   it("does not open absolute file paths in a native app when Monaco cannot handle them", async () => {

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -362,8 +362,10 @@ export function HighlightedCode({
   }
   const inlineText = extractText(children).trim();
   const resolvedPath = fileOpen?.resolveFilePath?.(inlineText) ?? null;
+  const hasFileResolver = typeof fileOpen?.resolveFilePath === "function";
   const inlineFilePath =
-    resolvedPath ?? (isLikelyFilePathTarget(inlineText) ? inlineText : null);
+    resolvedPath ??
+    (!hasFileResolver && isLikelyFilePathTarget(inlineText) ? inlineText : null);
   if (inlineFilePath && fileOpen) {
     return createElement(
       "button",
@@ -398,6 +400,13 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
   const filePath = href
     ? (encodedFilePath ?? localhostFilePath ?? hrefFilePath)
     : null;
+  const linkText = extractText(children).trim();
+  const requiresFileResolution =
+    !!encodedFilePath && linkText.startsWith("@");
+  const verifiedFilePath =
+    filePath && requiresFileResolution
+      ? (fileOpen?.resolveFilePath?.(filePath) ?? null)
+      : null;
   const externalHref = href ? normalizeExternalHref(href) : null;
   const openExternalHref = (target: string) => {
     void openUrl(target).catch((err) =>
@@ -407,6 +416,17 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
   const openFilePath = () => {
     if (!filePath) return;
     if (fileOpen) {
+      if (verifiedFilePath) {
+        try {
+          if (fileOpen.openFile(verifiedFilePath)) return;
+        } catch (err) {
+          console.error(
+            "Failed to open verified file link in Monaco:",
+            verifiedFilePath,
+            err,
+          );
+        }
+      }
       const displayFilePath = localhostFilePath ?? hrefFilePath;
       const resolvedDisplayFilePath = displayFilePath
         ? fileOpen.resolveFilePath?.(
@@ -443,6 +463,9 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
     );
   };
   if (filePath) {
+    if (requiresFileResolution && !verifiedFilePath) {
+      return createElement("span", props, children);
+    }
     const compactFilePath = localhostFilePath ?? hrefFilePath;
     const filePathLabel = compactFilePath
       ? formatFilePathDisplayLabel(compactFilePath)
@@ -455,7 +478,7 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
           "cc-file-path-link",
           typeof props.className === "string" ? props.className : undefined,
         ),
-        title: filePath,
+        title: verifiedFilePath ?? filePath,
         onClick: openFilePath,
       },
       filePathLabel,

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -12,8 +12,7 @@ import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { AnsiUp } from "ansi_up";
-import { invoke } from "@tauri-apps/api/core";
-import { openUrl } from "../services/tauri";
+import { openInEditor, openUrl } from "../services/tauri";
 import { CodeBlock } from "../components/chat/CodeBlock";
 import { MermaidBlock } from "../components/chat/MermaidBlock";
 import { StreamingContext } from "../components/chat/StreamingContext";
@@ -398,7 +397,6 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
         if (fileOpen.openFile(filePath)) return;
       } catch (err) {
         console.error("Failed to open file link in Monaco:", filePath, err);
-        return;
       }
     }
     const nativeTarget = parseFilePathTarget(filePath);
@@ -406,7 +404,7 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
       console.warn("No workspace file opener available for relative path:", filePath);
       return;
     }
-    void invoke("open_in_editor", { path: nativeTarget.path }).catch(
+    void openInEditor(nativeTarget.path).catch(
       (err) =>
         console.error("Failed to open path:", filePath, err),
     );

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -400,12 +400,17 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
   const filePath = href
     ? (encodedFilePath ?? localhostFilePath ?? hrefFilePath)
     : null;
-  const linkText = extractText(children).trim();
-  const requiresFileResolution =
-    !!encodedFilePath && linkText.startsWith("@");
+  const hasFileResolver = typeof fileOpen?.resolveFilePath === "function";
+  const compactFilePath = localhostFilePath ?? hrefFilePath;
+  const compactFilePathLabel = compactFilePath
+    ? formatFilePathDisplayLabel(compactFilePath)
+    : null;
   const verifiedFilePath =
-    filePath && requiresFileResolution
-      ? (fileOpen?.resolveFilePath?.(filePath) ?? null)
+    filePath && hasFileResolver
+      ? (fileOpen?.resolveFilePath?.(filePath) ??
+        (compactFilePathLabel
+          ? fileOpen?.resolveFilePath?.(compactFilePathLabel)
+          : null))
       : null;
   const externalHref = href ? normalizeExternalHref(href) : null;
   const openExternalHref = (target: string) => {
@@ -427,27 +432,12 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
           );
         }
       }
-      const displayFilePath = localhostFilePath ?? hrefFilePath;
-      const resolvedDisplayFilePath = displayFilePath
-        ? fileOpen.resolveFilePath?.(
-            formatFilePathDisplayLabel(displayFilePath),
-          )
-        : null;
-      if (resolvedDisplayFilePath) {
+      if (!hasFileResolver) {
         try {
-          if (fileOpen.openFile(resolvedDisplayFilePath)) return;
+          if (fileOpen.openFile(filePath)) return;
         } catch (err) {
-          console.error(
-            "Failed to open resolved file link in Monaco:",
-            resolvedDisplayFilePath,
-            err,
-          );
+          console.error("Failed to open file link in Monaco:", filePath, err);
         }
-      }
-      try {
-        if (fileOpen.openFile(filePath)) return;
-      } catch (err) {
-        console.error("Failed to open file link in Monaco:", filePath, err);
       }
     }
     if (localhostFilePath || hrefFilePath) {
@@ -463,13 +453,10 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
     );
   };
   if (filePath) {
-    if (requiresFileResolution && !verifiedFilePath) {
+    if (hasFileResolver && !verifiedFilePath) {
       return createElement("span", props, children);
     }
-    const compactFilePath = localhostFilePath ?? hrefFilePath;
-    const filePathLabel = compactFilePath
-      ? formatFilePathDisplayLabel(compactFilePath)
-      : children;
+    const filePathLabel = compactFilePathLabel ?? children;
     return createElement(
       "button",
       {

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -12,7 +12,7 @@ import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { AnsiUp } from "ansi_up";
-import { openInEditor, openUrl } from "../services/tauri";
+import { openUrl } from "../services/tauri";
 import { CodeBlock } from "../components/chat/CodeBlock";
 import { MermaidBlock } from "../components/chat/MermaidBlock";
 import { StreamingContext } from "../components/chat/StreamingContext";
@@ -20,7 +20,6 @@ import {
   decodeFilePathHref,
   decodeLocalhostFileUrlTarget,
   FILE_PATH_SCHEME,
-  parseFilePathTarget,
 } from "./filePathLinks";
 import { getCachedHighlight, highlightCode } from "./highlight";
 import { rehypeFilePathLinks } from "./rehypeFilePathLinks";
@@ -188,8 +187,6 @@ export interface MarkdownFileOpenContextValue {
 
 export const MarkdownFileOpenContext =
   createContext<MarkdownFileOpenContextValue | null>(null);
-
-const ABSOLUTE_FILE_PATH_REGEX = /^(?:[A-Za-z]:[\\/]|[\\/]|~[\\/]|~$)/;
 
 export function normalizeExternalHref(href: string): string | null {
   const trimmed = href.trim();
@@ -387,10 +384,17 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
   ...props
 }) => {
   const fileOpen = useContext(MarkdownFileOpenContext);
+  const encodedFilePath = href ? decodeFilePathHref(href) : null;
+  const localhostFilePath = href ? decodeLocalhostFileUrlTarget(href) : null;
   const filePath = href
-    ? (decodeFilePathHref(href) ?? decodeLocalhostFileUrlTarget(href))
+    ? (encodedFilePath ?? localhostFilePath)
     : null;
   const externalHref = href ? normalizeExternalHref(href) : null;
+  const openExternalHref = (target: string) => {
+    void openUrl(target).catch((err) =>
+      console.error("Failed to open URL:", target, err),
+    );
+  };
   const openFilePath = () => {
     if (!filePath) return;
     if (fileOpen) {
@@ -400,14 +404,13 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
         console.error("Failed to open file link in Monaco:", filePath, err);
       }
     }
-    const nativeTarget = parseFilePathTarget(filePath);
-    if (!ABSOLUTE_FILE_PATH_REGEX.test(nativeTarget.path)) {
-      console.warn("No workspace file opener available for relative path:", filePath);
+    if (localhostFilePath && externalHref) {
+      openExternalHref(externalHref);
       return;
     }
-    void openInEditor(nativeTarget.path).catch(
-      (err) =>
-        console.error("Failed to open path:", filePath, err),
+    console.warn(
+      "No workspace file opener available for chat file link:",
+      filePath,
     );
   };
   if (filePath) {
@@ -431,12 +434,12 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
       ...props,
       href: externalHref ?? href,
       onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
+        e.preventDefault();
         if (externalHref) {
-          e.preventDefault();
-          void openUrl(externalHref).catch((err) =>
-            console.error("Failed to open URL:", externalHref, err),
-          );
+          openExternalHref(externalHref);
+          return;
         }
+        console.warn("Blocked in-app navigation for chat link:", href);
       },
     },
     children,

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -19,8 +19,9 @@ import { MermaidBlock } from "../components/chat/MermaidBlock";
 import { StreamingContext } from "../components/chat/StreamingContext";
 import {
   decodeFilePathHref,
-  decodeLocalhostFileUrl,
+  decodeLocalhostFileUrlTarget,
   FILE_PATH_SCHEME,
+  parseFilePathTarget,
 } from "./filePathLinks";
 import { getCachedHighlight, highlightCode } from "./highlight";
 import { rehypeFilePathLinks } from "./rehypeFilePathLinks";
@@ -369,7 +370,7 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
 }) => {
   const fileOpen = useContext(MarkdownFileOpenContext);
   const filePath = href
-    ? (decodeFilePathHref(href) ?? decodeLocalhostFileUrl(href))
+    ? (decodeFilePathHref(href) ?? decodeLocalhostFileUrlTarget(href))
     : null;
   const openFilePath = () => {
     if (!filePath) return;
@@ -381,11 +382,12 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
         return;
       }
     }
-    if (!ABSOLUTE_FILE_PATH_REGEX.test(filePath)) {
+    const nativeTarget = parseFilePathTarget(filePath);
+    if (!ABSOLUTE_FILE_PATH_REGEX.test(nativeTarget.path)) {
       console.warn("No workspace file opener available for relative path:", filePath);
       return;
     }
-    void invoke("open_in_editor", { path: filePath }).catch(
+    void invoke("open_in_editor", { path: nativeTarget.path }).catch(
       (err) =>
         console.error("Failed to open path:", filePath, err),
     );

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -17,7 +17,11 @@ import { openUrl } from "../services/tauri";
 import { CodeBlock } from "../components/chat/CodeBlock";
 import { MermaidBlock } from "../components/chat/MermaidBlock";
 import { StreamingContext } from "../components/chat/StreamingContext";
-import { decodeFilePathHref, FILE_PATH_SCHEME } from "./filePathLinks";
+import {
+  decodeFilePathHref,
+  decodeLocalhostFileUrl,
+  FILE_PATH_SCHEME,
+} from "./filePathLinks";
 import { getCachedHighlight, highlightCode } from "./highlight";
 import { rehypeFilePathLinks } from "./rehypeFilePathLinks";
 
@@ -364,38 +368,49 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
   ...props
 }) => {
   const fileOpen = useContext(MarkdownFileOpenContext);
-  const filePath = href ? decodeFilePathHref(href) : null;
+  const filePath = href
+    ? (decodeFilePathHref(href) ?? decodeLocalhostFileUrl(href))
+    : null;
+  const openFilePath = () => {
+    if (!filePath) return;
+    if (fileOpen) {
+      try {
+        if (fileOpen.openFile(filePath)) return;
+      } catch (err) {
+        console.error("Failed to open file link in Monaco:", filePath, err);
+        return;
+      }
+    }
+    if (!ABSOLUTE_FILE_PATH_REGEX.test(filePath)) {
+      console.warn("No workspace file opener available for relative path:", filePath);
+      return;
+    }
+    void invoke("open_in_editor", { path: filePath }).catch(
+      (err) =>
+        console.error("Failed to open path:", filePath, err),
+    );
+  };
+  if (filePath) {
+    return createElement(
+      "button",
+      {
+        type: "button",
+        className: classNames(
+          "cc-file-path-link",
+          typeof props.className === "string" ? props.className : undefined,
+        ),
+        title: filePath,
+        onClick: openFilePath,
+      },
+      children,
+    );
+  }
   return createElement(
     "a",
     {
       ...props,
       href,
-      // Tooltip the actual path so a user hovering can see exactly
-      // what the click will open — the visible text is the path
-      // already, but title= adds redundancy on long paths that get
-      // visually truncated by surrounding wrap/ellipsis rules.
-      title: filePath ?? (props as { title?: string }).title,
       onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
-        if (filePath) {
-          e.preventDefault();
-          if (fileOpen) {
-            try {
-              if (fileOpen.openFile(filePath)) return;
-            } catch (err) {
-              console.error("Failed to open file link in Monaco:", filePath, err);
-              return;
-            }
-          }
-          if (!ABSOLUTE_FILE_PATH_REGEX.test(filePath)) {
-            console.warn("No workspace file opener available for relative path:", filePath);
-            return;
-          }
-          void invoke("open_in_editor", { path: filePath }).catch(
-            (err) =>
-              console.error("Failed to open path:", filePath, err),
-          );
-          return;
-        }
         const externalHref = href ? normalizeExternalHref(href) : null;
         if (externalHref) {
           e.preventDefault();
@@ -408,6 +423,10 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
     children,
   );
 };
+
+function classNames(...values: Array<string | undefined>): string {
+  return values.filter(Boolean).join(" ");
+}
 
 // Override <a> to open external links in the system browser instead of
 // navigating the webview, and to route `claudettepath:` links — produced

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -184,6 +184,7 @@ export const EXTERNAL_SCHEMES = /^https?:|^mailto:/i;
 
 export interface MarkdownFileOpenContextValue {
   openFile: (path: string) => boolean;
+  resolveFilePath?: (path: string) => string | null;
 }
 
 export const MarkdownFileOpenContext =
@@ -297,6 +298,7 @@ export function HighlightedCode({
     ? (className.match(/(?:^|\s)language-([^\s]+)/)?.[1] ?? null)
     : null;
   const isStreaming = useContext(StreamingContext);
+  const fileOpen = useContext(MarkdownFileOpenContext);
   // Memoize so re-renders that don't change `children` skip the recursive walk
   // and keep `code`'s identity stable — the highlight effect's deps then no
   // longer fire spuriously, so we don't enqueue redundant worker dispatches.
@@ -357,6 +359,23 @@ export function HighlightedCode({
       "code",
       { ...props, className },
       code.replace(/\n+$/, ""),
+    );
+  }
+  const inlineText = extractText(children).trim();
+  const resolvedPath = fileOpen?.resolveFilePath?.(inlineText) ?? null;
+  if (resolvedPath && fileOpen) {
+    return createElement(
+      "button",
+      {
+        type: "button",
+        className: classNames(
+          "cc-file-path-link",
+          typeof className === "string" ? className : undefined,
+        ),
+        title: resolvedPath,
+        onClick: () => fileOpen.openFile(resolvedPath),
+      },
+      children,
     );
   }
   return createElement("code", { ...props, className }, children);

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -1,4 +1,11 @@
-import React, { createElement, useContext, useEffect, useMemo, useReducer } from "react";
+import React, {
+  createContext,
+  createElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+} from "react";
 import type { PluggableList } from "unified";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -170,6 +177,26 @@ export const REMARK_PLUGINS: PluggableList = [remarkGfm];
 // Schemes that should open in the system browser rather than navigate the webview.
 export const EXTERNAL_SCHEMES = /^https?:|^mailto:/i;
 
+export interface MarkdownFileOpenContextValue {
+  openFile: (path: string) => boolean;
+}
+
+export const MarkdownFileOpenContext =
+  createContext<MarkdownFileOpenContextValue | null>(null);
+
+const ABSOLUTE_FILE_PATH_REGEX = /^(?:[A-Za-z]:[\\/]|[\\/]|~[\\/]|~$)/;
+
+export function normalizeExternalHref(href: string): string | null {
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+  if (/^mailto:/i.test(trimmed)) return trimmed;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  if (/^www\.[^\s/$.?#].[^\s]*$/i.test(trimmed)) {
+    return `https://${trimmed}`;
+  }
+  return null;
+}
+
 /**
  * URL transform that runs *inside* react-markdown after rehype but before
  * each `<a>`/`<img>` is rendered. react-markdown's `defaultUrlTransform`
@@ -330,43 +357,63 @@ export function HighlightedCode({
   return createElement("code", { ...props, className }, children);
 }
 
-// Override <a> to open external links in the system browser instead of
-// navigating the webview, and to route `claudettepath:` links — produced
-// by the file-path autolinker — through the OS default-app handler.
-export const MARKDOWN_COMPONENTS: Components = {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  a: ({ node, href, children, ...props }) => {
-    const filePath = href ? decodeFilePathHref(href) : null;
-    return createElement(
-      "a",
-      {
-        ...props,
-        href,
-        // Tooltip the actual path so a user hovering can see exactly
-        // what the click will open — the visible text is the path
-        // already, but title= adds redundancy on long paths that get
-        // visually truncated by surrounding wrap/ellipsis rules.
-        title: filePath ?? (props as { title?: string }).title,
-        onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
-          if (filePath) {
-            e.preventDefault();
-            void invoke("open_in_editor", { path: filePath }).catch(
-              (err) =>
-                console.error("Failed to open path:", filePath, err),
-            );
+const MarkdownLink: NonNullable<Components["a"]> = ({
+  node: _node,
+  href,
+  children,
+  ...props
+}) => {
+  const fileOpen = useContext(MarkdownFileOpenContext);
+  const filePath = href ? decodeFilePathHref(href) : null;
+  return createElement(
+    "a",
+    {
+      ...props,
+      href,
+      // Tooltip the actual path so a user hovering can see exactly
+      // what the click will open — the visible text is the path
+      // already, but title= adds redundancy on long paths that get
+      // visually truncated by surrounding wrap/ellipsis rules.
+      title: filePath ?? (props as { title?: string }).title,
+      onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
+        if (filePath) {
+          e.preventDefault();
+          if (fileOpen) {
+            try {
+              if (fileOpen.openFile(filePath)) return;
+            } catch (err) {
+              console.error("Failed to open file link in Monaco:", filePath, err);
+              return;
+            }
+          }
+          if (!ABSOLUTE_FILE_PATH_REGEX.test(filePath)) {
+            console.warn("No workspace file opener available for relative path:", filePath);
             return;
           }
-          if (href && EXTERNAL_SCHEMES.test(href)) {
-            e.preventDefault();
-            void openUrl(href).catch((err) =>
-              console.error("Failed to open URL:", href, err),
-            );
-          }
-        },
+          void invoke("open_in_editor", { path: filePath }).catch(
+            (err) =>
+              console.error("Failed to open path:", filePath, err),
+          );
+          return;
+        }
+        const externalHref = href ? normalizeExternalHref(href) : null;
+        if (externalHref) {
+          e.preventDefault();
+          void openUrl(externalHref).catch((err) =>
+            console.error("Failed to open URL:", externalHref, err),
+          );
+        }
       },
-      children,
-    );
-  },
+    },
+    children,
+  );
+};
+
+// Override <a> to open external links in the system browser instead of
+// navigating the webview, and to route `claudettepath:` links — produced
+// by the file-path autolinker — through the Monaco opener when possible.
+export const MARKDOWN_COMPONENTS: Components = {
+  a: MarkdownLink,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   pre: ({ node, children, ...props }) => {
     // Detect ```mermaid fences and route them to MermaidBlock instead of

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -20,6 +20,9 @@ import {
   decodeFilePathHref,
   decodeLocalhostFileUrlTarget,
   FILE_PATH_SCHEME,
+  formatFilePathDisplayLabel,
+  isExplicitFilePathTarget,
+  isLikelyFilePathTarget,
 } from "./filePathLinks";
 import { getCachedHighlight, highlightCode } from "./highlight";
 import { rehypeFilePathLinks } from "./rehypeFilePathLinks";
@@ -359,7 +362,9 @@ export function HighlightedCode({
   }
   const inlineText = extractText(children).trim();
   const resolvedPath = fileOpen?.resolveFilePath?.(inlineText) ?? null;
-  if (resolvedPath && fileOpen) {
+  const inlineFilePath =
+    resolvedPath ?? (isLikelyFilePathTarget(inlineText) ? inlineText : null);
+  if (inlineFilePath && fileOpen) {
     return createElement(
       "button",
       {
@@ -368,8 +373,8 @@ export function HighlightedCode({
           "cc-file-path-link",
           typeof className === "string" ? className : undefined,
         ),
-        title: resolvedPath,
-        onClick: () => fileOpen.openFile(resolvedPath),
+        title: inlineFilePath,
+        onClick: () => fileOpen.openFile(inlineFilePath),
       },
       children,
     );
@@ -386,8 +391,12 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
   const fileOpen = useContext(MarkdownFileOpenContext);
   const encodedFilePath = href ? decodeFilePathHref(href) : null;
   const localhostFilePath = href ? decodeLocalhostFileUrlTarget(href) : null;
+  const hrefFilePath =
+    href && !encodedFilePath && !localhostFilePath && isExplicitFilePathTarget(href)
+      ? href
+      : null;
   const filePath = href
-    ? (encodedFilePath ?? localhostFilePath)
+    ? (encodedFilePath ?? localhostFilePath ?? hrefFilePath)
     : null;
   const externalHref = href ? normalizeExternalHref(href) : null;
   const openExternalHref = (target: string) => {
@@ -398,14 +407,34 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
   const openFilePath = () => {
     if (!filePath) return;
     if (fileOpen) {
+      const displayFilePath = localhostFilePath ?? hrefFilePath;
+      const resolvedDisplayFilePath = displayFilePath
+        ? fileOpen.resolveFilePath?.(
+            formatFilePathDisplayLabel(displayFilePath),
+          )
+        : null;
+      if (resolvedDisplayFilePath) {
+        try {
+          if (fileOpen.openFile(resolvedDisplayFilePath)) return;
+        } catch (err) {
+          console.error(
+            "Failed to open resolved file link in Monaco:",
+            resolvedDisplayFilePath,
+            err,
+          );
+        }
+      }
       try {
         if (fileOpen.openFile(filePath)) return;
       } catch (err) {
         console.error("Failed to open file link in Monaco:", filePath, err);
       }
     }
-    if (localhostFilePath && externalHref) {
-      openExternalHref(externalHref);
+    if (localhostFilePath || hrefFilePath) {
+      console.warn(
+        "No workspace file match available for chat file link:",
+        filePath,
+      );
       return;
     }
     console.warn(
@@ -414,6 +443,10 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
     );
   };
   if (filePath) {
+    const compactFilePath = localhostFilePath ?? hrefFilePath;
+    const filePathLabel = compactFilePath
+      ? formatFilePathDisplayLabel(compactFilePath)
+      : children;
     return createElement(
       "button",
       {
@@ -425,7 +458,7 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
         title: filePath,
         onClick: openFilePath,
       },
-      children,
+      filePathLabel,
     );
   }
   return createElement(

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -390,6 +390,7 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
   const filePath = href
     ? (decodeFilePathHref(href) ?? decodeLocalhostFileUrlTarget(href))
     : null;
+  const externalHref = href ? normalizeExternalHref(href) : null;
   const openFilePath = () => {
     if (!filePath) return;
     if (fileOpen) {
@@ -428,9 +429,8 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
     "a",
     {
       ...props,
-      href,
+      href: externalHref ?? href,
       onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
-        const externalHref = href ? normalizeExternalHref(href) : null;
         if (externalHref) {
           e.preventDefault();
           void openUrl(externalHref).catch((err) =>

--- a/src/ui/src/utils/rehypeFilePathLinks.test.ts
+++ b/src/ui/src/utils/rehypeFilePathLinks.test.ts
@@ -47,6 +47,51 @@ describe("rehypeFilePathLinks", () => {
     expect(p.children[2]).toEqual({ type: "text", value: " now" });
   });
 
+  it("wraps a bare workspace file reference inside a paragraph", () => {
+    const tree = root(paragraph(text("Edit README.md next")));
+    run(tree);
+
+    const p = tree.children[0] as Element;
+    expect(p.children[0]).toEqual({ type: "text", value: "Edit " });
+    const link = p.children[1] as Element;
+    expect(link.tagName).toBe("a");
+    expect(link.properties?.href).toBe("claudettepath:README.md");
+    expect(link.children).toEqual([{ type: "text", value: "README.md" }]);
+    expect(p.children[2]).toEqual({ type: "text", value: " next" });
+  });
+
+  it("converts GFM domain-autolinked file names back into file links", () => {
+    const autolink: Element = {
+      type: "element",
+      tagName: "a",
+      properties: { href: "http://README.md" },
+      children: [text("README.md")],
+    };
+    const tree = root(paragraph(text("Edit "), autolink));
+    run(tree);
+
+    const p = tree.children[0] as Element;
+    const link = p.children[1] as Element;
+    expect(link.properties?.href).toBe("claudettepath:README.md");
+    expect(link.properties?.className).toEqual(["cc-file-path-link"]);
+  });
+
+  it("keeps real GFM autolinked URLs as URLs", () => {
+    const autolink: Element = {
+      type: "element",
+      tagName: "a",
+      properties: { href: "http://example.com" },
+      children: [text("example.com")],
+    };
+    const tree = root(paragraph(autolink));
+    run(tree);
+
+    const p = tree.children[0] as Element;
+    const link = p.children[0] as Element;
+    expect(link.properties?.href).toBe("http://example.com");
+    expect(link.properties?.className).toBeUndefined();
+  });
+
   it("leaves paths inside <code> alone", () => {
     const code: Element = {
       type: "element",

--- a/src/ui/src/utils/rehypeFilePathLinks.test.ts
+++ b/src/ui/src/utils/rehypeFilePathLinks.test.ts
@@ -60,6 +60,19 @@ describe("rehypeFilePathLinks", () => {
     expect(p.children[2]).toEqual({ type: "text", value: " next" });
   });
 
+  it("wraps leading at-sign file mentions but targets the file path", () => {
+    const tree = root(paragraph(text("Edit @README.md next")));
+    run(tree);
+
+    const p = tree.children[0] as Element;
+    expect(p.children[0]).toEqual({ type: "text", value: "Edit " });
+    const link = p.children[1] as Element;
+    expect(link.tagName).toBe("a");
+    expect(link.properties?.href).toBe("claudettepath:README.md");
+    expect(link.children).toEqual([{ type: "text", value: "@README.md" }]);
+    expect(p.children[2]).toEqual({ type: "text", value: " next" });
+  });
+
   it("converts GFM domain-autolinked file names back into file links", () => {
     const autolink: Element = {
       type: "element",

--- a/src/ui/src/utils/rehypeFilePathLinks.ts
+++ b/src/ui/src/utils/rehypeFilePathLinks.ts
@@ -1,8 +1,8 @@
 /**
- * Rehype plugin that scans text nodes for absolute file paths and rewrites
+ * Rehype plugin that scans text nodes for file paths and rewrites
  * each match as an `<a href="claudettepath:…">` element. The MARKDOWN_COMPONENTS.a
  * override in `markdown.ts` recognises that scheme and routes clicks into a
- * Tauri command so the user's default app opens the file.
+ * workspace file opener when one is available.
  *
  * Skipped contexts: anywhere already inside `<code>`, `<pre>`, or `<a>`. We
  * don't want to mangle code samples (where slashes are syntactic) or stack
@@ -12,12 +12,31 @@ import type { Plugin } from "unified";
 import type { Element, ElementContent, Root, Text } from "hast";
 import { visitParents } from "unist-util-visit-parents";
 
-import { detectFilePaths, encodeFilePathHref } from "./filePathLinks";
+import {
+  detectFileReferences,
+  encodeFilePathHref,
+  isLikelyRelativeFileReference,
+} from "./filePathLinks";
 
 const SKIP_TAGS = new Set(["code", "pre", "a"]);
 
 export const rehypeFilePathLinks: Plugin<[], Root> = () => {
   return (tree) => {
+    visitParents(tree, "element", (node: Element) => {
+      if (node.tagName !== "a") return;
+      const href =
+        typeof node.properties?.href === "string" ? node.properties.href : "";
+      const text = singleTextChild(node);
+      if (!href || !text || !isLikelyRelativeFileReference(text)) return;
+      if (!isAutolinkedFileReference(href, text)) return;
+
+      node.properties = {
+        ...node.properties,
+        href: encodeFilePathHref(text),
+        className: mergeClassName(node.properties.className, "cc-file-path-link"),
+      };
+    });
+
     visitParents(tree, "text", (node: Text, ancestors) => {
       // unist-util-visit-parents passes the ancestor chain root-first.
       // Any element ancestor that's a code/pre/a means we're inside one
@@ -28,7 +47,7 @@ export const rehypeFilePathLinks: Plugin<[], Root> = () => {
         }
       }
 
-      const matches = detectFilePaths(node.value);
+      const matches = detectFileReferences(node.value);
       if (matches.length === 0) return;
 
       const replacement: ElementContent[] = [];
@@ -66,3 +85,29 @@ export const rehypeFilePathLinks: Plugin<[], Root> = () => {
     });
   };
 };
+
+function singleTextChild(node: Element): string | null {
+  if (node.children.length !== 1) return null;
+  const child = node.children[0];
+  return child.type === "text" ? child.value.trim() : null;
+}
+
+function isAutolinkedFileReference(href: string, text: string): boolean {
+  const normalizedText = text.trim();
+  const normalizedHref = href.trim();
+  if (normalizedHref === normalizedText) return true;
+  return /^https?:\/\//i.test(normalizedHref)
+    && normalizedHref.replace(/^https?:\/\//i, "") === normalizedText;
+}
+
+function mergeClassName(
+  value: unknown,
+  className: string,
+): string[] {
+  const current = Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : typeof value === "string"
+      ? value.split(/\s+/).filter(Boolean)
+      : [];
+  return current.includes(className) ? current : [...current, className];
+}

--- a/src/ui/src/utils/rehypeFilePathLinks.ts
+++ b/src/ui/src/utils/rehypeFilePathLinks.ts
@@ -66,7 +66,7 @@ export const rehypeFilePathLinks: Plugin<[], Root> = () => {
             href: encodeFilePathHref(m.path),
             className: ["cc-file-path-link"],
           },
-          children: [{ type: "text", value: m.path }],
+          children: [{ type: "text", value: m.text ?? m.path }],
         });
         cursor = m.end;
       }


### PR DESCRIPTION
## Summary

- Treat agent-mentioned workspace file references like `README.md`, `CLAUDETTE_TEST.md`, `Cargo.toml`, `src/main.rs`, and `@README.md` as file links only when they resolve inside the current workspace.
- Route chat file-link clicks through Monaco, including Codex-style localhost file URLs such as `http://localhost:14254/Users/.../file.md:1` and same-origin absolute path hrefs such as `/Users/.../README.md:8`.
- Preserve line/column/range suffixes when opening in Monaco so the editor selects and reveals the requested location.
- Render local file URLs with compact inline file labels like `README.md:8` or `website/guide/quickstart.md:6`, not full localhost URLs.
- Keep chat mounted while Monaco or the diff viewer is active so opening/closing files does not reset the chat scroll position.
- Keep chat scroll restoration state component-scoped and prune entries when sessions disappear.
- Make inline file-link buttons use pointer cursors across markdown, user-message mentions, and tool activity rows.
- Make inline edit summaries clickable; when a matching diff is available, selecting the filename opens/highlights that diff, otherwise it falls back to opening the file in Monaco.
- Keep real external URLs clickable by normalizing `www.*` anchors to `https://...` and sending HTTP(S)/mailto links through `open_url` instead of webview navigation.
- Clear closed file-tab metadata so a file opened from chat can be closed and then opened from the same chat link again.
- Bound the workspace file-index cache, retry transient index-load failures, consume one-shot reveal targets after Monaco applies them, and document the behavior in the parallel agents docs.

## Root Cause

`remark-gfm` can autolink bare filename-looking text when the suffix is also a valid TLD, so `README.md` could become an external-style anchor. The existing file-path post-processor only handled plain text and skipped text already inside anchors, leaving those filename anchors on the browser/navigation path.

Some agents also emit local file references as localhost URLs. In the webview, those can arrive as either `http://localhost:14254/Users/.../file:line` URLs or same-origin absolute path anchors like `/Users/.../file:line`; the latter bypassed the localhost decoder entirely.

The close/reopen flash had two UI causes: `FileViewer` consumed stale close-tab nonces when a file was reopened, and the app layout unmounted chat whenever Monaco/diff took over the center pane. The first immediately closed reopened files; the second reset the chat scroll position.

## Implementation Notes

- File links render as buttons instead of navigable anchors when they target workspace files, preventing webview navigation/reset flashes.
- Markdown file buttons require workspace-index resolution whenever a resolver is available, including bare filename links, `@file` mentions, and compact labels derived from localhost file URLs.
- Monaco reveal state stores line/range metadata separately from the tab path and clears the matching nonce once applied, so returning to a tab does not clobber cursor selection.
- Inline-code and `@file` mention resolution use one `listWorkspaceFiles` index per workspace refresh, backed by `Set`/`Map` lookups and a small cache cap. Rejected index loads are evicted so the next render can retry.
- `@file` links require workspace-index verification so agent/user handles and emails remain plain text.
- Localhost URL and same-origin path decoding now use an explicit local-path classifier for rooted filesystem paths (`/Users/...`, `/home/...`, `~/...`, Windows drives, UNC paths, workspace roots). That avoids extension whack-a-mole for generated assets while still rejecting normal app routes.
- Chat, file, and diff center panes now stack in the layout; chat is hidden with `visibility` rather than unmounted or `display:none`, preserving the DOM scroll position.
- Chat scroll restoration uses component-owned refs and removes saved entries for sessions that are no longer present.
- Inline edit summaries select an existing diff tab target when `diffFiles`/`diffStagedFiles` contain the edited file; otherwise they open the source file.

## Tests

- `cd src/ui && bun run test -- src/components/chat/MessagesWithTurns.test.tsx src/utils/markdown.test.ts src/components/file-viewer/FileViewer.test.tsx src/hooks/useStickyScroll.test.tsx`
- `cd src/ui && bunx tsc -b`
- Previous pass also covered: `src/components/chat/ToolActivityRow.test.tsx`, `src/utils/filePathLinks.test.ts`, `src/utils/rehypeFilePathLinks.test.ts`, `src/components/chat/useWorkspaceFileIndex.test.tsx`, and `src/stores/useAppStore.fileTree.test.ts`
- `cd src/ui && bun run lint` (passes with existing unrelated warnings)
- `cd src/ui && bun run lint:css`
- `git diff --check`

## UAT

- Verified in the running dev app via `/claudette-debug` that opening and closing `README.md:8` preserves chat scroll position (`420` before, during, and after) and that file-link cursor style computes to `pointer`.
- Verified the stale close nonce no longer closes reopened file tabs immediately.
