### PR TITLE
feat(theme): add semantic design tokens and Base16 auto-import

### DIFF
--- a/site/src/content/docs/features/theming.mdx
+++ b/site/src/content/docs/features/theming.mdx
@@ -93,9 +93,38 @@ Each file must be valid JSON with the following structure:
 
 Any property you omit inherits the value from the **Default Dark** theme. You only need to specify the tokens you want to change — a theme file containing a single accent override is valid and will render correctly, with every other surface falling back to the default palette.
 
+## Importing Base16 Themes
+
+Claudette auto-detects and imports themes from the [Base16](https://github.com/tinted-theming/schemes) family — a community palette format that defines a theme with just 16 colors (`base00`–`base0F`). Drop a canonical Base16 JSON file into `~/.claudette/themes/`, restart, and it shows up in the theme picker alongside any native Claudette themes.
+
+Detection is automatic: a file is treated as Base16 if it has all 16 `base00`–`base0F` keys at the top level (each a 3- or 6-char hex with or without a leading `#`) and does **not** also declare any native Claudette tokens like `accent-primary` or `app-bg`. A file with both is treated as a Claudette theme — its author already chose what to map.
+
+The 16 base colors map onto Claudette's token vocabulary as follows:
+
+| Base16 | Role | → Claudette tokens |
+|---|---|---|
+| `base00` | default background | `app-bg`, `terminal-bg` |
+| `base01` | lighter background | `sidebar-bg`, `chat-header-bg`, `terminal-tab-bg` |
+| `base02` | selection background | `selected-bg`, `terminal-tab-active-bg` |
+| `base03` | comments / faint | `text-faint`, `syntax-comment`, `diff-line-number` |
+| `base04` | dark foreground | `text-dim`, `accent-neutral` |
+| `base05` | default foreground | `text-primary`, `terminal-fg` |
+| `base06` | light foreground | `text-muted` |
+| `base07` | lightest | `on-accent` |
+| `base08` | red | `accent-error`, `status-stopped`, `diff-removed-text`, `syntax-variable` |
+| `base09` | orange | `accent-warning`, `syntax-number` |
+| `base0A` | yellow | `badge-ask`, `syntax-type` |
+| `base0B` | green | `accent-success`, `badge-done`, `diff-added-text`, `syntax-string` |
+| `base0C` | cyan | `syntax-operator` |
+| `base0D` | blue | `accent-info`, `badge-plan`, `diff-hunk-header`, `syntax-function` |
+| `base0E` | purple | `accent-primary`, `syntax-keyword` |
+| `base0F` | brown | `accent-dim`, `accent-secondary` |
+
+The light/dark `color-scheme` is read from an optional `variant: "light"` or `variant: "dark"` field if present, otherwise inferred from `base00`'s relative luminance. The conversion happens in-memory at load time — no Claudette-format file is written back to disk.
+
 ## Color Properties Reference
 
-You can customize any of the following 57 CSS custom properties.
+You can customize any of the following CSS custom properties.
 
 ### Scheme
 
@@ -172,6 +201,46 @@ You can customize any of the following 57 CSS custom properties.
 | `badge-done` | Agent finished badge color |
 | `badge-plan` | Plan awaiting review badge color |
 | `badge-ask` | Agent question badge color |
+
+### Semantic Accents
+
+Semantic tokens express **meaning**, not color. New consumers should prefer these over the older `badge-*`, `status-*`, and `error-*` tokens. Every default derives from an existing token (`accent-success` from `badge-done`, `accent-error` from `status-stopped`, etc.) so a theme that omits them still renders coherently.
+
+| Property | Description |
+|----------|-------------|
+| `accent-success` | Successful action / positive confirmation |
+| `accent-success-rgb` | RGB triplet for `rgba(var(...), alpha)` layering — **always co-emit** with `accent-success` |
+| `accent-success-bg` | Tinted surface for success banners |
+| `accent-warning` | Caution / non-fatal warning |
+| `accent-warning-rgb` | RGB triplet for warning alpha layers |
+| `accent-warning-bg` | Tinted surface for warning banners |
+| `accent-error` | Error / destructive action |
+| `accent-error-rgb` | RGB triplet for error alpha layers |
+| `accent-error-bg` | Tinted surface for error banners |
+| `accent-info` | Informational / neutral notice |
+| `accent-info-rgb` | RGB triplet for info alpha layers |
+| `accent-info-bg` | Tinted surface for info banners |
+| `accent-neutral` | Muted emphasis text or icon — defaults to `text-muted` |
+| `accent-secondary` | Secondary brand accent — defaults to `mascot-pink` |
+
+:::caution
+The `-rgb` companion tokens are a CSS workaround: there is no way to extract `r,g,b` channels from a `var(--*)` value, so any `rgba(var(--*-rgb), alpha)` consumer needs both tokens to render. If you override `accent-success`, **always** override `accent-success-rgb` with the same color expressed as a comma-separated triplet (e.g. `"108, 204, 128"`).
+:::
+
+### Syntax Highlights
+
+Eight tokens that mirror Base16's `base08`–`base0F` semantic roles so syntax-highlight surfaces can share a vocabulary with imported Base16 themes. These are intentionally **brand-invariant** — they ship on `:root` and most themes inherit them unchanged.
+
+| Property | Description |
+|----------|-------------|
+| `syntax-keyword` | Control flow / `if`, `for`, `return` (base0E — purple) |
+| `syntax-string` | String literals (base0B — green) |
+| `syntax-number` | Numeric and boolean constants (base09 — orange) |
+| `syntax-comment` | Comments and docs (base03 — faint) |
+| `syntax-function` | Function and method names (base0D — blue) |
+| `syntax-type` | Types, classes, search highlights (base0A — yellow) |
+| `syntax-variable` | Variables and punctuation (base08 — red) |
+| `syntax-operator` | Operators and regular expressions (base0C — cyan) |
 
 ### Diff View
 

--- a/site/src/content/docs/features/theming.mdx
+++ b/site/src/content/docs/features/theming.mdx
@@ -105,22 +105,26 @@ The 16 base colors map onto Claudette's token vocabulary as follows:
 |---|---|---|
 | `base00` | default background | `app-bg`, `terminal-bg` |
 | `base01` | lighter background | `sidebar-bg`, `chat-header-bg`, `terminal-tab-bg` |
-| `base02` | selection background | `selected-bg`, `terminal-tab-active-bg` |
-| `base03` | comments / faint | `text-faint`, `syntax-comment`, `diff-line-number` |
-| `base04` | dark foreground | `text-dim`, `accent-neutral` |
+| `base02` | selection background | `selected-bg`, `terminal-tab-active-bg`, `divider` |
+| `base03` | comments / faint | `text-faint`, `text-dim`, `syntax-comment`, `diff-line-number` |
+| `base04` | dimmer foreground | `text-muted`, `accent-neutral` |
 | `base05` | default foreground | `text-primary`, `terminal-fg` |
-| `base06` | light foreground | `text-muted` |
+| `base06` | bright foreground emphasis | _unmapped — see note below_ |
 | `base07` | lightest | `on-accent` |
-| `base08` | red | `accent-error`, `status-stopped`, `diff-removed-text`, `syntax-variable` |
-| `base09` | orange | `accent-warning`, `syntax-number` |
+| `base08` | red | `accent-error` (+ triplet), `status-stopped`, `diff-removed-text`, `syntax-variable` |
+| `base09` | orange | `accent-warning` (+ triplet), `syntax-number` |
 | `base0A` | yellow | `badge-ask`, `syntax-type` |
-| `base0B` | green | `accent-success`, `badge-done`, `diff-added-text`, `syntax-string` |
+| `base0B` | green | `accent-success` (+ triplet), `badge-done`, `diff-added-text`, `syntax-string` |
 | `base0C` | cyan | `syntax-operator` |
-| `base0D` | blue | `accent-info`, `badge-plan`, `diff-hunk-header`, `syntax-function` |
-| `base0E` | purple | `accent-primary`, `syntax-keyword` |
-| `base0F` | brown | `accent-dim`, `accent-secondary` |
+| `base0D` | blue | `accent-info` (+ triplet), `badge-plan`, `diff-hunk-header`, `syntax-function` |
+| `base0E` | purple | `accent-primary`, `accent-tertiary` (+ triplet), `syntax-keyword` |
+| `base0F` | brown | `accent-dim`, `accent-secondary` (+ triplet) |
 
-The light/dark `color-scheme` is read from an optional `variant: "light"` or `variant: "dark"` field if present, otherwise inferred from `base00`'s relative luminance. The conversion happens in-memory at load time — no Claudette-format file is written back to disk.
+:::note
+**Text ramp mapping** — Claudette's `text-primary` → `text-muted` → `text-dim` → `text-faint` is a hierarchy of decreasing contrast against the background. In Base16's "ramp" (`base03`–`base06`), `base06` is actually *brighter* than `base05` (it's an emphasis tone, not a muted one), so it doesn't fit the "muted" role and is left unmapped. The muted/dim steps use `base04` and `base03` instead.
+:::
+
+The light/dark `color-scheme` is read from an optional `variant: "light"` or `variant: "dark"` field if present, otherwise inferred from `base00`'s relative luminance. Base key names are case-insensitive (`base0A` and `base0a` both work). The conversion happens in-memory at load time — no Claudette-format file is written back to disk.
 
 ## Color Properties Reference
 
@@ -204,28 +208,61 @@ You can customize any of the following CSS custom properties.
 
 ### Semantic Accents
 
-Semantic tokens express **meaning**, not color. New consumers should prefer these over the older `badge-*`, `status-*`, and `error-*` tokens. Every default derives from an existing token (`accent-success` from `badge-done`, `accent-error` from `status-stopped`, etc.) so a theme that omits them still renders coherently.
+Semantic tokens express **meaning**, not color. New consumers should prefer these over the older `badge-*`, `status-*`, and `error-*` tokens. Each family is a **five-token group**: the base color, an RGB triplet companion, plus pre-derived `-bg` / `-border` / `-fg` layers. A chip-style component can compose a filled-and-bordered surface from tokens alone — no `color-mix()` calls or per-component alpha math.
 
 | Property | Description |
 |----------|-------------|
 | `accent-success` | Successful action / positive confirmation |
-| `accent-success-rgb` | RGB triplet for `rgba(var(...), alpha)` layering — **always co-emit** with `accent-success` |
-| `accent-success-bg` | Tinted surface for success banners |
-| `accent-warning` | Caution / non-fatal warning |
-| `accent-warning-rgb` | RGB triplet for warning alpha layers |
-| `accent-warning-bg` | Tinted surface for warning banners |
-| `accent-error` | Error / destructive action |
-| `accent-error-rgb` | RGB triplet for error alpha layers |
-| `accent-error-bg` | Tinted surface for error banners |
-| `accent-info` | Informational / neutral notice |
-| `accent-info-rgb` | RGB triplet for info alpha layers |
-| `accent-info-bg` | Tinted surface for info banners |
+| `accent-success-rgb` | RGB triplet — `accent-success-bg` and `-border` derive from this |
+| `accent-success-bg` | Tinted surface (10% alpha) |
+| `accent-success-border` | Outline (30% alpha) |
+| `accent-success-fg` | Foreground text color when used on `accent-success-bg` |
+| `accent-warning` | Caution / non-fatal warning (and `-rgb`, `-bg`, `-border`, `-fg`) |
+| `accent-error` | Error / destructive action (and `-rgb`, `-bg`, `-border`, `-fg`) |
+| `accent-info` | Informational / neutral notice (and `-rgb`, `-bg`, `-border`, `-fg`) |
 | `accent-neutral` | Muted emphasis text or icon — defaults to `text-muted` |
-| `accent-secondary` | Secondary brand accent — defaults to `mascot-pink` |
+| `accent-secondary` | Secondary brand accent (and `-rgb`, `-bg`, `-border`, `-fg`) |
+| `accent-tertiary` | Tertiary brand accent (and `-rgb`, `-bg`, `-border`, `-fg`) |
+
+:::tip
+Overriding an accent in a custom theme is a **two-token** change: set the base color and its `-rgb` companion. The `-bg` / `-border` / `-fg` layers are pre-derived from `-rgb` in `:root`, so they automatically pick up your color.
+
+```json
+"accent-success":     "#1a7f37",
+"accent-success-rgb": "26, 127, 55"
+```
+
+If you also override `-bg` / `-border` / `-fg` directly, your literal values win. The pre-derived layers only apply when those tokens aren't set.
+:::
 
 :::caution
-The `-rgb` companion tokens are a CSS workaround: there is no way to extract `r,g,b` channels from a `var(--*)` value, so any `rgba(var(--*-rgb), alpha)` consumer needs both tokens to render. If you override `accent-success`, **always** override `accent-success-rgb` with the same color expressed as a comma-separated triplet (e.g. `"108, 204, 128"`).
+The `-rgb` companion tokens are a CSS workaround: there is no way to extract `r,g,b` channels from a `var(--*)` value, so any `rgba(var(--*-rgb), alpha)` consumer needs both tokens. **Always** co-emit `accent-success-rgb` with `accent-success`.
 :::
+
+### Category Slots (A–H)
+
+Eight pre-styled chip palettes for "item N of a set" UI — workspace tags, plugin types, env-provider chips. Each slot is brand-invariant by design: the color identity of "category C" stays stable across themes so muscle memory holds.
+
+Each slot ships as a `-bg` / `-border` / `-fg` triplet (no `-rgb` companion — these aren't expected to be alpha-composed at the call site). Use them directly:
+
+```css
+.workspace-tag {
+  background: var(--category-c-bg);
+  border: 1px solid var(--category-c-border);
+  color:  var(--category-c-fg);
+}
+```
+
+| Property | Default hue |
+|----------|-------------|
+| `category-a-bg` / `-border` / `-fg` | Rose |
+| `category-b-bg` / `-border` / `-fg` | Orange |
+| `category-c-bg` / `-border` / `-fg` | Amber |
+| `category-d-bg` / `-border` / `-fg` | Green |
+| `category-e-bg` / `-border` / `-fg` | Teal |
+| `category-f-bg` / `-border` / `-fg` | Blue |
+| `category-g-bg` / `-border` / `-fg` | Purple |
+| `category-h-bg` / `-border` / `-fg` | Pink |
 
 ### Syntax Highlights
 

--- a/site/src/content/docs/features/theming.mdx
+++ b/site/src/content/docs/features/theming.mdx
@@ -97,7 +97,29 @@ Any property you omit inherits the value from the **Default Dark** theme. You on
 
 Claudette auto-detects and imports themes from the [Base16](https://github.com/tinted-theming/schemes) family — a community palette format that defines a theme with just 16 colors (`base00`–`base0F`). Drop a canonical Base16 JSON file into `~/.claudette/themes/`, restart, and it shows up in the theme picker alongside any native Claudette themes.
 
-Detection is automatic: a file is treated as Base16 if it has all 16 `base00`–`base0F` keys at the top level (each a 3- or 6-char hex with or without a leading `#`) and does **not** also declare any native Claudette tokens like `accent-primary` or `app-bg`. A file with both is treated as a Claudette theme — its author already chose what to map.
+Two on-disk shapes are recognized:
+
+1. **Flat** — `base00`, `base01`, ... directly at the top level. This is the legacy Base16 JSON shape used by many community generators.
+
+2. **Nested under `palette`** — the current Tinted Theming spec (0.11+) wraps the base keys in a `palette` object alongside top-level `system`, `name`, `variant`, `author` fields:
+
+   ```json
+   {
+     "system": "base16",
+     "name": "Tomorrow Night",
+     "variant": "dark",
+     "palette": {
+       "base00": "1d1f21",
+       "base01": "282a2e",
+       "...": "...",
+       "base0F": "a3685a"
+     }
+   }
+   ```
+
+   YAML schemes from `tinted-theming/schemes` use this shape; running them through any YAML→JSON converter and dropping the result into `~/.claudette/themes/` works directly.
+
+Detection is automatic: a file is treated as Base16 if it provides all 16 `base00`–`base0F` slots (either shape, hex values 3- or 6-char with or without a leading `#`) and does **not** also declare any native Claudette tokens like `accent-primary` or `app-bg`. A file with both is treated as a Claudette theme — its author already chose what to map.
 
 The 16 base colors map onto Claudette's token vocabulary as follows:
 
@@ -208,35 +230,30 @@ You can customize any of the following CSS custom properties.
 
 ### Semantic Accents
 
-Semantic tokens express **meaning**, not color. New consumers should prefer these over the older `badge-*`, `status-*`, and `error-*` tokens. Each family is a **five-token group**: the base color, an RGB triplet companion, plus pre-derived `-bg` / `-border` / `-fg` layers. A chip-style component can compose a filled-and-bordered surface from tokens alone — no `color-mix()` calls or per-component alpha math.
+Semantic tokens express **meaning**, not color. New consumers should prefer these over the older `badge-*`, `status-*`, and `error-*` tokens. Each family is a **five-token group**: the base color, plus pre-derived `-bg` / `-border` / `-hover` / `-fg` layers. A chip-style component can compose a filled-and-bordered surface (with a hover state) from tokens alone — no `color-mix()` calls or per-component alpha math.
 
 | Property | Description |
 |----------|-------------|
-| `accent-success` | Successful action / positive confirmation |
-| `accent-success-rgb` | RGB triplet — `accent-success-bg` and `-border` derive from this |
-| `accent-success-bg` | Tinted surface (10% alpha) |
+| `accent-success` | Successful action / positive confirmation. Aliases `--badge-done` by default. |
+| `accent-success-bg` | Tinted surface (10% alpha of base, via `color-mix()`) |
 | `accent-success-border` | Outline (30% alpha) |
+| `accent-success-hover` | Hover state for interactive surfaces (15% alpha) |
 | `accent-success-fg` | Foreground text color when used on `accent-success-bg` |
-| `accent-warning` | Caution / non-fatal warning (and `-rgb`, `-bg`, `-border`, `-fg`) |
-| `accent-error` | Error / destructive action (and `-rgb`, `-bg`, `-border`, `-fg`) |
-| `accent-info` | Informational / neutral notice (and `-rgb`, `-bg`, `-border`, `-fg`) |
-| `accent-neutral` | Muted emphasis text or icon — defaults to `text-muted` |
-| `accent-secondary` | Secondary brand accent (and `-rgb`, `-bg`, `-border`, `-fg`) |
-| `accent-tertiary` | Tertiary brand accent (and `-rgb`, `-bg`, `-border`, `-fg`) |
+| `accent-warning` | Caution / non-fatal warning (and `-bg`, `-border`, `-hover`, `-fg`) |
+| `accent-error` | Error / destructive action. Aliases `--status-stopped` by default. (and full triplet) |
+| `accent-info` | Informational / neutral notice. Aliases `--badge-plan` by default. (and full triplet) |
+| `accent-neutral` | Muted emphasis text or icon — aliases `--text-muted` |
+| `accent-secondary` | Secondary brand accent. Aliases `--mascot-pink` by default. (and `-bg`, `-border`, `-fg`) |
+| `accent-tertiary` | Tertiary brand accent (and `-bg`, `-border`, `-fg`) |
 
 :::tip
-Overriding an accent in a custom theme is a **two-token** change: set the base color and its `-rgb` companion. The `-bg` / `-border` / `-fg` layers are pre-derived from `-rgb` in `:root`, so they automatically pick up your color.
+Overriding an accent in a custom theme is a **single-token change**: set the base color. The `-bg` / `-border` / `-hover` / `-fg` layers are derived from the base via `color-mix(in srgb, var(--accent-X) N%, transparent)` in `:root`, so they automatically pick up your override.
 
 ```json
-"accent-success":     "#1a7f37",
-"accent-success-rgb": "26, 127, 55"
+"accent-success": "#1a7f37"
 ```
 
-If you also override `-bg` / `-border` / `-fg` directly, your literal values win. The pre-derived layers only apply when those tokens aren't set.
-:::
-
-:::caution
-The `-rgb` companion tokens are a CSS workaround: there is no way to extract `r,g,b` channels from a `var(--*)` value, so any `rgba(var(--*-rgb), alpha)` consumer needs both tokens. **Always** co-emit `accent-success-rgb` with `accent-success`.
+Because `--accent-success` aliases `--badge-done`, a theme that overrides only `--badge-done` *also* gets a matching success family for free. If you want to break that link, override `--accent-success` explicitly. If you want to override the derived layers directly with literal `rgba()`/`color-mix()` values, your overrides win — the derivation only applies when those tokens aren't set.
 :::
 
 ### Category Slots (A–H)
@@ -276,8 +293,8 @@ Eight tokens that mirror Base16's `base08`–`base0F` semantic roles so syntax-h
 | `syntax-comment` | Comments and docs (base03 — faint) |
 | `syntax-function` | Function and method names (base0D — blue) |
 | `syntax-type` | Types, classes, search highlights (base0A — yellow) |
-| `syntax-variable` | Variables and punctuation (base08 — red) |
-| `syntax-operator` | Operators and regular expressions (base0C — cyan) |
+| `syntax-variable` | Variables (base08 — red) |
+| `syntax-operator` | Operators, punctuation, separators, terminators, braces, regexp (base0C — cyan) |
 
 ### Diff View
 

--- a/site/src/content/docs/features/theming.mdx
+++ b/site/src/content/docs/features/theming.mdx
@@ -133,14 +133,16 @@ The 16 base colors map onto Claudette's token vocabulary as follows:
 | `base05` | default foreground | `text-primary`, `terminal-fg` |
 | `base06` | bright foreground emphasis | _unmapped — see note below_ |
 | `base07` | lightest | `on-accent` |
-| `base08` | red | `accent-error` (+ triplet), `status-stopped`, `diff-removed-text`, `syntax-variable` |
-| `base09` | orange | `accent-warning` (+ triplet), `syntax-number` |
+| `base08` | red | `accent-error` family, `status-stopped`, `diff-removed-text`, `syntax-variable` |
+| `base09` | orange | `accent-warning` family, `syntax-number` |
 | `base0A` | yellow | `badge-ask`, `syntax-type` |
-| `base0B` | green | `accent-success` (+ triplet), `badge-done`, `diff-added-text`, `syntax-string` |
+| `base0B` | green | `accent-success` family, `badge-done`, `diff-added-text`, `syntax-string` |
 | `base0C` | cyan | `syntax-operator` |
-| `base0D` | blue | `accent-info` (+ triplet), `badge-plan`, `diff-hunk-header`, `syntax-function` |
-| `base0E` | purple | `accent-primary`, `accent-tertiary` (+ triplet), `syntax-keyword` |
-| `base0F` | brown | `accent-dim`, `accent-secondary` (+ triplet) |
+| `base0D` | blue | `accent-info` family, `badge-plan`, `diff-hunk-header`, `syntax-function` |
+| `base0E` | purple | `accent-primary`, `accent-tertiary` family, `syntax-keyword` |
+| `base0F` | brown | `accent-dim`, `accent-secondary` family |
+
+"family" above means the base color plus its derived `-bg` / `-border` / `-hover` / `-fg` companions. The base16 converter sets only the base; the companions derive in `:root` via `color-mix()`, so the whole family adapts together.
 
 :::note
 **Text ramp mapping** — Claudette's `text-primary` → `text-muted` → `text-dim` → `text-faint` is a hierarchy of decreasing contrast against the background. In Base16's "ramp" (`base03`–`base06`), `base06` is actually *brighter* than `base05` (it's an emphasis tone, not a muted one), so it doesn't fit the "muted" role and is left unmapped. The muted/dim steps use `base04` and `base03` instead.
@@ -240,11 +242,11 @@ Semantic tokens express **meaning**, not color. New consumers should prefer thes
 | `accent-success-hover` | Hover state for interactive surfaces (15% alpha) |
 | `accent-success-fg` | Foreground text color when used on `accent-success-bg` |
 | `accent-warning` | Caution / non-fatal warning (and `-bg`, `-border`, `-hover`, `-fg`) |
-| `accent-error` | Error / destructive action. Aliases `--status-stopped` by default. (and full triplet) |
-| `accent-info` | Informational / neutral notice. Aliases `--badge-plan` by default. (and full triplet) |
+| `accent-error` | Error / destructive action. Aliases `--status-stopped` by default. (and `-bg`, `-border`, `-hover`, `-fg`) |
+| `accent-info` | Informational / neutral notice. Aliases `--badge-plan` by default. (and `-bg`, `-border`, `-hover`, `-fg`) |
 | `accent-neutral` | Muted emphasis text or icon — aliases `--text-muted` |
-| `accent-secondary` | Secondary brand accent. Aliases `--mascot-pink` by default. (and `-bg`, `-border`, `-fg`) |
-| `accent-tertiary` | Tertiary brand accent (and `-bg`, `-border`, `-fg`) |
+| `accent-secondary` | Secondary brand accent. Aliases `--mascot-pink` by default. (and `-bg`, `-border`, `-fg` — no `-hover`) |
+| `accent-tertiary` | Tertiary brand accent (and `-bg`, `-border`, `-fg` — no `-hover`) |
 
 :::tip
 Overriding an accent in a custom theme is a **single-token change**: set the base color. The `-bg` / `-border` / `-hover` / `-fg` layers are derived from the base via `color-mix(in srgb, var(--accent-X) N%, transparent)` in `:root`, so they automatically pick up your override.
@@ -258,7 +260,9 @@ Because `--accent-success` aliases `--badge-done`, a theme that overrides only `
 
 ### Category Slots (A–H)
 
-Eight pre-styled chip palettes for "item N of a set" UI — workspace tags, plugin types, env-provider chips. Each slot is brand-invariant by design: the color identity of "category C" stays stable across themes so muscle memory holds.
+Eight pre-styled chip palettes for "item N of a set" UI — plugin badges, env-provider chips, future workspace tags. The default palette is brand-invariant: the same eight hues appear across most themes so the color identity of "category C" stays recognizable when users switch theme.
+
+Themes with a strong canonical palette (Rosé Pine, Solarized) deliberately override these slots in their `[data-theme]` block so chips render in the theme's own native colors. If you're authoring a custom theme and your palette has its own identity, follow that pattern.
 
 Each slot ships as a `-bg` / `-border` / `-fg` triplet (no `-rgb` companion — these aren't expected to be alpha-composed at the call site). Use them directly:
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -460,6 +460,56 @@ pub fn run_notification_command(
     Ok(())
 }
 
+/// Parse a single user-theme JSON file. Tries the native Claudette shape first
+/// (id/name/colors), then falls back to a permissive shape that accepts
+/// Base16 schemes: any JSON object whose top-level string fields include the
+/// 16 `base00`–`base0F` keys is captured as `colors`, with `id` synthesized
+/// from `file_stem` and `name` from the `scheme`/`name` field. Conversion to
+/// Claudette tokens happens in the frontend (see utils/theme.ts).
+///
+/// Returns `None` if the file is neither parseable nor a recognizable base16
+/// scheme — callers log and skip in that case.
+fn parse_theme_file(content: &str, file_stem: &str) -> Option<ThemeDefinition> {
+    if let Ok(theme) = serde_json::from_str::<ThemeDefinition>(content) {
+        return Some(theme);
+    }
+
+    let raw: HashMap<String, serde_json::Value> = serde_json::from_str(content).ok()?;
+    const BASE16_KEYS: [&str; 16] = [
+        "base00", "base01", "base02", "base03", "base04", "base05", "base06", "base07", "base08",
+        "base09", "base0A", "base0B", "base0C", "base0D", "base0E", "base0F",
+    ];
+    let has_full_base16 = BASE16_KEYS
+        .iter()
+        .all(|k| raw.get(*k).and_then(|v| v.as_str()).is_some());
+    if !has_full_base16 {
+        return None;
+    }
+
+    // Capture every string-valued top-level field so the frontend converter
+    // can read `variant`, `scheme`, etc. alongside the base16 hex values.
+    let colors: HashMap<String, String> = raw
+        .iter()
+        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+        .collect();
+
+    let name = colors
+        .get("scheme")
+        .or_else(|| colors.get("name"))
+        .cloned()
+        .unwrap_or_else(|| file_stem.to_string());
+    let author = colors.get("author").cloned();
+    let description = colors.get("description").cloned();
+
+    Some(ThemeDefinition {
+        id: file_stem.to_string(),
+        name,
+        author,
+        description,
+        colors,
+    })
+}
+
 #[tauri::command]
 pub async fn list_user_themes() -> Result<Vec<ThemeDefinition>, String> {
     tauri::async_runtime::spawn_blocking(|| {
@@ -522,13 +572,17 @@ pub async fn list_user_themes() -> Result<Vec<ThemeDefinition>, String> {
                 }
             };
 
-            match serde_json::from_str::<ThemeDefinition>(&content) {
-                Ok(theme) => themes.push(theme),
-                Err(e) => tracing::warn!(
+            let file_stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unnamed");
+
+            match parse_theme_file(&content, file_stem) {
+                Some(theme) => themes.push(theme),
+                None => tracing::warn!(
                     target: "claudette::ui",
                     path = %path.display(),
-                    error = %e,
-                    "skipping theme file: parse failed"
+                    "skipping theme file: not a Claudette or base16 scheme"
                 ),
             }
         }
@@ -549,6 +603,83 @@ mod tests {
         assert!(sounds.len() >= 2);
         assert_eq!(sounds[0], "Default");
         assert_eq!(sounds[1], "None");
+    }
+
+    #[test]
+    fn parse_theme_file_native_claudette_shape() {
+        let content = r##"{
+            "id": "my-theme",
+            "name": "My Theme",
+            "author": "alice",
+            "colors": {
+                "accent-primary": "#ff00aa",
+                "app-bg": "#111111"
+            }
+        }"##;
+        let theme = parse_theme_file(content, "my-theme").expect("should parse");
+        assert_eq!(theme.id, "my-theme");
+        assert_eq!(theme.name, "My Theme");
+        assert_eq!(theme.author.as_deref(), Some("alice"));
+        assert_eq!(
+            theme.colors.get("accent-primary").map(|s| s.as_str()),
+            Some("#ff00aa")
+        );
+    }
+
+    #[test]
+    fn parse_theme_file_canonical_base16() {
+        // Canonical Base16 Tomorrow Night (top-level baseXX keys, no `colors` wrapper).
+        let content = r#"{
+            "scheme": "Tomorrow Night",
+            "author": "Chris Kempson",
+            "base00": "1d1f21", "base01": "282a2e", "base02": "373b41", "base03": "969896",
+            "base04": "b4b7b4", "base05": "c5c8c6", "base06": "e0e0e0", "base07": "ffffff",
+            "base08": "cc6666", "base09": "de935f", "base0A": "f0c674", "base0B": "b5bd68",
+            "base0C": "8abeb7", "base0D": "81a2be", "base0E": "b294bb", "base0F": "a3685a"
+        }"#;
+        let theme = parse_theme_file(content, "tomorrow-night").expect("should parse");
+        assert_eq!(theme.id, "tomorrow-night");
+        assert_eq!(theme.name, "Tomorrow Night"); // from `scheme`
+        assert_eq!(theme.author.as_deref(), Some("Chris Kempson"));
+        // All 16 base keys preserved as-is for the frontend to convert.
+        for key in [
+            "base00", "base01", "base02", "base03", "base04", "base05", "base06", "base07",
+            "base08", "base09", "base0A", "base0B", "base0C", "base0D", "base0E", "base0F",
+        ] {
+            assert!(theme.colors.contains_key(key), "missing base16 key: {key}");
+        }
+    }
+
+    #[test]
+    fn parse_theme_file_base16_falls_back_to_stem_when_no_scheme() {
+        let content = r#"{
+            "base00": "000000", "base01": "111111", "base02": "222222", "base03": "333333",
+            "base04": "444444", "base05": "555555", "base06": "666666", "base07": "777777",
+            "base08": "880000", "base09": "990000", "base0A": "aa0000", "base0B": "bb0000",
+            "base0C": "cc0000", "base0D": "dd0000", "base0E": "ee0000", "base0F": "ff0000"
+        }"#;
+        let theme = parse_theme_file(content, "anon-scheme").expect("should parse");
+        assert_eq!(theme.id, "anon-scheme");
+        assert_eq!(theme.name, "anon-scheme");
+        assert!(theme.author.is_none());
+    }
+
+    #[test]
+    fn parse_theme_file_skips_partial_base16() {
+        // Missing base0F — not a complete base16 scheme, and not native Claudette.
+        let content = r#"{
+            "base00": "000000", "base01": "111111", "base02": "222222", "base03": "333333",
+            "base04": "444444", "base05": "555555", "base06": "666666", "base07": "777777",
+            "base08": "880000", "base09": "990000", "base0A": "aa0000", "base0B": "bb0000",
+            "base0C": "cc0000", "base0D": "dd0000", "base0E": "ee0000"
+        }"#;
+        assert!(parse_theme_file(content, "partial").is_none());
+    }
+
+    #[test]
+    fn parse_theme_file_skips_malformed_json() {
+        assert!(parse_theme_file("{ not valid json", "broken").is_none());
+        assert!(parse_theme_file("", "empty").is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -15,7 +15,7 @@ pub(crate) fn spawn_and_reap(mut child: std::process::Child) {
     });
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ThemeDefinition {
     pub id: String,
     pub name: String,
@@ -460,30 +460,68 @@ pub fn run_notification_command(
     Ok(())
 }
 
+/// Hex validation for Base16 slot values: accept `#rrggbb`, `rrggbb`,
+/// `#rgb`, or `rgb` (case-insensitive). Returns true if the string is a
+/// well-formed hex color.
+fn is_valid_hex_color(s: &str) -> bool {
+    let v = s.trim().strip_prefix('#').unwrap_or(s.trim());
+    (v.len() == 3 || v.len() == 6) && v.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Look up a Base16 slot tolerantly: real-world schemes in the wild use
+/// either `base0A` (Tinted Theming spec) or `base0a`. Accept both.
+fn read_base16_slot<'a>(
+    raw: &'a HashMap<String, serde_json::Value>,
+    suffix: &str,
+) -> Option<&'a str> {
+    let upper = format!("base{suffix}");
+    let lower = format!("base{}", suffix.to_lowercase());
+    raw.get(&upper)
+        .or_else(|| raw.get(&lower))
+        .and_then(|v| v.as_str())
+}
+
 /// Parse a single user-theme JSON file. Tries the native Claudette shape first
 /// (id/name/colors), then falls back to a permissive shape that accepts
-/// Base16 schemes: any JSON object whose top-level string fields include the
-/// 16 `base00`–`base0F` keys is captured as `colors`, with `id` synthesized
-/// from `file_stem` and `name` from the `scheme`/`name` field. Conversion to
-/// Claudette tokens happens in the frontend (see utils/theme.ts).
+/// Base16 schemes: any JSON object whose top-level fields include all 16
+/// `base00`–`base0F` slots with valid hex values is captured as `colors`,
+/// with `id` synthesized from `file_stem` and `name` from the `scheme`/`name`
+/// field. Conversion to Claudette tokens happens in the frontend (see
+/// utils/theme.ts).
 ///
-/// Returns `None` if the file is neither parseable nor a recognizable base16
-/// scheme — callers log and skip in that case.
-fn parse_theme_file(content: &str, file_stem: &str) -> Option<ThemeDefinition> {
-    if let Ok(theme) = serde_json::from_str::<ThemeDefinition>(content) {
-        return Some(theme);
-    }
+/// Returns `Err(reason)` if the file is neither a Claudette theme nor a
+/// well-formed Base16 scheme. Callers log the reason and skip — preserving
+/// the underlying error makes "malformed JSON" easy to distinguish from
+/// "valid JSON but unsupported shape" in the logs.
+fn parse_theme_file(content: &str, file_stem: &str) -> Result<ThemeDefinition, String> {
+    let native_err = match serde_json::from_str::<ThemeDefinition>(content) {
+        Ok(theme) => return Ok(theme),
+        Err(e) => e,
+    };
 
-    let raw: HashMap<String, serde_json::Value> = serde_json::from_str(content).ok()?;
-    const BASE16_KEYS: [&str; 16] = [
-        "base00", "base01", "base02", "base03", "base04", "base05", "base06", "base07", "base08",
-        "base09", "base0A", "base0B", "base0C", "base0D", "base0E", "base0F",
+    let raw: HashMap<String, serde_json::Value> = serde_json::from_str(content)
+        .map_err(|e| format!("invalid JSON: {e} (native parse: {native_err})"))?;
+
+    const BASE16_SUFFIXES: [&str; 16] = [
+        "00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "0A", "0B", "0C", "0D", "0E",
+        "0F",
     ];
-    let has_full_base16 = BASE16_KEYS
-        .iter()
-        .all(|k| raw.get(*k).and_then(|v| v.as_str()).is_some());
-    if !has_full_base16 {
-        return None;
+    // Every slot must exist AND be a valid hex string. Files that look almost
+    // base16 but ship malformed colors are skipped here so they never reach
+    // the frontend as broken Claudette themes.
+    let mut missing: Vec<String> = Vec::new();
+    for suffix in BASE16_SUFFIXES {
+        match read_base16_slot(&raw, suffix) {
+            Some(value) if is_valid_hex_color(value) => {}
+            Some(_) => missing.push(format!("base{suffix} (invalid hex)")),
+            None => missing.push(format!("base{suffix} (missing)")),
+        }
+    }
+    if !missing.is_empty() {
+        return Err(format!(
+            "not a Claudette theme (native parse: {native_err}); base16 fallback rejected: {}",
+            missing.join(", ")
+        ));
     }
 
     // Capture every string-valued top-level field so the frontend converter
@@ -501,7 +539,7 @@ fn parse_theme_file(content: &str, file_stem: &str) -> Option<ThemeDefinition> {
     let author = colors.get("author").cloned();
     let description = colors.get("description").cloned();
 
-    Some(ThemeDefinition {
+    Ok(ThemeDefinition {
         id: file_stem.to_string(),
         name,
         author,
@@ -578,11 +616,12 @@ pub async fn list_user_themes() -> Result<Vec<ThemeDefinition>, String> {
                 .unwrap_or("unnamed");
 
             match parse_theme_file(&content, file_stem) {
-                Some(theme) => themes.push(theme),
-                None => tracing::warn!(
+                Ok(theme) => themes.push(theme),
+                Err(reason) => tracing::warn!(
                     target: "claudette::ui",
                     path = %path.display(),
-                    "skipping theme file: not a Claudette or base16 scheme"
+                    reason = %reason,
+                    "skipping theme file"
                 ),
             }
         }
@@ -673,13 +712,65 @@ mod tests {
             "base08": "880000", "base09": "990000", "base0A": "aa0000", "base0B": "bb0000",
             "base0C": "cc0000", "base0D": "dd0000", "base0E": "ee0000"
         }"#;
-        assert!(parse_theme_file(content, "partial").is_none());
+        let err = parse_theme_file(content, "partial").unwrap_err();
+        assert!(
+            err.contains("base0F"),
+            "error should mention missing slot: {err}"
+        );
+        assert!(
+            err.contains("missing"),
+            "error should distinguish missing vs invalid: {err}"
+        );
     }
 
     #[test]
-    fn parse_theme_file_skips_malformed_json() {
-        assert!(parse_theme_file("{ not valid json", "broken").is_none());
-        assert!(parse_theme_file("", "empty").is_none());
+    fn parse_theme_file_rejects_invalid_hex_in_base16_slot() {
+        // All 16 slots present, but base05 is not a valid hex value — the file
+        // must be rejected with a clear reason instead of leaking to the frontend.
+        let content = r#"{
+            "base00": "000000", "base01": "111111", "base02": "222222", "base03": "333333",
+            "base04": "444444", "base05": "not-a-hex", "base06": "666666", "base07": "777777",
+            "base08": "880000", "base09": "990000", "base0A": "aa0000", "base0B": "bb0000",
+            "base0C": "cc0000", "base0D": "dd0000", "base0E": "ee0000", "base0F": "ff0000"
+        }"#;
+        let err = parse_theme_file(content, "broken").unwrap_err();
+        assert!(
+            err.contains("base05"),
+            "error should name the bad slot: {err}"
+        );
+        assert!(
+            err.contains("invalid hex"),
+            "error should distinguish invalid hex: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_theme_file_accepts_lowercase_base16_keys() {
+        // Some legacy base16 schemes ship lowercase `base0a`–`base0f`. Both
+        // casings must parse to the same shape.
+        let content = r#"{
+            "base00": "000000", "base01": "111111", "base02": "222222", "base03": "333333",
+            "base04": "444444", "base05": "555555", "base06": "666666", "base07": "777777",
+            "base08": "880000", "base09": "990000", "base0a": "aa0000", "base0b": "bb0000",
+            "base0c": "cc0000", "base0d": "dd0000", "base0e": "ee0000", "base0f": "ff0000"
+        }"#;
+        let theme = parse_theme_file(content, "lower").expect("should parse");
+        assert!(theme.colors.contains_key("base0a"));
+    }
+
+    #[test]
+    fn parse_theme_file_preserves_underlying_parse_error() {
+        let err = parse_theme_file("{ not valid json", "broken").unwrap_err();
+        assert!(
+            err.contains("invalid JSON"),
+            "error should include the parse failure: {err}"
+        );
+
+        let empty_err = parse_theme_file("", "empty").unwrap_err();
+        assert!(
+            empty_err.contains("invalid JSON"),
+            "empty file error should be clear: {empty_err}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -513,8 +513,27 @@ fn parse_theme_file(content: &str, file_stem: &str) -> Result<ThemeDefinition, S
         Err(e) => e,
     };
 
-    let raw: HashMap<String, serde_json::Value> = serde_json::from_str(content)
+    // Two-step parse so we can distinguish JSON-syntax errors from
+    // valid-JSON-of-the-wrong-shape errors in the logs. The first
+    // `from_str::<Value>` succeeds for any valid JSON; the `as_object`
+    // check then catches arrays, numbers, strings, etc.
+    let value: serde_json::Value = serde_json::from_str(content)
         .map_err(|e| format!("invalid JSON: {e} (native parse: {native_err})"))?;
+    let Some(obj) = value.as_object() else {
+        return Err(format!(
+            "theme file must be a JSON object, got {} (native parse: {native_err})",
+            match &value {
+                serde_json::Value::Array(_) => "array",
+                serde_json::Value::String(_) => "string",
+                serde_json::Value::Number(_) => "number",
+                serde_json::Value::Bool(_) => "boolean",
+                serde_json::Value::Null => "null",
+                serde_json::Value::Object(_) => unreachable!(),
+            }
+        ));
+    };
+    let raw: HashMap<String, serde_json::Value> =
+        obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 
     const BASE16_SUFFIXES: [&str; 16] = [
         "00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "0A", "0B", "0C", "0D", "0E",
@@ -831,6 +850,34 @@ mod tests {
             empty_err.contains("invalid JSON"),
             "empty file error should be clear: {empty_err}"
         );
+    }
+
+    #[test]
+    fn parse_theme_file_distinguishes_wrong_shape_from_invalid_json() {
+        // Valid JSON, wrong top-level type — should report "must be a JSON
+        // object" rather than the misleading "invalid JSON" used for true
+        // syntax errors.
+        for (content, kind) in [
+            ("[1, 2, 3]", "array"),
+            ("\"just a string\"", "string"),
+            ("42", "number"),
+            ("true", "boolean"),
+            ("null", "null"),
+        ] {
+            let err = parse_theme_file(content, "wrong-shape").unwrap_err();
+            assert!(
+                err.contains("must be a JSON object"),
+                "expected wrong-shape error for {kind}, got: {err}"
+            );
+            assert!(
+                err.contains(kind),
+                "error should name the unexpected type {kind}, got: {err}"
+            );
+            assert!(
+                !err.starts_with("invalid JSON:"),
+                "wrong-shape error must not be labeled 'invalid JSON' (got: {err})"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -468,16 +468,30 @@ fn is_valid_hex_color(s: &str) -> bool {
     (v.len() == 3 || v.len() == 6) && v.chars().all(|c| c.is_ascii_hexdigit())
 }
 
-/// Look up a Base16 slot tolerantly: real-world schemes in the wild use
-/// either `base0A` (Tinted Theming spec) or `base0a`. Accept both.
+/// Look up a Base16 slot tolerantly. Real-world Base16 files take two
+/// common shapes:
+///   - The legacy flat shape: `base00`, `base01`, ... at the top level.
+///   - The current Tinted Theming shape (spec-0.11+): the same keys nested
+///     under a `palette` object alongside top-level `system`, `name`,
+///     `variant`, `author` fields.
+/// We accept both, plus lowercase suffixes (`base0a` rather than `base0A`).
 fn read_base16_slot<'a>(
     raw: &'a HashMap<String, serde_json::Value>,
     suffix: &str,
 ) -> Option<&'a str> {
     let upper = format!("base{suffix}");
     let lower = format!("base{}", suffix.to_lowercase());
-    raw.get(&upper)
-        .or_else(|| raw.get(&lower))
+    // Top-level lookup (flat shape).
+    if let Some(v) = raw.get(&upper).or_else(|| raw.get(&lower))
+        && let Some(s) = v.as_str()
+    {
+        return Some(s);
+    }
+    // Nested-under-palette lookup (Tinted Theming canonical shape).
+    let palette = raw.get("palette")?.as_object()?;
+    palette
+        .get(&upper)
+        .or_else(|| palette.get(&lower))
         .and_then(|v| v.as_str())
 }
 
@@ -526,10 +540,20 @@ fn parse_theme_file(content: &str, file_stem: &str) -> Result<ThemeDefinition, S
 
     // Capture every string-valued top-level field so the frontend converter
     // can read `variant`, `scheme`, etc. alongside the base16 hex values.
-    let colors: HashMap<String, String> = raw
+    // For the Tinted Theming nested shape (palette: { base00: ... }), also
+    // flatten the palette's children into `palette.baseXX` keys so the TS
+    // lookup finds them.
+    let mut colors: HashMap<String, String> = raw
         .iter()
         .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
         .collect();
+    if let Some(palette) = raw.get("palette").and_then(|v| v.as_object()) {
+        for (k, v) in palette {
+            if let Some(s) = v.as_str() {
+                colors.insert(format!("palette.{k}"), s.to_string());
+            }
+        }
+    }
 
     let name = colors
         .get("scheme")
@@ -742,6 +766,42 @@ mod tests {
             err.contains("invalid hex"),
             "error should distinguish invalid hex: {err}"
         );
+    }
+
+    #[test]
+    fn parse_theme_file_accepts_tinted_theming_palette_nested_shape() {
+        // Current Tinted Theming canonical shape: base keys nested under
+        // `palette` alongside top-level metadata. Direct YAML→JSON
+        // conversion of `tinted-theming/schemes` files lands here.
+        let content = r##"{
+            "system": "base16",
+            "name": "Tomorrow Night",
+            "variant": "dark",
+            "author": "Chris Kempson",
+            "palette": {
+                "base00": "1d1f21", "base01": "282a2e", "base02": "373b41", "base03": "969896",
+                "base04": "b4b7b4", "base05": "c5c8c6", "base06": "e0e0e0", "base07": "ffffff",
+                "base08": "cc6666", "base09": "de935f", "base0A": "f0c674", "base0B": "b5bd68",
+                "base0C": "8abeb7", "base0D": "81a2be", "base0E": "b294bb", "base0F": "a3685a"
+            }
+        }"##;
+        let theme = parse_theme_file(content, "tomorrow-night").expect("should parse");
+        assert_eq!(theme.id, "tomorrow-night");
+        assert_eq!(theme.name, "Tomorrow Night");
+        assert_eq!(theme.author.as_deref(), Some("Chris Kempson"));
+        // Palette children must be flattened into `palette.baseXX` keys
+        // so the TS converter (which knows about this shape) can find them.
+        for key in [
+            "palette.base00",
+            "palette.base05",
+            "palette.base08",
+            "palette.base0F",
+        ] {
+            assert!(
+                theme.colors.contains_key(key),
+                "missing flattened palette key: {key}"
+            );
+        }
     }
 
     #[test]

--- a/src/ui/scripts/check-css-tokens.mjs
+++ b/src/ui/scripts/check-css-tokens.mjs
@@ -81,10 +81,16 @@ const HEX_EXCLUDED_FILES = new Set([
 
 // Rgba file-level exclusions (entire file is exempt from Rule 2).
 const RGBA_EXCLUDED_FILES = new Set([
-  // theme.test.ts test names and theme.ts doc comments reference the
-  // `rgba(var(--*-rgb), alpha)` pattern abstractly (with `*` or `...`),
-  // which the canonical token regex can't match.
+  // theme.test.ts test names mention the `rgba(var(...), alpha)` pattern
+  // abstractly in `it()` descriptions.
   "src/utils/theme.test.ts",
+  // theme.ts's base16 converter emits `rgba(${rgb-triplet}, ${alpha})`
+  // strings from template literals as it synthesizes the -bg / -border
+  // companion tokens for imported palettes. This is the one place in the
+  // app where building an rgba string from JS is the right answer — the
+  // alternative (calling out to a CSS-token derivation in `theme.css`) is
+  // impossible because the input is a per-theme palette only known at
+  // runtime. Do not extend this exemption to other files.
   "src/utils/theme.ts",
 ]);
 

--- a/src/ui/scripts/check-css-tokens.mjs
+++ b/src/ui/scripts/check-css-tokens.mjs
@@ -62,6 +62,12 @@ const HEX_EXCLUSIONS = [
   /getPropertyValue\(.*\)\.trim\(\) \|\| "#/,
   // `getPropertyValue("...").trim() || (... ? "#..." : ...)` ternary fallback.
   /getPropertyValue\(.*\)\.trim\(\)\s*\|\| \(.*\?.*"#/,
+  // `resolve("--prop", "#fallback")` and the ternary form
+  // `resolve("--prop", isDark ? "#fallback" : "#fallback")` — the
+  // canonical safety-fallback pattern in monacoTheme.ts, which routes
+  // CSS custom properties to Monaco's hex-requiring API and needs
+  // literal fallbacks that mirror `:root`.
+  /\bresolve\("--[a-z-]+",\s*[^)]*"#/,
   // `accentPreview: "#..."` / `accent_preview: "#..."`
   /(accentPreview|accent_preview):\s*"#/,
   // GitHub issue / PR number reference: `issue #896`, `PR #905`,
@@ -82,16 +88,9 @@ const HEX_EXCLUDED_FILES = new Set([
 // Rgba file-level exclusions (entire file is exempt from Rule 2).
 const RGBA_EXCLUDED_FILES = new Set([
   // theme.test.ts test names mention the `rgba(var(...), alpha)` pattern
-  // abstractly in `it()` descriptions.
+  // abstractly in `it()` descriptions; the test fixtures intentionally
+  // construct rgba strings to verify converter output.
   "src/utils/theme.test.ts",
-  // theme.ts's base16 converter emits `rgba(${rgb-triplet}, ${alpha})`
-  // strings from template literals as it synthesizes the -bg / -border
-  // companion tokens for imported palettes. This is the one place in the
-  // app where building an rgba string from JS is the right answer — the
-  // alternative (calling out to a CSS-token derivation in `theme.css`) is
-  // impossible because the input is a per-theme palette only known at
-  // runtime. Do not extend this exemption to other files.
-  "src/utils/theme.ts",
 ]);
 
 // --- Walker ---

--- a/src/ui/scripts/check-css-tokens.mjs
+++ b/src/ui/scripts/check-css-tokens.mjs
@@ -23,6 +23,9 @@
 //     to resolve, especially in the foreign-bundle case it's catching).
 //     Theme tokens cannot be the source of truth for an error overlay
 //     designed to render even when the surrounding app's CSS hasn't loaded.
+//   * `src/utils/theme.test.ts` — vitest cases that assert Base16 → Claudette
+//     token conversion produces specific hex values. The hex literals are
+//     fixtures and expected outputs, not styling.
 //
 // Runs from src/ui. Exits non-zero with a report when violations are found.
 //
@@ -72,6 +75,17 @@ const HEX_EXCLUSIONS = [
 const HEX_EXCLUDED_FILES = new Set([
   // Path is relative to uiRoot, with forward slashes.
   "src/utils/bootIdentityGuard.ts",
+  // Base16 conversion tests need hex fixtures and expected output values.
+  "src/utils/theme.test.ts",
+]);
+
+// Rgba file-level exclusions (entire file is exempt from Rule 2).
+const RGBA_EXCLUDED_FILES = new Set([
+  // theme.test.ts test names and theme.ts doc comments reference the
+  // `rgba(var(--*-rgb), alpha)` pattern abstractly (with `*` or `...`),
+  // which the canonical token regex can't match.
+  "src/utils/theme.test.ts",
+  "src/utils/theme.ts",
 ]);
 
 // --- Walker ---
@@ -125,6 +139,7 @@ for (const absPath of walk(SCAN_ROOT)) {
   const lines = source.split(/\r?\n/);
 
   const hexFileExcluded = HEX_EXCLUDED_FILES.has(rel);
+  const rgbaFileExcluded = RGBA_EXCLUDED_FILES.has(rel);
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -139,7 +154,7 @@ for (const absPath of walk(SCAN_ROOT)) {
     }
 
     // --- Rule 2: rgb/rgba literals ---
-    if (RGBA_OPEN_RE.test(line) && !RGBA_TOKEN_RE.test(line)) {
+    if (!rgbaFileExcluded && RGBA_OPEN_RE.test(line) && !RGBA_TOKEN_RE.test(line)) {
       rgbaHits.push(formatHit(rel, lineno, line));
     }
   }

--- a/src/ui/scripts/check-css-tokens.mjs
+++ b/src/ui/scripts/check-css-tokens.mjs
@@ -86,12 +86,13 @@ const HEX_EXCLUDED_FILES = new Set([
 ]);
 
 // Rgba file-level exclusions (entire file is exempt from Rule 2).
-const RGBA_EXCLUDED_FILES = new Set([
-  // theme.test.ts test names mention the `rgba(var(...), alpha)` pattern
-  // abstractly in `it()` descriptions; the test fixtures intentionally
-  // construct rgba strings to verify converter output.
-  "src/utils/theme.test.ts",
-]);
+// Currently empty — every prior file-level exemption (theme.ts, theme.test.ts)
+// became unnecessary after PR #799's color-mix refactor and converter
+// simplification removed all rgba() emission and abstract-pattern references.
+// New entries should only be added with a concrete justification and a clear
+// "do not extend" comment, the way bootIdentityGuard's HEX exemption is
+// documented above.
+const RGBA_EXCLUDED_FILES = new Set([]);
 
 // --- Walker ---
 

--- a/src/ui/src/components/chat/ChatErrorBanner.module.css
+++ b/src/ui/src/components/chat/ChatErrorBanner.module.css
@@ -35,7 +35,7 @@
 .actionButton {
   appearance: none;
   background: var(--chat-input-bg);
-  border: 1px solid var(--error-border);
+  border: 1px solid var(--accent-error-border);
   border-radius: 6px;
   padding: 4px 10px;
   font-size: 12px;

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -151,12 +151,12 @@
 }
 
 .errorBanner {
-  background: var(--error-bg);
-  border: 1px solid var(--error-border);
+  background: var(--accent-error-bg);
+  border: 1px solid var(--accent-error-border);
   border-radius: 8px;
   padding: 10px 14px;
   font-size: 13px;
-  color: var(--status-stopped);
+  color: var(--accent-error);
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -1562,9 +1562,9 @@
 }
 
 .queuedCancel:hover {
-  color: var(--status-stopped);
-  background: var(--error-bg);
-  border-color: var(--error-border);
+  color: var(--accent-error);
+  background: var(--accent-error-bg);
+  border-color: var(--accent-error-border);
 }
 
 /* Input area — Composer wrapper */

--- a/src/ui/src/components/chat/MermaidBlock.module.css
+++ b/src/ui/src/components/chat/MermaidBlock.module.css
@@ -28,9 +28,9 @@
 .error {
   margin: 16px 0;
   padding: 12px 16px;
-  border: 1px solid var(--error-border);
+  border: 1px solid var(--accent-error-border);
   border-radius: 8px;
-  background: var(--error-bg);
+  background: var(--accent-error-bg);
 }
 
 .errorLabel {

--- a/src/ui/src/components/chat/SetupScriptBanner.module.css
+++ b/src/ui/src/components/chat/SetupScriptBanner.module.css
@@ -37,18 +37,18 @@
 /* Danger treatment for failed / timed-out runs — kept on the collapsed chip
    too so the failure draws the eye even after the user collapses it. */
 .failed {
-  border-color: var(--error-border);
-  background: var(--error-bg);
+  border-color: var(--accent-error-border);
+  background: var(--accent-error-bg);
 }
 
 .failed:hover {
-  border-color: var(--error-border);
-  background: var(--error-hover);
+  border-color: var(--accent-error-border);
+  background: var(--accent-error-hover);
 }
 
 .failed.expanded {
-  border-color: var(--error-border);
-  background: var(--error-hover);
+  border-color: var(--accent-error-border);
+  background: var(--accent-error-hover);
 }
 
 /* ── Header (always visible — collapsed pill) ── */
@@ -187,7 +187,7 @@
 }
 
 .failed .body {
-  border-top-color: var(--error-border);
+  border-top-color: var(--accent-error-border);
 }
 
 @keyframes setupBannerReveal {

--- a/src/ui/src/components/file-viewer/monacoTheme.ts
+++ b/src/ui/src/components/file-viewer/monacoTheme.ts
@@ -64,23 +64,39 @@ export function applyMonacoTheme(monaco: typeof MonacoType): void {
   const removedBg = cssColorToHex(cs.getPropertyValue("--diff-removed-bg").trim()  || (isDark ? "#3a1a1a" : "#ffebee"));
   const addedFg   = cssColorToHex(cs.getPropertyValue("--diff-added-text").trim()  || (isDark ? "#6ccc80" : "#2e7d32"));
   const removedFg = cssColorToHex(cs.getPropertyValue("--diff-removed-text").trim()|| (isDark ? "#f07070" : "#c62828"));
-  const numberFg  = cssColorToHex(cs.getPropertyValue("--badge-plan").trim()       || (isDark ? "#8cb8e0" : "#4a8ab0"));
+
+  // Syntax tokens — fall back to the legacy `--badge-*` / `--accent-*`
+  // hexes if the new --syntax-* family hasn't loaded yet (e.g. early in
+  // first paint, before theme.css is applied). The fallbacks match :root
+  // in theme.css.
+  const syntaxKeyword  = cssColorToHex(cs.getPropertyValue("--syntax-keyword").trim()  || (isDark ? "#c0a0f0" : "#6848a8"));
+  const syntaxString   = cssColorToHex(cs.getPropertyValue("--syntax-string").trim()   || (isDark ? "#6ccc80" : "#1a7f37"));
+  const syntaxNumber   = cssColorToHex(cs.getPropertyValue("--syntax-number").trim()   || (isDark ? "#f0a050" : "#c27430"));
+  const syntaxComment  = cssColorToHex(cs.getPropertyValue("--syntax-comment").trim()  || (isDark ? "#686058" : "#b8afa5"));
+  const syntaxFunction = cssColorToHex(cs.getPropertyValue("--syntax-function").trim() || (isDark ? "#8cb8e0" : "#3d6da0"));
+  const syntaxType     = cssColorToHex(cs.getPropertyValue("--syntax-type").trim()     || (isDark ? "#e0c050" : "#a07820"));
+  const syntaxVariable = cssColorToHex(cs.getPropertyValue("--syntax-variable").trim() || (isDark ? "#f07070" : "#c42020"));
+  const syntaxOperator = cssColorToHex(cs.getPropertyValue("--syntax-operator").trim() || (isDark ? "#6cb6ff" : "#1d6fa5"));
   const transparent = withAlpha(bg, "00");
 
   monaco.editor.defineTheme("claudette", {
     base,
     inherit: true,
     rules: [
-      // Inherit all token colours from vs-dark/vs; only nudge a handful to
-      // match Claudette's palette so the editor feels native rather than
-      // jarring against the surrounding UI chrome.
-      { token: "comment",          foreground: token6(dim),       fontStyle: "italic" },
-      { token: "keyword",          foreground: token6(accent) },
-      { token: "string",           foreground: token6(addedFg) },
-      { token: "string.escape",    foreground: token6(accent) },
-      { token: "number",           foreground: token6(numberFg) },
-      { token: "regexp",           foreground: token6(removedFg) },
-      { token: "delimiter",        foreground: token6(muted) },
+      // Token rules use the canonical --syntax-* family so Monaco stays in
+      // visual lockstep with Shiki-rendered code blocks in chat. Inherits
+      // unspecified tokens from vs-dark/vs so we don't have to enumerate
+      // every grammar's scope set.
+      { token: "comment",          foreground: token6(syntaxComment), fontStyle: "italic" },
+      { token: "keyword",          foreground: token6(syntaxKeyword) },
+      { token: "string",           foreground: token6(syntaxString) },
+      { token: "string.escape",    foreground: token6(syntaxOperator) },
+      { token: "number",           foreground: token6(syntaxNumber) },
+      { token: "regexp",           foreground: token6(syntaxOperator) },
+      { token: "type",             foreground: token6(syntaxType) },
+      { token: "function",         foreground: token6(syntaxFunction) },
+      { token: "variable",         foreground: token6(syntaxVariable) },
+      { token: "delimiter",        foreground: token6(syntaxOperator) },
     ],
     colors: {
       // Editor surface

--- a/src/ui/src/components/file-viewer/monacoTheme.ts
+++ b/src/ui/src/components/file-viewer/monacoTheme.ts
@@ -4,6 +4,50 @@ function h(n: string): string {
   return parseInt(n).toString(16).padStart(2, "0");
 }
 
+/** Resolve a CSS custom property to a concrete sRGB color string.
+ *  Necessary because `getComputedStyle(root).getPropertyValue("--x")`
+ *  returns the *specified* value, which after PR #799's refactor includes
+ *  `var(--text-faint)` and `color-mix(in srgb, ...)` expressions. Monaco
+ *  needs concrete hex; those expressions can only be resolved by laying
+ *  out an element that uses them, then reading the COMPUTED `color`.
+ *
+ *  We reuse a single hidden element across calls within one
+ *  applyMonacoTheme invocation to keep DOM churn low. Returns the raw
+ *  fallback if the prop is unset or the resolver fails — the caller's
+ *  outer `cssColorToHex` will pass that through to Monaco. */
+interface ColorResolver {
+  resolve: (prop: string, fallback: string) => string;
+  dispose: () => void;
+}
+
+function makeColorResolver(): ColorResolver {
+  // Cache the probe element + getComputedStyle reference across reads
+  // — one Insert/Remove per applyMonacoTheme call instead of N.
+  const probe = document.createElement("span");
+  probe.style.position = "absolute";
+  probe.style.visibility = "hidden";
+  probe.style.pointerEvents = "none";
+  probe.setAttribute("aria-hidden", "true");
+  document.body.appendChild(probe);
+  return {
+    resolve: (prop, fallback) => {
+      // Setting `color: var(--x)` forces the browser to resolve the var
+      // chain (including any nested color-mix()) and store the concrete
+      // result. Reading `getComputedStyle.color` then returns a concrete
+      // sRGB color string the caller can convert to hex.
+      probe.style.color = "";
+      probe.style.color = `var(${prop})`;
+      const resolved = getComputedStyle(probe).color.trim();
+      // If the var is unset or the value is unparseable, the browser
+      // either leaves `color` empty or falls back to its initial value.
+      // The format sniff distinguishes a real color from those cases.
+      if (!resolved || !/^rgb/.test(resolved)) return fallback;
+      return resolved;
+    },
+    dispose: () => probe.remove(),
+  };
+}
+
 /** Convert any CSS color string to a Monaco-compatible 8-char-or-6-char hex.
  *  If the input is already a hex literal it's returned as-is so safety
  *  fallbacks (`getPropertyValue(...).trim() || "#..."`) flow through
@@ -38,46 +82,52 @@ function token6(hex: string): string {
 }
 
 export function applyMonacoTheme(monaco: typeof MonacoType): void {
-  // Inline `getPropertyValue("--x").trim() || "#…"` is the canonical
-  // safety-fallback pattern allowed by `scripts/check-css-tokens.sh`. The
-  // fallbacks mirror the corresponding tokens in `src/styles/theme.css`
-  // and only kick in if the stylesheet hasn't loaded yet — they exist so
-  // Monaco never receives an empty colour string. Keep them in sync if
-  // those tokens move.
+  // We resolve every CSS variable via a hidden probe element rather than
+  // raw `getPropertyValue`. This is critical after PR #799's color-mix
+  // refactor: tokens like `--accent-bg` and `--syntax-comment` are now
+  // declared via `color-mix(...)` or `var(--text-faint)` chains, and
+  // `getPropertyValue` returns the *literal expression* (e.g.
+  // `"color-mix(in srgb, var(--accent-primary) 8%, transparent)"`),
+  // which Monaco can't parse. The probe-based resolver reads the
+  // browser's COMPUTED color, which is always a concrete sRGB color
+  // string.
+  //
+  // Hex fallbacks in each call mirror :root in theme.css; they only
+  // kick in if the stylesheet hasn't loaded yet (or the var chain is
+  // broken) so Monaco never receives an empty/invalid color.
   const cs = getComputedStyle(document.documentElement);
   const isDark = (cs.getPropertyValue("--color-scheme").trim() || "dark") !== "light";
   const base: MonacoType.editor.BuiltinTheme = isDark ? "vs-dark" : "vs";
 
-  const bg        = cssColorToHex(cs.getPropertyValue("--app-bg").trim()           || (isDark ? "#1c1815" : "#ffffff"));
-  const fg        = cssColorToHex(cs.getPropertyValue("--text-primary").trim()     || (isDark ? "#f0ebe5" : "#1a1a1a"));
-  const muted     = cssColorToHex(cs.getPropertyValue("--text-muted").trim()       || (isDark ? "#b8afa5" : "#666666"));
-  const dim       = cssColorToHex(cs.getPropertyValue("--text-dim").trim()         || (isDark ? "#908880" : "#999999"));
-  const accent    = cssColorToHex(cs.getPropertyValue("--accent-primary").trim()   || (isDark ? "#e07850" : "#c45a35"));
-  const accentBg  = cssColorToHex(cs.getPropertyValue("--accent-bg").trim()        || (isDark ? "#1a1a1a" : "#f5f5f5"));
-  const selected  = cssColorToHex(cs.getPropertyValue("--selected-bg").trim()      || (isDark ? "#3a2820" : "#f0e8e0"));
-  const hovered   = cssColorToHex(cs.getPropertyValue("--hover-bg").trim()         || (isDark ? "#242220" : "#f5f5f5"));
-  const scrollbarThumb = cssColorToHex(cs.getPropertyValue("--scrollbar-thumb").trim() || (isDark ? "#242220" : "#f5f5f5"));
-  const scrollbarThumbHover = cssColorToHex(cs.getPropertyValue("--scrollbar-thumb-hover").trim() || (isDark ? "#e0785040" : "#c45a3540"));
-  const divider   = cssColorToHex(cs.getPropertyValue("--divider").trim()          || (isDark ? "#3d3832" : "#e0e0e0"));
-  const widgetBg  = cssColorToHex(cs.getPropertyValue("--sidebar-bg").trim()       || (isDark ? "#26221f" : "#f5f5f5"));
-  const addedBg   = cssColorToHex(cs.getPropertyValue("--diff-added-bg").trim()    || (isDark ? "#1a3a20" : "#e8f5e9"));
-  const removedBg = cssColorToHex(cs.getPropertyValue("--diff-removed-bg").trim()  || (isDark ? "#3a1a1a" : "#ffebee"));
-  const addedFg   = cssColorToHex(cs.getPropertyValue("--diff-added-text").trim()  || (isDark ? "#6ccc80" : "#2e7d32"));
-  const removedFg = cssColorToHex(cs.getPropertyValue("--diff-removed-text").trim()|| (isDark ? "#f07070" : "#c62828"));
+  const { resolve, dispose } = makeColorResolver();
+  try {
+    const bg        = cssColorToHex(resolve("--app-bg", isDark ? "#1c1815" : "#ffffff"));
+    const fg        = cssColorToHex(resolve("--text-primary", isDark ? "#f0ebe5" : "#1a1a1a"));
+    const muted     = cssColorToHex(resolve("--text-muted", isDark ? "#b8afa5" : "#666666"));
+    const dim       = cssColorToHex(resolve("--text-dim", isDark ? "#908880" : "#999999"));
+    const accent    = cssColorToHex(resolve("--accent-primary", isDark ? "#e07850" : "#c45a35"));
+    const accentBg  = cssColorToHex(resolve("--accent-bg", isDark ? "#1a1a1a" : "#f5f5f5"));
+    const selected  = cssColorToHex(resolve("--selected-bg", isDark ? "#3a2820" : "#f0e8e0"));
+    const hovered   = cssColorToHex(resolve("--hover-bg", isDark ? "#242220" : "#f5f5f5"));
+    const scrollbarThumb = cssColorToHex(resolve("--scrollbar-thumb", isDark ? "#242220" : "#f5f5f5"));
+    const scrollbarThumbHover = cssColorToHex(resolve("--scrollbar-thumb-hover", isDark ? "#e0785040" : "#c45a3540"));
+    const divider   = cssColorToHex(resolve("--divider", isDark ? "#3d3832" : "#e0e0e0"));
+    const widgetBg  = cssColorToHex(resolve("--sidebar-bg", isDark ? "#26221f" : "#f5f5f5"));
+    const addedBg   = cssColorToHex(resolve("--diff-added-bg", isDark ? "#1a3a20" : "#e8f5e9"));
+    const removedBg = cssColorToHex(resolve("--diff-removed-bg", isDark ? "#3a1a1a" : "#ffebee"));
+    const addedFg   = cssColorToHex(resolve("--diff-added-text", isDark ? "#6ccc80" : "#2e7d32"));
+    const removedFg = cssColorToHex(resolve("--diff-removed-text", isDark ? "#f07070" : "#c62828"));
 
-  // Syntax tokens — fall back to the legacy `--badge-*` / `--accent-*`
-  // hexes if the new --syntax-* family hasn't loaded yet (e.g. early in
-  // first paint, before theme.css is applied). The fallbacks match :root
-  // in theme.css.
-  const syntaxKeyword  = cssColorToHex(cs.getPropertyValue("--syntax-keyword").trim()  || (isDark ? "#c0a0f0" : "#6848a8"));
-  const syntaxString   = cssColorToHex(cs.getPropertyValue("--syntax-string").trim()   || (isDark ? "#6ccc80" : "#1a7f37"));
-  const syntaxNumber   = cssColorToHex(cs.getPropertyValue("--syntax-number").trim()   || (isDark ? "#f0a050" : "#c27430"));
-  const syntaxComment  = cssColorToHex(cs.getPropertyValue("--syntax-comment").trim()  || (isDark ? "#686058" : "#b8afa5"));
-  const syntaxFunction = cssColorToHex(cs.getPropertyValue("--syntax-function").trim() || (isDark ? "#8cb8e0" : "#3d6da0"));
-  const syntaxType     = cssColorToHex(cs.getPropertyValue("--syntax-type").trim()     || (isDark ? "#e0c050" : "#a07820"));
-  const syntaxVariable = cssColorToHex(cs.getPropertyValue("--syntax-variable").trim() || (isDark ? "#f07070" : "#c42020"));
-  const syntaxOperator = cssColorToHex(cs.getPropertyValue("--syntax-operator").trim() || (isDark ? "#6cb6ff" : "#1d6fa5"));
-  const transparent = withAlpha(bg, "00");
+    // Syntax tokens — fallbacks match :root in theme.css.
+    const syntaxKeyword  = cssColorToHex(resolve("--syntax-keyword", isDark ? "#c0a0f0" : "#6848a8"));
+    const syntaxString   = cssColorToHex(resolve("--syntax-string", isDark ? "#6ccc80" : "#1a7f37"));
+    const syntaxNumber   = cssColorToHex(resolve("--syntax-number", isDark ? "#f0a050" : "#c27430"));
+    const syntaxComment  = cssColorToHex(resolve("--syntax-comment", isDark ? "#686058" : "#b8afa5"));
+    const syntaxFunction = cssColorToHex(resolve("--syntax-function", isDark ? "#8cb8e0" : "#3d6da0"));
+    const syntaxType     = cssColorToHex(resolve("--syntax-type", isDark ? "#e0c050" : "#a07820"));
+    const syntaxVariable = cssColorToHex(resolve("--syntax-variable", isDark ? "#f07070" : "#c42020"));
+    const syntaxOperator = cssColorToHex(resolve("--syntax-operator", isDark ? "#6cb6ff" : "#1d6fa5"));
+    const transparent = withAlpha(bg, "00");
 
   monaco.editor.defineTheme("claudette", {
     base,
@@ -214,6 +264,12 @@ export function applyMonacoTheme(monaco: typeof MonacoType): void {
   });
 
   monaco.editor.setTheme("claudette");
+  } finally {
+    // Remove the probe element even if Monaco's defineTheme throws,
+    // otherwise repeated theme rebuilds (via the MutationObserver in
+    // initMonacoThemeSync) would leak detached <span>s.
+    dispose();
+  }
 }
 
 /** Apply the theme once, then keep it in sync with `data-theme` / inline

--- a/src/ui/src/components/modals/shared.module.css
+++ b/src/ui/src/components/modals/shared.module.css
@@ -68,12 +68,12 @@
 
 .btnDanger {
   composes: btn;
-  color: var(--status-stopped);
-  border-color: var(--status-stopped);
+  color: var(--accent-error);
+  border-color: var(--accent-error);
 }
 
 .btnDanger:hover {
-  background: var(--error-hover);
+  background: var(--accent-error-hover);
 }
 
 .btnPrimary {

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
@@ -32,8 +32,8 @@
 }
 
 .bannerFailed {
-  background: var(--error-bg);
-  --checks-panel-bg: color-mix(in srgb, var(--status-stopped) 16%, var(--chat-header-bg));
+  background: var(--accent-error-bg);
+  --checks-panel-bg: color-mix(in srgb, var(--accent-error) 16%, var(--chat-header-bg));
 }
 
 .bannerMerged {

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -1378,7 +1378,7 @@
 }
 
 .error {
-  color: var(--status-stopped);
+  color: var(--accent-error);
   font-size: 12px;
   margin-top: 4px;
 }
@@ -1887,7 +1887,7 @@
 .envErrorCard {
   margin: 4px 8px 8px 22px;
   padding: 10px 12px;
-  border-left: 2px solid var(--status-stopped);
+  border-left: 2px solid var(--accent-error);
   background: var(--accent-error-hover);
   border-radius: 0 4px 4px 0;
   display: flex;
@@ -2368,7 +2368,7 @@
   margin-top: var(--space-2);
   max-width: 760px;
   padding: var(--space-2) var(--space-3);
-  border-left: 2px solid var(--status-stopped);
+  border-left: 2px solid var(--accent-error);
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
   background: var(--accent-error-hover);
   color: var(--text-primary);
@@ -2725,7 +2725,7 @@
   padding: 1px 6px;
   border-radius: 3px;
   background: var(--accent-error-hover);
-  color: var(--status-stopped);
+  color: var(--accent-error);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.04em;

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -1374,7 +1374,7 @@
 }
 
 .btnDanger:hover {
-  background: var(--error-hover);
+  background: var(--accent-error-hover);
 }
 
 .error {
@@ -1691,9 +1691,9 @@
 }
 
 .authPanelError {
-  border: 1px solid var(--error-border);
+  border: 1px solid var(--accent-error-border);
   border-radius: var(--radius-md);
-  background: var(--error-bg);
+  background: var(--accent-error-bg);
   color: var(--status-stopped);
   font-size: 13px;
   line-height: 1.5;
@@ -1823,7 +1823,7 @@
 }
 
 .mcpRemoveBtn:hover {
-  background: var(--error-hover);
+  background: var(--accent-error-hover);
   color: var(--status-stopped);
 }
 
@@ -1888,7 +1888,7 @@
   margin: 4px 8px 8px 22px;
   padding: 10px 12px;
   border-left: 2px solid var(--status-stopped);
-  background: var(--error-hover);
+  background: var(--accent-error-hover);
   border-radius: 0 4px 4px 0;
   display: flex;
   flex-direction: column;
@@ -2370,7 +2370,7 @@
   padding: var(--space-2) var(--space-3);
   border-left: 2px solid var(--status-stopped);
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-  background: var(--error-hover);
+  background: var(--accent-error-hover);
   color: var(--text-primary);
   font-size: 12px;
   line-height: 1.4;
@@ -2724,7 +2724,7 @@
   display: inline-block;
   padding: 1px 6px;
   border-radius: 3px;
-  background: var(--error-hover);
+  background: var(--accent-error-hover);
   color: var(--status-stopped);
   font-size: 10px;
   font-weight: 600;
@@ -2801,9 +2801,9 @@
 .flagErrorBanner {
   margin: 12px 0 16px;
   padding: 12px 14px;
-  border: 1px solid var(--error-border);
+  border: 1px solid var(--accent-error-border);
   border-radius: 8px;
-  background: var(--error-bg);
+  background: var(--accent-error-bg);
   color: var(--text-primary);
   display: flex;
   align-items: flex-start;

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -1694,7 +1694,7 @@
   border: 1px solid var(--accent-error-border);
   border-radius: var(--radius-md);
   background: var(--accent-error-bg);
-  color: var(--status-stopped);
+  color: var(--accent-error);
   font-size: 13px;
   line-height: 1.5;
   padding: 10px 12px;
@@ -1824,7 +1824,7 @@
 
 .mcpRemoveBtn:hover {
   background: var(--accent-error-hover);
-  color: var(--status-stopped);
+  color: var(--accent-error);
 }
 
 .mcpStatusDot {

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -22,6 +22,7 @@ import type { EnvSourceInfo, EnvTarget } from "../../../types/env";
 import { PluginSettingInput } from "../PluginSettingInput";
 import { classifyPostActionError } from "../../modals/EnvTrustModal";
 import { summarizeError } from "../../modals/envTrustFormat";
+import { envProviderCategoryColor } from "./envProviderCategory";
 import styles from "../Settings.module.css";
 
 interface EnvPanelProps {
@@ -714,7 +715,18 @@ export function EnvPanel({ target }: EnvPanelProps) {
           const showDetails = hasError && !trustError;
           return (
             <div key={source.plugin_name}>
-              <div className={styles.mcpRow}>
+              <div
+                className={styles.mcpRow}
+                style={{
+                  // Category-colored leading bar — distinguishes
+                  // direnv/mise/nix/dotenv at a glance independently
+                  // of the status dot's state color. Third-party
+                  // providers cycle through the remaining slots so
+                  // multiple custom providers stay distinguishable.
+                  borderLeft: `3px solid ${envProviderCategoryColor(source.plugin_name)}`,
+                  paddingLeft: "var(--space-2)",
+                }}
+              >
                 <div className={styles.mcpInfo}>
                   <span
                     className={styles.mcpStatusDot}

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -721,8 +721,10 @@ export function EnvPanel({ target }: EnvPanelProps) {
                   // Category-colored leading bar — distinguishes
                   // direnv/mise/nix/dotenv at a glance independently
                   // of the status dot's state color. Third-party
-                  // providers cycle through the remaining slots so
-                  // multiple custom providers stay distinguishable.
+                  // providers receive a best-effort stable slot (E–H)
+                  // via FNV-1a hash; collisions across many third-party
+                  // providers are expected but the same name always
+                  // lands in the same slot across launches.
                   borderLeft: `3px solid ${envProviderCategoryColor(source.plugin_name)}`,
                   paddingLeft: "var(--space-2)",
                 }}

--- a/src/ui/src/components/settings/sections/PinnedPromptsManager.module.css
+++ b/src/ui/src/components/settings/sections/PinnedPromptsManager.module.css
@@ -404,7 +404,7 @@
 }
 
 .btnDestructiveText:hover:not(:disabled) {
-  background: var(--error-hover);
+  background: var(--accent-error-hover);
 }
 
 .btnDestructiveFill {

--- a/src/ui/src/components/settings/sections/PinnedPromptsManager.module.css
+++ b/src/ui/src/components/settings/sections/PinnedPromptsManager.module.css
@@ -400,7 +400,7 @@
 
 .btnDestructiveText {
   composes: btn;
-  color: var(--status-stopped);
+  color: var(--accent-error);
 }
 
 .btnDestructiveText:hover:not(:disabled) {
@@ -409,9 +409,9 @@
 
 .btnDestructiveFill {
   composes: btn;
-  background: var(--status-stopped);
+  background: var(--accent-error);
   color: var(--on-accent);
-  border-color: var(--status-stopped);
+  border-color: var(--accent-error);
 }
 
 .btnDestructiveFill:hover:not(:disabled) {

--- a/src/ui/src/components/settings/sections/envProviderCategory.test.ts
+++ b/src/ui/src/components/settings/sections/envProviderCategory.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { envProviderCategoryColor } from "./envProviderCategory";
+
+describe("envProviderCategoryColor", () => {
+  it("assigns the canonical slot to each bundled env provider", () => {
+    expect(envProviderCategoryColor("env-direnv")).toBe("var(--category-a-fg)");
+    expect(envProviderCategoryColor("env-mise")).toBe("var(--category-b-fg)");
+    expect(envProviderCategoryColor("env-nix-devshell")).toBe("var(--category-c-fg)");
+    expect(envProviderCategoryColor("env-dotenv")).toBe("var(--category-d-fg)");
+  });
+
+  it("returns a fallback slot E–H for unknown providers", () => {
+    const got = envProviderCategoryColor("env-custom-thing");
+    expect(got).toMatch(/^var\(--category-[efgh]-fg\)$/);
+  });
+
+  it("is stable across calls — same name always lands in the same slot", () => {
+    const first = envProviderCategoryColor("env-some-third-party");
+    const second = envProviderCategoryColor("env-some-third-party");
+    expect(first).toBe(second);
+  });
+
+  it("never assigns a third-party provider to a bundled slot (A–D)", () => {
+    // Probe with 50 distinct names and confirm the hash never collides
+    // with A/B/C/D, which are reserved for the bundled providers.
+    for (let i = 0; i < 50; i++) {
+      const name = `env-fictitious-${i}`;
+      const color = envProviderCategoryColor(name);
+      expect(color).not.toMatch(/category-[abcd]-/);
+    }
+  });
+
+  it("distributes distinct third-party names across multiple slots", () => {
+    const slots = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      slots.add(envProviderCategoryColor(`env-third-party-${i}`));
+    }
+    // With 4 fallback slots and 20 inputs we expect to land in at
+    // least 2 different slots — otherwise the hash is degenerate.
+    expect(slots.size).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/ui/src/components/settings/sections/envProviderCategory.ts
+++ b/src/ui/src/components/settings/sections/envProviderCategory.ts
@@ -1,0 +1,52 @@
+// Maps an env-provider plugin name onto one of the 8 category-slot
+// tokens (--category-a-fg … --category-h-fg). Bundled providers get
+// stable assignments so muscle memory holds across sessions; third-
+// party providers cycle through the remaining slots via a stable hash
+// so two custom providers get distinct colors (rather than both
+// fingerprinting to the same slot).
+//
+// The category-* tokens live in src/styles/theme.css and ship a full
+// bg/border/fg triplet — this module only returns the fg color since
+// the row indicator is a 3px vertical bar (no fill or outline).
+
+const BUNDLED_ASSIGNMENTS: Record<string, "a" | "b" | "c" | "d"> = {
+  "env-direnv": "a",
+  "env-mise": "b",
+  "env-nix-devshell": "c",
+  "env-dotenv": "d",
+};
+
+// Third-party providers cycle through E–H. Keep this set in sync with
+// the category-slot count in theme.css so we never reach for a slot
+// that doesn't exist.
+const FALLBACK_SLOTS = ["e", "f", "g", "h"] as const;
+
+function hashName(name: string): number {
+  // FNV-1a 32-bit. Cheap, stable, no Math.random — same plugin name
+  // always lands in the same slot across launches.
+  let h = 0x811c9dc5;
+  for (let i = 0; i < name.length; i++) {
+    h ^= name.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/**
+ * Return the CSS var name for an env-provider row's category color, or
+ * `null` if no category slot should be applied (e.g. a degraded state
+ * where coloring would clash with the existing error/disabled visuals).
+ *
+ * Caller use:
+ *
+ *     const accent = envProviderCategoryColor("env-mise");
+ *     // → "var(--category-b-fg)"
+ */
+export function envProviderCategoryColor(pluginName: string): string {
+  const bundled = BUNDLED_ASSIGNMENTS[pluginName];
+  if (bundled) {
+    return `var(--category-${bundled}-fg)`;
+  }
+  const slot = FALLBACK_SLOTS[hashName(pluginName) % FALLBACK_SLOTS.length];
+  return `var(--category-${slot}-fg)`;
+}

--- a/src/ui/src/components/settings/sections/envProviderCategory.ts
+++ b/src/ui/src/components/settings/sections/envProviderCategory.ts
@@ -1,9 +1,11 @@
 // Maps an env-provider plugin name onto one of the 8 category-slot
 // tokens (--category-a-fg … --category-h-fg). Bundled providers get
 // stable assignments so muscle memory holds across sessions; third-
-// party providers cycle through the remaining slots via a stable hash
-// so two custom providers get distinct colors (rather than both
-// fingerprinting to the same slot).
+// party providers receive a best-effort stable slot via FNV-1a hashing
+// across the four remaining slots. Hashing reduces clustering but
+// cannot guarantee uniqueness — collisions across N third-party
+// providers are expected at roughly N²/8 (birthday paradox); the
+// assignment is stable per name across launches.
 //
 // The category-* tokens live in src/styles/theme.css and ship a full
 // bg/border/fg triplet — this module only returns the fg color since
@@ -33,9 +35,10 @@ function hashName(name: string): number {
 }
 
 /**
- * Return the CSS var name for an env-provider row's category color, or
- * `null` if no category slot should be applied (e.g. a degraded state
- * where coloring would clash with the existing error/disabled visuals).
+ * Return the CSS var name for an env-provider row's category color.
+ * Every plugin name resolves to some slot — bundled providers map to
+ * their canonical slot (A–D), third-party providers hash into one of
+ * the remaining slots (E–H) deterministically.
  *
  * Caller use:
  *

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -310,8 +310,8 @@
 }
 
 .iconBtnDanger:hover {
-  color: var(--status-stopped);
-  background: var(--error-hover);
+  color: var(--accent-error);
+  background: var(--accent-error-hover);
 }
 
 .invalidBadge {

--- a/src/ui/src/components/terminal/TerminalPanel.module.css
+++ b/src/ui/src/components/terminal/TerminalPanel.module.css
@@ -273,8 +273,8 @@
   gap: 6px;
   padding: 10px 12px;
   border-radius: 6px;
-  background: var(--error-bg);
-  border: 1px solid var(--error-border);
+  background: var(--accent-error-bg);
+  border: 1px solid var(--accent-error-border);
   color: var(--text-primary);
   font-size: 12px;
   font-family: var(--font-mono);
@@ -363,8 +363,8 @@
   gap: 6px;
   padding: 10px 12px;
   border-radius: 6px;
-  background: var(--error-bg);
-  border: 1px solid var(--error-border);
+  background: var(--accent-error-bg);
+  border: 1px solid var(--accent-error-border);
   color: var(--text-primary);
   font-size: 12px;
   font-family: var(--font-mono);

--- a/src/ui/src/main.tsx
+++ b/src/ui/src/main.tsx
@@ -31,6 +31,9 @@ import { invoke } from "@tauri-apps/api/core";
 import { ErrorBoundary } from "./components/layout/ErrorBoundary";
 import { prewarmHighlighter } from "./utils/highlight";
 import { bootstrapGrammarRegistry } from "./utils/grammarRegistry";
+// Dev-only: registers window.__CLAUDETTE_THEME_PROOF__ so theme authors can
+// audit every token from the devtools console. No effect in release builds.
+import "./utils/themeProof";
 import App from "./App.tsx";
 
 const platform = navigator.platform.toLowerCase();

--- a/src/ui/src/styles/shikiClaudetteTheme.test.ts
+++ b/src/ui/src/styles/shikiClaudetteTheme.test.ts
@@ -1,0 +1,64 @@
+// Integration test: build the Claudette Shiki theme, load a small set of
+// grammars, and verify the highlighter actually emits `style="color:
+// var(--syntax-*)"` spans. This guards against a class of silent
+// regression Copilot flagged: Shiki could change its theme normalization
+// to reject non-hex foreground values in a future release, which would
+// disable our syntax coloring entirely while the unit-mocked highlighter
+// tests stay green.
+
+import { describe, expect, it } from "vitest";
+import { createHighlighterCore } from "shiki/core";
+import { createOnigurumaEngine } from "shiki/engine/oniguruma";
+import {
+  buildClaudetteShikiTheme,
+  CLAUDETTE_SHIKI_THEME_NAME,
+} from "./shikiClaudetteTheme";
+
+describe("Claudette Shiki theme — Shiki integration", () => {
+  it("highlights real code and emits var(--syntax-*) color values in inline styles", async () => {
+    const hl = await createHighlighterCore({
+      themes: [buildClaudetteShikiTheme()],
+      langs: [(await import("@shikijs/langs/typescript")).default],
+      engine: createOnigurumaEngine(import("shiki/wasm")),
+    });
+    try {
+      const html = hl.codeToHtml('const greeting = "hi";', {
+        lang: "typescript",
+        theme: CLAUDETTE_SHIKI_THEME_NAME,
+      });
+
+      // Shiki passes the foreground value verbatim into a `color:` rule.
+      // If a future normalization step strips CSS function-call values,
+      // this assertion fires before users notice gray code blocks.
+      expect(html).toContain("var(--syntax-");
+
+      // At least one token-group var should show up for this snippet:
+      // `const` (keyword) and the string literal both have non-default
+      // foregrounds in our scope map.
+      expect(html).toMatch(/var\(--syntax-(keyword|string|operator|variable)\)/);
+    } finally {
+      hl.dispose();
+    }
+  });
+
+  it("uses var(--app-bg) and var(--text-primary) for the editor surface", () => {
+    const theme = buildClaudetteShikiTheme();
+    expect(theme.colors).toBeDefined();
+    expect(theme.colors?.["editor.background"]).toBe("var(--app-bg)");
+    expect(theme.colors?.["editor.foreground"]).toBe("var(--text-primary)");
+  });
+
+  it("registers theme settings with var(--syntax-*) foregrounds (not hex literals)", () => {
+    const theme = buildClaudetteShikiTheme();
+    expect(theme.settings).toBeDefined();
+    expect(theme.settings!.length).toBeGreaterThan(0);
+    for (const rule of theme.settings!) {
+      // Every rule that sets a foreground must use a CSS var, not a hex,
+      // otherwise per-theme adaptation breaks.
+      const fg = rule.settings?.foreground;
+      if (fg) {
+        expect(fg).toMatch(/^var\(--syntax-/);
+      }
+    }
+  });
+});

--- a/src/ui/src/styles/shikiClaudetteTheme.ts
+++ b/src/ui/src/styles/shikiClaudetteTheme.ts
@@ -1,0 +1,129 @@
+// Claudette's Shiki theme — maps TextMate scopes onto the `--syntax-*`
+// CSS custom properties declared in `theme.css`. By using CSS `var()`
+// references as the foreground values (instead of literal hex), the
+// emitted inline `style="color: var(--syntax-keyword)"` resolves
+// per-theme at render time. A single Shiki theme covers all 14 built-in
+// Claudette themes AND every imported Base16 scheme — the cascade does
+// the work.
+//
+// Implementation note: Shiki's theme normalizer accepts any string in
+// the `foreground` field and emits it verbatim as the value of the
+// inline `style="color: <value>"`. CSS `var(...)` is a legal property
+// value, so the browser resolves it without further machinery.
+
+import type { ThemeRegistration } from "shiki/core";
+
+export const CLAUDETTE_SHIKI_THEME_NAME = "claudette";
+
+// Scope mappings follow the Base16 syntax roles (base08–base0F) so that
+// imported Base16 schemes produce coherent highlighting end-to-end:
+//   base08 → variable     base0C → operator
+//   base09 → number       base0D → function
+//   base0A → type         base0E → keyword
+//   base0B → string       base0F → (legacy/deprecated)
+// Comments map to base03 via the dedicated --syntax-comment.
+//
+// Each rule lists multiple TextMate scopes so the same color applies
+// regardless of which grammar tagged the token. Shiki resolves the
+// most specific scope match first, so broader scopes (e.g. "keyword")
+// act as fallbacks for grammars that don't emit the finer-grained
+// "keyword.control" / "keyword.operator" distinction.
+const SCOPE_RULES: ReadonlyArray<{ scope: string[]; var: string }> = [
+  {
+    scope: ["comment", "comment.line", "comment.block", "punctuation.definition.comment"],
+    var: "--syntax-comment",
+  },
+  {
+    scope: ["string", "string.quoted", "string.template", "punctuation.definition.string"],
+    var: "--syntax-string",
+  },
+  {
+    scope: [
+      "constant.numeric",
+      "constant.language",
+      "constant.character",
+      "constant.character.escape",
+      "constant.other",
+    ],
+    var: "--syntax-number",
+  },
+  {
+    scope: [
+      "entity.name.function",
+      "support.function",
+      "meta.function-call entity.name.function",
+      "meta.function-call",
+    ],
+    var: "--syntax-function",
+  },
+  {
+    scope: [
+      "entity.name.type",
+      "entity.name.class",
+      "entity.other.inherited-class",
+      "support.type",
+      "support.class",
+      "entity.name.tag",
+      "meta.type.annotation entity.name",
+    ],
+    var: "--syntax-type",
+  },
+  {
+    scope: [
+      "variable",
+      "variable.parameter",
+      "variable.other",
+      "variable.language",
+      "meta.definition.variable variable",
+    ],
+    var: "--syntax-variable",
+  },
+  {
+    scope: [
+      "keyword.operator",
+      "punctuation",
+      "punctuation.separator",
+      "punctuation.terminator",
+      "meta.brace",
+    ],
+    var: "--syntax-operator",
+  },
+  {
+    // Keyword is the broadest fallback for control flow, modifiers, and
+    // storage. Listed last so the more specific scopes above win when
+    // both match.
+    scope: [
+      "keyword",
+      "keyword.control",
+      "keyword.declaration",
+      "storage",
+      "storage.type",
+      "storage.modifier",
+      "support.type.property-name",
+    ],
+    var: "--syntax-keyword",
+  },
+];
+
+export function buildClaudetteShikiTheme(): ThemeRegistration {
+  return {
+    name: CLAUDETTE_SHIKI_THEME_NAME,
+    // `type` is metadata for theme switchers — Shiki doesn't care about it
+    // when emitting inline-style output, so "dark" here is a non-load-
+    // bearing default. Light/dark switching happens via the underlying
+    // CSS tokens themselves.
+    type: "dark",
+    settings: SCOPE_RULES.map((rule) => ({
+      scope: rule.scope,
+      settings: { foreground: `var(${rule.var})` },
+    })),
+    // Editor surface colors. Shiki uses these for the synthesized <pre>
+    // wrapper that we strip in the worker, but keeping them as tokens
+    // means a code block extracted with the wrapper still themes
+    // correctly downstream (e.g. when rendered standalone in tests).
+    colors: {
+      "editor.background": "var(--app-bg)",
+      "editor.foreground": "var(--text-primary)",
+    },
+  };
+}

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -99,24 +99,28 @@
   --accent-success-rgb:    108, 204, 128;
   --accent-success-bg:     rgba(var(--accent-success-rgb), 0.10);
   --accent-success-border: rgba(var(--accent-success-rgb), 0.30);
+  --accent-success-hover:  rgba(var(--accent-success-rgb), 0.15);
   --accent-success-fg:     var(--accent-success);
 
   --accent-warning:        #f0a050;
   --accent-warning-rgb:    240, 160, 80;
   --accent-warning-bg:     rgba(var(--accent-warning-rgb), 0.10);
   --accent-warning-border: rgba(var(--accent-warning-rgb), 0.30);
+  --accent-warning-hover:  rgba(var(--accent-warning-rgb), 0.15);
   --accent-warning-fg:     var(--accent-warning);
 
   --accent-error:          #e85050;
   --accent-error-rgb:      232, 80, 80;
   --accent-error-bg:       rgba(var(--accent-error-rgb), 0.10);
   --accent-error-border:   rgba(var(--accent-error-rgb), 0.30);
+  --accent-error-hover:    rgba(var(--accent-error-rgb), 0.15);
   --accent-error-fg:       var(--accent-error);
 
   --accent-info:           #8cb8e0;
   --accent-info-rgb:       140, 184, 224;
   --accent-info-bg:        rgba(var(--accent-info-rgb), 0.10);
   --accent-info-border:    rgba(var(--accent-info-rgb), 0.30);
+  --accent-info-hover:     rgba(var(--accent-info-rgb), 0.15);
   --accent-info-fg:        var(--accent-info);
 
   /* ---- UI-role tokens — neutral emphasis + secondary/tertiary brand accents.

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -88,6 +88,45 @@
   --badge-plan:          #8cb8e0;
   --badge-ask:           #f5a0b8;
 
+  /* ---- Semantic accents — success / warning / error / info.
+     New consumers should prefer these over the older --badge-*, --status-*,
+     and --error-* tokens. Defaults derive from existing tokens so themes
+     that don't override these still get coherent values. The -rgb companions
+     are literals (CSS lacks an rgb-from-var function), so a user theme that
+     overrides --accent-success without --accent-success-rgb will break alpha
+     layers — co-emit both when authoring themes. */
+  --accent-success:      var(--badge-done);
+  --accent-success-rgb:  108, 204, 128;
+  --accent-success-bg:   rgba(108, 204, 128, 0.10);
+  --accent-warning:      #f0a050;
+  --accent-warning-rgb:  240, 160, 80;
+  --accent-warning-bg:   rgba(240, 160, 80, 0.10);
+  --accent-error:        var(--status-stopped);
+  --accent-error-rgb:    232, 80, 80;
+  --accent-error-bg:     var(--error-bg);
+  --accent-info:         var(--badge-plan);
+  --accent-info-rgb:     140, 184, 224;
+  --accent-info-bg:      rgba(140, 184, 224, 0.10);
+
+  /* ---- UI-role tokens — neutral emphasis and a secondary brand accent.
+     Both derive from existing tokens; themes can override to break the link. */
+  --accent-neutral:      var(--text-muted);
+  --accent-secondary:    var(--mascot-pink);
+
+  /* ---- Syntax highlight palette — mirrors base16 base08–base0F roles so
+     base16 themes can map directly. Intentionally brand-invariant (like the
+     --tool-* tokens above): the default-dark palette ships these to :root
+     and themes inherit unless they have a specific reason to override
+     (e.g. high-contrast bumps saturation). */
+  --syntax-keyword:      #c0a0f0;
+  --syntax-string:       var(--badge-done);
+  --syntax-number:       #f0a050;
+  --syntax-comment:      var(--text-faint);
+  --syntax-function:     var(--badge-plan);
+  --syntax-type:         #e0c050;
+  --syntax-variable:     var(--diff-removed-text);
+  --syntax-operator:     #6cb6ff;
+
   /* ---- Tool activity — per-category hues used in chat tool chips.
      Intentionally brand-invariant: tool chips keep the same hue across
      every theme so users build a stable read/write/bash/etc. muscle
@@ -283,6 +322,11 @@
   --badge-plan: #6848a8;
   --badge-ask:  #a04828;
 
+  /* Deeper orange for warning on cream background — #f0a050 washes out. */
+  --accent-warning:     #c27430;
+  --accent-warning-rgb: 194, 116, 48;
+  --accent-warning-bg:  rgba(194, 116, 48, 0.10);
+
   --diff-added-bg:   rgba(26, 127, 55, 0.10);
   --diff-removed-bg: rgba(196, 32, 32, 0.10);
   --diff-added-text: #1a7f37;
@@ -381,6 +425,20 @@
   --badge-done: #00ffdd;
   --badge-plan: #66bbff;
   --badge-ask:  #ffbb44;
+
+  /* Max-saturation warning + syntax palette for legibility on near-black. */
+  --accent-warning:     #ffaa00;
+  --accent-warning-rgb: 255, 170, 0;
+  --accent-warning-bg:  rgba(255, 170, 0, 0.14);
+
+  --syntax-keyword:     #d090ff;
+  --syntax-string:      #44ff44;
+  --syntax-number:      #ffaa00;
+  --syntax-comment:     #888899;
+  --syntax-function:    #66bbff;
+  --syntax-type:        #ffdd00;
+  --syntax-variable:    #ff4444;
+  --syntax-operator:    #00ffdd;
 }
 
 /* ============================================================
@@ -523,6 +581,11 @@
   --badge-plan: #56949f;
   --badge-ask:  #ea9d34;
 
+  /* Rosé Pine gold for warning (matches --badge-ask hue). */
+  --accent-warning:     #ea9d34;
+  --accent-warning-rgb: 234, 157, 52;
+  --accent-warning-bg:  rgba(234, 157, 52, 0.10);
+
   --mascot-pink: #d7827e;
 
   --diff-added-bg:   rgba(40, 105, 131, 0.12);
@@ -625,6 +688,11 @@
   --badge-done: #859900;
   --badge-plan: #2aa198;
   --badge-ask:  #b58900;
+
+  /* Solarized yellow for warning (matches --badge-ask). */
+  --accent-warning:     #b58900;
+  --accent-warning-rgb: 181, 137, 0;
+  --accent-warning-bg:  rgba(181, 137, 0, 0.10);
 
   --mascot-pink: #d33682;
 

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -1358,30 +1358,12 @@ select:disabled {
 }
 
 /*
- * Shiki dual-theme code highlighting.
+ * Shiki code highlighting.
  *
- * The Shiki worker emits each token span with both `--shiki-light` and
- * `--shiki-dark` CSS variables and no inline `color`. The rules below pick
- * the correct variable based on the active color scheme. Built-in themes
- * are matched by `[data-theme]`; user themes signal their scheme via an
- * inline `color-scheme: light|dark` on `<html>` (set in theme.ts:applyTheme).
- *
- * Selector targets only the Shiki-emitted token spans (those carrying the
- * `--shiki-light` custom property inline) regardless of ancestor. The
- * diff viewer mounts Shiki HTML directly inside a `<span>` (no
- * `<pre><code>` wrapper), so an ancestor-constrained selector misses
- * those tokens and they render with no token color. The line-wrapper
- * spans Shiki also emits don't carry the inline property and so
- * harmlessly miss this rule and inherit `currentColor`. Using the
- * inline-style attribute selector keeps the rule independent of
- * CSS-module class hashing.
+ * The Shiki worker uses a single Claudette theme whose foreground colors
+ * are `var(--syntax-*)` references (see styles/shikiClaudetteTheme.ts).
+ * Token spans render with inline `style="color: var(--syntax-keyword)"`
+ * etc., which the cascade resolves per-theme — no JS-side dual-theme
+ * switching needed. Light/dark adaptation comes from each theme's
+ * `--syntax-*` declarations in this file.
  */
-[style*="--shiki-light"] {
-  color: var(--shiki-dark);
-}
-[data-theme="default-light"] [style*="--shiki-light"],
-[data-theme="rose-pine-dawn"] [style*="--shiki-light"],
-[data-theme="solarized-light"] [style*="--shiki-light"],
-html[style*="color-scheme: light"] [style*="--shiki-light"] {
-  color: var(--shiki-light);
-}

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -89,29 +89,83 @@
   --badge-ask:           #f5a0b8;
 
   /* ---- Semantic accents — success / warning / error / info.
-     New consumers should prefer these over the older --badge-*, --status-*,
-     and --error-* tokens. Defaults derive from existing tokens so themes
-     that don't override these still get coherent values. The -rgb companions
-     are literals (CSS lacks an rgb-from-var function), so a user theme that
-     overrides --accent-success without --accent-success-rgb will break alpha
-     layers — co-emit both when authoring themes. */
-  --accent-success:      var(--badge-done);
-  --accent-success-rgb:  108, 204, 128;
-  --accent-success-bg:   rgba(108, 204, 128, 0.10);
-  --accent-warning:      #f0a050;
-  --accent-warning-rgb:  240, 160, 80;
-  --accent-warning-bg:   rgba(240, 160, 80, 0.10);
-  --accent-error:        var(--status-stopped);
-  --accent-error-rgb:    232, 80, 80;
-  --accent-error-bg:     var(--error-bg);
-  --accent-info:         var(--badge-plan);
-  --accent-info-rgb:     140, 184, 224;
-  --accent-info-bg:      rgba(140, 184, 224, 0.10);
+     Each family is a triplet: -bg (tinted surface), -border (outline),
+     -fg (text color). All three derive from -rgb, so a theme that wants
+     a different green only needs to override --accent-success and
+     --accent-success-rgb — the bg/border/fg layers update in lockstep.
+     Authors MUST co-emit -rgb when overriding the base color; the bg/border
+     alpha layers cannot be expressed in terms of a `var()` color in CSS. */
+  --accent-success:        #6ccc80;
+  --accent-success-rgb:    108, 204, 128;
+  --accent-success-bg:     rgba(var(--accent-success-rgb), 0.10);
+  --accent-success-border: rgba(var(--accent-success-rgb), 0.30);
+  --accent-success-fg:     var(--accent-success);
 
-  /* ---- UI-role tokens — neutral emphasis and a secondary brand accent.
-     Both derive from existing tokens; themes can override to break the link. */
-  --accent-neutral:      var(--text-muted);
-  --accent-secondary:    var(--mascot-pink);
+  --accent-warning:        #f0a050;
+  --accent-warning-rgb:    240, 160, 80;
+  --accent-warning-bg:     rgba(var(--accent-warning-rgb), 0.10);
+  --accent-warning-border: rgba(var(--accent-warning-rgb), 0.30);
+  --accent-warning-fg:     var(--accent-warning);
+
+  --accent-error:          #e85050;
+  --accent-error-rgb:      232, 80, 80;
+  --accent-error-bg:       rgba(var(--accent-error-rgb), 0.10);
+  --accent-error-border:   rgba(var(--accent-error-rgb), 0.30);
+  --accent-error-fg:       var(--accent-error);
+
+  --accent-info:           #8cb8e0;
+  --accent-info-rgb:       140, 184, 224;
+  --accent-info-bg:        rgba(var(--accent-info-rgb), 0.10);
+  --accent-info-border:    rgba(var(--accent-info-rgb), 0.30);
+  --accent-info-fg:        var(--accent-info);
+
+  /* ---- UI-role tokens — neutral emphasis + secondary/tertiary brand accents.
+     Secondary and tertiary follow the full triplet pattern so chip-style UIs
+     can compose filled-and-bordered surfaces from tokens alone. */
+  --accent-neutral:        var(--text-muted);
+
+  --accent-secondary:      #f5a0b8;
+  --accent-secondary-rgb:  245, 160, 184;
+  --accent-secondary-bg:     rgba(var(--accent-secondary-rgb), 0.10);
+  --accent-secondary-border: rgba(var(--accent-secondary-rgb), 0.30);
+  --accent-secondary-fg:     var(--accent-secondary);
+
+  --accent-tertiary:       #c0a0f0;
+  --accent-tertiary-rgb:   192, 160, 240;
+  --accent-tertiary-bg:      rgba(var(--accent-tertiary-rgb), 0.10);
+  --accent-tertiary-border:  rgba(var(--accent-tertiary-rgb), 0.30);
+  --accent-tertiary-fg:      var(--accent-tertiary);
+
+  /* ---- Category slots A–H — eight distinguishable hues for "item N of a
+     set" UI like workspace tags, plugin badges, env-provider chips. Each
+     slot ships bg/border/fg directly (no -rgb here, no consumer expected
+     to layer custom alpha). Like --tool-* and --syntax-*, categories are
+     intentionally brand-invariant: a workspace's category color stays
+     stable across themes so muscle memory holds. */
+  --category-a-bg:     rgba(232, 88, 88, 0.12);
+  --category-a-border: rgba(232, 88, 88, 0.32);
+  --category-a-fg:     #e85858;
+  --category-b-bg:     rgba(240, 160, 80, 0.12);
+  --category-b-border: rgba(240, 160, 80, 0.32);
+  --category-b-fg:     #f0a050;
+  --category-c-bg:     rgba(230, 200, 77, 0.12);
+  --category-c-border: rgba(230, 200, 77, 0.32);
+  --category-c-fg:     #e6c84d;
+  --category-d-bg:     rgba(108, 204, 128, 0.12);
+  --category-d-border: rgba(108, 204, 128, 0.32);
+  --category-d-fg:     #6ccc80;
+  --category-e-bg:     rgba(108, 200, 184, 0.12);
+  --category-e-border: rgba(108, 200, 184, 0.32);
+  --category-e-fg:     #6cc8b8;
+  --category-f-bg:     rgba(108, 182, 255, 0.12);
+  --category-f-border: rgba(108, 182, 255, 0.32);
+  --category-f-fg:     #6cb6ff;
+  --category-g-bg:     rgba(192, 160, 240, 0.12);
+  --category-g-border: rgba(192, 160, 240, 0.32);
+  --category-g-fg:     #c0a0f0;
+  --category-h-bg:     rgba(245, 160, 184, 0.12);
+  --category-h-border: rgba(245, 160, 184, 0.32);
+  --category-h-fg:     #f5a0b8;
 
   /* ---- Syntax highlight palette — mirrors base16 base08–base0F roles so
      base16 themes can map directly. Intentionally brand-invariant (like the
@@ -119,12 +173,12 @@
      and themes inherit unless they have a specific reason to override
      (e.g. high-contrast bumps saturation). */
   --syntax-keyword:      #c0a0f0;
-  --syntax-string:       var(--badge-done);
+  --syntax-string:       #6ccc80;
   --syntax-number:       #f0a050;
   --syntax-comment:      var(--text-faint);
-  --syntax-function:     var(--badge-plan);
+  --syntax-function:     #8cb8e0;
   --syntax-type:         #e0c050;
-  --syntax-variable:     var(--diff-removed-text);
+  --syntax-variable:     #f07070;
   --syntax-operator:     #6cb6ff;
 
   /* ---- Tool activity — per-category hues used in chat tool chips.
@@ -322,10 +376,18 @@
   --badge-plan: #6848a8;
   --badge-ask:  #a04828;
 
-  /* Deeper orange for warning on cream background — #f0a050 washes out. */
-  --accent-warning:     #c27430;
-  --accent-warning-rgb: 194, 116, 48;
-  --accent-warning-bg:  rgba(194, 116, 48, 0.10);
+  /* Semantic accents tuned for cream paper — track --badge-done/--status-stopped/
+     --badge-plan above. Deeper orange for warning since #f0a050 washes out. */
+  --accent-success:       #1a7f37;
+  --accent-success-rgb:   26, 127, 55;
+  --accent-warning:       #c27430;
+  --accent-warning-rgb:   194, 116, 48;
+  --accent-error:         #c42020;
+  --accent-error-rgb:     196, 32, 32;
+  --accent-info:          #6848a8;
+  --accent-info-rgb:      104, 72, 168;
+  --accent-secondary:     #d7827e;
+  --accent-secondary-rgb: 215, 130, 126;
 
   --diff-added-bg:   rgba(26, 127, 55, 0.10);
   --diff-removed-bg: rgba(196, 32, 32, 0.10);
@@ -391,6 +453,15 @@
   --badge-plan: #8fbfdc;
   --badge-ask:  #fad07a;
 
+  --accent-success:       #99ad6a;
+  --accent-success-rgb:   153, 173, 106;
+  --accent-warning:       #fad07a;
+  --accent-warning-rgb:   250, 208, 122;
+  --accent-error:         #cf6a4c;
+  --accent-error-rgb:     207, 106, 76;
+  --accent-info:          #8fbfdc;
+  --accent-info-rgb:      143, 191, 220;
+
   --diff-added-bg: rgba(67, 112, 25, 0.25);
   --diff-removed-bg: rgba(112, 0, 9, 0.25);
   --diff-added-text: #d2ebbe;
@@ -426,10 +497,19 @@
   --badge-plan: #66bbff;
   --badge-ask:  #ffbb44;
 
-  /* Max-saturation warning + syntax palette for legibility on near-black. */
-  --accent-warning:     #ffaa00;
-  --accent-warning-rgb: 255, 170, 0;
-  --accent-warning-bg:  rgba(255, 170, 0, 0.14);
+  /* Max-saturation semantic + syntax palette for legibility on near-black. */
+  --accent-success:       #00ffdd;
+  --accent-success-rgb:   0, 255, 221;
+  --accent-warning:       #ffaa00;
+  --accent-warning-rgb:   255, 170, 0;
+  --accent-error:         #ff4444;
+  --accent-error-rgb:     255, 68, 68;
+  --accent-info:          #66bbff;
+  --accent-info-rgb:      102, 187, 255;
+  --accent-secondary:     #ff66cc;
+  --accent-secondary-rgb: 255, 102, 204;
+  --accent-tertiary:      #d090ff;
+  --accent-tertiary-rgb:  208, 144, 255;
 
   --syntax-keyword:     #d090ff;
   --syntax-string:      #44ff44;
@@ -480,6 +560,17 @@
   --badge-plan: #9ccfd8;
   --badge-ask:  #f6c177;
 
+  --accent-success:       #31748f;
+  --accent-success-rgb:   49, 116, 143;
+  --accent-warning:       #f6c177;
+  --accent-warning-rgb:   246, 193, 119;
+  --accent-error:         #eb6f92;
+  --accent-error-rgb:     235, 111, 146;
+  --accent-info:          #9ccfd8;
+  --accent-info-rgb:      156, 207, 216;
+  --accent-secondary:     #ebbcba;
+  --accent-secondary-rgb: 235, 188, 186;
+
   --mascot-pink: #ebbcba;
 
   --diff-added-bg:   rgba(49, 116, 143, 0.22);
@@ -528,6 +619,17 @@
   --badge-done: #3e8fb0;
   --badge-plan: #9ccfd8;
   --badge-ask:  #f6c177;
+
+  --accent-success:       #3e8fb0;
+  --accent-success-rgb:   62, 143, 176;
+  --accent-warning:       #f6c177;
+  --accent-warning-rgb:   246, 193, 119;
+  --accent-error:         #eb6f92;
+  --accent-error-rgb:     235, 111, 146;
+  --accent-info:          #9ccfd8;
+  --accent-info-rgb:      156, 207, 216;
+  --accent-secondary:     #ea9a97;
+  --accent-secondary-rgb: 234, 154, 151;
 
   --mascot-pink: #ea9a97;
 
@@ -581,10 +683,17 @@
   --badge-plan: #56949f;
   --badge-ask:  #ea9d34;
 
-  /* Rosé Pine gold for warning (matches --badge-ask hue). */
-  --accent-warning:     #ea9d34;
-  --accent-warning-rgb: 234, 157, 52;
-  --accent-warning-bg:  rgba(234, 157, 52, 0.10);
+  /* Rosé Pine palette tuned semantic accents. */
+  --accent-success:       #286983;
+  --accent-success-rgb:   40, 105, 131;
+  --accent-warning:       #ea9d34;
+  --accent-warning-rgb:   234, 157, 52;
+  --accent-error:         #b4637a;
+  --accent-error-rgb:     180, 99, 122;
+  --accent-info:          #56949f;
+  --accent-info-rgb:      86, 148, 159;
+  --accent-secondary:     #d7827e;
+  --accent-secondary-rgb: 215, 130, 126;
 
   --mascot-pink: #d7827e;
 
@@ -636,6 +745,17 @@
   --badge-done: #859900;
   --badge-plan: #2aa198;
   --badge-ask:  #b58900;
+
+  --accent-success:       #859900;
+  --accent-success-rgb:   133, 153, 0;
+  --accent-warning:       #b58900;
+  --accent-warning-rgb:   181, 137, 0;
+  --accent-error:         #dc322f;
+  --accent-error-rgb:     220, 50, 47;
+  --accent-info:          #2aa198;
+  --accent-info-rgb:      42, 161, 152;
+  --accent-secondary:     #d33682;
+  --accent-secondary-rgb: 211, 54, 130;
 
   --mascot-pink: #d33682;
 
@@ -689,10 +809,17 @@
   --badge-plan: #2aa198;
   --badge-ask:  #b58900;
 
-  /* Solarized yellow for warning (matches --badge-ask). */
-  --accent-warning:     #b58900;
-  --accent-warning-rgb: 181, 137, 0;
-  --accent-warning-bg:  rgba(181, 137, 0, 0.10);
+  /* Solarized palette tuned semantic accents. */
+  --accent-success:       #859900;
+  --accent-success-rgb:   133, 153, 0;
+  --accent-warning:       #b58900;
+  --accent-warning-rgb:   181, 137, 0;
+  --accent-error:         #dc322f;
+  --accent-error-rgb:     220, 50, 47;
+  --accent-info:          #2aa198;
+  --accent-info-rgb:      42, 161, 152;
+  --accent-secondary:     #d33682;
+  --accent-secondary-rgb: 211, 54, 130;
 
   --mascot-pink: #d33682;
 
@@ -743,6 +870,17 @@
   --badge-plan: #a8a9eb;
   --badge-ask:  #f38d70;
 
+  --accent-success:       #85dacc;
+  --accent-success-rgb:   133, 218, 204;
+  --accent-warning:       #f9cc6c;
+  --accent-warning-rgb:   249, 204, 108;
+  --accent-error:         #fd6883;
+  --accent-error-rgb:     253, 104, 131;
+  --accent-info:          #a8a9eb;
+  --accent-info-rgb:      168, 169, 235;
+  --accent-secondary:     #f38d70;
+  --accent-secondary-rgb: 243, 141, 112;
+
   --mascot-pink: #fd6883;
 
   --diff-added-bg:   rgba(173, 218, 120, 0.14);
@@ -791,6 +929,17 @@
   --badge-done: #829868;
   --badge-plan: #7aa8c0;
   --badge-ask:  #d4b880;
+
+  --accent-success:       #829868;
+  --accent-success-rgb:   130, 152, 104;
+  --accent-warning:       #d4b880;
+  --accent-warning-rgb:   212, 184, 128;
+  --accent-error:         #b56a53;
+  --accent-error-rgb:     181, 106, 83;
+  --accent-info:          #7aa8c0;
+  --accent-info-rgb:      122, 168, 192;
+  --accent-secondary:     #b56a53;
+  --accent-secondary-rgb: 181, 106, 83;
 
   --mascot-pink: #b56a53;
 
@@ -841,6 +990,17 @@
   --badge-plan: rgb(100, 160, 240);
   --badge-ask:  #f0a050;
 
+  --accent-success:       rgb(80, 220, 120);
+  --accent-success-rgb:   80, 220, 120;
+  --accent-warning:       #f0a050;
+  --accent-warning-rgb:   240, 160, 80;
+  --accent-error:         #f05050;
+  --accent-error-rgb:     240, 80, 80;
+  --accent-info:          #4a9eff;
+  --accent-info-rgb:      74, 158, 255;
+  --accent-secondary:     #f05080;
+  --accent-secondary-rgb: 240, 80, 128;
+
   --mascot-pink: #f05080;
 
   --diff-added-bg:   rgba(0, 180, 80, 0.12);
@@ -889,6 +1049,17 @@
   --badge-done: #50d8a0;
   --badge-plan: rgb(120, 170, 230);
   --badge-ask:  #f0a050;
+
+  --accent-success:       #50d8a0;
+  --accent-success-rgb:   80, 216, 160;
+  --accent-warning:       #f0a050;
+  --accent-warning-rgb:   240, 160, 80;
+  --accent-error:         #e85050;
+  --accent-error-rgb:     232, 80, 80;
+  --accent-info:          rgb(120, 170, 230);
+  --accent-info-rgb:      120, 170, 230;
+  --accent-secondary:     #e85080;
+  --accent-secondary-rgb: 232, 80, 128;
 
   --mascot-pink: #e85080;
 
@@ -939,6 +1110,19 @@
   --badge-done: #08a363;
   --badge-plan: #8adcff;
   --badge-ask:  #ffba75;
+
+  --accent-success:       #08a363;
+  --accent-success-rgb:   8, 163, 99;
+  --accent-warning:       #ffba75;
+  --accent-warning-rgb:   255, 186, 117;
+  --accent-error:         #d92828;
+  --accent-error-rgb:     217, 40, 40;
+  --accent-info:          #8adcff;
+  --accent-info-rgb:      138, 220, 255;
+  --accent-secondary:     #ed87ae;
+  --accent-secondary-rgb: 237, 135, 174;
+  --accent-tertiary:      #dcaeff;
+  --accent-tertiary-rgb:  220, 174, 255;
 
   --mascot-pink: #ed87ae;
 

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -148,11 +148,15 @@
   --accent-tertiary-fg:      var(--accent-tertiary);
 
   /* ---- Category slots A–H — eight distinguishable hues for "item N of a
-     set" UI like workspace tags, plugin badges, env-provider chips. Each
-     slot ships bg/border/fg directly (no -rgb here, no consumer expected
-     to layer custom alpha). Like --tool-* and --syntax-*, categories are
-     intentionally brand-invariant: a workspace's category color stays
-     stable across themes so muscle memory holds. */
+     set" UI like plugin badges, env-provider chips, future workspace
+     tags. Each slot ships bg/border/fg directly (no -rgb here, no
+     consumer expected to layer custom alpha).
+     The default palette below is brand-invariant by design — a category
+     identity stays recognizable across most themes so muscle memory
+     holds. Themes with a strong native palette (Rosé Pine, Solarized)
+     CAN override these in their [data-theme] block when the palette's
+     identity is itself part of the theme experience; see the per-theme
+     blocks below for examples. */
   --category-a-bg:     rgba(232, 88, 88, 0.12);
   --category-a-border: rgba(232, 88, 88, 0.32);
   --category-a-fg:     #e85858;

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -537,9 +537,12 @@
   --text-separator: #403d52;
   --divider: #26233a;
 
-  --hover-bg: #21202e;
-  --selected-bg: rgba(196, 167, 231, 0.14);
-  --toolbar-active: rgba(196, 167, 231, 0.14);
+  /* hover-bg / selected-bg use Rosé Pine's prescribed Highlight Low/Med
+     layers instead of arbitrary accent-rgba — matches the canonical
+     palette's "highlight" role per rosepinetheme.com/palette/ingredients. */
+  --hover-bg: #21202e;          /* Highlight Low  */
+  --selected-bg: #403d52;       /* Highlight Med  */
+  --toolbar-active: #403d52;
   --toolbar-active-text: #c4a7e7;
 
   --status-running: #9ccfd8;
@@ -550,6 +553,40 @@
   --accent-warning: #f6c177;  /* warning has no upstream source */
 
   --mascot-pink: #ebbcba;
+
+  /* Category slots A–F = the six named Rosé Pine accents in the order
+     Love/Gold/Rose/Pine/Foam/Iris. Slots G/H stay on the default-dark
+     palette since Rosé Pine doesn't ship a canonical hue for them. */
+  --category-a-fg: #eb6f92;  /* Love  */
+  --category-a-bg: color-mix(in srgb, #eb6f92 12%, transparent);
+  --category-a-border: color-mix(in srgb, #eb6f92 32%, transparent);
+  --category-b-fg: #f6c177;  /* Gold  */
+  --category-b-bg: color-mix(in srgb, #f6c177 12%, transparent);
+  --category-b-border: color-mix(in srgb, #f6c177 32%, transparent);
+  --category-c-fg: #ebbcba;  /* Rose  */
+  --category-c-bg: color-mix(in srgb, #ebbcba 12%, transparent);
+  --category-c-border: color-mix(in srgb, #ebbcba 32%, transparent);
+  --category-d-fg: #31748f;  /* Pine  */
+  --category-d-bg: color-mix(in srgb, #31748f 12%, transparent);
+  --category-d-border: color-mix(in srgb, #31748f 32%, transparent);
+  --category-e-fg: #9ccfd8;  /* Foam  */
+  --category-e-bg: color-mix(in srgb, #9ccfd8 12%, transparent);
+  --category-e-border: color-mix(in srgb, #9ccfd8 32%, transparent);
+  --category-f-fg: #c4a7e7;  /* Iris  */
+  --category-f-bg: color-mix(in srgb, #c4a7e7 12%, transparent);
+  --category-f-border: color-mix(in srgb, #c4a7e7 32%, transparent);
+
+  /* Syntax tokens follow the community-consensus Rosé Pine mapping (used
+     by official Neovim/VSCode plugins): Iris for keywords/types, Gold for
+     strings, Rose for numbers, Foam for functions, Muted for comments. */
+  --syntax-keyword:  #c4a7e7;  /* Iris   */
+  --syntax-string:   #f6c177;  /* Gold   */
+  --syntax-number:   #ebbcba;  /* Rose   */
+  --syntax-comment:  #6e6a86;  /* Muted  */
+  --syntax-function: #9ccfd8;  /* Foam   */
+  --syntax-type:     #9ccfd8;  /* Foam   */
+  --syntax-variable: #e0def4;  /* Text   */
+  --syntax-operator: #908caa;  /* Subtle */
 
   --diff-added-bg:   rgba(49, 116, 143, 0.22);
   --diff-removed-bg: rgba(235, 111, 146, 0.18);
@@ -587,9 +624,10 @@
   --text-separator: #44415a;
   --divider: #393552;
 
-  --hover-bg: #2a283e;
-  --selected-bg: rgba(196, 167, 231, 0.14);
-  --toolbar-active: rgba(196, 167, 231, 0.14);
+  /* Highlight Low/Med per the Moon variant of the canonical palette. */
+  --hover-bg: #2a283e;     /* Highlight Low (Moon) */
+  --selected-bg: #44415a;  /* Highlight Med (Moon) */
+  --toolbar-active: #44415a;
   --toolbar-active-text: #c4a7e7;
 
   --status-running: #9ccfd8;
@@ -600,6 +638,37 @@
   --accent-warning: #f6c177;  /* warning has no upstream source */
 
   --mascot-pink: #ea9a97;
+
+  /* Category slots A–F = Love/Gold/Rose/Pine/Foam/Iris. The Moon variant
+     uses a different Rose hue (#ea9a97 vs main's #ebbcba) per spec. */
+  --category-a-fg: #eb6f92;
+  --category-a-bg: color-mix(in srgb, #eb6f92 12%, transparent);
+  --category-a-border: color-mix(in srgb, #eb6f92 32%, transparent);
+  --category-b-fg: #f6c177;
+  --category-b-bg: color-mix(in srgb, #f6c177 12%, transparent);
+  --category-b-border: color-mix(in srgb, #f6c177 32%, transparent);
+  --category-c-fg: #ea9a97;  /* Rose (Moon)  */
+  --category-c-bg: color-mix(in srgb, #ea9a97 12%, transparent);
+  --category-c-border: color-mix(in srgb, #ea9a97 32%, transparent);
+  --category-d-fg: #3e8fb0;  /* Pine (Moon)  */
+  --category-d-bg: color-mix(in srgb, #3e8fb0 12%, transparent);
+  --category-d-border: color-mix(in srgb, #3e8fb0 32%, transparent);
+  --category-e-fg: #9ccfd8;
+  --category-e-bg: color-mix(in srgb, #9ccfd8 12%, transparent);
+  --category-e-border: color-mix(in srgb, #9ccfd8 32%, transparent);
+  --category-f-fg: #c4a7e7;
+  --category-f-bg: color-mix(in srgb, #c4a7e7 12%, transparent);
+  --category-f-border: color-mix(in srgb, #c4a7e7 32%, transparent);
+
+  /* Syntax tokens mirror rose-pine-main with Moon's tuned Rose/Pine. */
+  --syntax-keyword:  #c4a7e7;
+  --syntax-string:   #f6c177;
+  --syntax-number:   #ea9a97;  /* Rose (Moon) */
+  --syntax-comment:  #6e6a86;
+  --syntax-function: #9ccfd8;
+  --syntax-type:     #9ccfd8;
+  --syntax-variable: #e0def4;
+  --syntax-operator: #908caa;
 
   --diff-added-bg:   rgba(62, 143, 176, 0.22);
   --diff-removed-bg: rgba(235, 111, 146, 0.18);
@@ -640,9 +709,10 @@
   --text-separator: #dfdad9;
   --divider: #f2e9e1;
 
-  --hover-bg: #f4ede8;
-  --selected-bg: rgba(144, 122, 169, 0.14);
-  --toolbar-active: rgba(144, 122, 169, 0.14);
+  /* Highlight Low/Med per Dawn — pale parchment tints. */
+  --hover-bg: #f4ede8;     /* Highlight Low (Dawn) */
+  --selected-bg: #dfdad9;  /* Highlight Med (Dawn) */
+  --toolbar-active: #dfdad9;
   --toolbar-active-text: #907aa9;
 
   --status-running: #56949f;
@@ -651,6 +721,37 @@
   --badge-plan: #56949f;
   --badge-ask:  #ea9d34;
   --accent-warning: #ea9d34;  /* warning has no upstream source */
+
+  /* Category slots A–F = Love/Gold/Rose/Pine/Foam/Iris (Dawn variant
+     ships darker/more saturated values so chips read on cream paper). */
+  --category-a-fg: #b4637a;  /* Love (Dawn)  */
+  --category-a-bg: color-mix(in srgb, #b4637a 14%, transparent);
+  --category-a-border: color-mix(in srgb, #b4637a 34%, transparent);
+  --category-b-fg: #ea9d34;  /* Gold (Dawn)  */
+  --category-b-bg: color-mix(in srgb, #ea9d34 14%, transparent);
+  --category-b-border: color-mix(in srgb, #ea9d34 34%, transparent);
+  --category-c-fg: #d7827e;  /* Rose (Dawn)  */
+  --category-c-bg: color-mix(in srgb, #d7827e 14%, transparent);
+  --category-c-border: color-mix(in srgb, #d7827e 34%, transparent);
+  --category-d-fg: #286983;  /* Pine (Dawn)  */
+  --category-d-bg: color-mix(in srgb, #286983 14%, transparent);
+  --category-d-border: color-mix(in srgb, #286983 34%, transparent);
+  --category-e-fg: #56949f;  /* Foam (Dawn)  */
+  --category-e-bg: color-mix(in srgb, #56949f 14%, transparent);
+  --category-e-border: color-mix(in srgb, #56949f 34%, transparent);
+  --category-f-fg: #907aa9;  /* Iris (Dawn)  */
+  --category-f-bg: color-mix(in srgb, #907aa9 14%, transparent);
+  --category-f-border: color-mix(in srgb, #907aa9 34%, transparent);
+
+  /* Syntax tokens — Dawn-tuned palette mirrors community plugins. */
+  --syntax-keyword:  #907aa9;  /* Iris (Dawn)  */
+  --syntax-string:   #ea9d34;  /* Gold (Dawn)  */
+  --syntax-number:   #d7827e;  /* Rose (Dawn)  */
+  --syntax-comment:  #9893a5;  /* Muted (Dawn) */
+  --syntax-function: #56949f;  /* Foam (Dawn)  */
+  --syntax-type:     #56949f;  /* Foam (Dawn)  */
+  --syntax-variable: #575279;  /* Text (Dawn)  */
+  --syntax-operator: #797593;  /* Subtle (Dawn)*/
 
   --mascot-pink: #d7827e;
 

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -807,6 +807,49 @@
 
   --mascot-pink: #d33682;
 
+  /* Per Ethan Schoonover's canonical Solarized spec (ethanschoonover.com/
+     solarized), the 8 accent hues stay identical between dark and light
+     variants — only the base ramp inverts. Mapping all 8 onto category
+     slots A–H in spectral order surfaces orange and violet (previously
+     unused in Claudette) and gives users 8 distinct, hand-tuned tags. */
+  --category-a-fg: #dc322f;  /* red     */
+  --category-a-bg: color-mix(in srgb, #dc322f 14%, transparent);
+  --category-a-border: color-mix(in srgb, #dc322f 34%, transparent);
+  --category-b-fg: #cb4b16;  /* orange  */
+  --category-b-bg: color-mix(in srgb, #cb4b16 14%, transparent);
+  --category-b-border: color-mix(in srgb, #cb4b16 34%, transparent);
+  --category-c-fg: #b58900;  /* yellow  */
+  --category-c-bg: color-mix(in srgb, #b58900 14%, transparent);
+  --category-c-border: color-mix(in srgb, #b58900 34%, transparent);
+  --category-d-fg: #859900;  /* green   */
+  --category-d-bg: color-mix(in srgb, #859900 14%, transparent);
+  --category-d-border: color-mix(in srgb, #859900 34%, transparent);
+  --category-e-fg: #2aa198;  /* cyan    */
+  --category-e-bg: color-mix(in srgb, #2aa198 14%, transparent);
+  --category-e-border: color-mix(in srgb, #2aa198 34%, transparent);
+  --category-f-fg: #268bd2;  /* blue    */
+  --category-f-bg: color-mix(in srgb, #268bd2 14%, transparent);
+  --category-f-border: color-mix(in srgb, #268bd2 34%, transparent);
+  --category-g-fg: #6c71c4;  /* violet  */
+  --category-g-bg: color-mix(in srgb, #6c71c4 14%, transparent);
+  --category-g-border: color-mix(in srgb, #6c71c4 34%, transparent);
+  --category-h-fg: #d33682;  /* magenta */
+  --category-h-bg: color-mix(in srgb, #d33682 14%, transparent);
+  --category-h-border: color-mix(in srgb, #d33682 34%, transparent);
+
+  /* Syntax tokens follow Schoonover's loose role mapping: green for
+     keywords/operators, cyan for strings, magenta for numbers, base01
+     for comments (the canonical "optional emphasis" tone), blue for
+     functions, yellow for types, orange for variables. */
+  --syntax-keyword:  #859900;  /* green   */
+  --syntax-string:   #2aa198;  /* cyan    */
+  --syntax-number:   #d33682;  /* magenta */
+  --syntax-comment:  #586e75;  /* base01  */
+  --syntax-function: #268bd2;  /* blue    */
+  --syntax-type:     #b58900;  /* yellow  */
+  --syntax-variable: #cb4b16;  /* orange  */
+  --syntax-operator: #859900;  /* green   */
+
   --diff-added-bg:   rgba(133, 153, 0, 0.18);
   --diff-removed-bg: rgba(220, 50, 47, 0.18);
   --diff-added-text:   #859900;
@@ -859,6 +902,44 @@
   --accent-warning: #b58900;  /* warning has no upstream source */
 
   --mascot-pink: #d33682;
+
+  /* Solarized's accent palette is identical light↔dark by design
+     (only the base ramp inverts), so the category-slot and syntax-token
+     mappings exactly mirror solarized-dark above. See the comment there
+     for the spectral order. */
+  --category-a-fg: #dc322f;  /* red     */
+  --category-a-bg: color-mix(in srgb, #dc322f 14%, transparent);
+  --category-a-border: color-mix(in srgb, #dc322f 34%, transparent);
+  --category-b-fg: #cb4b16;  /* orange  */
+  --category-b-bg: color-mix(in srgb, #cb4b16 14%, transparent);
+  --category-b-border: color-mix(in srgb, #cb4b16 34%, transparent);
+  --category-c-fg: #b58900;  /* yellow  */
+  --category-c-bg: color-mix(in srgb, #b58900 14%, transparent);
+  --category-c-border: color-mix(in srgb, #b58900 34%, transparent);
+  --category-d-fg: #859900;  /* green   */
+  --category-d-bg: color-mix(in srgb, #859900 14%, transparent);
+  --category-d-border: color-mix(in srgb, #859900 34%, transparent);
+  --category-e-fg: #2aa198;  /* cyan    */
+  --category-e-bg: color-mix(in srgb, #2aa198 14%, transparent);
+  --category-e-border: color-mix(in srgb, #2aa198 34%, transparent);
+  --category-f-fg: #268bd2;  /* blue    */
+  --category-f-bg: color-mix(in srgb, #268bd2 14%, transparent);
+  --category-f-border: color-mix(in srgb, #268bd2 34%, transparent);
+  --category-g-fg: #6c71c4;  /* violet  */
+  --category-g-bg: color-mix(in srgb, #6c71c4 14%, transparent);
+  --category-g-border: color-mix(in srgb, #6c71c4 34%, transparent);
+  --category-h-fg: #d33682;  /* magenta */
+  --category-h-bg: color-mix(in srgb, #d33682 14%, transparent);
+  --category-h-border: color-mix(in srgb, #d33682 34%, transparent);
+
+  --syntax-keyword:  #859900;
+  --syntax-string:   #2aa198;
+  --syntax-number:   #d33682;
+  --syntax-comment:  #93a1a1;  /* base1 — readable on cream */
+  --syntax-function: #268bd2;
+  --syntax-type:     #b58900;
+  --syntax-variable: #cb4b16;
+  --syntax-operator: #859900;
 
   --diff-added-bg:   rgba(133, 153, 0, 0.14);
   --diff-removed-bg: rgba(220, 50, 47, 0.14);

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -15,13 +15,19 @@
    Coral accent on warm charcoal.
    ============================================================ */
 :root {
-  /* ---- Brand accent (coral) ---- */
+  /* ---- Brand accent (coral) ----
+     accent-bg/-bg-strong/-glow derive from --accent-primary via
+     color-mix(), so a theme (or Base16 import) that only sets
+     --accent-primary still gets matching surfaces and glow. Per-theme
+     blocks below can override the derived layers with literal rgba
+     to nudge alpha (default-light prefers a softer glow, etc.) — those
+     overrides win over the cascade-derived defaults. */
   --accent-primary:      #e07850;
   --accent-primary-rgb:  224, 120, 80;
   --accent-dim:          #c45a35;
-  --accent-bg:           rgba(224, 120, 80, 0.08);
-  --accent-bg-strong:    rgba(224, 120, 80, 0.15);
-  --accent-glow:         0 0 12px rgba(224, 120, 80, 0.25);
+  --accent-bg:           color-mix(in srgb, var(--accent-primary) 8%, transparent);
+  --accent-bg-strong:    color-mix(in srgb, var(--accent-primary) 15%, transparent);
+  --accent-glow:         0 0 12px color-mix(in srgb, var(--accent-primary) 25%, transparent);
   /* Text color to pair with an --accent-primary background. Dark text on
      our bright/medium accents; light themes override below. */
   --on-accent:           #1c1815;
@@ -89,55 +95,56 @@
   --badge-ask:           #f5a0b8;
 
   /* ---- Semantic accents — success / warning / error / info.
-     Each family is a triplet: -bg (tinted surface), -border (outline),
-     -fg (text color). All three derive from -rgb, so a theme that wants
-     a different green only needs to override --accent-success and
-     --accent-success-rgb — the bg/border/fg layers update in lockstep.
-     Authors MUST co-emit -rgb when overriding the base color; the bg/border
-     alpha layers cannot be expressed in terms of a `var()` color in CSS. */
-  --accent-success:        #6ccc80;
-  --accent-success-rgb:    108, 204, 128;
-  --accent-success-bg:     rgba(var(--accent-success-rgb), 0.10);
-  --accent-success-border: rgba(var(--accent-success-rgb), 0.30);
-  --accent-success-hover:  rgba(var(--accent-success-rgb), 0.15);
+     Each family aliases an existing palette token (where one exists)
+     and derives bg/border/hover/fg via color-mix(). This means a theme
+     that overrides ONLY the upstream token (--badge-done, --status-stopped,
+     --badge-plan) automatically gets a matching semantic family — the
+     additive compatibility contract holds end-to-end.
+
+     For warning there's no equivalent legacy token, so it stays a literal;
+     themes override --accent-warning directly when they need a different
+     hue. color-mix(in srgb, X N%, transparent) produces an N%-alpha
+     version of X — the modern replacement for the old rgba(var(--*-rgb),
+     N) pattern that required maintaining a separate `-rgb` triplet
+     token. */
+  --accent-success:        var(--badge-done);
+  --accent-success-bg:     color-mix(in srgb, var(--accent-success) 10%, transparent);
+  --accent-success-border: color-mix(in srgb, var(--accent-success) 30%, transparent);
+  --accent-success-hover:  color-mix(in srgb, var(--accent-success) 15%, transparent);
   --accent-success-fg:     var(--accent-success);
 
   --accent-warning:        #f0a050;
-  --accent-warning-rgb:    240, 160, 80;
-  --accent-warning-bg:     rgba(var(--accent-warning-rgb), 0.10);
-  --accent-warning-border: rgba(var(--accent-warning-rgb), 0.30);
-  --accent-warning-hover:  rgba(var(--accent-warning-rgb), 0.15);
+  --accent-warning-bg:     color-mix(in srgb, var(--accent-warning) 10%, transparent);
+  --accent-warning-border: color-mix(in srgb, var(--accent-warning) 30%, transparent);
+  --accent-warning-hover:  color-mix(in srgb, var(--accent-warning) 15%, transparent);
   --accent-warning-fg:     var(--accent-warning);
 
-  --accent-error:          #e85050;
-  --accent-error-rgb:      232, 80, 80;
-  --accent-error-bg:       rgba(var(--accent-error-rgb), 0.10);
-  --accent-error-border:   rgba(var(--accent-error-rgb), 0.30);
-  --accent-error-hover:    rgba(var(--accent-error-rgb), 0.15);
+  --accent-error:          var(--status-stopped);
+  --accent-error-bg:       color-mix(in srgb, var(--accent-error) 10%, transparent);
+  --accent-error-border:   color-mix(in srgb, var(--accent-error) 30%, transparent);
+  --accent-error-hover:    color-mix(in srgb, var(--accent-error) 15%, transparent);
   --accent-error-fg:       var(--accent-error);
 
-  --accent-info:           #8cb8e0;
-  --accent-info-rgb:       140, 184, 224;
-  --accent-info-bg:        rgba(var(--accent-info-rgb), 0.10);
-  --accent-info-border:    rgba(var(--accent-info-rgb), 0.30);
-  --accent-info-hover:     rgba(var(--accent-info-rgb), 0.15);
+  --accent-info:           var(--badge-plan);
+  --accent-info-bg:        color-mix(in srgb, var(--accent-info) 10%, transparent);
+  --accent-info-border:    color-mix(in srgb, var(--accent-info) 30%, transparent);
+  --accent-info-hover:     color-mix(in srgb, var(--accent-info) 15%, transparent);
   --accent-info-fg:        var(--accent-info);
 
   /* ---- UI-role tokens — neutral emphasis + secondary/tertiary brand accents.
-     Secondary and tertiary follow the full triplet pattern so chip-style UIs
-     can compose filled-and-bordered surfaces from tokens alone. */
+     Secondary aliases the existing --mascot-pink. Tertiary is a literal
+     because there's no upstream source. Both expose the full chip triplet
+     (bg/border/fg) derived via color-mix. */
   --accent-neutral:        var(--text-muted);
 
-  --accent-secondary:      #f5a0b8;
-  --accent-secondary-rgb:  245, 160, 184;
-  --accent-secondary-bg:     rgba(var(--accent-secondary-rgb), 0.10);
-  --accent-secondary-border: rgba(var(--accent-secondary-rgb), 0.30);
+  --accent-secondary:        var(--mascot-pink);
+  --accent-secondary-bg:     color-mix(in srgb, var(--accent-secondary) 10%, transparent);
+  --accent-secondary-border: color-mix(in srgb, var(--accent-secondary) 30%, transparent);
   --accent-secondary-fg:     var(--accent-secondary);
 
-  --accent-tertiary:       #c0a0f0;
-  --accent-tertiary-rgb:   192, 160, 240;
-  --accent-tertiary-bg:      rgba(var(--accent-tertiary-rgb), 0.10);
-  --accent-tertiary-border:  rgba(var(--accent-tertiary-rgb), 0.30);
+  --accent-tertiary:         #c0a0f0;
+  --accent-tertiary-bg:      color-mix(in srgb, var(--accent-tertiary) 10%, transparent);
+  --accent-tertiary-border:  color-mix(in srgb, var(--accent-tertiary) 30%, transparent);
   --accent-tertiary-fg:      var(--accent-tertiary);
 
   /* ---- Category slots A–H — eight distinguishable hues for "item N of a
@@ -380,18 +387,11 @@
   --badge-plan: #6848a8;
   --badge-ask:  #a04828;
 
-  /* Semantic accents tuned for cream paper — track --badge-done/--status-stopped/
-     --badge-plan above. Deeper orange for warning since #f0a050 washes out. */
-  --accent-success:       #1a7f37;
-  --accent-success-rgb:   26, 127, 55;
+  /* --accent-success/-error/-info derive from --badge-done/--status-stopped/
+     --badge-plan via :root color-mix(), so they pick up the overrides
+     above automatically. Only --accent-warning needs a per-theme override
+     (no upstream source), and a deeper orange for cream paper. */
   --accent-warning:       #c27430;
-  --accent-warning-rgb:   194, 116, 48;
-  --accent-error:         #c42020;
-  --accent-error-rgb:     196, 32, 32;
-  --accent-info:          #6848a8;
-  --accent-info-rgb:      104, 72, 168;
-  --accent-secondary:     #d7827e;
-  --accent-secondary-rgb: 215, 130, 126;
 
   --diff-added-bg:   rgba(26, 127, 55, 0.10);
   --diff-removed-bg: rgba(196, 32, 32, 0.10);
@@ -456,15 +456,7 @@
   --badge-done: #99ad6a;
   --badge-plan: #8fbfdc;
   --badge-ask:  #fad07a;
-
-  --accent-success:       #99ad6a;
-  --accent-success-rgb:   153, 173, 106;
-  --accent-warning:       #fad07a;
-  --accent-warning-rgb:   250, 208, 122;
-  --accent-error:         #cf6a4c;
-  --accent-error-rgb:     207, 106, 76;
-  --accent-info:          #8fbfdc;
-  --accent-info-rgb:      143, 191, 220;
+  --accent-warning: #fad07a;  /* warning has no upstream source; track --badge-ask hue */
 
   --diff-added-bg: rgba(67, 112, 25, 0.25);
   --diff-removed-bg: rgba(112, 0, 9, 0.25);
@@ -501,19 +493,11 @@
   --badge-plan: #66bbff;
   --badge-ask:  #ffbb44;
 
-  /* Max-saturation semantic + syntax palette for legibility on near-black. */
-  --accent-success:       #00ffdd;
-  --accent-success-rgb:   0, 255, 221;
-  --accent-warning:       #ffaa00;
-  --accent-warning-rgb:   255, 170, 0;
-  --accent-error:         #ff4444;
-  --accent-error-rgb:     255, 68, 68;
-  --accent-info:          #66bbff;
-  --accent-info-rgb:      102, 187, 255;
-  --accent-secondary:     #ff66cc;
-  --accent-secondary-rgb: 255, 102, 204;
-  --accent-tertiary:      #d090ff;
-  --accent-tertiary-rgb:  208, 144, 255;
+  /* Max-saturation warning + secondary + tertiary for legibility on near-black.
+     success/error/info derive from --badge-done/--status-stopped/--badge-plan. */
+  --accent-warning:   #ffaa00;
+  --accent-secondary: #ff66cc;
+  --accent-tertiary:  #d090ff;
 
   --syntax-keyword:     #d090ff;
   --syntax-string:      #44ff44;
@@ -563,17 +547,7 @@
   --badge-done: #31748f;
   --badge-plan: #9ccfd8;
   --badge-ask:  #f6c177;
-
-  --accent-success:       #31748f;
-  --accent-success-rgb:   49, 116, 143;
-  --accent-warning:       #f6c177;
-  --accent-warning-rgb:   246, 193, 119;
-  --accent-error:         #eb6f92;
-  --accent-error-rgb:     235, 111, 146;
-  --accent-info:          #9ccfd8;
-  --accent-info-rgb:      156, 207, 216;
-  --accent-secondary:     #ebbcba;
-  --accent-secondary-rgb: 235, 188, 186;
+  --accent-warning: #f6c177;  /* warning has no upstream source */
 
   --mascot-pink: #ebbcba;
 
@@ -623,17 +597,7 @@
   --badge-done: #3e8fb0;
   --badge-plan: #9ccfd8;
   --badge-ask:  #f6c177;
-
-  --accent-success:       #3e8fb0;
-  --accent-success-rgb:   62, 143, 176;
-  --accent-warning:       #f6c177;
-  --accent-warning-rgb:   246, 193, 119;
-  --accent-error:         #eb6f92;
-  --accent-error-rgb:     235, 111, 146;
-  --accent-info:          #9ccfd8;
-  --accent-info-rgb:      156, 207, 216;
-  --accent-secondary:     #ea9a97;
-  --accent-secondary-rgb: 234, 154, 151;
+  --accent-warning: #f6c177;  /* warning has no upstream source */
 
   --mascot-pink: #ea9a97;
 
@@ -686,18 +650,7 @@
   --badge-done: #286983;
   --badge-plan: #56949f;
   --badge-ask:  #ea9d34;
-
-  /* Rosé Pine palette tuned semantic accents. */
-  --accent-success:       #286983;
-  --accent-success-rgb:   40, 105, 131;
-  --accent-warning:       #ea9d34;
-  --accent-warning-rgb:   234, 157, 52;
-  --accent-error:         #b4637a;
-  --accent-error-rgb:     180, 99, 122;
-  --accent-info:          #56949f;
-  --accent-info-rgb:      86, 148, 159;
-  --accent-secondary:     #d7827e;
-  --accent-secondary-rgb: 215, 130, 126;
+  --accent-warning: #ea9d34;  /* warning has no upstream source */
 
   --mascot-pink: #d7827e;
 
@@ -749,17 +702,7 @@
   --badge-done: #859900;
   --badge-plan: #2aa198;
   --badge-ask:  #b58900;
-
-  --accent-success:       #859900;
-  --accent-success-rgb:   133, 153, 0;
-  --accent-warning:       #b58900;
-  --accent-warning-rgb:   181, 137, 0;
-  --accent-error:         #dc322f;
-  --accent-error-rgb:     220, 50, 47;
-  --accent-info:          #2aa198;
-  --accent-info-rgb:      42, 161, 152;
-  --accent-secondary:     #d33682;
-  --accent-secondary-rgb: 211, 54, 130;
+  --accent-warning: #b58900;  /* warning has no upstream source */
 
   --mascot-pink: #d33682;
 
@@ -812,18 +755,7 @@
   --badge-done: #859900;
   --badge-plan: #2aa198;
   --badge-ask:  #b58900;
-
-  /* Solarized palette tuned semantic accents. */
-  --accent-success:       #859900;
-  --accent-success-rgb:   133, 153, 0;
-  --accent-warning:       #b58900;
-  --accent-warning-rgb:   181, 137, 0;
-  --accent-error:         #dc322f;
-  --accent-error-rgb:     220, 50, 47;
-  --accent-info:          #2aa198;
-  --accent-info-rgb:      42, 161, 152;
-  --accent-secondary:     #d33682;
-  --accent-secondary-rgb: 211, 54, 130;
+  --accent-warning: #b58900;  /* warning has no upstream source */
 
   --mascot-pink: #d33682;
 
@@ -873,17 +805,8 @@
   --badge-done: #85dacc;
   --badge-plan: #a8a9eb;
   --badge-ask:  #f38d70;
-
-  --accent-success:       #85dacc;
-  --accent-success-rgb:   133, 218, 204;
-  --accent-warning:       #f9cc6c;
-  --accent-warning-rgb:   249, 204, 108;
-  --accent-error:         #fd6883;
-  --accent-error-rgb:     253, 104, 131;
-  --accent-info:          #a8a9eb;
-  --accent-info-rgb:      168, 169, 235;
-  --accent-secondary:     #f38d70;
-  --accent-secondary-rgb: 243, 141, 112;
+  --accent-warning:   #f9cc6c;  /* warning has no upstream source */
+  --accent-secondary: #f38d70;  /* overrides --mascot-pink alias */
 
   --mascot-pink: #fd6883;
 
@@ -933,17 +856,7 @@
   --badge-done: #829868;
   --badge-plan: #7aa8c0;
   --badge-ask:  #d4b880;
-
-  --accent-success:       #829868;
-  --accent-success-rgb:   130, 152, 104;
-  --accent-warning:       #d4b880;
-  --accent-warning-rgb:   212, 184, 128;
-  --accent-error:         #b56a53;
-  --accent-error-rgb:     181, 106, 83;
-  --accent-info:          #7aa8c0;
-  --accent-info-rgb:      122, 168, 192;
-  --accent-secondary:     #b56a53;
-  --accent-secondary-rgb: 181, 106, 83;
+  --accent-warning: #d4b880;  /* warning has no upstream source */
 
   --mascot-pink: #b56a53;
 
@@ -993,17 +906,11 @@
   --badge-done: #4a9eff;
   --badge-plan: rgb(100, 160, 240);
   --badge-ask:  #f0a050;
-
-  --accent-success:       rgb(80, 220, 120);
-  --accent-success-rgb:   80, 220, 120;
-  --accent-warning:       #f0a050;
-  --accent-warning-rgb:   240, 160, 80;
-  --accent-error:         #f05050;
-  --accent-error-rgb:     240, 80, 80;
-  --accent-info:          #4a9eff;
-  --accent-info-rgb:      74, 158, 255;
-  --accent-secondary:     #f05080;
-  --accent-secondary-rgb: 240, 80, 128;
+  /* Midnight Blue ships a brighter green for success than --badge-done would
+     give (which here is the brand blue) so successes stay distinguishable
+     from neutral activity. */
+  --accent-success: rgb(80, 220, 120);
+  --accent-warning: #f0a050;
 
   --mascot-pink: #f05080;
 
@@ -1054,16 +961,7 @@
   --badge-plan: rgb(120, 170, 230);
   --badge-ask:  #f0a050;
 
-  --accent-success:       #50d8a0;
-  --accent-success-rgb:   80, 216, 160;
-  --accent-warning:       #f0a050;
-  --accent-warning-rgb:   240, 160, 80;
-  --accent-error:         #e85050;
-  --accent-error-rgb:     232, 80, 80;
-  --accent-info:          rgb(120, 170, 230);
-  --accent-info-rgb:      120, 170, 230;
-  --accent-secondary:     #e85080;
-  --accent-secondary-rgb: 232, 80, 128;
+  --accent-warning: #f0a050;  /* warning has no upstream source */
 
   --mascot-pink: #e85080;
 
@@ -1115,18 +1013,8 @@
   --badge-plan: #8adcff;
   --badge-ask:  #ffba75;
 
-  --accent-success:       #08a363;
-  --accent-success-rgb:   8, 163, 99;
-  --accent-warning:       #ffba75;
-  --accent-warning-rgb:   255, 186, 117;
-  --accent-error:         #d92828;
-  --accent-error-rgb:     217, 40, 40;
-  --accent-info:          #8adcff;
-  --accent-info-rgb:      138, 220, 255;
-  --accent-secondary:     #ed87ae;
-  --accent-secondary-rgb: 237, 135, 174;
-  --accent-tertiary:      #dcaeff;
-  --accent-tertiary-rgb:  220, 174, 255;
+  --accent-warning:  #ffba75;  /* warning has no upstream source */
+  --accent-tertiary: #dcaeff;  /* sidekick's signature pale violet */
 
   --mascot-pink: #ed87ae;
 

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -701,14 +701,14 @@ describe("HighlightedCode", () => {
   });
 
   it("renders dangerouslySetInnerHTML when cache returns highlighted HTML", () => {
-    vi.mocked(getCachedHighlight).mockReturnValue('<span style="--shiki-light:black">fn</span>');
+    vi.mocked(getCachedHighlight).mockReturnValue('<span style="color:var(--syntax-keyword)">fn</span>');
     const html = renderToStaticMarkup(
       createElement(HighlightedCode, {
         className: "language-rust",
         children: "fn",
       }),
     );
-    expect(html).toBe('<code class="language-rust"><span style="--shiki-light:black">fn</span></code>');
+    expect(html).toBe('<code class="language-rust"><span style="color:var(--syntax-keyword)">fn</span></code>');
   });
 
   it("preserves className on the rendered code element", () => {

--- a/src/ui/src/utils/theme.test.ts
+++ b/src/ui/src/utils/theme.test.ts
@@ -47,6 +47,8 @@ const {
   getThemeDataAttr,
   cacheThemePreference,
   findTheme,
+  detectBase16,
+  convertBase16ToClaudette,
 } = await import("./theme");
 const { DEFAULT_THEME_ID } = await import("../styles/themes");
 
@@ -255,5 +257,146 @@ describe("findTheme", () => {
 
   it("throws when the themes array is empty", () => {
     expect(() => findTheme([], "anything")).toThrow("No themes are available.");
+  });
+});
+
+// Canonical Base16 "Tomorrow Night" — every key is a 6-char hex without `#`.
+// Used across the detection + conversion tests.
+const TOMORROW_NIGHT: Record<string, string> = {
+  base00: "1d1f21",
+  base01: "282a2e",
+  base02: "373b41",
+  base03: "969896",
+  base04: "b4b7b4",
+  base05: "c5c8c6",
+  base06: "e0e0e0",
+  base07: "ffffff",
+  base08: "cc6666",
+  base09: "de935f",
+  base0A: "f0c674",
+  base0B: "b5bd68",
+  base0C: "8abeb7",
+  base0D: "81a2be",
+  base0E: "b294bb",
+  base0F: "a3685a",
+};
+
+describe("detectBase16", () => {
+  it("returns true for a complete base16 palette", () => {
+    expect(detectBase16({ ...TOMORROW_NIGHT })).toBe(true);
+  });
+
+  it("returns true when hexes have a leading # and 3-char shorthand", () => {
+    const palette = Object.fromEntries(
+      Object.entries(TOMORROW_NIGHT).map(([k, v]) => [k, `#${v}`]),
+    );
+    palette.base00 = "#000";
+    expect(detectBase16(palette)).toBe(true);
+  });
+
+  it("returns false when any base key is missing", () => {
+    const partial = { ...TOMORROW_NIGHT };
+    delete partial.base0F;
+    expect(detectBase16(partial)).toBe(false);
+  });
+
+  it("returns false when a base value is not a valid hex string", () => {
+    const bad = { ...TOMORROW_NIGHT, base05: "not-a-hex" };
+    expect(detectBase16(bad)).toBe(false);
+  });
+
+  it("returns false when the file also declares Claudette tokens (hybrid is Claudette)", () => {
+    const hybrid = { ...TOMORROW_NIGHT, "accent-primary": "#abcdef" };
+    expect(detectBase16(hybrid)).toBe(false);
+  });
+
+  it("returns false for a plain Claudette theme without any base keys", () => {
+    expect(detectBase16({ "accent-primary": "#e07850", "app-bg": "#1c1815" })).toBe(false);
+  });
+});
+
+describe("convertBase16ToClaudette", () => {
+  const input = {
+    id: "tomorrow-night",
+    name: "Tomorrow Night",
+    description: "",
+    colors: { ...TOMORROW_NIGHT },
+  };
+
+  it("maps base16 roles onto Claudette tokens following the canonical spec", () => {
+    const out = convertBase16ToClaudette(input).colors;
+    expect(out["app-bg"]).toBe("#1d1f21");           // base00
+    expect(out["terminal-bg"]).toBe("#1d1f21");      // base00
+    expect(out["sidebar-bg"]).toBe("#282a2e");       // base01
+    expect(out["text-primary"]).toBe("#c5c8c6");     // base05
+    expect(out["accent-error"]).toBe("#cc6666");     // base08
+    expect(out["accent-warning"]).toBe("#de935f");   // base09
+    expect(out["accent-success"]).toBe("#b5bd68");   // base0B
+    expect(out["accent-info"]).toBe("#81a2be");      // base0D
+    expect(out["accent-primary"]).toBe("#b294bb");   // base0E
+    expect(out["accent-dim"]).toBe("#a3685a");       // base0F
+    expect(out["syntax-keyword"]).toBe("#b294bb");   // base0E
+    expect(out["syntax-string"]).toBe("#b5bd68");    // base0B
+    expect(out["syntax-comment"]).toBe("#969896");   // base03
+  });
+
+  it("co-emits -rgb companions for every accent so rgba(var(...),a) keeps working", () => {
+    const out = convertBase16ToClaudette(input).colors;
+    expect(out["accent-primary-rgb"]).toBe("178, 148, 187");   // base0E
+    expect(out["accent-success-rgb"]).toBe("181, 189, 104");   // base0B
+    expect(out["accent-error-rgb"]).toBe("204, 102, 102");     // base08
+    expect(out["accent-warning-rgb"]).toBe("222, 147, 95");    // base09
+    expect(out["accent-info-rgb"]).toBe("129, 162, 190");      // base0D
+  });
+
+  it("derives color-scheme=dark from base00 luminance when no variant field", () => {
+    const out = convertBase16ToClaudette(input).colors;
+    expect(out["color-scheme"]).toBe("dark");
+  });
+
+  it("derives color-scheme=light when base00 is bright", () => {
+    const light = {
+      id: "tomorrow",
+      name: "Tomorrow",
+      description: "",
+      colors: { ...TOMORROW_NIGHT, base00: "ffffff", base01: "f5f5f5" },
+    };
+    expect(convertBase16ToClaudette(light).colors["color-scheme"]).toBe("light");
+  });
+
+  it("prefers an explicit variant field over luminance detection", () => {
+    // base00 = dark hex but variant says light — variant wins.
+    const tagged = {
+      id: "weird",
+      name: "Weird",
+      description: "",
+      colors: { ...TOMORROW_NIGHT, variant: "light" },
+    };
+    expect(convertBase16ToClaudette(tagged).colors["color-scheme"]).toBe("light");
+  });
+
+  it("preserves theme metadata (id, name, author, description)", () => {
+    const withMeta = {
+      id: "tn",
+      name: "Tomorrow Night",
+      author: "Chris Kempson",
+      description: "Dark theme",
+      colors: { ...TOMORROW_NIGHT },
+    };
+    const out = convertBase16ToClaudette(withMeta);
+    expect(out.id).toBe("tn");
+    expect(out.name).toBe("Tomorrow Night");
+    expect(out.author).toBe("Chris Kempson");
+    expect(out.description).toBe("Dark theme");
+  });
+
+  it("returns the input unchanged when palette is invalid (defensive)", () => {
+    const broken = {
+      id: "broken",
+      name: "Broken",
+      description: "",
+      colors: { ...TOMORROW_NIGHT, base05: "not-a-hex" },
+    };
+    expect(convertBase16ToClaudette(broken)).toBe(broken);
   });
 });

--- a/src/ui/src/utils/theme.test.ts
+++ b/src/ui/src/utils/theme.test.ts
@@ -310,8 +310,26 @@ describe("detectBase16", () => {
     expect(detectBase16(hybrid)).toBe(false);
   });
 
+  it("treats any THEMEABLE_VARS token as a Claudette signal, not just accent-primary", () => {
+    // A hybrid that overrides only `terminal-bg` (a deep-in-the-list themeable
+    // var) must still be treated as Claudette so the author's override survives.
+    const hybridTerminal = { ...TOMORROW_NIGHT, "terminal-bg": "#abcdef" };
+    expect(detectBase16(hybridTerminal)).toBe(false);
+
+    const hybridSyntax = { ...TOMORROW_NIGHT, "syntax-keyword": "#abcdef" };
+    expect(detectBase16(hybridSyntax)).toBe(false);
+  });
+
   it("returns false for a plain Claudette theme without any base keys", () => {
     expect(detectBase16({ "accent-primary": "#e07850", "app-bg": "#1c1815" })).toBe(false);
+  });
+
+  it("accepts lowercase base0a–base0f as well as uppercase", () => {
+    const lower: Record<string, string> = {};
+    for (const [k, v] of Object.entries(TOMORROW_NIGHT)) {
+      lower[k.toLowerCase()] = v;
+    }
+    expect(detectBase16(lower)).toBe(true);
   });
 });
 
@@ -398,5 +416,54 @@ describe("convertBase16ToClaudette", () => {
       colors: { ...TOMORROW_NIGHT, base05: "not-a-hex" },
     };
     expect(convertBase16ToClaudette(broken)).toBe(broken);
+  });
+
+  it("maps text-muted to base04, NOT base06 — base06 is brighter than base05 in dark schemes", () => {
+    // Tomorrow Night: base05=#c5c8c6 (default fg), base06=#e0e0e0 (brighter),
+    // base04=#b4b7b4 (dimmer). 'muted' must be dimmer than primary.
+    const out = convertBase16ToClaudette(input).colors;
+    expect(out["text-primary"]).toBe("#c5c8c6");  // base05
+    expect(out["text-muted"]).toBe("#b4b7b4");    // base04 (less prominent than primary)
+    expect(out["text-dim"]).toBe("#969896");      // base03
+  });
+
+  it("emits full -bg/-border/-fg triplets for each status accent so imported palettes don't inherit baseline tints", () => {
+    const out = convertBase16ToClaudette(input).colors;
+    // success uses base0B (#b5bd68 → 181, 189, 104)
+    expect(out["accent-success-bg"]).toBe("rgba(181, 189, 104, 0.10)");
+    expect(out["accent-success-border"]).toBe("rgba(181, 189, 104, 0.30)");
+    expect(out["accent-success-fg"]).toBe("#b5bd68");
+    // error uses base08 (#cc6666 → 204, 102, 102)
+    expect(out["accent-error-bg"]).toBe("rgba(204, 102, 102, 0.10)");
+    expect(out["accent-error-border"]).toBe("rgba(204, 102, 102, 0.30)");
+    // warning uses base09 (#de935f → 222, 147, 95)
+    expect(out["accent-warning-bg"]).toBe("rgba(222, 147, 95, 0.10)");
+    expect(out["accent-warning-border"]).toBe("rgba(222, 147, 95, 0.30)");
+    // info uses base0D (#81a2be → 129, 162, 190)
+    expect(out["accent-info-bg"]).toBe("rgba(129, 162, 190, 0.10)");
+    expect(out["accent-info-border"]).toBe("rgba(129, 162, 190, 0.30)");
+  });
+
+  it("emits secondary + tertiary triplets from base0F and base0E", () => {
+    const out = convertBase16ToClaudette(input).colors;
+    expect(out["accent-secondary"]).toBe("#a3685a");        // base0F
+    expect(out["accent-secondary-bg"]).toBe("rgba(163, 104, 90, 0.10)");
+    expect(out["accent-tertiary"]).toBe("#b294bb");         // base0E
+    expect(out["accent-tertiary-bg"]).toBe("rgba(178, 148, 187, 0.10)");
+  });
+
+  it("accepts a base16 palette using lowercase keys (base0a–base0f)", () => {
+    const lower: Record<string, string> = {};
+    for (const [k, v] of Object.entries(TOMORROW_NIGHT)) {
+      lower[k.toLowerCase()] = v;
+    }
+    const out = convertBase16ToClaudette({
+      id: "tomorrow-lower",
+      name: "Tomorrow (lowercase)",
+      description: "",
+      colors: lower,
+    }).colors;
+    expect(out["accent-success"]).toBe("#b5bd68"); // base0B regardless of case
+    expect(out["accent-primary"]).toBe("#b294bb"); // base0E regardless of case
   });
 });

--- a/src/ui/src/utils/theme.test.ts
+++ b/src/ui/src/utils/theme.test.ts
@@ -358,13 +358,27 @@ describe("convertBase16ToClaudette", () => {
     expect(out["syntax-comment"]).toBe("#969896");   // base03
   });
 
-  it("co-emits -rgb companions for every accent so rgba(var(...),a) keeps working", () => {
+  it("co-emits the -rgb companion for --accent-primary (still consumed by legacy alpha overlays)", () => {
     const out = convertBase16ToClaudette(input).colors;
     expect(out["accent-primary-rgb"]).toBe("178, 148, 187");   // base0E
-    expect(out["accent-success-rgb"]).toBe("181, 189, 104");   // base0B
-    expect(out["accent-error-rgb"]).toBe("204, 102, 102");     // base08
-    expect(out["accent-warning-rgb"]).toBe("222, 147, 95");    // base09
-    expect(out["accent-info-rgb"]).toBe("129, 162, 190");      // base0D
+  });
+
+  it("emits only the BASE color for status/UI-role accents (bg/border/hover/fg derive via color-mix in :root)", () => {
+    const out = convertBase16ToClaudette(input).colors;
+    // Base colors should be set explicitly so the cascade can derive
+    // the tinted companions automatically.
+    expect(out["accent-success"]).toBe("#b5bd68");   // base0B
+    expect(out["accent-warning"]).toBe("#de935f");   // base09
+    expect(out["accent-error"]).toBe("#cc6666");     // base08
+    expect(out["accent-info"]).toBe("#81a2be");      // base0D
+    expect(out["accent-secondary"]).toBe("#a3685a"); // base0F
+    expect(out["accent-tertiary"]).toBe("#b294bb");  // base0E
+    // -bg/-border/-fg are NOT emitted — they derive from the base via
+    // color-mix() in :root so the converter doesn't need to bake alpha.
+    expect(out["accent-success-bg"]).toBeUndefined();
+    expect(out["accent-success-rgb"]).toBeUndefined();
+    expect(out["accent-error-bg"]).toBeUndefined();
+    expect(out["accent-secondary-bg"]).toBeUndefined();
   });
 
   it("derives color-scheme=dark from base00 luminance when no variant field", () => {
@@ -427,30 +441,10 @@ describe("convertBase16ToClaudette", () => {
     expect(out["text-dim"]).toBe("#969896");      // base03
   });
 
-  it("emits full -bg/-border/-fg triplets for each status accent so imported palettes don't inherit baseline tints", () => {
-    const out = convertBase16ToClaudette(input).colors;
-    // success uses base0B (#b5bd68 → 181, 189, 104)
-    expect(out["accent-success-bg"]).toBe("rgba(181, 189, 104, 0.10)");
-    expect(out["accent-success-border"]).toBe("rgba(181, 189, 104, 0.30)");
-    expect(out["accent-success-fg"]).toBe("#b5bd68");
-    // error uses base08 (#cc6666 → 204, 102, 102)
-    expect(out["accent-error-bg"]).toBe("rgba(204, 102, 102, 0.10)");
-    expect(out["accent-error-border"]).toBe("rgba(204, 102, 102, 0.30)");
-    // warning uses base09 (#de935f → 222, 147, 95)
-    expect(out["accent-warning-bg"]).toBe("rgba(222, 147, 95, 0.10)");
-    expect(out["accent-warning-border"]).toBe("rgba(222, 147, 95, 0.30)");
-    // info uses base0D (#81a2be → 129, 162, 190)
-    expect(out["accent-info-bg"]).toBe("rgba(129, 162, 190, 0.10)");
-    expect(out["accent-info-border"]).toBe("rgba(129, 162, 190, 0.30)");
-  });
-
-  it("emits secondary + tertiary triplets from base0F and base0E", () => {
-    const out = convertBase16ToClaudette(input).colors;
-    expect(out["accent-secondary"]).toBe("#a3685a");        // base0F
-    expect(out["accent-secondary-bg"]).toBe("rgba(163, 104, 90, 0.10)");
-    expect(out["accent-tertiary"]).toBe("#b294bb");         // base0E
-    expect(out["accent-tertiary-bg"]).toBe("rgba(178, 148, 187, 0.10)");
-  });
+  // The bg/border/hover/fg triplet members no longer come from the converter
+  // — they derive from the base color in :root via color-mix(). Coverage for
+  // the derivation itself lives in themeTokenParity.test.ts (which asserts
+  // the :root rules are present).
 
   it("accepts a base16 palette using lowercase keys (base0a–base0f)", () => {
     const lower: Record<string, string> = {};

--- a/src/ui/src/utils/theme.ts
+++ b/src/ui/src/utils/theme.ts
@@ -45,20 +45,27 @@ const THEMEABLE_VARS = [
   "badge-done",
   "badge-plan",
   "badge-ask",
-  "accent-success",
-  "accent-success-rgb",
-  "accent-success-bg",
-  "accent-warning",
-  "accent-warning-rgb",
-  "accent-warning-bg",
-  "accent-error",
-  "accent-error-rgb",
-  "accent-error-bg",
-  "accent-info",
-  "accent-info-rgb",
-  "accent-info-bg",
+  // Status accents — each family is a 5-token group (color, -rgb, -bg, -border, -fg).
+  // The -bg/-border/-fg layers derive from -rgb in :root, so a user theme typically
+  // only needs to set the base color + -rgb.
+  "accent-success", "accent-success-rgb", "accent-success-bg", "accent-success-border", "accent-success-fg",
+  "accent-warning", "accent-warning-rgb", "accent-warning-bg", "accent-warning-border", "accent-warning-fg",
+  "accent-error", "accent-error-rgb", "accent-error-bg", "accent-error-border", "accent-error-fg",
+  "accent-info", "accent-info-rgb", "accent-info-bg", "accent-info-border", "accent-info-fg",
+  // UI-role tokens — neutral plus secondary/tertiary brand accents.
   "accent-neutral",
-  "accent-secondary",
+  "accent-secondary", "accent-secondary-rgb", "accent-secondary-bg", "accent-secondary-border", "accent-secondary-fg",
+  "accent-tertiary", "accent-tertiary-rgb", "accent-tertiary-bg", "accent-tertiary-border", "accent-tertiary-fg",
+  // Category slots A–H for "item N of a set" UI (workspace tags, plugin types).
+  "category-a-bg", "category-a-border", "category-a-fg",
+  "category-b-bg", "category-b-border", "category-b-fg",
+  "category-c-bg", "category-c-border", "category-c-fg",
+  "category-d-bg", "category-d-border", "category-d-fg",
+  "category-e-bg", "category-e-border", "category-e-fg",
+  "category-f-bg", "category-f-border", "category-f-fg",
+  "category-g-bg", "category-g-border", "category-g-fg",
+  "category-h-bg", "category-h-border", "category-h-fg",
+  // Syntax highlight palette — mirrors base16 base08–base0F roles.
   "syntax-keyword",
   "syntax-string",
   "syntax-number",
@@ -99,6 +106,12 @@ const THEMEABLE_VARS = [
   "font-mono",
   "font-display",
 ];
+
+// Read-only re-export for the parity test (utils/themeTokenParity.test.ts).
+// Kept as a separate symbol with a `__` prefix so it's obviously not for
+// production callers — they should reach for the canonical Claudette tokens
+// via CSS, not enumerate them at runtime.
+export const __THEMEABLE_VARS: readonly string[] = THEMEABLE_VARS;
 
 /**
  * Apply user font overrides on top of the current theme.
@@ -256,18 +269,21 @@ export function cacheThemePreference(
 // ---- Base16 import support ------------------------------------------------
 //
 // Claudette accepts user themes in `~/.claudette/themes/*.json` either in
-// Claudette's native shape (id/name/colors with `--*` keys) or as a canonical
-// Base16 scheme (`base00`–`base0F` keys). Base16 files are detected and
-// converted into Claudette tokens at load time.
+// Claudette's native shape (id/name/colors with bare token names like
+// `accent-primary` — applyTheme prepends the `--` when setting the CSS
+// property) or as a canonical Base16 scheme (`base00`–`base0F` keys).
+// Base16 files are detected and converted into Claudette tokens at load time.
 
-const BASE16_KEYS = [
-  "base00", "base01", "base02", "base03",
-  "base04", "base05", "base06", "base07",
-  "base08", "base09", "base0A", "base0B",
-  "base0C", "base0D", "base0E", "base0F",
+const BASE16_KEY_SUFFIXES = [
+  "00", "01", "02", "03", "04", "05", "06", "07",
+  "08", "09", "0A", "0B", "0C", "0D", "0E", "0F",
 ] as const;
 
-type Base16Key = (typeof BASE16_KEYS)[number];
+type Base16Key =
+  | "base00" | "base01" | "base02" | "base03"
+  | "base04" | "base05" | "base06" | "base07"
+  | "base08" | "base09" | "base0A" | "base0B"
+  | "base0C" | "base0D" | "base0E" | "base0F";
 
 // Accept #rrggbb, rrggbb, #rgb, rgb (case-insensitive). Return canonical #rrggbb.
 function normalizeHex(value: string): string | null {
@@ -296,18 +312,36 @@ function hexLuminance(hex: string): number {
   return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
 }
 
+// Look up a base16 slot tolerantly: real-world files in the wild use either
+// `base0A` (Tinted Theming spec) or `base0a` (some legacy schemes). Accept
+// both by normalizing the suffix's case at lookup time.
+function readBase16Slot(
+  colors: Record<string, string>,
+  suffix: string,
+): string | undefined {
+  return colors[`base${suffix}`] ?? colors[`base${suffix.toLowerCase()}`];
+}
+
+// Token names that, when present in a `colors` map, strongly indicate the file
+// is a hand-authored Claudette theme rather than a Base16 scheme. Built from
+// THEMEABLE_VARS minus a few keys that could legitimately co-exist with a
+// base16 payload (e.g. `variant`, `scheme` aren't tokens).
+const CLAUDETTE_TOKEN_SET = new Set(THEMEABLE_VARS);
+
 /**
- * A theme payload is base16 iff its `colors` map contains all 16 baseXX keys
- * (case-insensitive on the hex digit) AND it does not already declare a
- * recognized Claudette token. The latter check makes hybrid files unambiguous:
- * if a file ships both `accent-primary` and a full base16 palette, treat it
- * as Claudette (the author already mapped what they wanted).
+ * A theme payload is base16 iff its `colors` map contains all 16 baseXX slots
+ * with valid hex values (case-insensitive on the hex digit) AND it does not
+ * declare ANY recognized Claudette token. The latter check makes hybrid files
+ * unambiguous: if a file ships both base16 keys and any THEMEABLE_VARS entry,
+ * we treat it as Claudette so the author's explicit mappings aren't silently
+ * overwritten by the converter.
  */
 export function detectBase16(colors: Record<string, string>): boolean {
-  const claudetteSignals = ["accent-primary", "app-bg", "text-primary"];
-  if (claudetteSignals.some((k) => k in colors)) return false;
-  for (const key of BASE16_KEYS) {
-    const value = colors[key];
+  for (const key of Object.keys(colors)) {
+    if (CLAUDETTE_TOKEN_SET.has(key)) return false;
+  }
+  for (const suffix of BASE16_KEY_SUFFIXES) {
+    const value = readBase16Slot(colors, suffix);
     if (typeof value !== "string") return false;
     if (normalizeHex(value) === null) return false;
   }
@@ -317,9 +351,12 @@ export function detectBase16(colors: Record<string, string>): boolean {
 /**
  * Map a base16 palette onto Claudette tokens following the canonical Tinted
  * Theming role spec: base00=bg, base05=fg, base08=red, base0A=yellow,
- * base0B=green, base0D=blue, base0E=purple, etc. `-rgb` companions are
- * co-emitted from each accent hex so `rgba(var(--*-rgb), alpha)` consumers
- * keep working.
+ * base0B=green, base0D=blue, base0E=purple, etc.
+ *
+ * For every status/UI-role accent we emit the full triplet companion set
+ * (-rgb, -bg, -border, -fg) so the imported palette doesn't inherit the
+ * baseline theme's tints. The bg/border/fg layers use the same alpha
+ * levels as :root in theme.css.
  *
  * `color-scheme` is read from a `variant` field if present (some base16
  * files declare `"variant": "light"`); otherwise derived from base00's
@@ -327,90 +364,109 @@ export function detectBase16(colors: Record<string, string>): boolean {
  */
 export function convertBase16ToClaudette(theme: ThemeDefinition): ThemeDefinition {
   const src = theme.colors;
-  const palette = {} as Record<Base16Key, string>;
-  for (const key of BASE16_KEYS) {
-    const norm = normalizeHex(src[key] ?? "");
+  const palette: Partial<Record<Base16Key, string>> = {};
+  for (const suffix of BASE16_KEY_SUFFIXES) {
+    const raw = readBase16Slot(src, suffix);
+    const norm = normalizeHex(raw ?? "");
     if (norm === null) {
       // detectBase16 should have caught this; bail out and return the input
       // unchanged so applyTheme treats it as a plain Claudette theme.
       return theme;
     }
-    palette[key] = norm;
+    palette[`base${suffix}` as Base16Key] = norm;
   }
+  const p = palette as Record<Base16Key, string>;
 
   const variant = (src["variant"] ?? "").toLowerCase();
   const scheme: "light" | "dark" =
     variant === "light" || variant === "dark"
       ? (variant as "light" | "dark")
-      : hexLuminance(palette.base00) < 0.5
+      : hexLuminance(p.base00) < 0.5
         ? "dark"
         : "light";
+
+  // Emit the full bg/border/fg triplet for a semantic accent. Alpha levels
+  // mirror the :root defaults in theme.css (10% tint, 30% outline).
+  const emitTriplet = (
+    out: Record<string, string>,
+    prefix: string,
+    hex: string,
+  ) => {
+    const rgb = hexToRgbTriplet(hex);
+    out[prefix] = hex;
+    out[`${prefix}-rgb`] = rgb;
+    out[`${prefix}-bg`] = `rgba(${rgb}, 0.10)`;
+    out[`${prefix}-border`] = `rgba(${rgb}, 0.30)`;
+    out[`${prefix}-fg`] = hex;
+  };
 
   const out: Record<string, string> = {
     "color-scheme": scheme,
 
     // Surfaces
-    "app-bg": palette.base00,
-    "sidebar-bg": palette.base01,
-    "sidebar-border": palette.base02,
-    "chat-input-bg": palette.base01,
-    "chat-header-bg": palette.base01,
-    "chat-user-bg": palette.base01,
-    "terminal-bg": palette.base00,
-    "terminal-tab-bg": palette.base01,
-    "terminal-tab-active-bg": palette.base02,
+    "app-bg": p.base00,
+    "sidebar-bg": p.base01,
+    "sidebar-border": p.base02,
+    "chat-input-bg": p.base01,
+    "chat-header-bg": p.base01,
+    "chat-user-bg": p.base01,
+    "terminal-bg": p.base00,
+    "terminal-tab-bg": p.base01,
+    "terminal-tab-active-bg": p.base02,
 
-    // Text ramp — base05 is default fg, then dimmer down through base04/03.
-    // base06 (light fg) maps to muted so it stays readable on the bg ramp.
-    "text-primary": palette.base05,
-    "text-muted": palette.base06,
-    "text-dim": palette.base04,
-    "text-faint": palette.base03,
-    "text-separator": palette.base02,
-    "on-accent": palette.base07,
-    "divider": palette.base02,
-    "selected-bg": palette.base02,
+    // Text ramp — Claudette's primary→muted→dim→faint hierarchy goes from
+    // highest to lowest contrast against the bg. In base16, base05 is the
+    // default foreground; base04→base03 are progressively dimmer. base06 is
+    // a HIGH-contrast tone (brighter than base05 in dark schemes), so it
+    // doesn't fit "muted" — we leave it unmapped here.
+    "text-primary": p.base05,
+    "text-muted": p.base04,
+    "text-dim": p.base03,
+    "text-faint": p.base03,
+    "text-separator": p.base02,
+    "on-accent": p.base07,
+    "divider": p.base02,
+    "selected-bg": p.base02,
 
-    // Status / semantic accents
-    "status-running": palette.base0B,
-    "status-stopped": palette.base08,
-    "badge-done": palette.base0B,
-    "badge-plan": palette.base0D,
-    "badge-ask": palette.base0A,
+    // Legacy semantic-ish tokens kept in sync with new accents.
+    "status-running": p.base0B,
+    "status-stopped": p.base08,
+    "badge-done": p.base0B,
+    "badge-plan": p.base0D,
+    "badge-ask": p.base0A,
 
-    "accent-success": palette.base0B,
-    "accent-success-rgb": hexToRgbTriplet(palette.base0B),
-    "accent-warning": palette.base09,
-    "accent-warning-rgb": hexToRgbTriplet(palette.base09),
-    "accent-error": palette.base08,
-    "accent-error-rgb": hexToRgbTriplet(palette.base08),
-    "accent-info": palette.base0D,
-    "accent-info-rgb": hexToRgbTriplet(palette.base0D),
-
-    "accent-neutral": palette.base04,
-    "accent-secondary": palette.base0F,
+    "accent-neutral": p.base04,
 
     // Brand accent uses base0E (purple) per the Tinted Theming convention.
-    "accent-primary": palette.base0E,
-    "accent-primary-rgb": hexToRgbTriplet(palette.base0E),
-    "accent-dim": palette.base0F,
+    "accent-primary": p.base0E,
+    "accent-primary-rgb": hexToRgbTriplet(p.base0E),
+    "accent-dim": p.base0F,
 
     // Diff
-    "diff-added-text": palette.base0B,
-    "diff-removed-text": palette.base08,
-    "diff-hunk-header": palette.base0D,
-    "diff-line-number": palette.base03,
+    "diff-added-text": p.base0B,
+    "diff-removed-text": p.base08,
+    "diff-hunk-header": p.base0D,
+    "diff-line-number": p.base03,
 
     // Syntax — direct base08-base0F mapping per spec.
-    "syntax-variable": palette.base08,
-    "syntax-number": palette.base09,
-    "syntax-type": palette.base0A,
-    "syntax-string": palette.base0B,
-    "syntax-operator": palette.base0C,
-    "syntax-function": palette.base0D,
-    "syntax-keyword": palette.base0E,
-    "syntax-comment": palette.base03,
+    "syntax-variable": p.base08,
+    "syntax-number": p.base09,
+    "syntax-type": p.base0A,
+    "syntax-string": p.base0B,
+    "syntax-operator": p.base0C,
+    "syntax-function": p.base0D,
+    "syntax-keyword": p.base0E,
+    "syntax-comment": p.base03,
   };
+
+  // Status + UI-role accents — full triplets so imported palettes don't
+  // inherit baseline tints.
+  emitTriplet(out, "accent-success", p.base0B);
+  emitTriplet(out, "accent-warning", p.base09);
+  emitTriplet(out, "accent-error", p.base08);
+  emitTriplet(out, "accent-info", p.base0D);
+  emitTriplet(out, "accent-secondary", p.base0F);
+  emitTriplet(out, "accent-tertiary", p.base0E);
 
   return {
     id: theme.id,

--- a/src/ui/src/utils/theme.ts
+++ b/src/ui/src/utils/theme.ts
@@ -45,6 +45,28 @@ const THEMEABLE_VARS = [
   "badge-done",
   "badge-plan",
   "badge-ask",
+  "accent-success",
+  "accent-success-rgb",
+  "accent-success-bg",
+  "accent-warning",
+  "accent-warning-rgb",
+  "accent-warning-bg",
+  "accent-error",
+  "accent-error-rgb",
+  "accent-error-bg",
+  "accent-info",
+  "accent-info-rgb",
+  "accent-info-bg",
+  "accent-neutral",
+  "accent-secondary",
+  "syntax-keyword",
+  "syntax-string",
+  "syntax-number",
+  "syntax-comment",
+  "syntax-function",
+  "syntax-type",
+  "syntax-variable",
+  "syntax-operator",
   "diff-added-bg",
   "diff-removed-bg",
   "diff-added-text",
@@ -231,6 +253,174 @@ export function cacheThemePreference(
   }
 }
 
+// ---- Base16 import support ------------------------------------------------
+//
+// Claudette accepts user themes in `~/.claudette/themes/*.json` either in
+// Claudette's native shape (id/name/colors with `--*` keys) or as a canonical
+// Base16 scheme (`base00`–`base0F` keys). Base16 files are detected and
+// converted into Claudette tokens at load time.
+
+const BASE16_KEYS = [
+  "base00", "base01", "base02", "base03",
+  "base04", "base05", "base06", "base07",
+  "base08", "base09", "base0A", "base0B",
+  "base0C", "base0D", "base0E", "base0F",
+] as const;
+
+type Base16Key = (typeof BASE16_KEYS)[number];
+
+// Accept #rrggbb, rrggbb, #rgb, rgb (case-insensitive). Return canonical #rrggbb.
+function normalizeHex(value: string): string | null {
+  const v = value.trim().replace(/^#/, "");
+  if (/^[0-9a-fA-F]{6}$/.test(v)) return `#${v.toLowerCase()}`;
+  if (/^[0-9a-fA-F]{3}$/.test(v)) {
+    const [r, g, b] = v;
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
+  }
+  return null;
+}
+
+function hexToRgbTriplet(hex: string): string {
+  const v = hex.replace(/^#/, "");
+  const r = parseInt(v.slice(0, 2), 16);
+  const g = parseInt(v.slice(2, 4), 16);
+  const b = parseInt(v.slice(4, 6), 16);
+  return `${r}, ${g}, ${b}`;
+}
+
+function hexLuminance(hex: string): number {
+  const v = hex.replace(/^#/, "");
+  const r = parseInt(v.slice(0, 2), 16);
+  const g = parseInt(v.slice(2, 4), 16);
+  const b = parseInt(v.slice(4, 6), 16);
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
+/**
+ * A theme payload is base16 iff its `colors` map contains all 16 baseXX keys
+ * (case-insensitive on the hex digit) AND it does not already declare a
+ * recognized Claudette token. The latter check makes hybrid files unambiguous:
+ * if a file ships both `accent-primary` and a full base16 palette, treat it
+ * as Claudette (the author already mapped what they wanted).
+ */
+export function detectBase16(colors: Record<string, string>): boolean {
+  const claudetteSignals = ["accent-primary", "app-bg", "text-primary"];
+  if (claudetteSignals.some((k) => k in colors)) return false;
+  for (const key of BASE16_KEYS) {
+    const value = colors[key];
+    if (typeof value !== "string") return false;
+    if (normalizeHex(value) === null) return false;
+  }
+  return true;
+}
+
+/**
+ * Map a base16 palette onto Claudette tokens following the canonical Tinted
+ * Theming role spec: base00=bg, base05=fg, base08=red, base0A=yellow,
+ * base0B=green, base0D=blue, base0E=purple, etc. `-rgb` companions are
+ * co-emitted from each accent hex so `rgba(var(--*-rgb), alpha)` consumers
+ * keep working.
+ *
+ * `color-scheme` is read from a `variant` field if present (some base16
+ * files declare `"variant": "light"`); otherwise derived from base00's
+ * relative luminance.
+ */
+export function convertBase16ToClaudette(theme: ThemeDefinition): ThemeDefinition {
+  const src = theme.colors;
+  const palette = {} as Record<Base16Key, string>;
+  for (const key of BASE16_KEYS) {
+    const norm = normalizeHex(src[key] ?? "");
+    if (norm === null) {
+      // detectBase16 should have caught this; bail out and return the input
+      // unchanged so applyTheme treats it as a plain Claudette theme.
+      return theme;
+    }
+    palette[key] = norm;
+  }
+
+  const variant = (src["variant"] ?? "").toLowerCase();
+  const scheme: "light" | "dark" =
+    variant === "light" || variant === "dark"
+      ? (variant as "light" | "dark")
+      : hexLuminance(palette.base00) < 0.5
+        ? "dark"
+        : "light";
+
+  const out: Record<string, string> = {
+    "color-scheme": scheme,
+
+    // Surfaces
+    "app-bg": palette.base00,
+    "sidebar-bg": palette.base01,
+    "sidebar-border": palette.base02,
+    "chat-input-bg": palette.base01,
+    "chat-header-bg": palette.base01,
+    "chat-user-bg": palette.base01,
+    "terminal-bg": palette.base00,
+    "terminal-tab-bg": palette.base01,
+    "terminal-tab-active-bg": palette.base02,
+
+    // Text ramp — base05 is default fg, then dimmer down through base04/03.
+    // base06 (light fg) maps to muted so it stays readable on the bg ramp.
+    "text-primary": palette.base05,
+    "text-muted": palette.base06,
+    "text-dim": palette.base04,
+    "text-faint": palette.base03,
+    "text-separator": palette.base02,
+    "on-accent": palette.base07,
+    "divider": palette.base02,
+    "selected-bg": palette.base02,
+
+    // Status / semantic accents
+    "status-running": palette.base0B,
+    "status-stopped": palette.base08,
+    "badge-done": palette.base0B,
+    "badge-plan": palette.base0D,
+    "badge-ask": palette.base0A,
+
+    "accent-success": palette.base0B,
+    "accent-success-rgb": hexToRgbTriplet(palette.base0B),
+    "accent-warning": palette.base09,
+    "accent-warning-rgb": hexToRgbTriplet(palette.base09),
+    "accent-error": palette.base08,
+    "accent-error-rgb": hexToRgbTriplet(palette.base08),
+    "accent-info": palette.base0D,
+    "accent-info-rgb": hexToRgbTriplet(palette.base0D),
+
+    "accent-neutral": palette.base04,
+    "accent-secondary": palette.base0F,
+
+    // Brand accent uses base0E (purple) per the Tinted Theming convention.
+    "accent-primary": palette.base0E,
+    "accent-primary-rgb": hexToRgbTriplet(palette.base0E),
+    "accent-dim": palette.base0F,
+
+    // Diff
+    "diff-added-text": palette.base0B,
+    "diff-removed-text": palette.base08,
+    "diff-hunk-header": palette.base0D,
+    "diff-line-number": palette.base03,
+
+    // Syntax — direct base08-base0F mapping per spec.
+    "syntax-variable": palette.base08,
+    "syntax-number": palette.base09,
+    "syntax-type": palette.base0A,
+    "syntax-string": palette.base0B,
+    "syntax-operator": palette.base0C,
+    "syntax-function": palette.base0D,
+    "syntax-keyword": palette.base0E,
+    "syntax-comment": palette.base03,
+  };
+
+  return {
+    id: theme.id,
+    name: theme.name,
+    author: theme.author,
+    description: theme.description,
+    colors: out,
+  };
+}
+
 export async function loadAllThemes(): Promise<ThemeDefinition[]> {
   let userThemes: ThemeDefinition[] = [];
   try {
@@ -254,7 +444,10 @@ export async function loadAllThemes(): Promise<ThemeDefinition[]> {
     });
   }
   for (const theme of userThemes) {
-    themesById.set(theme.id, theme);
+    const resolved = detectBase16(theme.colors)
+      ? convertBase16ToClaudette(theme)
+      : theme;
+    themesById.set(resolved.id, resolved);
   }
   return Array.from(themesById.values());
 }

--- a/src/ui/src/utils/theme.ts
+++ b/src/ui/src/utils/theme.ts
@@ -48,10 +48,10 @@ const THEMEABLE_VARS = [
   // Status accents — each family is a 5-token group (color, -rgb, -bg, -border, -fg).
   // The -bg/-border/-fg layers derive from -rgb in :root, so a user theme typically
   // only needs to set the base color + -rgb.
-  "accent-success", "accent-success-rgb", "accent-success-bg", "accent-success-border", "accent-success-fg",
-  "accent-warning", "accent-warning-rgb", "accent-warning-bg", "accent-warning-border", "accent-warning-fg",
-  "accent-error", "accent-error-rgb", "accent-error-bg", "accent-error-border", "accent-error-fg",
-  "accent-info", "accent-info-rgb", "accent-info-bg", "accent-info-border", "accent-info-fg",
+  "accent-success", "accent-success-rgb", "accent-success-bg", "accent-success-border", "accent-success-hover", "accent-success-fg",
+  "accent-warning", "accent-warning-rgb", "accent-warning-bg", "accent-warning-border", "accent-warning-hover", "accent-warning-fg",
+  "accent-error", "accent-error-rgb", "accent-error-bg", "accent-error-border", "accent-error-hover", "accent-error-fg",
+  "accent-info", "accent-info-rgb", "accent-info-bg", "accent-info-border", "accent-info-hover", "accent-info-fg",
   // UI-role tokens — neutral plus secondary/tertiary brand accents.
   "accent-neutral",
   "accent-secondary", "accent-secondary-rgb", "accent-secondary-bg", "accent-secondary-border", "accent-secondary-fg",

--- a/src/ui/src/utils/theme.ts
+++ b/src/ui/src/utils/theme.ts
@@ -368,10 +368,12 @@ export function detectBase16(colors: Record<string, string>): boolean {
  * Theming role spec: base00=bg, base05=fg, base08=red, base0A=yellow,
  * base0B=green, base0D=blue, base0E=purple, etc.
  *
- * For every status/UI-role accent we emit the full triplet companion set
- * (-rgb, -bg, -border, -fg) so the imported palette doesn't inherit the
- * baseline theme's tints. The bg/border/fg layers use the same alpha
- * levels as :root in theme.css.
+ * Emits only BASE colors for the semantic accent families (success / warning
+ * / error / info / secondary / tertiary). The `-bg` / `-border` / `-hover`
+ * / `-fg` companions derive from each base in `:root` via `color-mix()`,
+ * so the cascade fills them in automatically — no per-companion emission
+ * needed here. The legacy `--accent-primary-rgb` is still co-emitted
+ * because terminal-selection and a few other consumers still read it.
  *
  * `color-scheme` is read from a `variant` field if present (some base16
  * files declare `"variant": "light"`); otherwise derived from base00's

--- a/src/ui/src/utils/theme.ts
+++ b/src/ui/src/utils/theme.ts
@@ -45,17 +45,20 @@ const THEMEABLE_VARS = [
   "badge-done",
   "badge-plan",
   "badge-ask",
-  // Status accents — each family is a 5-token group (color, -rgb, -bg, -border, -fg).
-  // The -bg/-border/-fg layers derive from -rgb in :root, so a user theme typically
-  // only needs to set the base color + -rgb.
-  "accent-success", "accent-success-rgb", "accent-success-bg", "accent-success-border", "accent-success-hover", "accent-success-fg",
-  "accent-warning", "accent-warning-rgb", "accent-warning-bg", "accent-warning-border", "accent-warning-hover", "accent-warning-fg",
-  "accent-error", "accent-error-rgb", "accent-error-bg", "accent-error-border", "accent-error-hover", "accent-error-fg",
-  "accent-info", "accent-info-rgb", "accent-info-bg", "accent-info-border", "accent-info-hover", "accent-info-fg",
+  // Status accents — each family is a 5-token group: base color (which a
+  // theme can override), plus -bg/-border/-hover/-fg layers derived from
+  // the base via color-mix(in srgb, var(--accent-X) N%, transparent) in
+  // :root. A theme that overrides --accent-success automatically gets a
+  // matching tinted surface and outline; no -rgb companion needed.
+  "accent-success", "accent-success-bg", "accent-success-border", "accent-success-hover", "accent-success-fg",
+  "accent-warning", "accent-warning-bg", "accent-warning-border", "accent-warning-hover", "accent-warning-fg",
+  "accent-error", "accent-error-bg", "accent-error-border", "accent-error-hover", "accent-error-fg",
+  "accent-info", "accent-info-bg", "accent-info-border", "accent-info-hover", "accent-info-fg",
   // UI-role tokens — neutral plus secondary/tertiary brand accents.
+  // Same color-mix derivation; only the base needs overriding per theme.
   "accent-neutral",
-  "accent-secondary", "accent-secondary-rgb", "accent-secondary-bg", "accent-secondary-border", "accent-secondary-fg",
-  "accent-tertiary", "accent-tertiary-rgb", "accent-tertiary-bg", "accent-tertiary-border", "accent-tertiary-fg",
+  "accent-secondary", "accent-secondary-bg", "accent-secondary-border", "accent-secondary-fg",
+  "accent-tertiary", "accent-tertiary-bg", "accent-tertiary-border", "accent-tertiary-fg",
   // Category slots A–H for "item N of a set" UI (workspace tags, plugin types).
   "category-a-bg", "category-a-border", "category-a-fg",
   "category-b-bg", "category-b-border", "category-b-fg",
@@ -312,14 +315,26 @@ function hexLuminance(hex: string): number {
   return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
 }
 
-// Look up a base16 slot tolerantly: real-world files in the wild use either
-// `base0A` (Tinted Theming spec) or `base0a` (some legacy schemes). Accept
-// both by normalizing the suffix's case at lookup time.
+// Look up a base16 slot tolerantly. Accepts:
+//   - Top-level `base0X` keys (the legacy "flat" Base16 JSON shape).
+//   - Nested under `palette` (the canonical Tinted Theming YAML→JSON shape;
+//     when serialized from `palette: { base00: ... }` the entries land as
+//     `"palette.base00"` after the loader flattens string-valued fields).
+//   - Lowercase `base0a` instead of uppercase `base0A` (some legacy schemes).
+// The Rust loader (settings.rs) is also schema-tolerant on the input side,
+// so a file in any of these shapes ends up here with the right keys.
 function readBase16Slot(
   colors: Record<string, string>,
   suffix: string,
 ): string | undefined {
-  return colors[`base${suffix}`] ?? colors[`base${suffix.toLowerCase()}`];
+  const upper = `base${suffix}`;
+  const lower = `base${suffix.toLowerCase()}`;
+  return (
+    colors[upper] ??
+    colors[lower] ??
+    colors[`palette.${upper}`] ??
+    colors[`palette.${lower}`]
+  );
 }
 
 // Token names that, when present in a `colors` map, strongly indicate the file
@@ -385,21 +400,6 @@ export function convertBase16ToClaudette(theme: ThemeDefinition): ThemeDefinitio
         ? "dark"
         : "light";
 
-  // Emit the full bg/border/fg triplet for a semantic accent. Alpha levels
-  // mirror the :root defaults in theme.css (10% tint, 30% outline).
-  const emitTriplet = (
-    out: Record<string, string>,
-    prefix: string,
-    hex: string,
-  ) => {
-    const rgb = hexToRgbTriplet(hex);
-    out[prefix] = hex;
-    out[`${prefix}-rgb`] = rgb;
-    out[`${prefix}-bg`] = `rgba(${rgb}, 0.10)`;
-    out[`${prefix}-border`] = `rgba(${rgb}, 0.30)`;
-    out[`${prefix}-fg`] = hex;
-  };
-
   const out: Record<string, string> = {
     "color-scheme": scheme,
 
@@ -457,16 +457,18 @@ export function convertBase16ToClaudette(theme: ThemeDefinition): ThemeDefinitio
     "syntax-function": p.base0D,
     "syntax-keyword": p.base0E,
     "syntax-comment": p.base03,
-  };
 
-  // Status + UI-role accents — full triplets so imported palettes don't
-  // inherit baseline tints.
-  emitTriplet(out, "accent-success", p.base0B);
-  emitTriplet(out, "accent-warning", p.base09);
-  emitTriplet(out, "accent-error", p.base08);
-  emitTriplet(out, "accent-info", p.base0D);
-  emitTriplet(out, "accent-secondary", p.base0F);
-  emitTriplet(out, "accent-tertiary", p.base0E);
+    // Status + UI-role accent BASE colors. The -bg/-border/-hover/-fg
+    // companions derive from the base via color-mix() in :root, so
+    // we only need to set the base here — the cascade handles the
+    // tinted surface, outline, hover, and fg layers.
+    "accent-success": p.base0B,
+    "accent-warning": p.base09,
+    "accent-error": p.base08,
+    "accent-info": p.base0D,
+    "accent-secondary": p.base0F,
+    "accent-tertiary": p.base0E,
+  };
 
   return {
     id: theme.id,

--- a/src/ui/src/utils/themeProof.ts
+++ b/src/ui/src/utils/themeProof.ts
@@ -1,0 +1,184 @@
+// Dev-only theme proof page. Renders every design token as a labeled swatch
+// so theme authors can audit their palette end-to-end while porting. Mount
+// from the devtools console:
+//
+//     __CLAUDETTE_THEME_PROOF__()
+//
+// Close the overlay with Esc or by calling the function again.
+//
+// Gated behind `import.meta.env.DEV` — excluded from release builds.
+
+import { __THEMEABLE_VARS } from "./theme";
+
+const OVERLAY_ID = "__claudette-theme-proof__";
+
+// Group tokens for visual organization. Each entry is [section title, prefix-match-regex].
+// Anything that doesn't match a section appears under "Other".
+const SECTIONS: ReadonlyArray<readonly [string, RegExp]> = [
+  ["Brand accent", /^(accent-primary|accent-dim|accent-bg|accent-glow|on-accent)/],
+  ["Status accents", /^accent-(success|warning|error|info)/],
+  ["UI roles", /^accent-(neutral|secondary|tertiary)/],
+  ["Category slots A–H", /^category-/],
+  ["Syntax highlights", /^syntax-/],
+  ["Legacy semantic", /^(badge-|status-|error-)/],
+  ["Text ramp", /^text-/],
+  ["Surfaces", /^(app-bg|sidebar-|chat-|terminal-)/],
+  ["Interactive", /^(hover-|selected-|divider|toolbar-)/],
+  ["Diff", /^diff-/],
+  ["Shadows", /^shadow-/],
+  ["Overlay", /^overlay-/],
+  ["Typography", /^font-/],
+] as const;
+
+function classify(name: string): string {
+  for (const [title, re] of SECTIONS) {
+    if (re.test(name)) return title;
+  }
+  return "Other";
+}
+
+function renderSwatch(token: string): HTMLElement {
+  const root = getComputedStyle(document.documentElement);
+  const value = root.getPropertyValue(`--${token}`).trim();
+  const isColorish =
+    /^#|^rgb|^rgba|^hsl|^var/.test(value) ||
+    /-(bg|border|fg|text|primary|dim|glow|hover|selected|cursor|selection)$/.test(token);
+
+  const row = document.createElement("div");
+  row.style.cssText = `
+    display: grid;
+    grid-template-columns: 80px 1fr 1fr;
+    gap: 12px;
+    align-items: center;
+    padding: 6px 10px;
+    border-radius: 6px;
+    font: 12px/1.4 ui-monospace, monospace;
+  `;
+
+  const swatch = document.createElement("div");
+  swatch.style.cssText = `
+    width: 72px;
+    height: 32px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--divider);
+    background: ${isColorish && value ? `var(--${token})` : "transparent"};
+  `;
+  if (!isColorish) {
+    // Diagonal stripe pattern to mark non-color tokens. Built from text-faint
+    // so it tracks the active theme.
+    swatch.style.background = "repeating-linear-gradient(45deg, transparent, transparent 6px, var(--text-faint) 6px, var(--text-faint) 12px)";
+    swatch.style.opacity = "0.35";
+    swatch.title = "non-color token";
+  }
+
+  const nameEl = document.createElement("code");
+  nameEl.textContent = `--${token}`;
+  nameEl.style.cssText = "color: var(--text-primary); opacity: 0.95;";
+
+  const valEl = document.createElement("code");
+  valEl.textContent = value || "(unset)";
+  valEl.style.cssText = "color: var(--text-muted); word-break: break-all;";
+
+  row.append(swatch, nameEl, valEl);
+  return row;
+}
+
+function renderProof(): HTMLElement {
+  const overlay = document.createElement("div");
+  overlay.id = OVERLAY_ID;
+  overlay.style.cssText = `
+    position: fixed; inset: 0;
+    background: var(--app-bg);
+    color: var(--text-primary);
+    z-index: 999999;
+    overflow: auto;
+    padding: 24px 32px;
+    font-family: var(--font-sans);
+  `;
+
+  const header = document.createElement("header");
+  header.style.cssText = "display:flex; justify-content:space-between; align-items:baseline; margin-bottom: 16px; padding-bottom: 12px; border-bottom: 1px solid var(--divider);";
+  const title = document.createElement("h1");
+  title.textContent = "Theme proof — dev only";
+  title.style.cssText = "font-size: 20px; margin: 0;";
+  const hint = document.createElement("div");
+  hint.textContent = "Press Esc or call __CLAUDETTE_THEME_PROOF__() again to close.";
+  hint.style.cssText = "font-size: 11px; color: var(--text-muted);";
+  header.append(title, hint);
+  overlay.append(header);
+
+  // Group tokens by section.
+  const groups = new Map<string, string[]>();
+  for (const t of __THEMEABLE_VARS) {
+    if (t === "color-scheme") continue;
+    const section = classify(t);
+    if (!groups.has(section)) groups.set(section, []);
+    groups.get(section)!.push(t);
+  }
+
+  // Render in SECTIONS order, then "Other" last.
+  const order = [...SECTIONS.map(([t]) => t), "Other"];
+  for (const section of order) {
+    const tokens = groups.get(section);
+    if (!tokens || tokens.length === 0) continue;
+    const h2 = document.createElement("h2");
+    h2.textContent = `${section} (${tokens.length})`;
+    h2.style.cssText = "font-size: 14px; margin: 20px 0 8px; color: var(--accent-primary);";
+    overlay.append(h2);
+    for (const token of tokens.sort()) {
+      overlay.append(renderSwatch(token));
+    }
+  }
+
+  // Append category strip showing all 8 chip-styled slots side by side —
+  // the headline use case @codefriar called out (workspace tag chips).
+  const stripWrap = document.createElement("section");
+  stripWrap.style.cssText = "margin-top: 28px; padding-top: 16px; border-top: 1px solid var(--divider);";
+  const stripTitle = document.createElement("h2");
+  stripTitle.textContent = "Category slots — rendered as chips";
+  stripTitle.style.cssText = "font-size: 14px; margin: 0 0 12px; color: var(--accent-primary);";
+  stripWrap.append(stripTitle);
+  const strip = document.createElement("div");
+  strip.style.cssText = "display:flex; flex-wrap:wrap; gap: 8px;";
+  for (const slot of ["a", "b", "c", "d", "e", "f", "g", "h"]) {
+    const chip = document.createElement("span");
+    chip.textContent = `category-${slot}`;
+    chip.style.cssText = `
+      display: inline-flex; align-items: center;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font: 11px/1 ui-monospace, monospace;
+      background: var(--category-${slot}-bg);
+      border: 1px solid var(--category-${slot}-border);
+      color: var(--category-${slot}-fg);
+    `;
+    strip.append(chip);
+  }
+  stripWrap.append(strip);
+  overlay.append(stripWrap);
+
+  return overlay;
+}
+
+export function toggleThemeProof(): void {
+  const existing = document.getElementById(OVERLAY_ID);
+  if (existing) {
+    existing.remove();
+    return;
+  }
+  const overlay = renderProof();
+  const escHandler = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      overlay.remove();
+      document.removeEventListener("keydown", escHandler);
+    }
+  };
+  document.addEventListener("keydown", escHandler);
+  document.body.append(overlay);
+}
+
+// Expose on window in dev builds. Same pattern as __CLAUDETTE_STORE__.
+if (import.meta.env.DEV && typeof window !== "undefined") {
+  (window as unknown as Record<string, unknown>).__CLAUDETTE_THEME_PROOF__ =
+    toggleThemeProof;
+}

--- a/src/ui/src/utils/themeProof.ts
+++ b/src/ui/src/utils/themeProof.ts
@@ -160,17 +160,30 @@ function renderProof(): HTMLElement {
   return overlay;
 }
 
+// Per-overlay keydown handler, kept at module scope so toggleThemeProof's
+// close path can detach it (the previous version only detached on Esc-close,
+// leaking a listener every time the user toggled the overlay shut via
+// repeated console calls).
+let escHandler: ((e: KeyboardEvent) => void) | null = null;
+
+function dismissProof(overlay: HTMLElement): void {
+  overlay.remove();
+  if (escHandler) {
+    document.removeEventListener("keydown", escHandler);
+    escHandler = null;
+  }
+}
+
 export function toggleThemeProof(): void {
   const existing = document.getElementById(OVERLAY_ID);
   if (existing) {
-    existing.remove();
+    dismissProof(existing);
     return;
   }
   const overlay = renderProof();
-  const escHandler = (e: KeyboardEvent) => {
+  escHandler = (e: KeyboardEvent) => {
     if (e.key === "Escape") {
-      overlay.remove();
-      document.removeEventListener("keydown", escHandler);
+      dismissProof(overlay);
     }
   };
   document.addEventListener("keydown", escHandler);

--- a/src/ui/src/utils/themeTokenParity.test.ts
+++ b/src/ui/src/utils/themeTokenParity.test.ts
@@ -1,0 +1,164 @@
+// Token-parity validator: catches drift between the runtime-side
+// THEMEABLE_VARS allowlist (utils/theme.ts) and the design-token source of
+// truth (styles/theme.css). When the two go out of sync:
+//
+//  - A token defined in theme.css but missing from THEMEABLE_VARS cannot be
+//    overridden by a user JSON theme (the apply path skips it).
+//  - A token listed in THEMEABLE_VARS but missing from theme.css produces a
+//    broken `var()` reference if any component reads it.
+//
+// We also assert that every per-theme [data-theme] block uses only token
+// names that also exist in :root — catching future themes that introduce
+// new tokens without registering them, which the original PR feedback
+// (@codefriar) called out as a long-term maintenance risk.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const THEME_CSS_PATH = join(__dirname, "../styles/theme.css");
+
+function readThemeCss(): string {
+  return readFileSync(THEME_CSS_PATH, "utf8");
+}
+
+// Extract a single CSS rule body by selector. Brace-aware so nested
+// function-call commas (alpha layers, gradients) don't break the parse.
+function ruleBody(css: string, selector: string): string {
+  const idx = css.indexOf(selector);
+  if (idx === -1) throw new Error(`selector ${selector} not found in theme.css`);
+  // Find the opening brace after the selector.
+  const open = css.indexOf("{", idx);
+  if (open === -1) throw new Error(`no opening brace for ${selector}`);
+  let depth = 1;
+  let i = open + 1;
+  while (i < css.length && depth > 0) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}") depth--;
+    if (depth === 0) return css.slice(open + 1, i);
+    i++;
+  }
+  throw new Error(`unbalanced braces for ${selector}`);
+}
+
+// Collect every `--token-name:` declaration in a rule body. Captures the
+// name without the leading `--`.
+function collectDeclarations(body: string): Set<string> {
+  const decls = new Set<string>();
+  const re = /--([a-z][a-z0-9-]*)\s*:/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    decls.add(m[1]);
+  }
+  return decls;
+}
+
+// Tokens defined in :root but intentionally NOT exposed via THEMEABLE_VARS
+// (i.e., not user-overridable). Most are non-color foundations: spacing,
+// sizing, radii, motion. Plus a few internal-only color compositions.
+const NON_THEMEABLE_ROOT_TOKENS = new Set<string>([
+  // Geometry & motion
+  "scrollbar-size", "scrollbar-edge-inset", "scrollbar-thumb", "scrollbar-thumb-hover",
+  "workspace-header-h", "tab-bar-h",
+  "space-1", "space-2", "space-3", "space-4", "space-5", "space-6", "space-8", "space-10", "space-12", "space-16",
+  "transition-fast", "transition-normal", "transition-slow", "ease-out-quick",
+  "sidebar-width",
+  "radius-xs", "radius-sm", "radius-md", "radius-lg", "radius-xl", "radius-pill", "border-radius",
+  // Typography ramp (sizes/weights/lines and composite role tokens)
+  "fs-xs", "fs-sm", "fs-base", "fs-md", "fs-lg", "fs-xl", "fs-2xl", "fs-3xl", "fs-4xl",
+  "lh-tight", "lh-snug", "lh-body", "lh-loose",
+  "fw-regular", "fw-medium", "fw-semibold", "fw-bold",
+  "h1-size", "h1-weight", "h1-line",
+  "h2-size", "h2-weight", "h2-line",
+  "h3-size", "h3-weight", "h3-line",
+  "h4-size", "h4-weight", "h4-line",
+  "body-size", "body-weight", "body-line",
+  "caption-size", "caption-weight", "caption-line",
+  "code-size", "code-weight", "code-line",
+  // Internal brand-invariant palettes (consumed by components, not user-themeable).
+  // Themes can still tune these if they need to via CSS — but we don't
+  // promise they're user-JSON-overridable.
+  "purple-bg", "purple-bg-hover", "purple-border", "purple-border-hover",
+  "purple-btn-bg", "purple-btn-bg-hover", "purple-text",
+  "tool-read", "tool-write", "tool-edit", "tool-bash", "tool-web", "tool-agent", "tool-task",
+  "ultrathink-red", "ultrathink-orange", "ultrathink-yellow", "ultrathink-green",
+  "ultrathink-blue", "ultrathink-indigo", "ultrathink-violet",
+  "ultrathink-red-shimmer", "ultrathink-orange-shimmer", "ultrathink-yellow-shimmer",
+  "ultrathink-green-shimmer", "ultrathink-blue-shimmer", "ultrathink-indigo-shimmer",
+  "ultrathink-violet-shimmer",
+  // Derived composites — defined in :root via var(), no per-theme override expected.
+  "context-meter-normal", "context-meter-warn", "context-meter-near-full", "context-meter-critical",
+  "metric-negative", "metric-negative-soft",
+  // git-gutter-modified is set per-theme but not exposed via the user JSON allowlist yet.
+  "git-gutter-modified",
+]);
+
+// THEMEABLE_VARS entries that are valid CSS but not literal `--token` keys
+// in :root (they're well-known CSS properties applied directly).
+const NON_TOKEN_THEMEABLE_VARS = new Set<string>([
+  "color-scheme",
+]);
+
+describe("theme token parity", () => {
+  it(":root in theme.css and THEMEABLE_VARS stay in sync", async () => {
+    const css = readThemeCss();
+    const rootTokens = collectDeclarations(ruleBody(css, ":root"));
+
+    // Import lazily so the test runs even if theme.ts has the side-effect
+    // module-level globals from the other test file's stubs in scope.
+    const themeModule: unknown = await import("./theme");
+    type ThemeModuleWithVars = { __THEMEABLE_VARS?: string[] };
+    // THEMEABLE_VARS is module-private, so the validator reads the list via
+    // the export below. Add a small accessor in theme.ts if not present.
+    const exposed = (themeModule as ThemeModuleWithVars).__THEMEABLE_VARS;
+    expect(exposed, "theme.ts must export __THEMEABLE_VARS for the parity test").toBeDefined();
+    const themeableVars = new Set(exposed!);
+
+    // 1) Every entry in THEMEABLE_VARS that is a CSS token must exist in :root.
+    const missingFromRoot: string[] = [];
+    for (const name of themeableVars) {
+      if (NON_TOKEN_THEMEABLE_VARS.has(name)) continue;
+      if (!rootTokens.has(name)) missingFromRoot.push(name);
+    }
+    expect(missingFromRoot, "THEMEABLE_VARS entries with no matching --token in :root").toEqual([]);
+
+    // 2) Every token in :root that's a "color-ish" themeable token must be
+    //    in THEMEABLE_VARS — unless explicitly listed as non-themeable.
+    const missingFromAllowlist: string[] = [];
+    for (const name of rootTokens) {
+      if (NON_THEMEABLE_ROOT_TOKENS.has(name)) continue;
+      if (themeableVars.has(name)) continue;
+      missingFromAllowlist.push(name);
+    }
+    expect(missingFromAllowlist, "tokens in :root missing from THEMEABLE_VARS").toEqual([]);
+  });
+
+  it("every [data-theme] block uses only tokens that also exist in :root", () => {
+    const css = readThemeCss();
+    const rootTokens = collectDeclarations(ruleBody(css, ":root"));
+
+    // Find all [data-theme="..."] selectors.
+    const themeBlockRe = /\[data-theme="([a-z0-9-]+)"\]\s*\{/g;
+    const themeIds: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = themeBlockRe.exec(css)) !== null) {
+      themeIds.push(m[1]);
+    }
+    expect(themeIds.length).toBeGreaterThan(0);
+
+    const offenders: { theme: string; token: string }[] = [];
+    for (const themeId of themeIds) {
+      const body = ruleBody(css, `[data-theme="${themeId}"]`);
+      const decls = collectDeclarations(body);
+      for (const token of decls) {
+        if (!rootTokens.has(token)) {
+          offenders.push({ theme: themeId, token });
+        }
+      }
+    }
+    expect(
+      offenders,
+      "per-theme blocks must not introduce tokens that aren't declared in :root first",
+    ).toEqual([]);
+  });
+});

--- a/src/ui/src/utils/themeTokenParity.test.ts
+++ b/src/ui/src/utils/themeTokenParity.test.ts
@@ -94,10 +94,10 @@ const NON_THEMEABLE_ROOT_TOKENS = new Set<string>([
 ]);
 
 // THEMEABLE_VARS entries that are valid CSS but not literal `--token` keys
-// in :root (they're well-known CSS properties applied directly).
-const NON_TOKEN_THEMEABLE_VARS = new Set<string>([
-  "color-scheme",
-]);
+// in :root (they're well-known CSS properties applied directly). Empty
+// today — `--color-scheme` IS declared in :root and is genuinely
+// themeable, so it stays in the strict parity check below.
+const NON_TOKEN_THEMEABLE_VARS = new Set<string>([]);
 
 describe("theme token parity", () => {
   it(":root in theme.css and THEMEABLE_VARS stay in sync", async () => {

--- a/src/ui/src/workers/highlight.worker.ts
+++ b/src/ui/src/workers/highlight.worker.ts
@@ -30,6 +30,10 @@ import { createHighlighterCore, type HighlighterCore } from "shiki/core";
 import { createOnigurumaEngine } from "shiki/engine/oniguruma";
 import { toHtml } from "hast-util-to-html";
 import type { Element, ElementContent, Root } from "hast";
+import {
+  buildClaudetteShikiTheme,
+  CLAUDETTE_SHIKI_THEME_NAME,
+} from "../styles/shikiClaudetteTheme";
 
 // Each entry imports a single grammar. Vite code-splits each into its own
 // chunk; only languages actually used are downloaded.
@@ -100,10 +104,10 @@ const failedLangs = new Set<string>();
 function getHighlighter(): Promise<HighlighterCore> {
   if (!highlighterPromise) {
     highlighterPromise = createHighlighterCore({
-      themes: [
-        import("@shikijs/themes/github-light"),
-        import("@shikijs/themes/github-dark"),
-      ],
+      // Single Claudette theme whose token colors are `var(--syntax-*)`
+      // references. The cascade resolves them per-theme at render time —
+      // no separate light/dark themes needed.
+      themes: [buildClaudetteShikiTheme()],
       langs: [],
       engine: createOnigurumaEngine(import("shiki/wasm")),
     });
@@ -200,8 +204,7 @@ async function highlight(code: string, lang: string): Promise<string | null> {
     const useLang = lang ? await ensureLang(hl, lang) : "text";
     const root = hl.codeToHast(code, {
       lang: useLang,
-      themes: { light: "github-light", dark: "github-dark" },
-      defaultColor: false,
+      theme: CLAUDETTE_SHIKI_THEME_NAME,
     });
     const codeEl = findCodeElement(root);
     if (!codeEl) return null;

--- a/src/ui/src/workers/highlight.worker.ts
+++ b/src/ui/src/workers/highlight.worker.ts
@@ -1,8 +1,14 @@
 /**
  * Shiki syntax-highlighting worker.
  *
- * Holds a single Shiki highlighter loaded with `github-light` + `github-dark`
- * themes. Grammars are loaded on demand via the fine-grained `@shikijs/langs/*`
+ * Holds a single Shiki highlighter loaded with the Claudette theme (see
+ * `../styles/shikiClaudetteTheme.ts`). The theme's `foreground` values are
+ * `var(--syntax-*)` references, so emitted spans inherit per-theme colors
+ * from the active Claudette theme without the worker needing to know which
+ * theme is active. No more dual-theme (`github-light` + `github-dark`)
+ * machinery — light/dark switching happens entirely via the CSS cascade.
+ *
+ * Grammars are loaded on demand via the fine-grained `@shikijs/langs/*`
  * dynamic imports below — only languages actually requested at runtime are
  * fetched, and Vite splits each into its own chunk. Plugin-contributed
  * grammars are registered ahead of time via `register-grammar` messages


### PR DESCRIPTION
## Summary

Closes #797.

Adds a semantic design-token vocabulary and a Base16 auto-import path so Claudette themes can communicate **meaning**, not just color, and so canonical Base16 schemes can be dropped into `~/.claudette/themes/` and Just Work.

This PR is **additive** — every existing built-in and user theme renders byte-identical at the chrome level. After several review rounds, the architecture stabilized around two key ideas:

1. **`color-mix()` derivation in `:root`**. Each new semantic accent (`--accent-success/warning/error/info/secondary/tertiary`) is a five-token family: a base color plus `-bg` / `-border` / `-hover` / `-fg` derived from it via `color-mix(in srgb, var(--accent-X) N%, transparent)`. A theme that overrides only the base color gets matching tinted surfaces and outlines for free. Where a legacy token exists, the new base aliases it (`--accent-success: var(--badge-done)`, `--accent-error: var(--status-stopped)`, etc.), so a user theme overriding only the legacy token also propagates through the new family automatically.
2. **Base16 import** — drop a canonical Base16 file (flat top-level keys OR Tinted Theming's `palette:` nested shape) into `~/.claudette/themes/`. The Rust loader recognizes both shapes, validates hex, and forwards the palette to the frontend. The TS converter detects the file as Base16 and maps `base00`–`base0F` onto Claudette tokens following the canonical Tinted Theming role spec. Surfaces, accents, syntax tokens, and category slots all re-theme end-to-end through the cascade.

```mermaid
flowchart LR
    A[~/.claudette/themes/*.json] --> B{Rust: list_user_themes}
    B -->|matches native shape| C[ThemeDefinition]
    B -->|fails, has 16 baseXX flat or palette:.baseXX| D[Synthesized ThemeDefinition<br/>id=stem, name=scheme]
    B -->|neither| E[Skip, log reason]
    C --> F[loadAllThemes]
    D --> F
    F -->|detectBase16 true| G[convertBase16ToClaudette<br/>sets only base colors]
    F -->|detectBase16 false| H[Pass through]
    G --> I[applyTheme inline setProperty]
    H --> I
    I --> J[color-mix in :root derives<br/>-bg/-border/-hover/-fg per family]
```

## Token vocabulary (current)

- **Status family** — `--accent-success/-warning/-error/-info`, each with `-bg`/`-border`/`-hover`/`-fg`. Base is aliased to the corresponding legacy token where one exists.
- **UI roles** — `--accent-neutral` (single token), `--accent-secondary`/`-tertiary` with `-bg`/`-border`/`-fg`.
- **Category slots A–H** — `-bg`/`-border`/`-fg` per slot. Default palette is brand-invariant; Rosé Pine and Solarized variants override these in their `[data-theme]` blocks to surface each palette's native hues.
- **Syntax highlights** — `--syntax-keyword/-string/-number/-comment/-function/-type/-variable/-operator`. Plumbed end-to-end through both Shiki (chat code blocks) and Monaco (file viewer).

Note: the new family does **not** carry `-rgb` companions. Those were an early-draft workaround for CSS's lack of an `rgba(var())` extraction; `color-mix()` replaces them cleanly. Only `--accent-primary-rgb` is retained because terminal-selection and a few other legacy consumers still read it.

## Complexity Notes

- **Modern CSS requirement**: `color-mix()` shipped in Chromium 111 / WebKit 16.2 / Firefox 113 (all 2023). Tauri 2 uses the system webview, and Claudette's supported platforms ship newer than that.
- **Monaco needs computed-value resolution**: `getComputedStyle(root).getPropertyValue("--x")` returns the literal `var()` / `color-mix()` expression, not a resolved color. `monacoTheme.ts` uses a hidden probe element to read the resolved `getComputedStyle(probe).color` instead. See the comment in `makeColorResolver`.
- **Category slots are not strictly invariant**: themes with a strong canonical palette (Rosé Pine, Solarized) override slots in their `[data-theme]` block. This is intentional — the slot identity stays stable for users who never switch theme, and for users who *do* switch, the colors adopt the new theme's palette.
- **Detection heuristic**: a JSON file is Base16 iff it has all 16 `base00`–`base0F` slots (flat OR nested under `palette:`) AND declares no recognized Claudette tokens from `THEMEABLE_VARS`. Hybrid files are treated as Claudette to preserve any explicit author mapping.

## Test Steps

1. **Unit tests (all green in CI)**:
   - `cd src/ui && bun run test --run src/utils/theme.test.ts` — `detectBase16` + `convertBase16ToClaudette` correctness (positive/negative detection, hybrid handling, lowercase keys, text-ramp mapping).
   - `cd src/ui && bun run test --run src/utils/themeTokenParity.test.ts` — asserts `THEMEABLE_VARS` ↔ `:root` parity and that no `[data-theme]` block introduces orphan tokens.
   - `cd src/ui && bun run test --run src/styles/shikiClaudetteTheme.test.ts` — integration test: builds the theme, loads a real grammar, asserts the highlighter emits `style="color: var(--syntax-*)"` spans.
   - `cargo test -p claudette-tauri parse_theme_file` — 8 Rust cases covering native Claudette JSON, canonical Base16 (flat), Tinted Theming `palette:` nested, lowercase keys, malformed hex, partial schemes, malformed JSON.

2. **Lint + typecheck (all green)**:
   - `cd src/ui && bun run lint && bun run lint:css && bunx tsc -b`
   - `cargo fmt --all --check && cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` (`RUSTFLAGS="-Dwarnings"`)

3. **Manual: existing themes**: launch `./scripts/dev.sh`, cycle through all 14 built-in themes via Settings → Appearance. Each renders identically to before this PR at the chrome level. Rosé Pine and Solarized now show their canonical palettes in code blocks (Shiki + Monaco) and category-slot consumers (env-provider rows in Settings).

4. **Manual: Base16 import (flat shape)**: save the minimal JSON below as `~/.claudette/themes/tomorrow-night.json`, restart, select in Settings → Appearance. Confirm: app bg = base00 dark, accent = base0E purple, syntax keywords purple, success states base0B green, errors base08 red.
   ```json
   {
     "scheme": "Tomorrow Night",
     "base00": "1d1f21", "base01": "282a2e", "base02": "373b41", "base03": "969896",
     "base04": "b4b7b4", "base05": "c5c8c6", "base06": "e0e0e0", "base07": "ffffff",
     "base08": "cc6666", "base09": "de935f", "base0A": "f0c674", "base0B": "b5bd68",
     "base0C": "8abeb7", "base0D": "81a2be", "base0E": "b294bb", "base0F": "a3685a"
   }
   ```

5. **Manual: Base16 import (`palette:` nested shape)**: convert any YAML from [tinted-theming/schemes](https://github.com/tinted-theming/schemes) to JSON and drop it in directly. Confirm it appears in the picker and applies correctly.

6. **Manual: dev-only proof page**: in a dev build, open devtools and run `__CLAUDETTE_THEME_PROOF__()`. Confirm every token renders as a labeled swatch and the category-slot chip strip reflects the active theme.

## Checklist

- [x] Tests added/updated — TS (`theme.test.ts`, `themeTokenParity.test.ts`, `shikiClaudetteTheme.test.ts`, `envProviderCategory.test.ts`) + Rust (`parse_theme_file_*` × 8)
- [x] Documentation updated — `site/src/content/docs/features/theming.mdx` covers semantic accents, category slots, syntax tokens, Base16 import (both shapes)