### PR TITLE
fix(dashboard): make stats strip and analytics grid degrade gracefully at narrow widths

### DIFF
--- a/src/ui/src/components/metrics/metrics.module.css
+++ b/src/ui/src/components/metrics/metrics.module.css
@@ -2,7 +2,12 @@
 
 .statsStrip {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  /* auto-fit lets the strip step down 6 → 5 → 4 → 3 → 2 → 1 as the
+     dashboard panel narrows (driven by window size OR sidebar drag),
+     instead of jumping straight from 6 cols to 2 at a single viewport
+     breakpoint. 160px floor keeps the tile values legible at the bottom
+     of the step ladder. */
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 12px;
   padding: 12px 20px;
   border-bottom: 1px solid var(--divider);
@@ -14,12 +19,17 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  min-width: 0;
   min-height: 76px;
   padding: 10px 14px;
   border: 1px solid var(--divider);
   border-radius: 8px;
   background: var(--hover-bg-subtle);
   overflow: hidden;
+  /* Each tile is its own inline-size container so `.tileValue`'s
+     clamp() can reference the tile's own width (`cqi`) instead of the
+     viewport — values scale down before they clip. */
+  container-type: inline-size;
 }
 
 .tileLabel {
@@ -32,10 +42,18 @@
 
 .tileValue {
   font-family: var(--font-mono);
-  font-size: 22px;
+  /* Scales 16px → 22px with tile width. At the 160px auto-fit floor a
+     22px value clipped its trailing character ($53.11, +387 -…);
+     clamp() lets it shrink instead. The hard ellipsis below catches
+     anything still too long for the floor (e.g. very large totals). */
+  font-size: clamp(16px, 9cqi, 22px);
   color: var(--text-primary);
   line-height: 1;
   margin-top: 4px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tileValueAccent {
@@ -43,9 +61,14 @@
 }
 
 .tileSub {
+  display: block;
   font-size: 11px;
   color: var(--text-muted);
   margin-top: 4px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tileChart {
@@ -112,17 +135,19 @@
 
 .analyticsGrid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  /* Same auto-fit treatment as `.statsStrip` — the analytics panels
+     pack 4 → 3 → 2 → 1 as the dashboard panel narrows. 220px keeps
+     room for a row label plus its inline progress bar / value pair. */
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 12px;
 }
 
 @media (max-width: 1100px) {
-  .analyticsGrid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-  .statsStrip {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  /* `.statsStrip` and `.analyticsGrid` no longer need a viewport-based
+     breakpoint — `auto-fit minmax(...)` above handles their column
+     stepping. The rules left here apply to layouts that aren't part of
+     the responsive grid (`.hideNarrow` opts elements out at small
+     viewports; `.leaderRow` collapses extra columns). */
   .hideNarrow {
     display: none;
   }

--- a/src/ui/src/components/metrics/metricsCss.test.ts
+++ b/src/ui/src/components/metrics/metricsCss.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CSS_PATH = join(__dirname, "metrics.module.css");
+
+function readCss(): string {
+  return readFileSync(CSS_PATH, "utf8");
+}
+
+function ruleBody(css: string, selector: string): string {
+  const re = new RegExp(
+    `${selector.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\s*{([^}]*)}`,
+  );
+  const match = css.match(re);
+  if (!match) throw new Error(`selector ${selector} not found in CSS`);
+  return match[1];
+}
+
+describe("metrics.module.css invariants", () => {
+  it("packs the stats strip with auto-fit so it steps down with the dashboard width", () => {
+    const body = ruleBody(readCss(), ".statsStrip");
+    expect(body).toMatch(
+      /grid-template-columns:\s*repeat\(\s*auto-fit\s*,\s*minmax\(\s*160px\s*,\s*1fr\s*\)\s*\)/,
+    );
+  });
+
+  it("packs the analytics grid with auto-fit so panels step 4 → 1 instead of 4 → 2 → 1", () => {
+    const body = ruleBody(readCss(), ".analyticsGrid");
+    expect(body).toMatch(
+      /grid-template-columns:\s*repeat\(\s*auto-fit\s*,\s*minmax\(\s*220px\s*,\s*1fr\s*\)\s*\)/,
+    );
+  });
+
+  it("makes each tile its own inline-size container so tile values can scale", () => {
+    const body = ruleBody(readCss(), ".tile");
+    expect(body).toMatch(/container-type:\s*inline-size/);
+    expect(body).toMatch(/min-width:\s*0/);
+  });
+
+  it("scales tile values with the tile width via clamp() and cqi", () => {
+    const body = ruleBody(readCss(), ".tileValue");
+    expect(body).toMatch(/font-size:\s*clamp\([^)]*cqi[^)]*\)/);
+    // The clamp is the headroom; ellipsis is the safety net for outlier values
+    // (huge totals, long currency strings) at the auto-fit floor.
+    expect(body).toMatch(/white-space:\s*nowrap/);
+    expect(body).toMatch(/text-overflow:\s*ellipsis/);
+  });
+
+  it("ellipsizes tile sub-text instead of wrapping into the chart area below", () => {
+    const body = ruleBody(readCss(), ".tileSub");
+    expect(body).toMatch(/white-space:\s*nowrap/);
+    expect(body).toMatch(/text-overflow:\s*ellipsis/);
+    expect(body).toMatch(/min-width:\s*0/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #407.

The Dashboard's stats strip and analytics grid had a single `@media (max-width: 1100px)` breakpoint that jumped straight from 6 → 2 (stats) and 4 → 2 (analytics) columns. Between ~700px and ~1100px, the wide layout stuck around while values overflowed: `$53.11` lost its trailing `1`, `+387 -…` lost the delete count, the SUCCESS ring overlapped its sub-label, and TOKENS' three-segment sub-line wrapped into four rows over the sparkline. Viewport breakpoints also missed the sidebar-resize case — the dashboard panel can be narrow even when the window is wide.

This switches both grids to `repeat(auto-fit, minmax(N, 1fr))` so they step 6 → 5 → 4 → 3 → 2 → 1 driven by their own width, and makes each tile its own container-query context so `.tileValue` can scale via `clamp(16px, 9cqi, 22px)` instead of clipping at a fixed 22px.

## Files

- `src/ui/src/components/metrics/metrics.module.css` — `.statsStrip` and `.analyticsGrid` use `auto-fit minmax(...)`; `.tile` gets `container-type: inline-size` + `min-width: 0`; `.tileValue` and `.tileSub` get `clamp()` sizing (value) and `nowrap`/`ellipsis` fallbacks. The redundant `.statsStrip` / `.analyticsGrid` rules in the 1100px @media block are dropped; `.hideNarrow` and `.leaderRow` stay (they're not part of the grid stepping).
- `src/ui/src/components/metrics/metricsCss.test.ts` — new invariant test mirroring `sidebarCss.test.ts`. Pins the auto-fit shapes, the tile's container-type, and the ellipsis fallbacks so future drift on these rules is caught in CI.

## Test plan

- [x] `bunx tsc -b` — clean.
- [x] `bunx vitest run` — 2135 passed (5 new metrics-CSS invariants), 6 pre-existing skips.
- [x] `bun run lint:css` — design-token + font-mono checks pass.
- [ ] Manual: launch the dev app, resize the dashboard panel between ~700px and ~1300px (window resize and sidebar drag both). Verify:
  - Stats strip steps through 6 → 5 → 4 → 3 → 2 → 1 columns instead of jumping at 1100px.
  - Tile values (`$53.11`, `+387 -45`, `109 in · 24.9k out · 97% cached`) scale or ellipsize cleanly without clipping past the tile edge.
  - SUCCESS ring no longer overlaps its `completed sessions` sub-label at narrow widths.
  - Analytics panels step 4 → 3 → 2 → 1 instead of jumping at 1100px.

## Notes

- Followed the issue's suggested direction directly (container queries + `auto-fit minmax` + `clamp(cqi)`).
- Did not modify `TokenUsageTile.tsx` — the CSS `text-overflow: ellipsis` handles the "% cached" suffix dropping out at narrow widths without needing JS-side abbreviation. Happy to add an explicit container-query class for the suffix if you want a more deliberate truncation than ellipsis.
- The sparkline-padding nit from the issue ("extends right up to the tile edge with no padding") is not addressed here — the tile's `padding: 10px 14px` already gives horizontal room and the sparkline sits inside it; the visual perception may have been the bottom-edge alignment from `justify-content: space-between`. Happy to revisit in a follow-up if there's a specific case I'm missing.