### PR TITLE
fix(devshell): forward args ("$@") in build-app / fmt / run-tests wrappers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -578,7 +578,7 @@
               }
               {
                 name = "build-app";
-                command = "cargo tauri icon assets/logo.png && cargo tauri build --features server,alternative-backends";
+                command = ''cargo tauri icon assets/logo.png && cargo tauri build --features server,alternative-backends "$@"'';
                 help = "Build release app bundle (.app / .deb) with embedded server";
                 category = "development";
               }
@@ -600,13 +600,13 @@
               }
               {
                 name = "fmt";
-                command = "cargo fmt --all && cd src/ui && bunx eslint --fix .";
+                command = ''cargo fmt --all && cd src/ui && bunx eslint --fix . "$@"'';
                 help = "Format Rust and TypeScript code";
                 category = "quality";
               }
               {
                 name = "run-tests";
-                command = "cargo test --workspace --all-features";
+                command = ''cargo test --workspace --all-features "$@"'';
                 help = "Run all Rust tests";
                 category = "quality";
               }


### PR DESCRIPTION
## Summary

- Append `"$@"` to the `build-app`, `fmt`, and `run-tests` devshell wrappers in `flake.nix` so flags passed on the CLI reach the underlying tool instead of being silently swallowed.

Closes #725.

## Notes

The issue body refers to these wrappers as `build-app`, `fmt-fix`, and `test-all` — the current names are `build-app`, `fmt`, and `run-tests` (renamed since the issue was filed). The fix targets the wrappers as they exist on `main` today.

For each wrapper, `"$@"` is appended to the final action in the chain:
- `build-app` → after `cargo tauri build ...` (enables `build-app --debug`, `--target=...`, etc.)
- `fmt` → after `bunx eslint --fix .` (enables `fmt path/to/file.ts`)
- `run-tests` → after `cargo test ...` (enables `run-tests some::test_name -- --nocapture`)

## Test plan

- [ ] `direnv reload && build-app --help` reaches `cargo tauri build`'s arg parser rather than being swallowed.
- [ ] `direnv reload && run-tests --help` reaches `cargo test`'s arg parser.
- [ ] `direnv reload && fmt --help` reaches `eslint`'s arg parser.
- [ ] `dev --help` still works (no regression on the original `dev` wrapper fix from 636bcab0).