### PR TITLE
feat(repo): prompt for declared inputs on workspace create

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -117,6 +117,7 @@ export default defineConfig({
             { slug: 'features/project-view-issues-prs' },
             { slug: 'features/mcp-servers' },
             { slug: 'features/per-repo-settings' },
+            { slug: 'features/required-inputs' },
             { slug: 'features/claude-remote-control' },
           ],
         },

--- a/site/src/content/docs/features/per-repo-settings.mdx
+++ b/site/src/content/docs/features/per-repo-settings.mdx
@@ -109,6 +109,12 @@ The **Inherited** section (read-only) shows which flags are currently coming fro
 
 See [Agent Configuration → Claude CLI Flags](/claudette/features/agent-configuration/#claude-cli-flags) for the full list of available flags and how global defaults work.
 
+## Required Inputs
+
+Declare named inputs that every new workspace must supply before it can be created. Each input has a name (the env var key), a type (string / number / boolean) used for client-side validation, and an optional label / description for the workspace-create prompt. The supplied values become environment variables in the workspace session — visible to the agent, the terminal, and the setup/archive scripts.
+
+See [Required Inputs](/claudette/features/required-inputs/) for the full reference.
+
 ## Custom Instructions
 
 Text that is appended to the agent's system prompt at the start of every chat in this repository. Use this to give the agent context about your project:

--- a/site/src/content/docs/features/required-inputs.mdx
+++ b/site/src/content/docs/features/required-inputs.mdx
@@ -1,0 +1,47 @@
+---
+title: Required Inputs
+description: Per-repo declared values that every new workspace must supply — exposed as environment variables to the agent, terminal, and scripts.
+---
+
+A repo can optionally declare named inputs that every new workspace must supply before it can be created. The values become environment variables in that workspace's session — visible to the agent, the integrated terminal, and the repo's setup/archive scripts.
+
+This is useful when a project needs values that nothing on disk can produce: a ticket ID for the agent to reference, an `ENVIRONMENT=staging` flag for scripts, or a numeric retry budget for that task.
+
+## Declaring inputs
+
+Open `Settings > Repository` and find the **Required inputs** section between **Environment** and **Custom instructions**. Click **+ Add required input**, then for each row set:
+
+- **Name** — the environment variable name (must be a valid identifier: letters, digits, and underscores; cannot start with a digit). This is the literal `$NAME` your scripts and the agent will see.
+- **Type** — one of:
+  - **String** — any text value.
+  - **Number** — numeric values, with optional min/max bounds enforced before the workspace is created.
+  - **Boolean** — `true` or `false`. Always serialized to those literal strings in the env.
+- **Label** — what the workspace-create prompt shows next to the field. Defaults to the name when empty.
+- **Description** — optional helper text shown under the label.
+- **Placeholder / Default / Min / Max** — type-specific extras.
+
+Changes save automatically (~400 ms after you stop typing). An empty schema clears the column and new workspaces no longer prompt.
+
+## Creating a workspace
+
+When a repo has declared inputs, creating a workspace opens a prompt that collects values for every declared field. The prompt validates against each type — typing `abc` for a number, or leaving a required string blank, blocks the **Create workspace** button — so a misconfigured workspace can't be created.
+
+Cancelling the prompt aborts the entire create flow; no worktree is allocated and no branch is created.
+
+## Where the values show up
+
+Once supplied, the values are persisted on the workspace row and merged into the resolved environment whenever Claudette spawns:
+
+- **The agent CLI subprocess** — your declared inputs are env vars in the agent's process.
+- **The integrated terminal** — your shell sees them just like any other `$NAME`.
+- **The setup script** that runs on workspace creation, and any later re-run.
+- **The archive script** that runs when a workspace is archived.
+
+They sit at "after env-provider plugins (direnv, mise, dotenv, nix-devshell), before `CLAUDETTE_*` workspace-context vars" in the precedence stack. So a declared `PATH` would override what direnv exported, but no value can override `$CLAUDETTE_WORKSPACE_NAME` and friends.
+
+## Limits
+
+- Values are captured **once** at workspace-create time. There is no UI today to edit them on an existing workspace; create a new workspace instead.
+- The schema is per-repo. Different repos declare different inputs (or none at all).
+- Values are stored as plain text in the local SQLite database, with the same risk profile as the **Setup script** field. Don't put secrets here unless you're comfortable with that storage. There is no integration with the OS keychain yet.
+- The CLI client and batch manifests do not yet accept `--input` / `inputs:` — the server-side validator will error if a repo with declared inputs is created from those paths. Use the GUI for the initial create; the CLI/batch path will gain a flag in a follow-up release.

--- a/site/src/content/docs/features/required-inputs.mdx
+++ b/site/src/content/docs/features/required-inputs.mdx
@@ -19,12 +19,13 @@ Open `Settings > Repository` and find the **Required inputs** section between **
 - **Label** — what the workspace-create prompt shows next to the field. Defaults to the name when empty.
 - **Description** — optional helper text shown under the label.
 - **Placeholder / Default / Min / Max** — type-specific extras.
+- **Required at workspace creation** — defaults to on. Turn it off when a script can tolerate the env var being empty: the workspace-create modal will let the user submit without filling the field in, and the env var is set to the empty string `""` (so downstream scripts can `[ -z "$X" ]` uniformly). Booleans are always required — they always carry a `true`/`false` value.
 
 Changes save automatically (~400 ms after you stop typing). An empty schema clears the column and new workspaces no longer prompt.
 
 ## Creating a workspace
 
-When a repo has declared inputs, creating a workspace opens a prompt that collects values for every declared field. The prompt validates against each type — typing `abc` for a number, or leaving a required string blank, blocks the **Create workspace** button — so a misconfigured workspace can't be created.
+When a repo has declared inputs, creating a workspace opens a prompt that collects values for every declared field. The prompt validates against each type — typing `abc` for a number, or leaving a *required* string blank, blocks the **Create workspace** button — so a misconfigured workspace can't be created. Non-required fields show a muted "· optional" cue next to the label and accept blank submissions; their env var ends up as the empty string.
 
 Cancelling the prompt aborts the entire create flow; no worktree is allocated and no branch is created.
 

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -1440,6 +1440,12 @@ async fn handle_create_workspace(
         repo_id: repository_id,
         name,
         branch_prefix: &branch_prefix,
+        // Remote server doesn't yet plumb required-input values through —
+        // matches the CLI v1 scope. The shared op will reject the create
+        // with `OpsError::Validation` if the repo declares inputs, which
+        // surfaces back to the WS client as a clear error rather than a
+        // silently misconfigured workspace.
+        input_values: None,
     };
     let out = if preserve_supplied_name {
         ops_workspace::create_preserving_supplied_name(

--- a/src-server/tests/chat_snapshot.rs
+++ b/src-server/tests/chat_snapshot.rs
@@ -56,6 +56,7 @@ fn make_repo(id: &str) -> Repository {
         archive_script_auto_run: false,
         base_branch: None,
         default_remote: None,
+        required_inputs: None,
         path_valid: true,
     }
 }
@@ -72,6 +73,7 @@ fn make_workspace(id: &str, repo_id: &str) -> Workspace {
         status_line: String::new(),
         created_at: String::new(),
         sort_order: 0,
+        input_values: None,
     }
 }
 

--- a/src-server/tests/env_provider_integration.rs
+++ b/src-server/tests/env_provider_integration.rs
@@ -70,6 +70,7 @@ fn make_repo(path: &str) -> Repository {
         archive_script_auto_run: false,
         base_branch: None,
         default_remote: None,
+        required_inputs: None,
         path_valid: true,
     }
 }
@@ -86,6 +87,7 @@ fn make_workspace(repo_id: &str, worktree: &str) -> Workspace {
         status_line: String::new(),
         created_at: "2026-01-01 00:00:00".into(),
         sort_order: 0,
+        input_values: None,
     }
 }
 

--- a/src-server/tests/restore_workspace.rs
+++ b/src-server/tests/restore_workspace.rs
@@ -60,6 +60,7 @@ async fn setup() -> (
         archive_script_auto_run: false,
         base_branch: None,
         default_remote: None,
+        required_inputs: None,
         path_valid: true,
     };
     db.insert_repository(&repo).unwrap();
@@ -106,6 +107,7 @@ async fn restore_workspace_recreates_worktree_for_archived() {
             repo_id: &repo.id,
             name: "feature",
             branch_prefix: "test/",
+            input_values: None,
         },
     )
     .await
@@ -189,6 +191,7 @@ async fn restore_workspace_errors_when_workspace_already_active() {
             repo_id: &repo.id,
             name: "feature",
             branch_prefix: "test/",
+            input_values: None,
         },
     )
     .await

--- a/src-tauri/src/commands/chat/remote_control.rs
+++ b/src-tauri/src/commands/chat/remote_control.rs
@@ -439,7 +439,7 @@ async fn ensure_persistent_session_for_remote_control(
         let registry = state.plugins_snapshot().await;
         let (progress, output) =
             crate::commands::env::make_env_sinks(app.clone(), ws_info_for_env.id.clone());
-        claudette::env_provider::resolve_with_registry_streaming(
+        let mut resolved = claudette::env_provider::resolve_with_registry_streaming(
             &registry,
             &state.env_cache,
             std::path::Path::new(worktree_path),
@@ -448,7 +448,11 @@ async fn ensure_persistent_session_for_remote_control(
             Some(&progress),
             Some(output),
         )
-        .await
+        .await;
+        if let Ok(db) = Database::open(db_path) {
+            crate::commands::env::merge_workspace_input_env(&db, &workspace.id, &mut resolved);
+        }
+        resolved
     };
     crate::commands::env::register_resolved_with_watcher(
         state,
@@ -1353,6 +1357,7 @@ mod tests {
             status_line: String::new(),
             created_at: "2026-05-08T00:00:00Z".to_string(),
             sort_order: 0,
+            input_values: None,
         }
     }
 

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -1653,7 +1653,7 @@ pub async fn send_chat_message(
         let registry = state.plugins_snapshot().await;
         let (progress, output) =
             crate::commands::env::make_env_sinks(app.clone(), ws_info_for_env.id.clone());
-        claudette::env_provider::resolve_with_registry_streaming(
+        let mut resolved = claudette::env_provider::resolve_with_registry_streaming(
             &registry,
             &state.env_cache,
             std::path::Path::new(&worktree_path),
@@ -1662,7 +1662,14 @@ pub async fn send_chat_message(
             Some(&progress),
             Some(output),
         )
-        .await
+        .await;
+        // Layer the workspace's declared input values over the env-provider
+        // stack — the agent CLI subprocess sees them as plain env vars,
+        // and the drift check below treats them like any other source.
+        if let Ok(db) = Database::open(&state.db_path) {
+            crate::commands::env::merge_workspace_input_env(&db, &ws.id, &mut resolved);
+        }
+        resolved
     };
     crate::commands::env::register_resolved_with_watcher(
         &state,

--- a/src-tauri/src/commands/chat/session.rs
+++ b/src-tauri/src/commands/chat/session.rs
@@ -230,6 +230,7 @@ mod tests {
             archive_script_auto_run: false,
             base_branch: None,
             default_remote: None,
+            required_inputs: None,
             path_valid: true,
         }
     }
@@ -246,6 +247,7 @@ mod tests {
             status_line: String::new(),
             created_at: String::new(),
             sort_order: 0,
+            input_values: None,
         }
     }
 

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -258,6 +258,7 @@ mod tests {
             archive_script_auto_run: false,
             base_branch: Some("main".into()),
             default_remote: None,
+            required_inputs: None,
             path_valid: true,
         }
     }
@@ -277,6 +278,7 @@ mod tests {
             status_line: String::new(),
             created_at: String::new(),
             sort_order: 0,
+            input_values: None,
         }
     }
 

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -286,6 +286,28 @@ fn enabled_key(repo_id: &str, plugin_name: &str) -> String {
 }
 
 /// Load the set of env-provider plugin names that have been explicitly
+/// disabled for a repo. Absent settings = enabled (default), so the
+/// returned set contains only names with the setting set to `"false"`.
+pub(crate) fn load_disabled_providers(db: &Database, repo_id: &str) -> HashSet<String> {
+    // We list all app settings with the repo+env_provider prefix.
+    // Pattern is precise; rusqlite does this cheaply via LIKE.
+    let prefix = format!("repo:{repo_id}:env_provider:");
+    db.list_app_settings_with_prefix(&prefix)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(key, value)| {
+            if value == "false" {
+                // key = "repo:{repo_id}:env_provider:{plugin_name}:enabled"
+                let rest = key.strip_prefix(&prefix)?;
+                let plugin_name = rest.strip_suffix(":enabled")?;
+                Some(plugin_name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 /// Layer a workspace's stored input values onto an already-resolved env.
 ///
 /// Sits at "after env-provider plugins, before workspace-context vars" in the
@@ -314,28 +336,6 @@ pub(crate) fn merge_workspace_input_env(
             );
         }
     }
-}
-
-/// disabled for a repo. Absent settings = enabled (default), so the
-/// returned set contains only names with the setting set to `"false"`.
-pub(crate) fn load_disabled_providers(db: &Database, repo_id: &str) -> HashSet<String> {
-    // We list all app settings with the repo+env_provider prefix.
-    // Pattern is precise; rusqlite does this cheaply via LIKE.
-    let prefix = format!("repo:{repo_id}:env_provider:");
-    db.list_app_settings_with_prefix(&prefix)
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|(key, value)| {
-            if value == "false" {
-                // key = "repo:{repo_id}:env_provider:{plugin_name}:enabled"
-                let rest = key.strip_prefix(&prefix)?;
-                let plugin_name = rest.strip_suffix(":enabled")?;
-                Some(plugin_name.to_string())
-            } else {
-                None
-            }
-        })
-        .collect()
 }
 
 /// Strip sources whose plugin is globally disabled in the Plugins

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -286,6 +286,36 @@ fn enabled_key(repo_id: &str, plugin_name: &str) -> String {
 }
 
 /// Load the set of env-provider plugin names that have been explicitly
+/// Layer a workspace's stored input values onto an already-resolved env.
+///
+/// Sits at "after env-provider plugins, before workspace-context vars" in the
+/// precedence stack — users typed these values explicitly, so they win over
+/// whatever direnv/mise/dotenv contributed for the same key, but the
+/// `CLAUDETTE_*` markers applied later still override them. No-op when the
+/// workspace has no stored values.
+pub(crate) fn merge_workspace_input_env(
+    db: &Database,
+    workspace_id: &str,
+    resolved: &mut claudette::env_provider::ResolvedEnv,
+) {
+    match db.get_workspace_input_values(workspace_id) {
+        Ok(Some(values)) => {
+            for (k, v) in values {
+                resolved.vars.insert(k, Some(v));
+            }
+        }
+        Ok(None) => {}
+        Err(e) => {
+            tracing::warn!(
+                target: "claudette::env",
+                workspace_id,
+                error = %e,
+                "failed to load workspace input values for env merge"
+            );
+        }
+    }
+}
+
 /// disabled for a repo. Absent settings = enabled (default), so the
 /// returned set contains only names with the setting set to `"false"`.
 pub(crate) fn load_disabled_providers(db: &Database, repo_id: &str) -> HashSet<String> {

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -6,7 +6,7 @@ use tauri::{AppHandle, State};
 use claudette::config;
 use claudette::db::{Database, is_duplicate_repository_path_error};
 use claudette::git;
-use claudette::model::Repository;
+use claudette::model::{Repository, RepositoryInputField, validate_input_schema};
 use claudette::process::command;
 
 use crate::state::AppState;
@@ -101,6 +101,7 @@ pub async fn add_repository(
         archive_script_auto_run: false,
         base_branch,
         default_remote,
+        required_inputs: None,
         path_valid: true,
     };
 
@@ -194,6 +195,29 @@ pub async fn set_archive_script_auto_run(
 ) -> Result<(), String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     db.update_repository_archive_script_auto_run(&repo_id, enabled)
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Replace the repo's declared input schema. An empty `schema` (or omitted)
+/// clears the column so the workspace-create prompt is suppressed again.
+///
+/// Validates env-var-name shape and rejects duplicate keys before writing —
+/// the editor enforces this client-side too, but the server is the authority.
+#[tauri::command]
+pub async fn update_repository_required_inputs(
+    repo_id: String,
+    schema: Vec<RepositoryInputField>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    validate_input_schema(&schema)?;
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let serialized = if schema.is_empty() {
+        None
+    } else {
+        Some(schema.as_slice())
+    };
+    db.update_repository_required_inputs(&repo_id, serialized)
         .map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -497,6 +521,7 @@ async fn init_repository_inner(
         archive_script_auto_run: false,
         base_branch: Some("main".to_string()),
         default_remote: None,
+        required_inputs: None,
         path_valid: true,
     };
 

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -2514,6 +2514,7 @@ mod tests {
             archive_script_auto_run: false,
             base_branch: None,
             default_remote: None,
+            required_inputs: None,
             path_valid: true,
         }
     }
@@ -2530,6 +2531,7 @@ mod tests {
             status_line: String::new(),
             created_at: String::new(),
             sort_order: 0,
+            input_values: None,
         }
     }
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -10,9 +10,7 @@ use claudette::db::Database;
 use claudette::fork::{self, ForkInputs};
 use claudette::git;
 use claudette::mcp_supervisor::McpSupervisor;
-use claudette::model::{
-    AgentStatus, ChatMessage, ChatRole, Workspace, WorkspaceStatus, coerce_input_value,
-};
+use claudette::model::{AgentStatus, ChatMessage, ChatRole, Workspace, WorkspaceStatus};
 use claudette::names::NameGenerator;
 use claudette::ops::workspace::{self as ops_workspace, CreateParams, SetupResult};
 use claudette::ops::{NoopHooks, NotificationEvent, OpsHooks, WorkspaceChangeKind};
@@ -129,11 +127,6 @@ pub(crate) async fn create_workspace_inner(
 ) -> Result<CreateWorkspaceResult, String> {
     let mut db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
 
-    // Validate input values against the repo's declared schema BEFORE
-    // allocating a worktree, so a bad input doesn't leave an orphan branch
-    // / worktree directory behind.
-    let validated_inputs = validate_workspace_inputs(&db, repo_id, input_values.as_ref())?;
-
     let (prefix_mode, prefix_custom) = ops_workspace::read_branch_prefix_settings(&db);
     let prefix = ops_workspace::resolve_branch_prefix(&prefix_mode, &prefix_custom).await;
     let worktree_base = state.worktree_base_dir.read().await.clone();
@@ -142,6 +135,13 @@ pub(crate) async fn create_workspace_inner(
         repo_id,
         name,
         branch_prefix: &prefix,
+        // Validation + persistence of input_values happens inside the op
+        // (`ops::workspace::create_inner` runs `validate_repository_inputs`
+        // before allocating a worktree and `set_workspace_input_values`
+        // after `insert_workspace` succeeds). All callers — GUI, IPC, WS
+        // server — share the same enforcement that way; we no longer have
+        // to repeat the validate-then-persist dance per caller.
+        input_values: input_values.as_ref(),
     };
     let out = if preserve_supplied_name {
         ops_workspace::create_preserving_supplied_name(
@@ -156,11 +156,10 @@ pub(crate) async fn create_workspace_inner(
     }
     .map_err(|e| e.to_string())?;
 
-    // Persist values before running setup — setup needs them in its env.
-    if let Some(ref values) = validated_inputs {
-        db.set_workspace_input_values(&out.workspace.id, Some(values))
-            .map_err(|e| e.to_string())?;
-    }
+    // The op already persisted the coerced values and populated the
+    // workspace struct. Re-borrow here so the setup-script env synth
+    // below reads the canonical post-coercion form.
+    let validated_inputs = out.workspace.input_values.clone();
 
     // Run the setup script BEFORE resolving the env-provider stack.
     // Many `.claudette.json` setups exist precisely to prime that stack
@@ -279,48 +278,11 @@ pub(crate) async fn create_workspace_inner(
     hooks.workspace_changed(&out.workspace.id, WorkspaceChangeKind::Created);
     hooks.notification(NotificationEvent::SessionStart);
 
-    let mut returned = out.workspace;
-    returned.input_values = validated_inputs;
-
     Ok(CreateWorkspaceResult {
-        workspace: returned,
+        workspace: out.workspace,
         default_session_id: out.default_session_id,
         setup_result,
     })
-}
-
-/// Cross-check supplied values against the repo's `required_inputs`. Returns
-/// the coerced map (so type-shaped numbers round-trip through `f64::parse`
-/// before being written) or a human-readable error explaining the first
-/// problem. A repo with no schema accepts no inputs — supplying values is
-/// silently ignored to keep the API forgiving for callers (e.g. the CLI)
-/// that don't yet know the schema is empty.
-pub(crate) fn validate_workspace_inputs(
-    db: &Database,
-    repo_id: &str,
-    supplied: Option<&std::collections::HashMap<String, String>>,
-) -> Result<Option<std::collections::HashMap<String, String>>, String> {
-    let repo = db
-        .get_repository(repo_id)
-        .map_err(|e| e.to_string())?
-        .ok_or("Repository not found")?;
-    let Some(schema) = repo.required_inputs.as_ref() else {
-        return Ok(None);
-    };
-    if schema.is_empty() {
-        return Ok(None);
-    }
-    let supplied_map = supplied.cloned().unwrap_or_default();
-    let mut coerced = std::collections::HashMap::with_capacity(schema.len());
-    for field in schema {
-        let key = field.key();
-        let raw = supplied_map
-            .get(key)
-            .ok_or_else(|| format!("Missing value for required input {key:?}."))?;
-        let value = coerce_input_value(field, raw)?;
-        coerced.insert(key.to_string(), value);
-    }
-    Ok(Some(coerced))
 }
 
 /// Build a minimal [`ResolvedEnv`] from a workspace's input-value map so it

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -10,7 +10,9 @@ use claudette::db::Database;
 use claudette::fork::{self, ForkInputs};
 use claudette::git;
 use claudette::mcp_supervisor::McpSupervisor;
-use claudette::model::{AgentStatus, ChatMessage, ChatRole, Workspace, WorkspaceStatus};
+use claudette::model::{
+    AgentStatus, ChatMessage, ChatRole, Workspace, WorkspaceStatus, coerce_input_value,
+};
 use claudette::names::NameGenerator;
 use claudette::ops::workspace::{self as ops_workspace, CreateParams, SetupResult};
 use claudette::ops::{NoopHooks, NotificationEvent, OpsHooks, WorkspaceChangeKind};
@@ -73,6 +75,10 @@ pub async fn create_workspace(
     repo_id: String,
     name: String,
     skip_setup: Option<bool>,
+    // Values for the repo's declared `required_inputs`. When the repo has
+    // no schema this is ignored; when it does, every declared key must be
+    // present and each value must pass its type's coercion.
+    input_values: Option<std::collections::HashMap<String, String>>,
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<CreateWorkspaceResult, String> {
@@ -97,6 +103,7 @@ pub async fn create_workspace(
         &name,
         skip_setup.unwrap_or(false),
         false,
+        input_values,
         &app,
         &state,
     )
@@ -116,10 +123,17 @@ pub(crate) async fn create_workspace_inner(
     name: &str,
     skip_setup: bool,
     preserve_supplied_name: bool,
+    input_values: Option<std::collections::HashMap<String, String>>,
     app: &AppHandle,
     state: &AppState,
 ) -> Result<CreateWorkspaceResult, String> {
     let mut db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+
+    // Validate input values against the repo's declared schema BEFORE
+    // allocating a worktree, so a bad input doesn't leave an orphan branch
+    // / worktree directory behind.
+    let validated_inputs = validate_workspace_inputs(&db, repo_id, input_values.as_ref())?;
+
     let (prefix_mode, prefix_custom) = ops_workspace::read_branch_prefix_settings(&db);
     let prefix = ops_workspace::resolve_branch_prefix(&prefix_mode, &prefix_custom).await;
     let worktree_base = state.worktree_base_dir.read().await.clone();
@@ -141,6 +155,12 @@ pub(crate) async fn create_workspace_inner(
         ops_workspace::create(&mut db, &NoopHooks, worktree_base.as_path(), params).await
     }
     .map_err(|e| e.to_string())?;
+
+    // Persist values before running setup — setup needs them in its env.
+    if let Some(ref values) = validated_inputs {
+        db.set_workspace_input_values(&out.workspace.id, Some(values))
+            .map_err(|e| e.to_string())?;
+    }
 
     // Run the setup script BEFORE resolving the env-provider stack.
     // Many `.claudette.json` setups exist precisely to prime that stack
@@ -206,6 +226,16 @@ pub(crate) async fn create_workspace_inner(
         },
     );
 
+    // First-create setup runs BEFORE the env-provider resolve (see comment
+    // above) so we can't reuse the cached `ResolvedEnv`. We still want the
+    // workspace's input values visible to the setup script, so synthesize a
+    // minimal `ResolvedEnv` from them. `None` when the workspace has no
+    // declared inputs — the streaming setup then runs with the inherited
+    // PATH only, as before.
+    let inputs_only_env = validated_inputs.as_ref().map(input_values_to_resolved_env);
+    let mut workspace_with_inputs = out.workspace.clone();
+    workspace_with_inputs.input_values = validated_inputs.clone();
+
     let setup_result = if skip_setup {
         None
     } else {
@@ -219,13 +249,13 @@ pub(crate) async fn create_workspace_inner(
             crate::commands::env::make_workspace_terminal_sink(&out.workspace.id),
         );
         ops_workspace::resolve_and_run_setup_streaming(
-            &out.workspace,
+            &workspace_with_inputs,
             Path::new(&repo.path),
             Path::new(&out.worktree_path),
             repo.setup_script.as_deref(),
             repo.base_branch.as_deref(),
             repo.default_remote.as_deref(),
-            None,
+            inputs_only_env.as_ref(),
             sink,
         )
         .await
@@ -249,11 +279,62 @@ pub(crate) async fn create_workspace_inner(
     hooks.workspace_changed(&out.workspace.id, WorkspaceChangeKind::Created);
     hooks.notification(NotificationEvent::SessionStart);
 
+    let mut returned = out.workspace;
+    returned.input_values = validated_inputs;
+
     Ok(CreateWorkspaceResult {
-        workspace: out.workspace,
+        workspace: returned,
         default_session_id: out.default_session_id,
         setup_result,
     })
+}
+
+/// Cross-check supplied values against the repo's `required_inputs`. Returns
+/// the coerced map (so type-shaped numbers round-trip through `f64::parse`
+/// before being written) or a human-readable error explaining the first
+/// problem. A repo with no schema accepts no inputs — supplying values is
+/// silently ignored to keep the API forgiving for callers (e.g. the CLI)
+/// that don't yet know the schema is empty.
+pub(crate) fn validate_workspace_inputs(
+    db: &Database,
+    repo_id: &str,
+    supplied: Option<&std::collections::HashMap<String, String>>,
+) -> Result<Option<std::collections::HashMap<String, String>>, String> {
+    let repo = db
+        .get_repository(repo_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Repository not found")?;
+    let Some(schema) = repo.required_inputs.as_ref() else {
+        return Ok(None);
+    };
+    if schema.is_empty() {
+        return Ok(None);
+    }
+    let supplied_map = supplied.cloned().unwrap_or_default();
+    let mut coerced = std::collections::HashMap::with_capacity(schema.len());
+    for field in schema {
+        let key = field.key();
+        let raw = supplied_map
+            .get(key)
+            .ok_or_else(|| format!("Missing value for required input {key:?}."))?;
+        let value = coerce_input_value(field, raw)?;
+        coerced.insert(key.to_string(), value);
+    }
+    Ok(Some(coerced))
+}
+
+/// Build a minimal [`ResolvedEnv`] from a workspace's input-value map so it
+/// can be passed to spawn sites that expect a `ResolvedEnv` (the setup
+/// script path, primarily). The `sources` vec stays empty because no
+/// env-provider plugin contributed these — they're declared inputs.
+pub(crate) fn input_values_to_resolved_env(
+    values: &std::collections::HashMap<String, String>,
+) -> claudette::env_provider::ResolvedEnv {
+    let mut env = claudette::env_provider::ResolvedEnv::default();
+    for (k, v) in values {
+        env.vars.insert(k.clone(), Some(v.clone()));
+    }
+    env
 }
 
 #[derive(Serialize)]
@@ -553,7 +634,7 @@ async fn resolve_env_for_workspace(
         Some((p, o)) => (Some(p), Some(o)),
         None => (None, None),
     };
-    let resolved = claudette::env_provider::resolve_with_registry_streaming(
+    let mut resolved = claudette::env_provider::resolve_with_registry_streaming(
         &registry,
         &state.env_cache,
         Path::new(worktree),
@@ -565,6 +646,12 @@ async fn resolve_env_for_workspace(
         output,
     )
     .await;
+    // Apply per-workspace input values on top of the env-provider stack.
+    // Opening the DB again is cheap; closing it inside the helper keeps
+    // this call site free of error noise on transient lock contention.
+    if let Ok(db) = Database::open(&state.db_path) {
+        crate::commands::env::merge_workspace_input_env(&db, &ws.id, &mut resolved);
+    }
     crate::commands::env::register_resolved_with_watcher(
         state,
         Path::new(worktree),
@@ -1900,6 +1987,7 @@ pub async fn import_worktrees(
             status_line: String::new(),
             created_at: now_iso(),
             sort_order: 0,
+            input_values: None,
         };
 
         created.push(ws);

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -484,11 +484,12 @@ async fn handle_create_workspace(
     let state = app_state(app)?;
 
     // The CLI / batch fan-out path doesn't yet surface required inputs
-    // (deferred to v1.x). When a repo has declared inputs, `create_workspace_inner`
-    // raises a clear error from `validate_workspace_inputs` rather than silently
-    // creating a workspace with missing env. Until the CLI grows `--input
-    // KEY=VALUE` flags, batch runs against an input-declaring repo will need
-    // to be created from the GUI.
+    // (deferred to v1.x). When a repo has declared inputs, the shared
+    // `ops::workspace::create_inner` raises a clear error from
+    // `validate_repository_inputs` rather than silently creating a
+    // workspace with missing env. Until the CLI grows `--input KEY=VALUE`
+    // flags, batch runs against an input-declaring repo will need to be
+    // created from the GUI.
     let input_values: Option<std::collections::HashMap<String, String>> = params
         .get("input_values")
         .and_then(|v| serde_json::from_value(v.clone()).ok());

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -483,11 +483,22 @@ async fn handle_create_workspace(
 
     let state = app_state(app)?;
 
+    // The CLI / batch fan-out path doesn't yet surface required inputs
+    // (deferred to v1.x). When a repo has declared inputs, `create_workspace_inner`
+    // raises a clear error from `validate_workspace_inputs` rather than silently
+    // creating a workspace with missing env. Until the CLI grows `--input
+    // KEY=VALUE` flags, batch runs against an input-declaring repo will need
+    // to be created from the GUI.
+    let input_values: Option<std::collections::HashMap<String, String>> = params
+        .get("input_values")
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+
     let result = crate::commands::workspace::create_workspace_inner(
         repo_id,
         name,
         skip_setup,
         preserve_supplied_name,
+        input_values,
         app,
         &state,
     )
@@ -1449,6 +1460,7 @@ mod tests {
             archive_script_auto_run: false,
             base_branch: None,
             default_remote: None,
+            required_inputs: None,
             path_valid: true,
         }
     }
@@ -1465,6 +1477,7 @@ mod tests {
             status_line: String::new(),
             created_at: String::new(),
             sort_order: 0,
+            input_values: None,
         }
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -989,6 +989,7 @@ fn main() {
             commands::repository::reorder_repositories,
             commands::repository::set_setup_script_auto_run,
             commands::repository::set_archive_script_auto_run,
+            commands::repository::update_repository_required_inputs,
             // Workspace
             commands::workspace::create_workspace,
             commands::workspace::fork_workspace_at_checkpoint,
@@ -1487,6 +1488,7 @@ mod tests {
                 archive_script_auto_run: false,
                 base_branch: None,
                 default_remote: None,
+                required_inputs: None,
                 path_valid: true,
             };
             db.insert_repository(&repo).expect("insert repo");

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -133,7 +133,7 @@ pub async fn spawn_pty(
         repo_path: root_path.clone(),
         repo_id: repo_id_opt,
     };
-    let resolved_env = {
+    let mut resolved_env = {
         // Snapshot the plugin registry — `plugins_snapshot` releases
         // the outer RwLock immediately so opening the Plugins
         // settings page (which awaits `list_claudette_plugins`) is
@@ -152,6 +152,14 @@ pub async fn spawn_pty(
         )
         .await
     };
+    // Layer the workspace's declared input values over the env-provider
+    // stack so the interactive shell (and anything the user runs in it)
+    // sees them. Reopening the DB here mirrors the rest of pty.rs — every
+    // Tauri command opens its own `rusqlite::Connection` because the type
+    // isn't `Send`.
+    if let Ok(db) = claudette::db::Database::open(&state.db_path) {
+        crate::commands::env::merge_workspace_input_env(&db, &workspace_id, &mut resolved_env);
+    }
     crate::commands::env::register_resolved_with_watcher(
         &state,
         std::path::Path::new(&working_dir),

--- a/src/db/repository.rs
+++ b/src/db/repository.rs
@@ -7,7 +7,7 @@
 
 use rusqlite::{OptionalExtension, params};
 
-use crate::model::Repository;
+use crate::model::{Repository, RepositoryInputField};
 
 use super::Database;
 
@@ -44,6 +44,24 @@ impl Database {
     }
 
     fn parse_repo_row(row: &rusqlite::Row) -> rusqlite::Result<Repository> {
+        let required_inputs_raw: Option<String> = row.get(15)?;
+        // Tolerate corrupt / forward-version JSON by dropping the schema rather
+        // than failing the entire SELECT — losing prompts is preferable to a
+        // dead sidebar. A warning trace lets ops notice the regression.
+        let required_inputs = required_inputs_raw.and_then(|s| {
+            match serde_json::from_str::<Vec<RepositoryInputField>>(&s) {
+                Ok(v) if !v.is_empty() => Some(v),
+                Ok(_) => None,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "claudette::db",
+                        error = %e,
+                        "failed to parse repositories.required_inputs JSON; treating as empty"
+                    );
+                    None
+                }
+            }
+        });
         Ok(Repository {
             id: row.get(0)?,
             path: row.get(1)?,
@@ -60,13 +78,14 @@ impl Database {
             default_remote: row.get(12)?,
             archive_script: row.get(13)?,
             archive_script_auto_run: row.get::<_, i32>(14).unwrap_or(0) != 0,
+            required_inputs,
             path_valid: true, // validated after load
         })
     }
 
     pub fn list_repositories(&self) -> Result<Vec<Repository>, rusqlite::Error> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, path, name, icon, path_slug, created_at, setup_script, custom_instructions, sort_order, branch_rename_preferences, setup_script_auto_run, base_branch, default_remote, archive_script, archive_script_auto_run
+            "SELECT id, path, name, icon, path_slug, created_at, setup_script, custom_instructions, sort_order, branch_rename_preferences, setup_script_auto_run, base_branch, default_remote, archive_script, archive_script_auto_run, required_inputs
              FROM repositories ORDER BY sort_order, name",
         )?;
         let rows = stmt.query_map([], Self::parse_repo_row)?;
@@ -76,7 +95,7 @@ impl Database {
     pub fn get_repository(&self, id: &str) -> Result<Option<Repository>, rusqlite::Error> {
         self.conn
             .query_row(
-                "SELECT id, path, name, icon, path_slug, created_at, setup_script, custom_instructions, sort_order, branch_rename_preferences, setup_script_auto_run, base_branch, default_remote, archive_script, archive_script_auto_run
+                "SELECT id, path, name, icon, path_slug, created_at, setup_script, custom_instructions, sort_order, branch_rename_preferences, setup_script_auto_run, base_branch, default_remote, archive_script, archive_script_auto_run, required_inputs
                  FROM repositories WHERE id = ?1",
                 params![id],
                 Self::parse_repo_row,
@@ -228,6 +247,32 @@ impl Database {
         )?;
         Ok(())
     }
+
+    /// Persist the per-repo schema of declared inputs.
+    ///
+    /// An empty schema (`Some(&[])` or `None`) clears the column — callers
+    /// pass `None` to mean "this repo no longer prompts on workspace
+    /// creation". JSON serialization is infallible for this enum and is
+    /// surfaced as `rusqlite::Error::ToSqlConversionFailure` if it ever
+    /// breaks so a corrupt row can't sneak in.
+    pub fn update_repository_required_inputs(
+        &self,
+        id: &str,
+        schema: Option<&[RepositoryInputField]>,
+    ) -> Result<(), rusqlite::Error> {
+        let serialized = match schema {
+            Some(fields) if !fields.is_empty() => Some(
+                serde_json::to_string(fields)
+                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?,
+            ),
+            _ => None,
+        };
+        self.conn.execute(
+            "UPDATE repositories SET required_inputs = ?1 WHERE id = ?2",
+            params![serialized, id],
+        )?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -313,5 +358,52 @@ mod tests {
         let repos = db.list_repositories().unwrap();
         assert_eq!(repos[0].name, "My Project");
         assert_eq!(repos[0].path_slug, "my-project");
+    }
+
+    #[test]
+    fn required_inputs_roundtrip_via_update() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/r1", "r1"))
+            .unwrap();
+        // Empty / unset → None on read.
+        let repos = db.list_repositories().unwrap();
+        assert!(repos[0].required_inputs.is_none());
+
+        // Write a typed schema, read it back.
+        let schema = vec![
+            RepositoryInputField::String {
+                key: "TICKET_ID".into(),
+                label: "Ticket".into(),
+                description: None,
+                default: None,
+                placeholder: Some("PROJ-123".into()),
+            },
+            RepositoryInputField::Number {
+                key: "RETRIES".into(),
+                label: "Retries".into(),
+                description: None,
+                default: Some(3.0),
+                min: Some(0.0),
+                max: Some(10.0),
+                step: None,
+                unit: None,
+            },
+        ];
+        db.update_repository_required_inputs("r1", Some(&schema))
+            .unwrap();
+        let repos = db.list_repositories().unwrap();
+        let loaded = repos[0]
+            .required_inputs
+            .as_ref()
+            .expect("required_inputs should round-trip");
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].key(), "TICKET_ID");
+        assert_eq!(loaded[1].key(), "RETRIES");
+
+        // Empty slice clears the column back to NULL.
+        db.update_repository_required_inputs("r1", Some(&[]))
+            .unwrap();
+        let repos = db.list_repositories().unwrap();
+        assert!(repos[0].required_inputs.is_none());
     }
 }

--- a/src/db/repository.rs
+++ b/src/db/repository.rs
@@ -377,6 +377,7 @@ mod tests {
                 description: None,
                 default: None,
                 placeholder: Some("PROJ-123".into()),
+                required: true,
             },
             RepositoryInputField::Number {
                 key: "RETRIES".into(),
@@ -387,6 +388,7 @@ mod tests {
                 max: Some(10.0),
                 step: None,
                 unit: None,
+                required: true,
             },
         ];
         db.update_repository_required_inputs("r1", Some(&schema))

--- a/src/db/test_support.rs
+++ b/src/db/test_support.rs
@@ -24,6 +24,7 @@ pub(crate) fn make_repo(id: &str, path: &str, name: &str) -> Repository {
         archive_script_auto_run: false,
         base_branch: None,
         default_remote: None,
+        required_inputs: None,
         path_valid: true,
     }
 }
@@ -40,6 +41,7 @@ pub(crate) fn make_workspace(id: &str, repo_id: &str, name: &str) -> Workspace {
         status_line: String::new(),
         created_at: String::new(),
         sort_order: 0,
+        input_values: None,
     }
 }
 

--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -121,7 +121,7 @@ impl Database {
 
     pub fn list_workspaces(&self) -> Result<Vec<Workspace>, rusqlite::Error> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, repository_id, name, branch_name, worktree_path, status, status_line, created_at, sort_order
+            "SELECT id, repository_id, name, branch_name, worktree_path, status, status_line, created_at, sort_order, input_values
              FROM workspaces ORDER BY repository_id, sort_order, created_at",
         )?;
         let rows = stmt.query_map([], |row| {
@@ -138,6 +138,21 @@ impl Database {
             } else {
                 crate::model::AgentStatus::Idle
             };
+            let input_values_raw: Option<String> = row.get(9)?;
+            let input_values = input_values_raw.and_then(|s| {
+                match serde_json::from_str::<std::collections::HashMap<String, String>>(&s) {
+                    Ok(m) if !m.is_empty() => Some(m),
+                    Ok(_) => None,
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "claudette::db",
+                            error = %e,
+                            "failed to parse workspaces.input_values JSON; treating as empty"
+                        );
+                        None
+                    }
+                }
+            });
             Ok(Workspace {
                 id: row.get(0)?,
                 repository_id: row.get(1)?,
@@ -149,9 +164,53 @@ impl Database {
                 status_line: row.get(6)?,
                 created_at: row.get(7)?,
                 sort_order: row.get(8)?,
+                input_values,
             })
         })?;
         rows.collect()
+    }
+
+    /// Persist the values a workspace was created with for its repo's
+    /// declared `required_inputs`. Pass an empty map (or `None`) to clear.
+    pub fn set_workspace_input_values(
+        &self,
+        workspace_id: &str,
+        values: Option<&std::collections::HashMap<String, String>>,
+    ) -> Result<(), rusqlite::Error> {
+        let serialized = match values {
+            Some(map) if !map.is_empty() => Some(
+                serde_json::to_string(map)
+                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?,
+            ),
+            _ => None,
+        };
+        self.conn.execute(
+            "UPDATE workspaces SET input_values = ?1 WHERE id = ?2",
+            params![serialized, workspace_id],
+        )?;
+        Ok(())
+    }
+
+    /// Read just the input values for a workspace without loading the full
+    /// row. Used by env-injection helpers that only need the map.
+    pub fn get_workspace_input_values(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<std::collections::HashMap<String, String>>, rusqlite::Error> {
+        let raw: Option<Option<String>> = self
+            .conn
+            .query_row(
+                "SELECT input_values FROM workspaces WHERE id = ?1",
+                params![workspace_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(raw.flatten().and_then(|s| {
+            match serde_json::from_str::<std::collections::HashMap<String, String>>(&s) {
+                Ok(m) if !m.is_empty() => Some(m),
+                _ => None,
+            }
+        }))
     }
 
     /// Reassign per-repository `sort_order` of workspaces in the supplied
@@ -1404,5 +1463,35 @@ mod tests {
                 panic!("expected FromSqlConversionFailure for unknown status, got: {other:?}",)
             }
         }
+    }
+
+    #[test]
+    fn input_values_roundtrip() {
+        let db = setup_db_with_workspace();
+        // Default is None.
+        let workspaces = db.list_workspaces().unwrap();
+        let ws = workspaces.iter().find(|w| w.id == "w1").unwrap();
+        assert!(ws.input_values.is_none());
+
+        // Persist and read back.
+        let mut values = std::collections::HashMap::new();
+        values.insert("TICKET_ID".to_string(), "PROJ-42".to_string());
+        values.insert("RETRIES".to_string(), "5".to_string());
+        db.set_workspace_input_values("w1", Some(&values)).unwrap();
+
+        let loaded = db.get_workspace_input_values("w1").unwrap();
+        assert_eq!(
+            loaded.as_ref().unwrap().get("TICKET_ID"),
+            Some(&"PROJ-42".to_string())
+        );
+        assert_eq!(
+            loaded.as_ref().unwrap().get("RETRIES"),
+            Some(&"5".to_string())
+        );
+
+        // Empty map clears.
+        db.set_workspace_input_values("w1", Some(&std::collections::HashMap::new()))
+            .unwrap();
+        assert!(db.get_workspace_input_values("w1").unwrap().is_none());
     }
 }

--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -205,10 +205,24 @@ impl Database {
                 |row| row.get(0),
             )
             .optional()?;
+        // Match `list_workspaces`'s warn-and-degrade behavior: a corrupt
+        // JSON blob is logged at warn level and treated as empty, so the
+        // env merge silently dropping input values can be diagnosed from
+        // logs rather than guessed at. Empty maps round-trip to `None` so
+        // callers can early-return without a contains-key check.
         Ok(raw.flatten().and_then(|s| {
             match serde_json::from_str::<std::collections::HashMap<String, String>>(&s) {
                 Ok(m) if !m.is_empty() => Some(m),
-                _ => None,
+                Ok(_) => None,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "claudette::db",
+                        workspace_id,
+                        error = %e,
+                        "failed to parse workspaces.input_values JSON; treating as empty"
+                    );
+                    None
+                }
             }
         }))
     }

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -256,6 +256,14 @@ async fn fork_after_worktree(
     if let Some(o) = db.lookup_workspace_sort_order(&new_ws.id)? {
         new_ws.sort_order = o;
     }
+    // `insert_workspace` only writes the original columns — `input_values`
+    // lives in its own write path. Without this, a fork would return a
+    // struct carrying the source's inputs but the DB row would be NULL,
+    // and every subsequent terminal/agent/script env merge would read
+    // nothing for those keys.
+    if let Some(values) = new_ws.input_values.as_ref() {
+        db.set_workspace_input_values(&new_ws.id, Some(values))?;
+    }
 
     copy_history(db, &source_ws.id, &new_ws.id, checkpoint)?;
 

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -250,6 +250,7 @@ async fn fork_after_worktree(
         // assigned (MAX+1 within repo) so callers handing this struct back
         // to the UI render the new fork at the right sidebar position.
         sort_order: 0,
+        input_values: source_ws.input_values.clone(),
     };
     db.insert_workspace(&new_ws)?;
     if let Some(o) = db.lookup_workspace_sort_order(&new_ws.id)? {
@@ -621,6 +622,7 @@ mod tests {
             archive_script_auto_run: false,
             base_branch: None,
             default_remote: None,
+            required_inputs: None,
             path_valid: true,
             created_at: String::new(),
         }
@@ -638,6 +640,7 @@ mod tests {
             status_line: String::new(),
             created_at: String::new(),
             sort_order: 0,
+            input_values: None,
         }
     }
 
@@ -1167,6 +1170,7 @@ mod tests {
             archive_script_auto_run: false,
             base_branch: None,
             default_remote: None,
+            required_inputs: None,
             path_valid: true,
             created_at: String::new(),
         })
@@ -1182,6 +1186,7 @@ mod tests {
             status_line: String::new(),
             created_at: String::new(),
             sort_order: 0,
+            input_values: None,
         };
         db.insert_workspace(&source_ws).unwrap();
 

--- a/src/migrations/20260513200000_repo_required_inputs.sql
+++ b/src/migrations/20260513200000_repo_required_inputs.sql
@@ -1,0 +1,6 @@
+-- Per-repo declared inputs (JSON array of {type,key,label,...}) and the
+-- values a specific workspace was created with (JSON object {key:string}).
+-- Both nullable: a repo without declared inputs leaves NULL; a workspace
+-- whose repo has no inputs leaves NULL.
+ALTER TABLE repositories ADD COLUMN required_inputs TEXT;
+ALTER TABLE workspaces ADD COLUMN input_values TEXT;

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -230,6 +230,11 @@ pub const MIGRATIONS: &[Migration] = &[
         legacy_version: None,
     },
     Migration {
+        id: "20260513200000_repo_required_inputs",
+        sql: include_str!("20260513200000_repo_required_inputs.sql"),
+        legacy_version: None,
+    },
+    Migration {
         id: "20260517190000_agent_scheduled_tasks",
         sql: include_str!("20260517190000_agent_scheduled_tasks.sql"),
         legacy_version: None,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -8,6 +8,7 @@ mod metrics;
 mod pinned_prompt;
 mod remote_connection;
 mod repository;
+mod repository_input;
 mod terminal_tab;
 mod workspace;
 
@@ -26,5 +27,9 @@ pub use metrics::{
 pub use pinned_prompt::PinnedPrompt;
 pub use remote_connection::RemoteConnection;
 pub use repository::Repository;
+pub use repository_input::{
+    RepositoryInputField, coerce_value as coerce_input_value, validate_input_key,
+    validate_schema as validate_input_schema,
+};
 pub use terminal_tab::{TerminalTab, TerminalTabKind};
 pub use workspace::{AgentStatus, Workspace, WorkspaceStatus};

--- a/src/model/repository.rs
+++ b/src/model/repository.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 
+use super::RepositoryInputField;
+
 #[derive(Debug, Clone, Serialize)]
 #[allow(dead_code)]
 pub struct Repository {
@@ -33,6 +35,11 @@ pub struct Repository {
     /// Explicit remote name for push/pull/PR operations (e.g. "origin").
     /// None means auto-detect (first configured remote).
     pub default_remote: Option<String>,
+    /// Per-repo declared inputs. New workspaces must supply a value for each
+    /// declared field at creation time; those values become env vars in the
+    /// workspace session. `None` (i.e. empty schema) means "no prompts" and
+    /// is the default for newly-added repositories.
+    pub required_inputs: Option<Vec<RepositoryInputField>>,
     /// Runtime-only: whether the repo path still exists on disk. Not persisted.
     pub path_valid: bool,
 }

--- a/src/model/repository_input.rs
+++ b/src/model/repository_input.rs
@@ -1,0 +1,256 @@
+use serde::{Deserialize, Serialize};
+
+/// One declared per-repo input. New workspaces are required to supply a value
+/// for each declared field before they can be created; the value then becomes
+/// an environment variable visible to the agent, terminal, and setup/archive
+/// scripts for that workspace.
+///
+/// The `type` discriminator drives the input the UI renders (and the
+/// validation it applies before the value is serialized to a string).
+/// Everything ultimately crosses the env boundary as a string — the type is
+/// purely a UX/validation aid.
+///
+/// Shape intentionally mirrors `PluginSettingField` (Lua plugin manifests) so
+/// the frontend can render both with the same `PluginSettingInput` component.
+/// `select` is not supported in v1.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum RepositoryInputField {
+    Boolean {
+        key: String,
+        label: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default: Option<bool>,
+    },
+    String {
+        key: String,
+        label: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        placeholder: Option<String>,
+    },
+    Number {
+        key: String,
+        label: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default: Option<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min: Option<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max: Option<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        step: Option<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        unit: Option<String>,
+    },
+}
+
+impl RepositoryInputField {
+    pub fn key(&self) -> &str {
+        match self {
+            Self::Boolean { key, .. } | Self::String { key, .. } | Self::Number { key, .. } => key,
+        }
+    }
+}
+
+/// `key` must look like a POSIX-ish environment variable name. We're slightly
+/// stricter than POSIX (no leading digit) so the names round-trip through
+/// shells without surprise. Returns `Err` with a human-readable reason.
+pub fn validate_input_key(key: &str) -> Result<(), String> {
+    if key.is_empty() {
+        return Err("Input name cannot be empty.".to_string());
+    }
+    let mut chars = key.chars();
+    let first = chars.next().unwrap();
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return Err(format!(
+            "Input name {key:?} must start with a letter or underscore."
+        ));
+    }
+    for c in chars {
+        if !(c.is_ascii_alphanumeric() || c == '_') {
+            return Err(format!(
+                "Input name {key:?} can only contain letters, digits, and underscores."
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate that the schema is well-formed: every key passes
+/// `validate_input_key` and no two fields share the same key.
+pub fn validate_schema(schema: &[RepositoryInputField]) -> Result<(), String> {
+    let mut seen = std::collections::HashSet::new();
+    for field in schema {
+        let key = field.key();
+        validate_input_key(key)?;
+        if !seen.insert(key.to_string()) {
+            return Err(format!("Duplicate input name {key:?}."));
+        }
+    }
+    Ok(())
+}
+
+/// Coerce a supplied value (already serialized as a string from the
+/// frontend) against its declared type. Returns the canonicalized string
+/// to persist, or an error explaining why it was rejected.
+///
+/// Boolean: accepts `"true"`/`"false"` (lowercase), canonicalizes to those.
+/// Number: must parse as `f64`; min/max checked when set; canonical form
+/// is the original string trimmed (we don't reformat e.g. "1.0" → "1").
+/// String: any value accepted; whitespace preserved.
+pub fn coerce_value(field: &RepositoryInputField, raw: &str) -> Result<String, String> {
+    match field {
+        RepositoryInputField::Boolean { key, .. } => match raw {
+            "true" | "false" => Ok(raw.to_string()),
+            other => Err(format!(
+                "Input {key:?} must be a boolean (\"true\" or \"false\"), got {other:?}."
+            )),
+        },
+        RepositoryInputField::Number { key, min, max, .. } => {
+            let trimmed = raw.trim();
+            let parsed: f64 = trimmed
+                .parse()
+                .map_err(|_| format!("Input {key:?} must be a number, got {raw:?}."))?;
+            if let Some(lo) = min
+                && parsed < *lo
+            {
+                return Err(format!("Input {key:?} must be ≥ {lo}, got {parsed}."));
+            }
+            if let Some(hi) = max
+                && parsed > *hi
+            {
+                return Err(format!("Input {key:?} must be ≤ {hi}, got {parsed}."));
+            }
+            Ok(trimmed.to_string())
+        }
+        RepositoryInputField::String { .. } => Ok(raw.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_key_accepts_typical_env_names() {
+        validate_input_key("TICKET_ID").unwrap();
+        validate_input_key("_internal").unwrap();
+        validate_input_key("a1").unwrap();
+    }
+
+    #[test]
+    fn validate_key_rejects_leading_digit_and_bad_chars() {
+        assert!(validate_input_key("").is_err());
+        assert!(validate_input_key("1FOO").is_err());
+        assert!(validate_input_key("FOO-BAR").is_err());
+        assert!(validate_input_key("FOO BAR").is_err());
+    }
+
+    #[test]
+    fn schema_rejects_duplicate_keys() {
+        let schema = vec![
+            RepositoryInputField::String {
+                key: "DUP".into(),
+                label: "A".into(),
+                description: None,
+                default: None,
+                placeholder: None,
+            },
+            RepositoryInputField::Boolean {
+                key: "DUP".into(),
+                label: "B".into(),
+                description: None,
+                default: None,
+            },
+        ];
+        let err = validate_schema(&schema).unwrap_err();
+        assert!(err.contains("Duplicate"));
+    }
+
+    #[test]
+    fn coerce_boolean() {
+        let field = RepositoryInputField::Boolean {
+            key: "FLAG".into(),
+            label: "Flag".into(),
+            description: None,
+            default: None,
+        };
+        assert_eq!(coerce_value(&field, "true").unwrap(), "true");
+        assert_eq!(coerce_value(&field, "false").unwrap(), "false");
+        assert!(coerce_value(&field, "True").is_err());
+        assert!(coerce_value(&field, "yes").is_err());
+    }
+
+    #[test]
+    fn coerce_number_with_bounds() {
+        let field = RepositoryInputField::Number {
+            key: "N".into(),
+            label: "N".into(),
+            description: None,
+            default: None,
+            min: Some(0.0),
+            max: Some(10.0),
+            step: None,
+            unit: None,
+        };
+        assert_eq!(coerce_value(&field, "5").unwrap(), "5");
+        assert_eq!(coerce_value(&field, "  3.5  ").unwrap(), "3.5");
+        assert!(coerce_value(&field, "abc").is_err());
+        assert!(coerce_value(&field, "-1").is_err());
+        assert!(coerce_value(&field, "11").is_err());
+    }
+
+    #[test]
+    fn coerce_string_accepts_anything() {
+        let field = RepositoryInputField::String {
+            key: "S".into(),
+            label: "S".into(),
+            description: None,
+            default: None,
+            placeholder: None,
+        };
+        assert_eq!(coerce_value(&field, "PROJ-123").unwrap(), "PROJ-123");
+        assert_eq!(coerce_value(&field, "").unwrap(), "");
+        assert_eq!(coerce_value(&field, "  spaces  ").unwrap(), "  spaces  ");
+    }
+
+    #[test]
+    fn serde_roundtrip_all_variants() {
+        let schema = vec![
+            RepositoryInputField::String {
+                key: "TICKET_ID".into(),
+                label: "Ticket".into(),
+                description: Some("JIRA key".into()),
+                default: None,
+                placeholder: Some("PROJ-123".into()),
+            },
+            RepositoryInputField::Number {
+                key: "RETRIES".into(),
+                label: "Retries".into(),
+                description: None,
+                default: Some(3.0),
+                min: Some(0.0),
+                max: Some(10.0),
+                step: Some(1.0),
+                unit: None,
+            },
+            RepositoryInputField::Boolean {
+                key: "DEBUG".into(),
+                label: "Debug".into(),
+                description: None,
+                default: Some(false),
+            },
+        ];
+        let json = serde_json::to_string(&schema).unwrap();
+        let parsed: Vec<RepositoryInputField> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, schema);
+    }
+}

--- a/src/model/repository_input.rs
+++ b/src/model/repository_input.rs
@@ -103,9 +103,10 @@ pub fn validate_schema(schema: &[RepositoryInputField]) -> Result<(), String> {
 /// to persist, or an error explaining why it was rejected.
 ///
 /// Boolean: accepts `"true"`/`"false"` (lowercase), canonicalizes to those.
-/// Number: must parse as `f64`; min/max checked when set; canonical form
-/// is the original string trimmed (we don't reformat e.g. "1.0" → "1").
-/// String: any value accepted; whitespace preserved.
+/// Number: must parse as a finite `f64`; min/max checked when set; canonical
+/// form is the original string trimmed (we don't reformat e.g. "1.0" → "1").
+/// String: any non-empty value accepted (whitespace-only is rejected so the
+/// CLI / IPC path can't silently bypass the modal's "required" contract).
 pub fn coerce_value(field: &RepositoryInputField, raw: &str) -> Result<String, String> {
     match field {
         RepositoryInputField::Boolean { key, .. } => match raw {
@@ -119,6 +120,15 @@ pub fn coerce_value(field: &RepositoryInputField, raw: &str) -> Result<String, S
             let parsed: f64 = trimmed
                 .parse()
                 .map_err(|_| format!("Input {key:?} must be a number, got {raw:?}."))?;
+            // `f64::from_str` happily accepts "NaN" / "inf" / "-inf", and the
+            // `<` / `>` comparisons against NaN are always false — without
+            // this check, a CLI/IPC caller could persist `NaN` and the scripts
+            // downstream would see literal "NaN". Frontend already rejects.
+            if !parsed.is_finite() {
+                return Err(format!(
+                    "Input {key:?} must be a finite number, got {raw:?}."
+                ));
+            }
             if let Some(lo) = min
                 && parsed < *lo
             {
@@ -131,7 +141,16 @@ pub fn coerce_value(field: &RepositoryInputField, raw: &str) -> Result<String, S
             }
             Ok(trimmed.to_string())
         }
-        RepositoryInputField::String { .. } => Ok(raw.to_string()),
+        RepositoryInputField::String { key, .. } => {
+            // Match the frontend's "required" contract — every declared input
+            // must carry a non-blank value. Without this, IPC/CLI callers can
+            // bypass the modal and persist `""`, which would defeat the
+            // declaration entirely.
+            if raw.trim().is_empty() {
+                return Err(format!("Input {key:?} cannot be blank."));
+            }
+            Ok(raw.to_string())
+        }
     }
 }
 
@@ -209,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    fn coerce_string_accepts_anything() {
+    fn coerce_string_rejects_blank_and_whitespace() {
         let field = RepositoryInputField::String {
             key: "S".into(),
             label: "S".into(),
@@ -218,8 +237,33 @@ mod tests {
             placeholder: None,
         };
         assert_eq!(coerce_value(&field, "PROJ-123").unwrap(), "PROJ-123");
-        assert_eq!(coerce_value(&field, "").unwrap(), "");
+        // Whitespace-padded values are preserved verbatim — the user may
+        // have meant the leading/trailing spaces. Only purely blank input
+        // is rejected.
         assert_eq!(coerce_value(&field, "  spaces  ").unwrap(), "  spaces  ");
+        assert!(coerce_value(&field, "").is_err());
+        assert!(coerce_value(&field, "   ").is_err());
+        assert!(coerce_value(&field, "\t\n").is_err());
+    }
+
+    #[test]
+    fn coerce_number_rejects_non_finite() {
+        let field = RepositoryInputField::Number {
+            key: "N".into(),
+            label: "N".into(),
+            description: None,
+            default: None,
+            min: None,
+            max: None,
+            step: None,
+            unit: None,
+        };
+        // `f64::from_str` parses these — the explicit `is_finite` check is
+        // what makes the backend match the frontend's rejection.
+        assert!(coerce_value(&field, "NaN").is_err());
+        assert!(coerce_value(&field, "inf").is_err());
+        assert!(coerce_value(&field, "-inf").is_err());
+        assert!(coerce_value(&field, "Infinity").is_err());
     }
 
     #[test]

--- a/src/model/repository_input.rs
+++ b/src/model/repository_input.rs
@@ -10,6 +10,12 @@ use serde::{Deserialize, Serialize};
 /// Everything ultimately crosses the env boundary as a string — the type is
 /// purely a UX/validation aid.
 ///
+/// `required` defaults to `true` (via `default_required` below) so existing
+/// schemas keep their "value mandatory at create time" behavior. Marking a
+/// field `required: false` lets the user submit the workspace-create modal
+/// without filling that field in — the env var is still set, but to an empty
+/// string for string/number, so downstream scripts can `[ -z "$X" ]` check.
+///
 /// Shape intentionally mirrors `PluginSettingField` (Lua plugin manifests) so
 /// the frontend can render both with the same `PluginSettingInput` component.
 /// `select` is not supported in v1.
@@ -23,6 +29,11 @@ pub enum RepositoryInputField {
         description: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         default: Option<bool>,
+        /// Booleans always carry a value (`true` / `false`), so this flag is
+        /// effectively informational for the boolean variant — the coercer
+        /// ignores it. Kept for schema symmetry across variants.
+        #[serde(default = "default_required")]
+        required: bool,
     },
     String {
         key: String,
@@ -33,6 +44,8 @@ pub enum RepositoryInputField {
         default: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         placeholder: Option<String>,
+        #[serde(default = "default_required")]
+        required: bool,
     },
     Number {
         key: String,
@@ -49,13 +62,33 @@ pub enum RepositoryInputField {
         step: Option<f64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         unit: Option<String>,
+        #[serde(default = "default_required")]
+        required: bool,
     },
+}
+
+/// serde's `#[serde(default)]` on a `bool` would default to `false`. We want
+/// the opposite — existing schemas (and any third-party producer that omits
+/// the field) should be treated as required. A free function gives us that.
+fn default_required() -> bool {
+    true
 }
 
 impl RepositoryInputField {
     pub fn key(&self) -> &str {
         match self {
             Self::Boolean { key, .. } | Self::String { key, .. } | Self::Number { key, .. } => key,
+        }
+    }
+
+    /// Whether the user must supply a non-blank value when creating a
+    /// workspace. Booleans always have a value so this returns `true` for
+    /// them regardless of the schema flag — the flag is meaningless for
+    /// booleans (see comment on the variant).
+    pub fn is_required(&self) -> bool {
+        match self {
+            Self::Boolean { .. } => true,
+            Self::String { required, .. } | Self::Number { required, .. } => *required,
         }
     }
 }
@@ -103,10 +136,10 @@ pub fn validate_schema(schema: &[RepositoryInputField]) -> Result<(), String> {
 /// to persist, or an error explaining why it was rejected.
 ///
 /// Boolean: accepts `"true"`/`"false"` (lowercase), canonicalizes to those.
-/// Number: must parse as a finite `f64`; min/max checked when set; canonical
-/// form is the original string trimmed (we don't reformat e.g. "1.0" → "1").
-/// String: any non-empty value accepted (whitespace-only is rejected so the
-/// CLI / IPC path can't silently bypass the modal's "required" contract).
+/// Number: must parse as a finite `f64` when supplied; min/max checked when
+/// set. A blank input is rejected when the field is `required`, accepted as
+/// `""` when not (downstream scripts get an empty env var to test with).
+/// String: required ⇒ non-blank; not required ⇒ any value (including blank).
 pub fn coerce_value(field: &RepositoryInputField, raw: &str) -> Result<String, String> {
     match field {
         RepositoryInputField::Boolean { key, .. } => match raw {
@@ -115,8 +148,23 @@ pub fn coerce_value(field: &RepositoryInputField, raw: &str) -> Result<String, S
                 "Input {key:?} must be a boolean (\"true\" or \"false\"), got {other:?}."
             )),
         },
-        RepositoryInputField::Number { key, min, max, .. } => {
+        RepositoryInputField::Number {
+            key,
+            min,
+            max,
+            required,
+            ..
+        } => {
             let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                // Non-required numeric inputs pass through as an empty string
+                // — the workspace's env var is set to `""` so scripts can
+                // detect "user didn't supply" uniformly via `[ -z "$X" ]`.
+                if !required {
+                    return Ok(String::new());
+                }
+                return Err(format!("Input {key:?} is required."));
+            }
             let parsed: f64 = trimmed
                 .parse()
                 .map_err(|_| format!("Input {key:?} must be a number, got {raw:?}."))?;
@@ -141,13 +189,13 @@ pub fn coerce_value(field: &RepositoryInputField, raw: &str) -> Result<String, S
             }
             Ok(trimmed.to_string())
         }
-        RepositoryInputField::String { key, .. } => {
-            // Match the frontend's "required" contract — every declared input
-            // must carry a non-blank value. Without this, IPC/CLI callers can
-            // bypass the modal and persist `""`, which would defeat the
-            // declaration entirely.
-            if raw.trim().is_empty() {
-                return Err(format!("Input {key:?} cannot be blank."));
+        RepositoryInputField::String { key, required, .. } => {
+            // Required strings must carry a non-blank value (matches the
+            // frontend's modal contract). Non-required strings pass through
+            // verbatim — including whitespace-only, in case the user
+            // deliberately wants leading/trailing space.
+            if *required && raw.trim().is_empty() {
+                return Err(format!("Input {key:?} is required."));
             }
             Ok(raw.to_string())
         }
@@ -157,6 +205,33 @@ pub fn coerce_value(field: &RepositoryInputField, raw: &str) -> Result<String, S
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Convenience constructors so the tests below don't drown in
+    /// `..Default::default()`-style boilerplate per variant.
+    fn string_field(key: &str) -> RepositoryInputField {
+        RepositoryInputField::String {
+            key: key.into(),
+            label: key.into(),
+            description: None,
+            default: None,
+            placeholder: None,
+            required: true,
+        }
+    }
+
+    fn number_field(key: &str, min: Option<f64>, max: Option<f64>) -> RepositoryInputField {
+        RepositoryInputField::Number {
+            key: key.into(),
+            label: key.into(),
+            description: None,
+            default: None,
+            min,
+            max,
+            step: None,
+            unit: None,
+            required: true,
+        }
+    }
 
     #[test]
     fn validate_key_accepts_typical_env_names() {
@@ -176,18 +251,13 @@ mod tests {
     #[test]
     fn schema_rejects_duplicate_keys() {
         let schema = vec![
-            RepositoryInputField::String {
-                key: "DUP".into(),
-                label: "A".into(),
-                description: None,
-                default: None,
-                placeholder: None,
-            },
+            string_field("DUP"),
             RepositoryInputField::Boolean {
                 key: "DUP".into(),
                 label: "B".into(),
                 description: None,
                 default: None,
+                required: true,
             },
         ];
         let err = validate_schema(&schema).unwrap_err();
@@ -201,6 +271,7 @@ mod tests {
             label: "Flag".into(),
             description: None,
             default: None,
+            required: true,
         };
         assert_eq!(coerce_value(&field, "true").unwrap(), "true");
         assert_eq!(coerce_value(&field, "false").unwrap(), "false");
@@ -210,16 +281,7 @@ mod tests {
 
     #[test]
     fn coerce_number_with_bounds() {
-        let field = RepositoryInputField::Number {
-            key: "N".into(),
-            label: "N".into(),
-            description: None,
-            default: None,
-            min: Some(0.0),
-            max: Some(10.0),
-            step: None,
-            unit: None,
-        };
+        let field = number_field("N", Some(0.0), Some(10.0));
         assert_eq!(coerce_value(&field, "5").unwrap(), "5");
         assert_eq!(coerce_value(&field, "  3.5  ").unwrap(), "3.5");
         assert!(coerce_value(&field, "abc").is_err());
@@ -229,13 +291,7 @@ mod tests {
 
     #[test]
     fn coerce_string_rejects_blank_and_whitespace() {
-        let field = RepositoryInputField::String {
-            key: "S".into(),
-            label: "S".into(),
-            description: None,
-            default: None,
-            placeholder: None,
-        };
+        let field = string_field("S");
         assert_eq!(coerce_value(&field, "PROJ-123").unwrap(), "PROJ-123");
         // Whitespace-padded values are preserved verbatim — the user may
         // have meant the leading/trailing spaces. Only purely blank input
@@ -248,22 +304,66 @@ mod tests {
 
     #[test]
     fn coerce_number_rejects_non_finite() {
-        let field = RepositoryInputField::Number {
-            key: "N".into(),
-            label: "N".into(),
-            description: None,
-            default: None,
-            min: None,
-            max: None,
-            step: None,
-            unit: None,
-        };
+        let field = number_field("N", None, None);
         // `f64::from_str` parses these — the explicit `is_finite` check is
         // what makes the backend match the frontend's rejection.
         assert!(coerce_value(&field, "NaN").is_err());
         assert!(coerce_value(&field, "inf").is_err());
         assert!(coerce_value(&field, "-inf").is_err());
         assert!(coerce_value(&field, "Infinity").is_err());
+    }
+
+    #[test]
+    fn coerce_optional_string_accepts_blank() {
+        let field = RepositoryInputField::String {
+            key: "NOTES".into(),
+            label: "Notes".into(),
+            description: None,
+            default: None,
+            placeholder: None,
+            required: false,
+        };
+        assert_eq!(coerce_value(&field, "").unwrap(), "");
+        assert_eq!(coerce_value(&field, "   ").unwrap(), "   ");
+        assert_eq!(coerce_value(&field, "anything").unwrap(), "anything");
+    }
+
+    #[test]
+    fn coerce_optional_number_blank_yields_empty() {
+        let field = RepositoryInputField::Number {
+            key: "BUDGET".into(),
+            label: "Budget".into(),
+            description: None,
+            default: None,
+            min: None,
+            max: None,
+            step: None,
+            unit: None,
+            required: false,
+        };
+        // Blank → "" so downstream scripts can `[ -z "$BUDGET" ]`.
+        assert_eq!(coerce_value(&field, "").unwrap(), "");
+        assert_eq!(coerce_value(&field, "  ").unwrap(), "");
+        // Non-blank still goes through full numeric + finite validation.
+        assert_eq!(coerce_value(&field, "42").unwrap(), "42");
+        assert!(coerce_value(&field, "NaN").is_err());
+        assert!(coerce_value(&field, "abc").is_err());
+    }
+
+    #[test]
+    fn legacy_schema_without_required_defaults_to_true() {
+        // Older persisted schemas don't have the `required` field. Make
+        // sure they deserialize as required so behavior doesn't silently
+        // shift for users upgrading.
+        let legacy_json = r#"[
+            {"type":"string","key":"TICKET_ID","label":"Ticket"},
+            {"type":"number","key":"BUDGET","label":"Budget"},
+            {"type":"boolean","key":"DEBUG","label":"Debug"}
+        ]"#;
+        let parsed: Vec<RepositoryInputField> = serde_json::from_str(legacy_json).unwrap();
+        assert!(parsed.iter().all(|f| f.is_required()));
+        // And blank coercion against a legacy string still rejects.
+        assert!(coerce_value(&parsed[0], "").is_err());
     }
 
     #[test]
@@ -275,6 +375,7 @@ mod tests {
                 description: Some("JIRA key".into()),
                 default: None,
                 placeholder: Some("PROJ-123".into()),
+                required: true,
             },
             RepositoryInputField::Number {
                 key: "RETRIES".into(),
@@ -285,12 +386,14 @@ mod tests {
                 max: Some(10.0),
                 step: Some(1.0),
                 unit: None,
+                required: false,
             },
             RepositoryInputField::Boolean {
                 key: "DEBUG".into(),
                 label: "Debug".into(),
                 description: None,
                 default: Some(false),
+                required: true,
             },
         ];
         let json = serde_json::to_string(&schema).unwrap();

--- a/src/model/workspace.rs
+++ b/src/model/workspace.rs
@@ -82,4 +82,9 @@ pub struct Workspace {
     /// Per-repository display order for the sidebar. Persisted via the
     /// `workspaces.sort_order` column; reassigned by `reorder_workspaces`.
     pub sort_order: i32,
+    /// Values supplied at workspace-create time for the repo's declared
+    /// `required_inputs`. Keys mirror the schema's field keys; values are
+    /// already coerced to strings on the way in. `None` when the repo had
+    /// no inputs declared (the common case).
+    pub input_values: Option<std::collections::HashMap<String, String>>,
 }

--- a/src/ops/workspace.rs
+++ b/src/ops/workspace.rs
@@ -98,9 +98,22 @@ pub fn validate_repository_inputs(
     let mut coerced = HashMap::with_capacity(schema.len());
     for field in schema {
         let key = field.key();
-        let raw = supplied_map
-            .get(key)
-            .ok_or_else(|| format!("Missing value for required input {key:?}."))?;
+        // For non-required fields, an omitted key is treated as an empty
+        // string: the workspace's env var is set to "" so downstream scripts
+        // can uniformly `[ -z "$X" ]` instead of having to distinguish
+        // "missing from map" vs "explicitly blank". For required fields,
+        // a missing key is still a hard error.
+        let raw_owned: String;
+        let raw: &str = match supplied_map.get(key) {
+            Some(value) => value.as_str(),
+            None if !field.is_required() => {
+                raw_owned = String::new();
+                raw_owned.as_str()
+            }
+            None => {
+                return Err(format!("Missing value for required input {key:?}."));
+            }
+        };
         let value = coerce_input_value(field, raw)?;
         coerced.insert(key.to_string(), value);
     }
@@ -1310,6 +1323,7 @@ mod tests {
                 description: None,
                 default: None,
                 placeholder: None,
+                required: true,
             }]),
         )
         .unwrap();
@@ -1363,6 +1377,7 @@ mod tests {
                 description: None,
                 default: None,
                 placeholder: None,
+                required: true,
             }]),
         )
         .unwrap();

--- a/src/ops/workspace.rs
+++ b/src/ops/workspace.rs
@@ -202,6 +202,10 @@ async fn create_inner(
         status_line: String::new(),
         created_at: now_iso(),
         sort_order: 0,
+        // input_values are persisted by the caller (create_workspace_inner)
+        // after this op returns and before the setup script runs. Default
+        // to None here so the struct is valid mid-creation.
+        input_values: None,
     };
 
     if let Err(e) = db.insert_workspace(&ws) {
@@ -1163,6 +1167,7 @@ mod tests {
             archive_script_auto_run: false,
             base_branch: None,
             default_remote: None,
+            required_inputs: None,
             path_valid: true,
         };
         db.insert_repository(&repo).unwrap();

--- a/src/ops/workspace.rs
+++ b/src/ops/workspace.rs
@@ -23,13 +23,15 @@ use serde::Serialize;
 use tokio::io::AsyncBufReadExt;
 use tokio::process::Command as TokioCommand;
 
+use std::collections::HashMap;
+
 use crate::agent;
 use crate::config;
 use crate::db::Database;
 use crate::env::{WorkspaceEnv, enriched_path};
 use crate::env_provider::ResolvedEnv;
 use crate::git;
-use crate::model::{AgentStatus, Workspace, WorkspaceStatus};
+use crate::model::{AgentStatus, Repository, Workspace, WorkspaceStatus, coerce_input_value};
 use crate::workspace_alloc::{allocate_workspace_name, is_valid_workspace_name};
 
 use super::{NotificationEvent, OpsError, OpsHooks, WorkspaceChangeKind};
@@ -65,6 +67,44 @@ pub struct CreateParams<'a> {
     /// Branch prefix already resolved by the caller (e.g.
     /// `"jamesbrink/"`). Empty string is allowed.
     pub branch_prefix: &'a str,
+    /// Values for the repo's declared `required_inputs`. Validated against
+    /// the schema before the worktree is allocated; passing `None` against
+    /// a repo that declares inputs fails the create with
+    /// [`OpsError::Validation`]. Live here (rather than at the Tauri layer)
+    /// so every call site — GUI, IPC, WS server, future callers — enforces
+    /// the invariant uniformly.
+    pub input_values: Option<&'a HashMap<String, String>>,
+}
+
+/// Validate a repository's declared input schema against a supplied value
+/// map. Returns the coerced values to persist (or `Ok(None)` when the repo
+/// declares no inputs). Errors are formatted for user-facing display.
+///
+/// Used internally by [`create`] and exposed so the GUI layer can pre-check
+/// values before showing a "creating…" state on the modal — failing fast
+/// avoids the surprise of allocating a worktree only to surface a "missing
+/// value" error after the fact.
+pub fn validate_repository_inputs(
+    repo: &Repository,
+    supplied: Option<&HashMap<String, String>>,
+) -> Result<Option<HashMap<String, String>>, String> {
+    let Some(schema) = repo.required_inputs.as_ref() else {
+        return Ok(None);
+    };
+    if schema.is_empty() {
+        return Ok(None);
+    }
+    let supplied_map = supplied.cloned().unwrap_or_default();
+    let mut coerced = HashMap::with_capacity(schema.len());
+    for field in schema {
+        let key = field.key();
+        let raw = supplied_map
+            .get(key)
+            .ok_or_else(|| format!("Missing value for required input {key:?}."))?;
+        let value = coerce_input_value(field, raw)?;
+        coerced.insert(key.to_string(), value);
+    }
+    Ok(Some(coerced))
 }
 
 /// Result of a successful [`create`]. `default_session_id` is the chat
@@ -143,6 +183,12 @@ async fn create_inner(
         .find(|r| r.id == params.repo_id)
         .ok_or_else(|| OpsError::NotFound("Repository not found".to_string()))?;
 
+    // Validate declared inputs BEFORE allocating a worktree — fail-fast so
+    // a missing/invalid value doesn't leave an orphan worktree directory
+    // behind. Every caller (GUI, IPC, WS server) gets this check uniformly.
+    let validated_inputs =
+        validate_repository_inputs(repo, params.input_values).map_err(OpsError::Validation)?;
+
     let repo_path = repo.path.clone();
 
     let (allocation, actual_path) = {
@@ -202,9 +248,9 @@ async fn create_inner(
         status_line: String::new(),
         created_at: now_iso(),
         sort_order: 0,
-        // input_values are persisted by the caller (create_workspace_inner)
-        // after this op returns and before the setup script runs. Default
-        // to None here so the struct is valid mid-creation.
+        // Populated below after `insert_workspace` succeeds. Left `None`
+        // here only so the struct is valid mid-creation; the persisted
+        // value comes from `validated_inputs`.
         input_values: None,
     };
 
@@ -213,6 +259,18 @@ async fn create_inner(
         let _ = git::branch_delete(&repo_path, &ws.branch_name).await;
         return Err(OpsError::Db(e));
     }
+    // Persist any declared input values to the dedicated column. The
+    // workspace row was inserted without them — `insert_workspace`'s SQL
+    // only writes the original columns — so the agent/terminal/script env
+    // merges would read NULL without this.
+    if let Some(values) = validated_inputs.as_ref()
+        && let Err(e) = db.set_workspace_input_values(&ws.id, Some(values))
+    {
+        let _ = git::remove_worktree(&repo_path, &actual_path, true).await;
+        let _ = git::branch_delete(&repo_path, &ws.branch_name).await;
+        return Err(OpsError::Db(e));
+    }
+    ws.input_values = validated_inputs;
     // Patch sort_order to the value the DB assigned so the workspace this
     // op returns lands at the bottom of its repo group immediately, instead
     // of rendering at sort_order=0 until the next workspace-list reload.
@@ -1189,6 +1247,7 @@ mod tests {
                 repo_id: &repo.id,
                 name: "scratch",
                 branch_prefix: "test/",
+                input_values: None,
             },
         )
         .await
@@ -1215,6 +1274,7 @@ mod tests {
                 repo_id: &repo.id,
                 name: "agent-pipeline",
                 branch_prefix: "test/",
+                input_values: None,
             },
         )
         .await
@@ -1227,6 +1287,121 @@ mod tests {
                 .unwrap()
         );
         assert!(!db.claim_branch_auto_rename(&created.workspace.id).unwrap());
+    }
+
+    /// Regression for the cross-caller bug Copilot caught on #807: the WS
+    /// server bypasses the GUI's pre-check, so the shared op itself has to
+    /// reject a create against a repo that declared inputs when the caller
+    /// passes `input_values: None`. Without this, remote/CLI callers could
+    /// create workspaces with NULL `input_values` and silently misconfigure
+    /// the workspace's env.
+    #[tokio::test]
+    async fn create_rejects_missing_required_inputs() {
+        let (_repo_dir, _db_dir, mut db, repo) = setup_repo_and_db().await;
+        let worktree_base = tempfile::tempdir().unwrap();
+        let hooks = RecordingHooks::default();
+
+        // Declare a single required input on the repo.
+        db.update_repository_required_inputs(
+            &repo.id,
+            Some(&[crate::model::RepositoryInputField::String {
+                key: "TICKET_ID".into(),
+                label: "Ticket".into(),
+                description: None,
+                default: None,
+                placeholder: None,
+            }]),
+        )
+        .unwrap();
+
+        let result = create(
+            &mut db,
+            &hooks,
+            worktree_base.path(),
+            CreateParams {
+                repo_id: &repo.id,
+                name: "feature",
+                branch_prefix: "test/",
+                input_values: None, // caller doesn't yet support inputs
+            },
+        )
+        .await;
+
+        match result {
+            Err(OpsError::Validation(msg)) => {
+                assert!(
+                    msg.contains("TICKET_ID"),
+                    "expected validation error to name the missing key, got {msg:?}"
+                );
+            }
+            other => panic!("expected OpsError::Validation, got {other:?}"),
+        }
+
+        // No worktree allocation, no DB row, no Created hook.
+        let workspaces = db.list_workspaces().unwrap();
+        assert!(workspaces.is_empty(), "validation must run before insert");
+        assert!(
+            hooks.changes().is_empty(),
+            "no lifecycle hook should fire on validation failure"
+        );
+    }
+
+    /// Pair with the rejection test — when the caller supplies values that
+    /// satisfy the declared schema, the op persists them to the workspace
+    /// row and surfaces them on the returned struct.
+    #[tokio::test]
+    async fn create_persists_supplied_input_values() {
+        let (_repo_dir, _db_dir, mut db, repo) = setup_repo_and_db().await;
+        let worktree_base = tempfile::tempdir().unwrap();
+        let hooks = RecordingHooks::default();
+
+        db.update_repository_required_inputs(
+            &repo.id,
+            Some(&[crate::model::RepositoryInputField::String {
+                key: "TICKET_ID".into(),
+                label: "Ticket".into(),
+                description: None,
+                default: None,
+                placeholder: None,
+            }]),
+        )
+        .unwrap();
+
+        let mut supplied = std::collections::HashMap::new();
+        supplied.insert("TICKET_ID".to_string(), "PROJ-42".to_string());
+
+        let created = create(
+            &mut db,
+            &hooks,
+            worktree_base.path(),
+            CreateParams {
+                repo_id: &repo.id,
+                name: "feature",
+                branch_prefix: "test/",
+                input_values: Some(&supplied),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Returned struct carries the values…
+        assert_eq!(
+            created
+                .workspace
+                .input_values
+                .as_ref()
+                .unwrap()
+                .get("TICKET_ID"),
+            Some(&"PROJ-42".to_string()),
+        );
+        // …and they also land on disk (this is what was broken before the
+        // op took over persistence — the struct looked right but the row
+        // had NULL `input_values` and the env merge read nothing).
+        let from_db = db
+            .get_workspace_input_values(&created.workspace.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(from_db.get("TICKET_ID"), Some(&"PROJ-42".to_string()));
     }
 
     /// Regression for the `claudette workspace archive --delete-branch`
@@ -1247,6 +1422,7 @@ mod tests {
                 repo_id: &repo.id,
                 name: "feature",
                 branch_prefix: "test/",
+                input_values: None,
             },
         )
         .await
@@ -1294,6 +1470,7 @@ mod tests {
                 repo_id: &repo.id,
                 name: "feature",
                 branch_prefix: "test/",
+                input_values: None,
             },
         )
         .await
@@ -1343,6 +1520,7 @@ mod tests {
                     repo_id: &repo.id,
                     name,
                     branch_prefix: "test/",
+                    input_values: None,
                 },
             )
             .await
@@ -1404,6 +1582,7 @@ mod tests {
                 repo_id: &repo.id,
                 name: "archived",
                 branch_prefix: "test/",
+                input_values: None,
             },
         )
         .await
@@ -1416,6 +1595,7 @@ mod tests {
                 repo_id: &repo.id,
                 name: "active",
                 branch_prefix: "test/",
+                input_values: None,
             },
         )
         .await
@@ -1484,6 +1664,7 @@ mod tests {
                     repo_id: &repo.id,
                     name,
                     branch_prefix: "test/",
+                    input_values: None,
                 },
             )
             .await

--- a/src/ops/workspace.rs
+++ b/src/ops/workspace.rs
@@ -275,10 +275,14 @@ async fn create_inner(
     // Persist any declared input values to the dedicated column. The
     // workspace row was inserted without them — `insert_workspace`'s SQL
     // only writes the original columns — so the agent/terminal/script env
-    // merges would read NULL without this.
+    // merges would read NULL without this. If the write fails, roll back
+    // the row too — otherwise the DB ends up with a workspace pointing at
+    // a worktree we're about to delete, with `input_values` NULL — exactly
+    // the state we use to mean "no inputs declared".
     if let Some(values) = validated_inputs.as_ref()
         && let Err(e) = db.set_workspace_input_values(&ws.id, Some(values))
     {
+        let _ = db.delete_workspace(&ws.id);
         let _ = git::remove_worktree(&repo_path, &actual_path, true).await;
         let _ = git::branch_delete(&repo_path, &ws.branch_name).await;
         return Err(OpsError::Db(e));

--- a/src/ui/src/components/chat/ChatPanel.staleTranscript.test.tsx
+++ b/src/ui/src/components/chat/ChatPanel.staleTranscript.test.tsx
@@ -199,6 +199,7 @@ function makeWorkspace(): Workspace {
     sort_order: 0,
     remote_connection_id: null,
     agent_status: "Idle",
+    input_values: null,
   };
 }
 
@@ -221,6 +222,7 @@ function makeRepository(): Repository {
     default_remote: null,
     path_valid: true,
     remote_connection_id: null,
+    required_inputs: null,
   };
 }
 

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -177,6 +177,10 @@ export function ChatPanel() {
         status_line: "",
         created_at: new Date().toISOString(),
         sort_order: ws.sort_order + 1,
+        // Fork inherits its source workspace's input_values once the
+        // backend completes the create — this placeholder is swapped out
+        // by `commitPendingFork` before any env merge reads it.
+        input_values: null,
         remote_connection_id: null,
       };
       const previousSelection = selectedWorkspaceId;

--- a/src/ui/src/components/chat/MessagesWithTurns.test.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.test.tsx
@@ -135,6 +135,7 @@ beforeEach(() => {
         status_line: "",
         created_at: "2026-05-08T00:00:00.000Z",
         sort_order: 0,
+        input_values: null,
         remote_connection_id: null,
         agent_status: "Idle",
       },

--- a/src/ui/src/components/chat/PlanApprovalCard.test.tsx
+++ b/src/ui/src/components/chat/PlanApprovalCard.test.tsx
@@ -111,6 +111,7 @@ beforeEach(() => {
         status: "Active",
         agent_status: "Idle",
         status_line: "",
+        input_values: null,
         remote_connection_id: null,
       },
     ],

--- a/src/ui/src/components/chat/WorkspaceEmptyTabs.test.tsx
+++ b/src/ui/src/components/chat/WorkspaceEmptyTabs.test.tsx
@@ -54,6 +54,7 @@ function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
     status_line: "",
     created_at: "2026-05-09T12:00:00Z",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
     ...overrides,
   };
@@ -77,6 +78,7 @@ function makeRepo(overrides: Partial<Repository> = {}): Repository {
     base_branch: null,
     default_remote: null,
     path_valid: true,
+    required_inputs: null,
     remote_connection_id: null,
     ...overrides,
   };

--- a/src/ui/src/components/chat/chatTurnLifecycle.test.ts
+++ b/src/ui/src/components/chat/chatTurnLifecycle.test.ts
@@ -23,6 +23,7 @@ function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
     created_at: "2026-05-21T00:00:00Z",
     sort_order: 0,
     remote_connection_id: null,
+    input_values: null,
     ...overrides,
   };
 }

--- a/src/ui/src/components/files/FilesPanel.cache.test.tsx
+++ b/src/ui/src/components/files/FilesPanel.cache.test.tsx
@@ -69,6 +69,7 @@ function makeWorkspace(id: string): Workspace {
     status_line: "",
     created_at: "2026-05-17T00:00:00Z",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
   };
 }

--- a/src/ui/src/components/layout/WelcomeEmptyState.test.tsx
+++ b/src/ui/src/components/layout/WelcomeEmptyState.test.tsx
@@ -30,6 +30,7 @@ function makeRepo(overrides: Partial<Repository> = {}): Repository {
     base_branch: null,
     default_remote: null,
     path_valid: true,
+    required_inputs: null,
     remote_connection_id: null,
     ...overrides,
   };

--- a/src/ui/src/components/modals/BulkCleanupArchivedModal.helpers.test.ts
+++ b/src/ui/src/components/modals/BulkCleanupArchivedModal.helpers.test.ts
@@ -26,6 +26,7 @@ function makeArchived(id: string, ageInDays: number): Workspace {
     status_line: "",
     created_at: String(NOW - ageInDays * DAY),
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
   };
 }
@@ -194,6 +195,7 @@ describe("groupByRepository", () => {
       archive_script_auto_run: false,
       base_branch: null,
       default_remote: null,
+      required_inputs: null,
       path_valid: true,
       remote_connection_id: null,
     };

--- a/src/ui/src/components/modals/BulkCleanupArchivedModal.tsx
+++ b/src/ui/src/components/modals/BulkCleanupArchivedModal.tsx
@@ -269,6 +269,7 @@ export function BulkCleanupArchivedModal() {
         status_line: "",
         created_at: "",
         sort_order: 0,
+        input_values: null,
         remote_connection_id: null,
       } satisfies Workspace;
     });

--- a/src/ui/src/components/modals/ModalRouter.tsx
+++ b/src/ui/src/components/modals/ModalRouter.tsx
@@ -16,6 +16,7 @@ import { MissingCliModal } from "./MissingCliModal";
 import { KeyboardShortcutsModal } from "./KeyboardShortcutsModal";
 import { EnvTrustModal } from "./EnvTrustModal";
 import { PiLoginModalRoute } from "./PiLoginModalRoute";
+import { RequiredInputsModal } from "./RequiredInputsModal";
 
 export function ModalRouter() {
   const activeModal = useAppStore((s) => s.activeModal);
@@ -55,6 +56,8 @@ export function ModalRouter() {
       return <EnvTrustModal />;
     case "piLogin":
       return <PiLoginModalRoute />;
+    case "requiredInputs":
+      return <RequiredInputsModal />;
     default:
       return null;
   }

--- a/src/ui/src/components/modals/RequiredInputsModal.module.css
+++ b/src/ui/src/components/modals/RequiredInputsModal.module.css
@@ -88,8 +88,16 @@
   transition: background 120ms ease;
 }
 
+/* Same token the rest of Claudette's toggles use (`.mcpToggleOn` in
+ * Settings.module.css). The earlier `--accent-bg` fallback resolved to
+ * `--text-dim` in this theme, which read as "off". */
 .toggleOn {
-  background: var(--accent-bg, var(--text-dim));
+  background: var(--accent-primary);
+}
+
+.toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
 .toggleKnob {

--- a/src/ui/src/components/modals/RequiredInputsModal.module.css
+++ b/src/ui/src/components/modals/RequiredInputsModal.module.css
@@ -1,0 +1,114 @@
+/* Layout for the workspace-create required-inputs prompt.
+ *
+ * Two-column row per field: label + env-var key in parens on the left,
+ * the input control on the right. We deliberately don't reuse
+ * `PluginSettingInput`'s stacked layout here because compact-form modals
+ * read better with the label adjacent to the input, not above it.
+ */
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+}
+
+.fieldRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.labelGroup {
+  flex: 0 0 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.labelText {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  color: var(--text-primary);
+  overflow-wrap: anywhere; /* long labels wrap inside their column */
+}
+
+/* The env var key in parens next to the label. Mono so it visually reads
+ * as an identifier the agent / scripts will see, dim so it doesn't compete
+ * with the human label. */
+.envKey {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--text-dim);
+  font-weight: var(--fw-regular);
+}
+
+.description {
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.control {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.input {
+  width: 100%;
+  background: var(--chat-input-bg);
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  padding: 6px 10px;
+  color: var(--text-primary);
+  font-size: var(--fs-sm);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  border-color: var(--accent-color, var(--text-dim));
+}
+
+.numberInput {
+  composes: input;
+}
+
+.toggle {
+  position: relative;
+  flex: 0 0 auto;
+  width: 36px;
+  height: 20px;
+  border-radius: 12px;
+  background: var(--divider);
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.toggleOn {
+  background: var(--accent-bg, var(--text-dim));
+}
+
+.toggleKnob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--app-bg);
+  transition: transform 120ms ease;
+}
+
+.toggleOn .toggleKnob {
+  transform: translateX(16px);
+}
+
+.error {
+  color: var(--status-stopped);
+  font-size: var(--fs-xs);
+  margin-top: 4px;
+}

--- a/src/ui/src/components/modals/RequiredInputsModal.module.css
+++ b/src/ui/src/components/modals/RequiredInputsModal.module.css
@@ -50,6 +50,15 @@
   line-height: 1.4;
 }
 
+/* Inline "· optional" cue next to the label so users know they can submit
+ * the modal without filling this field. Muted to keep the label as the
+ * primary read. */
+.optional {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-regular);
+}
+
 .control {
   flex: 1 1 auto;
   min-width: 0;

--- a/src/ui/src/components/modals/RequiredInputsModal.tsx
+++ b/src/ui/src/components/modals/RequiredInputsModal.tsx
@@ -1,0 +1,256 @@
+/**
+ * Workspace-create prompt for repos that declare required inputs.
+ *
+ * Opens before `createWorkspace` is invoked, collects a value for every
+ * declared field, and resolves a promise the orchestration hook is awaiting.
+ * Validates client-side (type + bounds) so users see errors instantly; the
+ * backend re-validates on receive.
+ *
+ * Wire-up:
+ *   - `promptRequiredInputsIfDeclared` opens the modal with `{ schema,
+ *     repoName, resolve }` and `await`s the promise.
+ *   - This modal calls `resolve(values | null)` on submit / cancel and
+ *     closes itself.
+ *
+ * Field layout: each row is `[Label (ENV_NAME)] [input]` — see
+ * `RequiredInputsModal.module.css` for the rationale (compact-form modals
+ * read better with adjacent labels than with the stacked layout we use in
+ * the settings panel).
+ */
+import { useCallback, useId, useMemo, useState } from "react";
+import { useAppStore } from "../../stores/useAppStore";
+import {
+  coerceInputValue,
+  type RepositoryInputField,
+} from "../../types/repositoryInput";
+import { Modal } from "./Modal";
+import shared from "./shared.module.css";
+import styles from "./RequiredInputsModal.module.css";
+
+type ResolveFn = (values: Record<string, string> | null) => void;
+
+interface ModalState {
+  schema: RepositoryInputField[];
+  repoName: string;
+  resolve: ResolveFn;
+}
+
+function readModalState(data: Record<string, unknown>): ModalState | null {
+  const { schema, repoName, resolve } = data;
+  if (!Array.isArray(schema)) return null;
+  if (typeof resolve !== "function") return null;
+  return {
+    schema: schema as RepositoryInputField[],
+    repoName: typeof repoName === "string" ? repoName : "",
+    resolve: resolve as ResolveFn,
+  };
+}
+
+/** Initial field values: prefer the declared default, otherwise an empty
+ *  string. Stored as strings throughout since the wire shape to the backend
+ *  is `Record<string, string>`. */
+function defaultValuesFor(
+  schema: RepositoryInputField[],
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const field of schema) {
+    switch (field.type) {
+      case "boolean":
+        out[field.key] = field.default ? "true" : "false";
+        break;
+      case "string":
+        out[field.key] = field.default ?? "";
+        break;
+      case "number":
+        out[field.key] =
+          typeof field.default === "number" ? String(field.default) : "";
+        break;
+    }
+  }
+  return out;
+}
+
+export function RequiredInputsModal() {
+  const modalData = useAppStore((s) => s.modalData);
+  const closeModal = useAppStore((s) => s.closeModal);
+
+  const state = readModalState(modalData);
+  const initial = useMemo(
+    () => (state ? defaultValuesFor(state.schema) : {}),
+    [state],
+  );
+  const [values, setValues] = useState<Record<string, string>>(initial);
+  const [submitted, setSubmitted] = useState(false);
+
+  const setValue = useCallback((key: string, raw: string) => {
+    setValues((prev) => ({ ...prev, [key]: raw }));
+  }, []);
+
+  // Bail when the modal payload is malformed. closeModal() races React's
+  // render scheduler when the user mashes Escape twice in a row.
+  if (!state) {
+    return null;
+  }
+
+  // Per-field errors recomputed each render (cheap — handful of fields).
+  // Only surface them after the user has tried to submit so the modal
+  // opens clean.
+  const errors: Record<string, string | null> = {};
+  for (const field of state.schema) {
+    const raw = values[field.key] ?? "";
+    const result = coerceInputValue(field, raw);
+    errors[field.key] = result.ok ? null : result.error;
+  }
+  const firstError = state.schema
+    .map((f) => errors[f.key])
+    .find((e): e is string => typeof e === "string");
+
+  const submit = () => {
+    setSubmitted(true);
+    if (firstError) return;
+    const coerced: Record<string, string> = {};
+    for (const field of state.schema) {
+      const raw = values[field.key] ?? "";
+      const result = coerceInputValue(field, raw);
+      if (!result.ok) return;
+      coerced[field.key] = result.value;
+    }
+    state.resolve(coerced);
+    closeModal();
+  };
+
+  const cancel = () => {
+    state.resolve(null);
+    closeModal();
+  };
+
+  const title = state.repoName
+    ? `Configure new workspace — ${state.repoName}`
+    : "Configure new workspace";
+
+  return (
+    <Modal title={title} onClose={cancel} wide>
+      <div className={shared.warning}>
+        This repo declares inputs that every new workspace needs. They&apos;ll
+        become environment variables for the agent, terminal, and scripts.
+      </div>
+      <div className={styles.fields}>
+        {state.schema.map((field) => (
+          <FieldRow
+            key={field.key}
+            field={field}
+            value={values[field.key] ?? ""}
+            onChange={(raw) => setValue(field.key, raw)}
+            error={submitted ? errors[field.key] : null}
+          />
+        ))}
+      </div>
+      <div className={shared.actions}>
+        <button className={shared.btn} onClick={cancel} type="button">
+          Cancel
+        </button>
+        <button
+          className={shared.btnPrimary}
+          onClick={submit}
+          type="button"
+          disabled={submitted && firstError !== undefined}
+        >
+          Create workspace
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+interface FieldRowProps {
+  field: RepositoryInputField;
+  value: string;
+  onChange: (raw: string) => void;
+  error: string | null;
+}
+
+/** Single labeled row in the prompt — every field type uses the same
+ *  two-column layout (label left, control right) so the form is visually
+ *  consistent. The toggle sits at the left edge of the control column, the
+ *  same place text/number inputs start. */
+function FieldRow({ field, value, onChange, error }: FieldRowProps) {
+  const inputId = useId();
+  const checked = field.type === "boolean" && value === "true";
+
+  return (
+    <div>
+      <div className={styles.fieldRow}>
+        <FieldLabel
+          field={field}
+          // The toggle is a `<button>`, not an `<input>` — `htmlFor`
+          // wouldn't move focus to it. Drop the association for booleans
+          // and rely on the toggle's `aria-label` instead.
+          htmlFor={field.type === "boolean" ? undefined : inputId}
+        />
+        <div className={styles.control}>
+          {field.type === "boolean" && (
+            <button
+              type="button"
+              role="switch"
+              aria-checked={checked}
+              aria-label={field.label}
+              className={`${styles.toggle} ${checked ? styles.toggleOn : ""}`}
+              onClick={() => onChange(checked ? "false" : "true")}
+            >
+              <span className={styles.toggleKnob} />
+            </button>
+          )}
+          {field.type === "number" && (
+            <input
+              id={inputId}
+              type="number"
+              className={styles.numberInput}
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder={
+                typeof field.default === "number"
+                  ? String(field.default)
+                  : undefined
+              }
+              min={field.min ?? undefined}
+              max={field.max ?? undefined}
+              step={field.step ?? undefined}
+            />
+          )}
+          {field.type === "string" && (
+            <input
+              id={inputId}
+              type="text"
+              className={styles.input}
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder={field.placeholder ?? undefined}
+            />
+          )}
+        </div>
+      </div>
+      {error && <div className={styles.error}>{error}</div>}
+    </div>
+  );
+}
+
+interface FieldLabelProps {
+  field: RepositoryInputField;
+  htmlFor: string | undefined;
+}
+
+/** Two-line label: the human label + env-key in parens up top, optional
+ *  description below in a smaller muted font. The env key is in mono so it
+ *  visually reads as the identifier the agent/scripts will see. */
+function FieldLabel({ field, htmlFor }: FieldLabelProps) {
+  return (
+    <label className={styles.labelGroup} htmlFor={htmlFor}>
+      <span className={styles.labelText}>
+        {field.label} <span className={styles.envKey}>({field.key})</span>
+      </span>
+      {field.description && (
+        <span className={styles.description}>{field.description}</span>
+      )}
+    </label>
+  );
+}

--- a/src/ui/src/components/modals/RequiredInputsModal.tsx
+++ b/src/ui/src/components/modals/RequiredInputsModal.tsx
@@ -17,7 +17,7 @@
  * read better with adjacent labels than with the stacked layout we use in
  * the settings panel).
  */
-import { useCallback, useId, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   coerceInputValue,
@@ -81,6 +81,38 @@ export function RequiredInputsModal() {
   );
   const [values, setValues] = useState<Record<string, string>>(initial);
   const [submitted, setSubmitted] = useState(false);
+  // `creating` reflects "the orchestrator has the values and is making the
+  // workspace" — we keep the modal mounted in that state so the transition
+  // to the next modal (setup-script prompt) is atomic. Without this we'd
+  // briefly show an empty backdrop between modals.
+  const [creating, setCreating] = useState(false);
+
+  // Track whether we've already settled the orchestrator's promise. The
+  // resolve callback must fire at most once — submit / cancel / unmount
+  // can all reach it, and the orchestrator's `await` would deadlock the
+  // single-flight `creationInFlight` guard if none of them did.
+  const settledRef = useRef(false);
+  // Pull the resolver out via ref so the unmount cleanup can read the
+  // latest one without re-running on every store-driven render.
+  const resolveRef = useRef<ResolveFn | null>(null);
+  resolveRef.current = state?.resolve ?? null;
+
+  const settle = useCallback((result: Record<string, string> | null) => {
+    if (settledRef.current) return;
+    settledRef.current = true;
+    resolveRef.current?.(result);
+  }, []);
+
+  // Cleanup runs when the modal unmounts — including when something else
+  // (auto-opened missing-CLI modal, env-trust modal racing in) replaces
+  // `activeModal` and yanks us off the DOM. Without this, the orchestrator
+  // stays parked on `await new Promise(...)` forever and the in-flight
+  // creation guard never clears.
+  useEffect(() => {
+    return () => {
+      settle(null);
+    };
+  }, [settle]);
 
   const setValue = useCallback((key: string, raw: string) => {
     setValues((prev) => ({ ...prev, [key]: raw }));
@@ -106,6 +138,7 @@ export function RequiredInputsModal() {
     .find((e): e is string => typeof e === "string");
 
   const submit = () => {
+    if (creating) return;
     setSubmitted(true);
     if (firstError) return;
     const coerced: Record<string, string> = {};
@@ -115,12 +148,21 @@ export function RequiredInputsModal() {
       if (!result.ok) return;
       coerced[field.key] = result.value;
     }
-    state.resolve(coerced);
-    closeModal();
+    // Resolve the orchestrator's awaited promise but leave the modal
+    // mounted. The orchestrator either replaces this modal with the
+    // setup-script prompt (`openModal("confirmSetupScript", …)`) or
+    // explicitly closes it once it's done. Keeping the modal up until
+    // then prevents a transient `activeModal === null` frame that some
+    // background listeners (env-trust events, etc.) can race into.
+    setCreating(true);
+    settle(coerced);
   };
 
   const cancel = () => {
-    state.resolve(null);
+    // Ignore the backdrop / Escape after submit — the orchestrator owns
+    // the lifecycle from that point on.
+    if (creating) return;
+    settle(null);
     closeModal();
   };
 
@@ -142,20 +184,26 @@ export function RequiredInputsModal() {
             value={values[field.key] ?? ""}
             onChange={(raw) => setValue(field.key, raw)}
             error={submitted ? errors[field.key] : null}
+            disabled={creating}
           />
         ))}
       </div>
       <div className={shared.actions}>
-        <button className={shared.btn} onClick={cancel} type="button">
+        <button
+          className={shared.btn}
+          onClick={cancel}
+          type="button"
+          disabled={creating}
+        >
           Cancel
         </button>
         <button
           className={shared.btnPrimary}
           onClick={submit}
           type="button"
-          disabled={submitted && firstError !== undefined}
+          disabled={creating || (submitted && firstError !== undefined)}
         >
-          Create workspace
+          {creating ? "Creating…" : "Create workspace"}
         </button>
       </div>
     </Modal>
@@ -167,13 +215,14 @@ interface FieldRowProps {
   value: string;
   onChange: (raw: string) => void;
   error: string | null;
+  disabled: boolean;
 }
 
 /** Single labeled row in the prompt — every field type uses the same
  *  two-column layout (label left, control right) so the form is visually
  *  consistent. The toggle sits at the left edge of the control column, the
  *  same place text/number inputs start. */
-function FieldRow({ field, value, onChange, error }: FieldRowProps) {
+function FieldRow({ field, value, onChange, error, disabled }: FieldRowProps) {
   const inputId = useId();
   const checked = field.type === "boolean" && value === "true";
 
@@ -196,6 +245,7 @@ function FieldRow({ field, value, onChange, error }: FieldRowProps) {
               aria-label={field.label}
               className={`${styles.toggle} ${checked ? styles.toggleOn : ""}`}
               onClick={() => onChange(checked ? "false" : "true")}
+              disabled={disabled}
             >
               <span className={styles.toggleKnob} />
             </button>
@@ -215,6 +265,7 @@ function FieldRow({ field, value, onChange, error }: FieldRowProps) {
               min={field.min ?? undefined}
               max={field.max ?? undefined}
               step={field.step ?? undefined}
+              disabled={disabled}
             />
           )}
           {field.type === "string" && (
@@ -225,6 +276,7 @@ function FieldRow({ field, value, onChange, error }: FieldRowProps) {
               value={value}
               onChange={(e) => onChange(e.target.value)}
               placeholder={field.placeholder ?? undefined}
+              disabled={disabled}
             />
           )}
         </div>

--- a/src/ui/src/components/modals/RequiredInputsModal.tsx
+++ b/src/ui/src/components/modals/RequiredInputsModal.tsx
@@ -103,13 +103,31 @@ export function RequiredInputsModal() {
     resolveRef.current?.(result);
   }, []);
 
-  // Cleanup runs when the modal unmounts — including when something else
-  // (auto-opened missing-CLI modal, env-trust modal racing in) replaces
-  // `activeModal` and yanks us off the DOM. Without this, the orchestrator
-  // stays parked on `await new Promise(...)` forever and the in-flight
-  // creation guard never clears.
+  // Cleanup runs when the modal unmounts. There are two cases to
+  // distinguish:
+  //
+  //   1. Something else replaced `activeModal` (auto-opened missing-CLI
+  //      modal, env-trust modal racing in). The orchestrator would
+  //      otherwise sit on `await new Promise(...)` forever, so we must
+  //      resolve `null` to let it bail. In this case the store's
+  //      `activeModal` has already moved away from "requiredInputs"
+  //      (that's what caused the unmount in the first place).
+  //
+  //   2. React StrictMode's dev-only mount → unmount → remount cycle.
+  //      Here `activeModal` is still "requiredInputs" — the store wasn't
+  //      touched. If we resolved `null` we'd falsely tell the orchestrator
+  //      the user cancelled, it would return, and the user would be
+  //      stuck staring at a "Creating…" modal whose submit no-ops because
+  //      the orchestrator is gone. The remount's fresh `settledRef`
+  //      inherits the same `resolve` from `modalData`, so the second
+  //      mount's submit still reaches the orchestrator.
   useEffect(() => {
     return () => {
+      if (useAppStore.getState().activeModal === "requiredInputs") {
+        // StrictMode pseudo-unmount — the next mount of this same modal
+        // owns the resolver; let it.
+        return;
+      }
       settle(null);
     };
   }, [settle]);

--- a/src/ui/src/components/modals/RequiredInputsModal.tsx
+++ b/src/ui/src/components/modals/RequiredInputsModal.tsx
@@ -21,6 +21,7 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 import { useAppStore } from "../../stores/useAppStore";
 import {
   coerceInputValue,
+  isFieldRequired,
   type RepositoryInputField,
 } from "../../types/repositoryInput";
 import { Modal } from "./Modal";
@@ -311,12 +312,16 @@ interface FieldLabelProps {
 
 /** Two-line label: the human label + env-key in parens up top, optional
  *  description below in a smaller muted font. The env key is in mono so it
- *  visually reads as the identifier the agent/scripts will see. */
+ *  visually reads as the identifier the agent/scripts will see. Adds a
+ *  muted "(optional)" suffix when the field is non-required so the user
+ *  knows blank is OK before they hit submit and the validator passes them. */
 function FieldLabel({ field, htmlFor }: FieldLabelProps) {
+  const optional = !isFieldRequired(field);
   return (
     <label className={styles.labelGroup} htmlFor={htmlFor}>
       <span className={styles.labelText}>
         {field.label} <span className={styles.envKey}>({field.key})</span>
+        {optional && <span className={styles.optional}> · optional</span>}
       </span>
       {field.description && (
         <span className={styles.description}>{field.description}</span>

--- a/src/ui/src/components/project/RepoIssuesSection.test.tsx
+++ b/src/ui/src/components/project/RepoIssuesSection.test.tsx
@@ -80,6 +80,7 @@ function makeWorkspace(over: Partial<Workspace> = {}): Workspace {
     status_line: "",
     created_at: "1700000000",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
     ...over,
   };

--- a/src/ui/src/components/project/workspaceScmLink.test.ts
+++ b/src/ui/src/components/project/workspaceScmLink.test.ts
@@ -18,6 +18,7 @@ function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
     status_line: "",
     created_at: "1700000000",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
     ...overrides,
   };

--- a/src/ui/src/components/right-sidebar/RightSidebar.cache.test.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.cache.test.tsx
@@ -79,6 +79,7 @@ function makeWorkspace(id: string): Workspace {
     status_line: "",
     created_at: "2026-05-17T00:00:00Z",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
   };
 }

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -2816,3 +2816,102 @@
   font-size: 13px;
   line-height: 1.4;
 }
+
+/* Required inputs editor (per-repo declared workspace-create prompts).
+ *
+ * These selectors are local to RequiredInputsEditor — we intentionally do NOT
+ * reuse `.textInput` / `.numberInput` for the inline inputs because both have
+ * fixed widths (`100%` and `80px` respectively) that fight a flex row with
+ * multiple children. The dedicated classes below set their own widths and
+ * skip the `margin-top` that `.textInput` adds for vertical stacks.
+ */
+.requiredInputsList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+}
+
+.requiredInputRow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  background: var(--inset-bg, transparent);
+}
+
+.requiredInputHeaderRow {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+/* Base style for every inline input/select inside a required-input row.
+ * Matches `.textInput` visually but without `width: 100%` so flex children
+ * can size themselves correctly. */
+.requiredInputField {
+  font-size: 12px;
+  padding: 5px 8px;
+  border-radius: 3px;
+  border: 1px solid var(--sidebar-border);
+  background: var(--input-bg, var(--selected-bg));
+  color: var(--text-primary);
+  font-family: inherit;
+  min-width: 0; /* lets flex children shrink below their content width */
+}
+
+.requiredInputField:focus {
+  outline: none;
+  border-color: var(--accent-color, var(--text-primary));
+}
+
+.requiredInputKeyInput {
+  flex: 1 1 0;
+  font-family: var(--font-mono);
+}
+
+.requiredInputTypeSelect {
+  flex: 0 0 auto;
+  width: 110px;
+}
+
+/* Single-row inputs (label, description, placeholder) stretch to the row
+ * width. Defined explicitly here instead of reusing `.textInput` so the
+ * margin-top stack-spacing doesn't fight the `gap` on the parent row. */
+.requiredInputFullWidth {
+  width: 100%;
+}
+
+.requiredInputNumberRow {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+/* Wider than the shared `.numberInput` (80px) because each one carries a
+ * descriptive placeholder ("Min (optional)") that needs room to read. */
+.requiredInputNumberField {
+  flex: 1 1 140px;
+  min-width: 120px;
+  max-width: 200px;
+}
+
+.addPromptButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px dashed var(--divider);
+  border-radius: 6px;
+  background: none;
+  color: var(--text-muted);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.addPromptButton:hover {
+  border-color: var(--text-dim);
+  color: var(--text-primary);
+}

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -17,6 +17,7 @@ import { RepoIcon } from "../../shared/RepoIcon";
 import { IconPicker } from "../../modals/IconPicker";
 import { ClaudeFlagsSettings } from "./ClaudeFlagsSettings";
 import { EnvPanel } from "./EnvPanel";
+import { RequiredInputsEditor } from "./RequiredInputsEditor";
 import {
   InheritedGlobalsList,
   PinnedPromptsManager,
@@ -523,6 +524,8 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
         <div className={styles.fieldLabel}>{t("repo_environment")}</div>
         <EnvPanel target={envTarget} />
       </div>
+
+      <RequiredInputsEditor repoId={repoId} />
 
       <div className={styles.fieldGroup}>
         <div className={styles.fieldLabel}>{t("repo_custom_instructions")}</div>

--- a/src/ui/src/components/settings/sections/RequiredInputsEditor.test.ts
+++ b/src/ui/src/components/settings/sections/RequiredInputsEditor.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { blankRow, isPristinePlaceholder } from "./RequiredInputsEditor";
+
+describe("isPristinePlaceholder", () => {
+  it("treats a freshly added, untouched row as a placeholder", () => {
+    // `addRow` inserts exactly this — it should be dropped silently on save.
+    expect(isPristinePlaceholder(blankRow())).toBe(true);
+  });
+
+  it("does not treat a row with a temporarily-blank key as a placeholder", () => {
+    // The rename hazard: an existing field whose key the user just cleared.
+    // Persisting now must NOT drop it from the schema, so it can't be
+    // mistaken for a brand-new placeholder.
+    expect(
+      isPristinePlaceholder({ ...blankRow(), key: "", label: "Ticket" }),
+    ).toBe(false);
+    expect(
+      isPristinePlaceholder({ ...blankRow(), key: "", description: "ID" }),
+    ).toBe(false);
+    expect(
+      isPristinePlaceholder({ ...blankRow(), key: "", type: "number" }),
+    ).toBe(false);
+    expect(
+      isPristinePlaceholder({ ...blankRow(), key: "", min: "0" }),
+    ).toBe(false);
+    expect(
+      isPristinePlaceholder({ ...blankRow(), key: "", required: false }),
+    ).toBe(false);
+  });
+
+  it("does not treat a fully-specified row as a placeholder", () => {
+    expect(
+      isPristinePlaceholder({ ...blankRow(), key: "TICKET_ID" }),
+    ).toBe(false);
+  });
+
+  it("ignores whitespace-only values the same as blank", () => {
+    expect(
+      isPristinePlaceholder({ ...blankRow(), key: "   ", label: "  " }),
+    ).toBe(true);
+  });
+});

--- a/src/ui/src/components/settings/sections/RequiredInputsEditor.tsx
+++ b/src/ui/src/components/settings/sections/RequiredInputsEditor.tsx
@@ -1,0 +1,416 @@
+/**
+ * Per-repo "required inputs" schema editor. Each field declares a name (used
+ * as the env var key for the workspace session), a type (boolean / string /
+ * number) used for client-side validation in the workspace-create modal, an
+ * optional label/description for the prompt, and — for number — optional
+ * min/max bounds.
+ *
+ * Saves through the dedicated `update_repository_required_inputs` Tauri
+ * command. Lives outside `RepoSettings.tsx` because that file is already a
+ * god file per CLAUDE.md — keeping new declarative editors as their own
+ * components stops the trend.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { updateRepositoryRequiredInputs } from "../../../services/tauri";
+import { useAppStore } from "../../../stores/useAppStore";
+import {
+  validateInputKey,
+  type RepositoryInputField,
+  type RepositoryInputType,
+} from "../../../types/repositoryInput";
+import styles from "../Settings.module.css";
+
+interface RequiredInputsEditorProps {
+  repoId: string;
+}
+
+/** Local row shape — keeps non-discriminated extras around so toggling type
+ *  doesn't lose what the user typed for number bounds (etc). The serialize
+ *  step on save trims to the type-relevant fields. */
+interface EditorRow {
+  /** UI-only identifier — survives row deletion/reorder without colliding
+   *  with the user-editable `key` field. */
+  rowId: string;
+  key: string;
+  type: RepositoryInputType;
+  label: string;
+  description: string;
+  placeholder: string;
+  defaultBool: boolean;
+  defaultString: string;
+  defaultNumber: string;
+  min: string;
+  max: string;
+}
+
+function blankRow(): EditorRow {
+  return {
+    rowId: typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `row-${Math.random().toString(36).slice(2)}`,
+    key: "",
+    type: "string",
+    label: "",
+    description: "",
+    placeholder: "",
+    defaultBool: false,
+    defaultString: "",
+    defaultNumber: "",
+    min: "",
+    max: "",
+  };
+}
+
+function rowFromField(field: RepositoryInputField): EditorRow {
+  const base = blankRow();
+  base.key = field.key;
+  base.label = field.label;
+  base.description = field.description ?? "";
+  base.type = field.type;
+  switch (field.type) {
+    case "boolean":
+      base.defaultBool = field.default ?? false;
+      break;
+    case "string":
+      base.defaultString = field.default ?? "";
+      base.placeholder = field.placeholder ?? "";
+      break;
+    case "number":
+      base.defaultNumber =
+        typeof field.default === "number" ? String(field.default) : "";
+      base.min = typeof field.min === "number" ? String(field.min) : "";
+      base.max = typeof field.max === "number" ? String(field.max) : "";
+      break;
+  }
+  return base;
+}
+
+/** Convert a row to the wire shape, returning either the field or an inline
+ *  reason it's not yet savable. Empty labels fall back to the key so the
+ *  workspace-create modal always has *something* to render as the prompt
+ *  label.
+ */
+function rowToField(
+  row: EditorRow,
+): { ok: true; field: RepositoryInputField } | { ok: false; error: string } {
+  const keyErr = validateInputKey(row.key.trim());
+  if (keyErr) return { ok: false, error: keyErr };
+  const key = row.key.trim();
+  const label = row.label.trim() || key;
+  const description = row.description.trim() || null;
+  switch (row.type) {
+    case "boolean":
+      return {
+        ok: true,
+        field: {
+          type: "boolean",
+          key,
+          label,
+          description,
+          default: row.defaultBool,
+        },
+      };
+    case "string":
+      return {
+        ok: true,
+        field: {
+          type: "string",
+          key,
+          label,
+          description,
+          default: row.defaultString.trim() || null,
+          placeholder: row.placeholder.trim() || null,
+        },
+      };
+    case "number": {
+      const parseOptional = (s: string): number | null => {
+        const t = s.trim();
+        if (t === "") return null;
+        const n = Number(t);
+        return Number.isFinite(n) ? n : NaN;
+      };
+      const defaultN = parseOptional(row.defaultNumber);
+      const minN = parseOptional(row.min);
+      const maxN = parseOptional(row.max);
+      if (Number.isNaN(defaultN as number)) {
+        return { ok: false, error: `"${label}": default must be a number.` };
+      }
+      if (Number.isNaN(minN as number)) {
+        return { ok: false, error: `"${label}": min must be a number.` };
+      }
+      if (Number.isNaN(maxN as number)) {
+        return { ok: false, error: `"${label}": max must be a number.` };
+      }
+      if (minN !== null && maxN !== null && minN > maxN) {
+        return { ok: false, error: `"${label}": min must be ≤ max.` };
+      }
+      return {
+        ok: true,
+        field: {
+          type: "number",
+          key,
+          label,
+          description,
+          default: defaultN,
+          min: minN,
+          max: maxN,
+          step: null,
+          unit: null,
+        },
+      };
+    }
+  }
+}
+
+export function RequiredInputsEditor({ repoId }: RequiredInputsEditorProps) {
+  const repo = useAppStore((s) =>
+    s.repositories.find((r) => r.id === repoId),
+  );
+  const updateRepo = useAppStore((s) => s.updateRepository);
+
+  const [rows, setRows] = useState<EditorRow[]>(() =>
+    (repo?.required_inputs ?? []).map(rowFromField),
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset local state when switching repos. We watch repoId, not `repo`, so
+  // optimistic store updates from this editor don't churn the local rows.
+  useEffect(() => {
+    setRows((repo?.required_inputs ?? []).map(rowFromField));
+    setError(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repoId]);
+
+  // Debounce save: ref-based so rapid edits within ~400ms coalesce into one
+  // round-trip (matches the pattern used elsewhere in RepoSettings).
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rowsRef = useRef(rows);
+  rowsRef.current = rows;
+
+  const flushSave = useCallback(async () => {
+    const current = rowsRef.current;
+    // Drop rows whose key is still empty — they're WIP placeholders the
+    // user hasn't filled in yet. Surfacing a "key required" error for
+    // those would be noisy on every keystroke.
+    const candidates = current.filter((r) => r.key.trim() !== "");
+    const seen = new Set<string>();
+    const fields: RepositoryInputField[] = [];
+    for (const row of candidates) {
+      const result = rowToField(row);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      if (seen.has(result.field.key)) {
+        setError(`Duplicate input name "${result.field.key}".`);
+        return;
+      }
+      seen.add(result.field.key);
+      fields.push(result.field);
+    }
+    try {
+      setError(null);
+      await updateRepositoryRequiredInputs(repoId, fields);
+      updateRepo(repoId, {
+        required_inputs: fields.length === 0 ? null : fields,
+      });
+    } catch (e) {
+      setError(String(e));
+    }
+  }, [repoId, updateRepo]);
+
+  const queueSave = useCallback(() => {
+    if (saveTimer.current) clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => {
+      void flushSave();
+    }, 400);
+  }, [flushSave]);
+
+  // Flush on unmount so a quick edit + tab-switch doesn't lose changes.
+  useEffect(() => {
+    return () => {
+      if (saveTimer.current) {
+        clearTimeout(saveTimer.current);
+        void flushSave();
+      }
+    };
+  }, [flushSave]);
+
+  const updateRow = useCallback(
+    (rowId: string, patch: Partial<EditorRow>) => {
+      setRows((prev) =>
+        prev.map((r) => (r.rowId === rowId ? { ...r, ...patch } : r)),
+      );
+      queueSave();
+    },
+    [queueSave],
+  );
+
+  const addRow = useCallback(() => {
+    setRows((prev) => [...prev, blankRow()]);
+  }, []);
+
+  const removeRow = useCallback(
+    (rowId: string) => {
+      setRows((prev) => prev.filter((r) => r.rowId !== rowId));
+      queueSave();
+    },
+    [queueSave],
+  );
+
+  return (
+    <div className={styles.fieldGroup}>
+      <div className={styles.fieldLabel}>Required inputs</div>
+      <div className={`${styles.fieldHint} ${styles.fieldHintSpaced}`}>
+        Values new workspaces must supply before they're created. Each becomes
+        an environment variable in the workspace session — visible to the
+        agent, the terminal, and your setup/archive scripts.
+      </div>
+
+      {rows.length === 0 && (
+        <div className={styles.fieldHint}>
+          No required inputs declared. Workspaces in this repo will create
+          immediately without prompting.
+        </div>
+      )}
+
+      {rows.length > 0 && (
+        <div className={styles.requiredInputsList}>
+          {rows.map((row) => (
+            <RequiredInputRow
+              key={row.rowId}
+              row={row}
+              onChange={(patch) => updateRow(row.rowId, patch)}
+              onRemove={() => removeRow(row.rowId)}
+            />
+          ))}
+        </div>
+      )}
+
+      {error && <div className={styles.envErrorHint}>{error}</div>}
+
+      <button
+        type="button"
+        className={styles.addPromptButton}
+        onClick={addRow}
+      >
+        + Add required input
+      </button>
+    </div>
+  );
+}
+
+interface RowProps {
+  row: EditorRow;
+  onChange: (patch: Partial<EditorRow>) => void;
+  onRemove: () => void;
+}
+
+function RequiredInputRow({ row, onChange, onRemove }: RowProps) {
+  const keyError = row.key.trim() === "" ? null : validateInputKey(row.key.trim());
+  // Compose the base inline-field style with each input's role-specific
+  // sizing class. `.requiredInputField` carries the visual chrome (border,
+  // padding, font); the role class carries the flex-sizing rules.
+  const field = styles.requiredInputField;
+  const fullWidth = `${field} ${styles.requiredInputFullWidth}`;
+  return (
+    <div className={styles.requiredInputRow}>
+      <div className={styles.requiredInputHeaderRow}>
+        <input
+          type="text"
+          value={row.key}
+          onChange={(e) => onChange({ key: e.target.value })}
+          placeholder="EXAMPLE_ENV"
+          className={`${field} ${styles.requiredInputKeyInput}`}
+          aria-label="Input name (env var)"
+        />
+        <select
+          value={row.type}
+          onChange={(e) =>
+            onChange({ type: e.target.value as RepositoryInputType })
+          }
+          className={`${field} ${styles.requiredInputTypeSelect}`}
+          aria-label="Input type"
+        >
+          <option value="string">String</option>
+          <option value="number">Number</option>
+          <option value="boolean">Boolean</option>
+        </select>
+        <button
+          type="button"
+          onClick={onRemove}
+          className={styles.mcpRemoveBtn}
+          aria-label="Remove input"
+          title="Remove input"
+        >
+          ×
+        </button>
+      </div>
+      {keyError && <div className={styles.envErrorHint}>{keyError}</div>}
+      <input
+        type="text"
+        value={row.label}
+        onChange={(e) => onChange({ label: e.target.value })}
+        placeholder="Label (shown in the workspace-create prompt)"
+        className={fullWidth}
+        aria-label="Prompt label"
+      />
+      <input
+        type="text"
+        value={row.description}
+        onChange={(e) => onChange({ description: e.target.value })}
+        placeholder="Description (optional)"
+        className={fullWidth}
+        aria-label="Description"
+      />
+      {row.type === "string" && (
+        <input
+          type="text"
+          value={row.placeholder}
+          onChange={(e) => onChange({ placeholder: e.target.value })}
+          placeholder="Placeholder (optional)"
+          className={fullWidth}
+          aria-label="Placeholder"
+        />
+      )}
+      {row.type === "number" && (
+        <div className={styles.requiredInputNumberRow}>
+          <input
+            type="number"
+            value={row.min}
+            onChange={(e) => onChange({ min: e.target.value })}
+            placeholder="Min (optional)"
+            className={`${field} ${styles.requiredInputNumberField}`}
+            aria-label="Minimum"
+          />
+          <input
+            type="number"
+            value={row.max}
+            onChange={(e) => onChange({ max: e.target.value })}
+            placeholder="Max (optional)"
+            className={`${field} ${styles.requiredInputNumberField}`}
+            aria-label="Maximum"
+          />
+          <input
+            type="number"
+            value={row.defaultNumber}
+            onChange={(e) => onChange({ defaultNumber: e.target.value })}
+            placeholder="Default (optional)"
+            className={`${field} ${styles.requiredInputNumberField}`}
+            aria-label="Default value"
+          />
+        </div>
+      )}
+      {row.type === "boolean" && (
+        <label className={styles.autoRunLabel}>
+          <input
+            type="checkbox"
+            checked={row.defaultBool}
+            onChange={(e) => onChange({ defaultBool: e.target.checked })}
+          />
+          Default to enabled
+        </label>
+      )}
+    </div>
+  );
+}

--- a/src/ui/src/components/settings/sections/RequiredInputsEditor.tsx
+++ b/src/ui/src/components/settings/sections/RequiredInputsEditor.tsx
@@ -187,54 +187,74 @@ export function RequiredInputsEditor({ repoId }: RequiredInputsEditorProps) {
   const rowsRef = useRef(rows);
   rowsRef.current = rows;
 
-  const flushSave = useCallback(async () => {
-    const current = rowsRef.current;
-    // Drop rows whose key is still empty — they're WIP placeholders the
-    // user hasn't filled in yet. Surfacing a "key required" error for
-    // those would be noisy on every keystroke.
-    const candidates = current.filter((r) => r.key.trim() !== "");
-    const seen = new Set<string>();
-    const fields: RepositoryInputField[] = [];
-    for (const row of candidates) {
-      const result = rowToField(row);
-      if (!result.ok) {
-        setError(result.error);
-        return;
+  // `flushSave` takes the (repoId, rows) snapshot explicitly so the
+  // queued timer can save against the data and target it was scheduled
+  // with, not whatever is current at fire time. Without that, switching
+  // repos within the debounce window would let the timer write the new
+  // repo's rows back into the previous repo's `required_inputs` —
+  // `rowsRef.current` gets reset by the repo-change effect, but the timer
+  // still carries the previous repo id in its captured closure.
+  const flushSave = useCallback(
+    async (targetRepoId: string, rowsToSave: EditorRow[]) => {
+      // Drop rows whose key is still empty — they're WIP placeholders the
+      // user hasn't filled in yet. Surfacing a "key required" error for
+      // those would be noisy on every keystroke.
+      const candidates = rowsToSave.filter((r) => r.key.trim() !== "");
+      const seen = new Set<string>();
+      const fields: RepositoryInputField[] = [];
+      for (const row of candidates) {
+        const result = rowToField(row);
+        if (!result.ok) {
+          setError(result.error);
+          return;
+        }
+        if (seen.has(result.field.key)) {
+          setError(`Duplicate input name "${result.field.key}".`);
+          return;
+        }
+        seen.add(result.field.key);
+        fields.push(result.field);
       }
-      if (seen.has(result.field.key)) {
-        setError(`Duplicate input name "${result.field.key}".`);
-        return;
+      try {
+        setError(null);
+        await updateRepositoryRequiredInputs(targetRepoId, fields);
+        updateRepo(targetRepoId, {
+          required_inputs: fields.length === 0 ? null : fields,
+        });
+      } catch (e) {
+        setError(String(e));
       }
-      seen.add(result.field.key);
-      fields.push(result.field);
-    }
-    try {
-      setError(null);
-      await updateRepositoryRequiredInputs(repoId, fields);
-      updateRepo(repoId, {
-        required_inputs: fields.length === 0 ? null : fields,
-      });
-    } catch (e) {
-      setError(String(e));
-    }
-  }, [repoId, updateRepo]);
+    },
+    [updateRepo],
+  );
 
   const queueSave = useCallback(() => {
     if (saveTimer.current) clearTimeout(saveTimer.current);
+    // Snapshot the target repo and rows at schedule time. The timer
+    // callback uses these directly so a subsequent repo switch (which
+    // resets `rowsRef.current` to the new repo's data) can't make the
+    // pending save write the wrong rows to the wrong repo.
+    const capturedRepoId = repoId;
+    const capturedRows = rowsRef.current;
     saveTimer.current = setTimeout(() => {
-      void flushSave();
+      saveTimer.current = null;
+      void flushSave(capturedRepoId, capturedRows);
     }, 400);
-  }, [flushSave]);
+  }, [flushSave, repoId]);
 
   // Flush on unmount so a quick edit + tab-switch doesn't lose changes.
+  // We also flush on `repoId` change so the *previous* repo's pending
+  // edits land before we switch — the timer is cleared either way.
   useEffect(() => {
+    const previousRepoId = repoId;
     return () => {
-      if (saveTimer.current) {
+      if (saveTimer.current !== null) {
         clearTimeout(saveTimer.current);
-        void flushSave();
+        saveTimer.current = null;
+        void flushSave(previousRepoId, rowsRef.current);
       }
     };
-  }, [flushSave]);
+  }, [repoId, flushSave]);
 
   const updateRow = useCallback(
     (rowId: string, patch: Partial<EditorRow>) => {

--- a/src/ui/src/components/settings/sections/RequiredInputsEditor.tsx
+++ b/src/ui/src/components/settings/sections/RequiredInputsEditor.tsx
@@ -49,7 +49,8 @@ interface EditorRow {
   required: boolean;
 }
 
-function blankRow(): EditorRow {
+// Exported for unit testing the placeholder-vs-mid-edit distinction.
+export function blankRow(): EditorRow {
   return {
     rowId: typeof crypto !== "undefined" && "randomUUID" in crypto
       ? crypto.randomUUID()
@@ -66,6 +67,31 @@ function blankRow(): EditorRow {
     max: "",
     required: true,
   };
+}
+
+/** True when a row is a brand-new placeholder the user added but hasn't
+ *  touched — a blank key *and* every other field still at its `blankRow`
+ *  default. These are dropped silently on save (they aren't real fields).
+ *
+ *  A row whose key is only *temporarily* blank (e.g. cleared mid-rename
+ *  while the label / bounds are still set) is deliberately NOT pristine:
+ *  treating it as a placeholder would let the debounced save persist a
+ *  schema that drops the field, silently deleting an existing input. Those
+ *  rows instead hold the save until the key is valid again. */
+export function isPristinePlaceholder(row: EditorRow): boolean {
+  return (
+    row.key.trim() === "" &&
+    row.label.trim() === "" &&
+    row.description.trim() === "" &&
+    row.placeholder.trim() === "" &&
+    row.defaultString.trim() === "" &&
+    row.defaultNumber.trim() === "" &&
+    row.min.trim() === "" &&
+    row.max.trim() === "" &&
+    row.type === "string" &&
+    row.defaultBool === false &&
+    row.required === true
+  );
 }
 
 function rowFromField(field: RepositoryInputField): EditorRow {
@@ -209,10 +235,18 @@ export function RequiredInputsEditor({ repoId }: RequiredInputsEditorProps) {
   // still carries the previous repo id in its captured closure.
   const flushSave = useCallback(
     async (targetRepoId: string, rowsToSave: EditorRow[]) => {
-      // Drop rows whose key is still empty — they're WIP placeholders the
-      // user hasn't filled in yet. Surfacing a "key required" error for
-      // those would be noisy on every keystroke.
-      const candidates = rowsToSave.filter((r) => r.key.trim() !== "");
+      // Drop brand-new untouched placeholder rows — they aren't real fields
+      // yet, and surfacing a "key required" error for them would be noisy on
+      // every keystroke.
+      const candidates = rowsToSave.filter((r) => !isPristinePlaceholder(r));
+      // A non-placeholder row with a temporarily-blank key is an in-progress
+      // edit (typically a rename). Persisting now would drop that field from
+      // the schema — silent data loss — so hold the save and leave the last
+      // persisted schema intact until the key is filled in again. Matches the
+      // row-level UI, which also stays quiet (no error) while a key is blank.
+      if (candidates.some((r) => r.key.trim() === "")) {
+        return;
+      }
       const seen = new Set<string>();
       const fields: RepositoryInputField[] = [];
       for (const row of candidates) {

--- a/src/ui/src/components/settings/sections/RequiredInputsEditor.tsx
+++ b/src/ui/src/components/settings/sections/RequiredInputsEditor.tsx
@@ -18,6 +18,7 @@ import {
   type RepositoryInputField,
   type RepositoryInputType,
 } from "../../../types/repositoryInput";
+import { PLAIN_TEXT_INPUT_PROPS } from "../../../utils/textInput";
 import styles from "../Settings.module.css";
 
 interface RequiredInputsEditorProps {
@@ -268,23 +269,39 @@ export function RequiredInputsEditor({ repoId }: RequiredInputsEditorProps) {
     };
   }, [repoId, flushSave]);
 
+  // Mutators apply the change to `rowsRef.current` *synchronously* before
+  // calling `setRows`, then `queueSave`. `setRows` is async — React schedules
+  // the render after this event handler returns — so the render-phase
+  // `rowsRef.current = rows;` assignment hasn't picked up the new state yet
+  // when `queueSave` runs. Reading the ref then would snapshot the *old*
+  // rows and the timer would persist them back, silently reverting whatever
+  // the user just toggled or typed. Updating the ref first closes that gap.
   const updateRow = useCallback(
     (rowId: string, patch: Partial<EditorRow>) => {
-      setRows((prev) =>
-        prev.map((r) => (r.rowId === rowId ? { ...r, ...patch } : r)),
+      const next = rowsRef.current.map((r) =>
+        r.rowId === rowId ? { ...r, ...patch } : r,
       );
+      rowsRef.current = next;
+      setRows(next);
       queueSave();
     },
     [queueSave],
   );
 
   const addRow = useCallback(() => {
-    setRows((prev) => [...prev, blankRow()]);
+    const next = [...rowsRef.current, blankRow()];
+    rowsRef.current = next;
+    setRows(next);
+    // Intentionally no `queueSave` — a freshly added row has an empty
+    // key and `flushSave` would drop it anyway. The next keystroke
+    // (which lands via `updateRow`) is what triggers the first save.
   }, []);
 
   const removeRow = useCallback(
     (rowId: string) => {
-      setRows((prev) => prev.filter((r) => r.rowId !== rowId));
+      const next = rowsRef.current.filter((r) => r.rowId !== rowId);
+      rowsRef.current = next;
+      setRows(next);
       queueSave();
     },
     [queueSave],
@@ -355,6 +372,7 @@ function RequiredInputRow({ row, onChange, onRemove }: RowProps) {
           placeholder="EXAMPLE_ENV"
           className={`${field} ${styles.requiredInputKeyInput}`}
           aria-label="Input name (env var)"
+          {...PLAIN_TEXT_INPUT_PROPS}
         />
         <select
           value={row.type}

--- a/src/ui/src/components/settings/sections/RequiredInputsEditor.tsx
+++ b/src/ui/src/components/settings/sections/RequiredInputsEditor.tsx
@@ -41,6 +41,11 @@ interface EditorRow {
   defaultNumber: string;
   min: string;
   max: string;
+  /** Whether the workspace-create modal blocks submit while this field is
+   *  blank. Defaults to `true` — same behavior every declared input has had
+   *  historically. Setting to `false` lets the user submit without filling
+   *  it in; the env var is then set to `""` for scripts to consume. */
+  required: boolean;
 }
 
 function blankRow(): EditorRow {
@@ -58,6 +63,7 @@ function blankRow(): EditorRow {
     defaultNumber: "",
     min: "",
     max: "",
+    required: true,
   };
 }
 
@@ -67,6 +73,9 @@ function rowFromField(field: RepositoryInputField): EditorRow {
   base.label = field.label;
   base.description = field.description ?? "";
   base.type = field.type;
+  // `required` defaults to true server-side too — `?? true` matches the
+  // wire contract for schemas saved before this field existed.
+  base.required = field.required ?? true;
   switch (field.type) {
     case "boolean":
       base.defaultBool = field.default ?? false;
@@ -108,6 +117,7 @@ function rowToField(
           label,
           description,
           default: row.defaultBool,
+          required: row.required,
         },
       };
     case "string":
@@ -120,6 +130,7 @@ function rowToField(
           description,
           default: row.defaultString.trim() || null,
           placeholder: row.placeholder.trim() || null,
+          required: row.required,
         },
       };
     case "number": {
@@ -156,6 +167,7 @@ function rowToField(
           max: maxN,
           step: null,
           unit: null,
+          required: row.required,
         },
       };
     }
@@ -429,6 +441,20 @@ function RequiredInputRow({ row, onChange, onRemove }: RowProps) {
             onChange={(e) => onChange({ defaultBool: e.target.checked })}
           />
           Default to enabled
+        </label>
+      )}
+      {/* "Required" is meaningless for booleans — they always carry a
+       *  true/false value — so we only surface the toggle for string /
+       *  number variants. The schema still serializes the field for
+       *  booleans (defaulting to `true`) for wire-shape symmetry. */}
+      {row.type !== "boolean" && (
+        <label className={styles.autoRunLabel}>
+          <input
+            type="checkbox"
+            checked={row.required}
+            onChange={(e) => onChange({ required: e.target.checked })}
+          />
+          Required at workspace creation
         </label>
       )}
     </div>

--- a/src/ui/src/hooks/promptRequiredInputs.ts
+++ b/src/ui/src/hooks/promptRequiredInputs.ts
@@ -1,0 +1,41 @@
+/**
+ * Open the `requiredInputs` modal for a repo and resolve with the values
+ * the user submitted — or `null` if they cancelled (or the repo has no
+ * declared schema, in which case the modal is skipped entirely).
+ *
+ * Lives outside the React tree so both the hook-based orchestrator
+ * (`createWorkspaceOrchestrated`) and the Sidebar's own inline create flow
+ * can share the same prompt. Without this, only one of those two paths
+ * would prompt and the other would silently send no values, causing the
+ * backend validator to reject the create with a "Missing value for
+ * required input" error.
+ */
+import { useAppStore } from "../stores/useAppStore";
+import type { RepositoryInputField } from "../types/repositoryInput";
+
+export interface PromptResult {
+  /** `null` ⇒ the user cancelled. `Record` ⇒ values to forward verbatim
+   *  to `createWorkspace`. `undefined` ⇒ no prompt was needed (repo has
+   *  no declared schema) — callers should pass `null` to the Tauri call. */
+  values: Record<string, string> | null | undefined;
+}
+
+/** Returns `undefined` immediately when the repo declares no inputs, so the
+ *  caller can distinguish "skipped" from "cancelled". */
+export async function promptRequiredInputsIfDeclared(
+  repoId: string,
+): Promise<PromptResult> {
+  const repo = useAppStore.getState().repositories.find((r) => r.id === repoId);
+  const schema = repo?.required_inputs ?? null;
+  if (!schema || schema.length === 0) {
+    return { values: undefined };
+  }
+  const values = await new Promise<Record<string, string> | null>((resolve) => {
+    useAppStore.getState().openModal("requiredInputs", {
+      schema: schema satisfies RepositoryInputField[],
+      repoName: repo?.name ?? "",
+      resolve,
+    });
+  });
+  return { values };
+}

--- a/src/ui/src/hooks/promptRequiredInputs.ts
+++ b/src/ui/src/hooks/promptRequiredInputs.ts
@@ -18,6 +18,13 @@ export interface PromptResult {
    *  to `createWorkspace`. `undefined` ⇒ no prompt was needed (repo has
    *  no declared schema) — callers should pass `null` to the Tauri call. */
   values: Record<string, string> | null | undefined;
+  /** `true` when this call opened a modal that's still visible to the user.
+   *  The orchestrator owns closing it (either by `openModal(...)` to a
+   *  replacement, or an explicit `closeModal()` when no follow-up modal
+   *  appears). When `values` is `null` (cancel) the modal closed itself
+   *  before resolving, so this is `false`. When `values` is `undefined`
+   *  (no schema) no modal was opened at all, so this is also `false`. */
+  modalStillOpen: boolean;
 }
 
 /** Returns `undefined` immediately when the repo declares no inputs, so the
@@ -28,7 +35,7 @@ export async function promptRequiredInputsIfDeclared(
   const repo = useAppStore.getState().repositories.find((r) => r.id === repoId);
   const schema = repo?.required_inputs ?? null;
   if (!schema || schema.length === 0) {
-    return { values: undefined };
+    return { values: undefined, modalStillOpen: false };
   }
   const values = await new Promise<Record<string, string> | null>((resolve) => {
     useAppStore.getState().openModal("requiredInputs", {
@@ -37,5 +44,8 @@ export async function promptRequiredInputsIfDeclared(
       resolve,
     });
   });
-  return { values };
+  // On submit, the modal calls `resolve` but leaves itself mounted so the
+  // orchestrator can replace it atomically. On cancel, the modal calls
+  // `closeModal()` itself before resolving with `null`.
+  return { values, modalStillOpen: values !== null };
 }

--- a/src/ui/src/hooks/useCreateWorkspace.test.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.test.ts
@@ -51,6 +51,7 @@ function makeRepo(overrides: Partial<Repository> = {}): Repository {
     base_branch: null,
     default_remote: null,
     path_valid: true,
+    required_inputs: null,
     remote_connection_id: null,
     ...overrides,
   };
@@ -68,6 +69,7 @@ function makeWorkspace(id: string, repoId = "repo-1"): Workspace {
     status_line: "",
     created_at: "2026-01-01T00:00:00Z",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
   };
 }

--- a/src/ui/src/hooks/useCreateWorkspace.test.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.test.ts
@@ -252,12 +252,14 @@ describe("createWorkspaceOrchestrated", () => {
       "repo-1",
       "calm-protea",
       true,
+      null,
     );
     expect(mockCreateWorkspace).toHaveBeenNthCalledWith(
       2,
       "repo-1",
       "bold-aster",
       true,
+      null,
     );
   });
 

--- a/src/ui/src/hooks/useCreateWorkspace.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.ts
@@ -8,6 +8,7 @@ import {
 } from "../services/tauri";
 import { runAndRecordSetupScript } from "../utils/setupScriptMessage";
 import type { Workspace } from "../types/workspace";
+import { promptRequiredInputsIfDeclared } from "./promptRequiredInputs";
 
 /** Build the optimistic-placeholder Workspace inserted at the start
  *  of a create flow. The fields are best-effort approximations of
@@ -33,6 +34,10 @@ function buildPlaceholderWorkspace(repoId: string, slug: string): Workspace {
     // row's `sort_order` from `db.list_workspaces` lands at the
     // correct position once `commitPendingCreate` swaps it in.
     sort_order: Number.MAX_SAFE_INTEGER,
+    // `input_values` is populated by the backend after the create; the
+    // placeholder is a stub the orchestrator swaps out as soon as the
+    // real row arrives, so leaving this `null` is fine.
+    input_values: null,
     remote_connection_id: null,
   };
 }
@@ -167,6 +172,18 @@ async function runCreateWorkspaceOrchestrated(
   // displays in the "Preparing workspace…" placard.
   let placeholderId: string | null = null;
   try {
+    // If the repo declares required inputs, prompt the user before
+    // creating anything — we don't want a half-created workspace lying
+    // around if the user cancels.
+    const prompt = await promptRequiredInputsIfDeclared(repoId);
+    if (prompt.values === null) {
+      // User cancelled the modal — abort the whole flow before allocating
+      // a slug. Returning null instead of throwing keeps the surface
+      // identical to "the in-flight guard rejected us".
+      return null;
+    }
+    const inputValues = prompt.values ?? null;
+
     const generated = await generateWorkspaceName();
     // Clear the pre-slug indicator the moment we have a slug, even on
     // the no-placeholder (`selectOnCreate: false`) path. Otherwise the
@@ -189,7 +206,12 @@ async function runCreateWorkspaceOrchestrated(
       // for a workspace whose row is hidden.
       useAppStore.getState().expandRepo(repoId);
     }
-    const result = await createWorkspace(repoId, generated.slug, true);
+    const result = await createWorkspace(
+      repoId,
+      generated.slug,
+      true,
+      inputValues,
+    );
 
     // The Rust `Workspace` model doesn't serialize the UI-only
     // `remote_connection_id` field, so the IPC payload arrives with it

--- a/src/ui/src/hooks/useCreateWorkspace.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.ts
@@ -183,6 +183,19 @@ async function runCreateWorkspaceOrchestrated(
       return null;
     }
     const inputValues = prompt.values ?? null;
+    // The prompt left the modal mounted so we can replace it atomically
+    // with the next one (or close it explicitly). `closeRequiredInputs`
+    // is the local helper that ensures we only close that modal — never
+    // some unrelated modal a background event opened in the meantime.
+    let modalStillOpen = prompt.modalStillOpen;
+    const closeRequiredInputs = () => {
+      if (!modalStillOpen) return;
+      const store = useAppStore.getState();
+      if (store.activeModal === "requiredInputs") {
+        store.closeModal();
+      }
+      modalStillOpen = false;
+    };
 
     const generated = await generateWorkspaceName();
     // Clear the pre-slug indicator the moment we have a slug, even on
@@ -260,6 +273,8 @@ async function runCreateWorkspaceOrchestrated(
     }
 
     // Setup script — auto-run if the repo opted in, otherwise prompt.
+    // Either branch either replaces or explicitly closes the still-mounted
+    // requiredInputs modal so the user never sees a transient empty frame.
     try {
       const config = await getRepoConfig(repoId);
       const repo = useAppStore
@@ -283,7 +298,13 @@ async function runCreateWorkspaceOrchestrated(
               workspaceName: result.workspace.name,
             },
           });
+          closeRequiredInputs();
         } else {
+          // `openModal` overwrites `activeModal` + `modalData` atomically,
+          // so the requiredInputs modal is replaced by the setup-script
+          // modal in a single render. No explicit close needed here, and
+          // `modalStillOpen` is cleared so the finally-handler doesn't
+          // also try to close.
           useAppStore.getState().openModal("confirmSetupScript", {
             workspaceId: result.workspace.id,
             sessionId,
@@ -291,10 +312,15 @@ async function runCreateWorkspaceOrchestrated(
             script,
             source,
           });
+          modalStillOpen = false;
         }
+      } else {
+        closeRequiredInputs();
       }
     } catch {
-      // No config or unreadable — nothing to prompt.
+      // No config or unreadable — nothing to prompt. Drop the input modal
+      // so the user isn't left looking at a "Creating…" button.
+      closeRequiredInputs();
     }
 
     return { workspaceId: result.workspace.id, sessionId };
@@ -331,6 +357,13 @@ async function runCreateWorkspaceOrchestrated(
     // recovery surface).
     if (placeholderId) {
       useAppStore.getState().cancelPendingCreate(placeholderId, null);
+    }
+    // Also drop the requiredInputs modal if it's still showing
+    // "Creating…" — otherwise the user is left looking at a frozen
+    // modal whose orchestrator has already thrown.
+    const store = useAppStore.getState();
+    if (store.activeModal === "requiredInputs") {
+      store.closeModal();
     }
     // Re-throw so the caller decides whether to alert / toast.
     throw e;

--- a/src/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -173,6 +173,7 @@ function makeWorkspace(
     created_at: "2026-01-01T00:00:00Z",
     sort_order: 0,
     remote_connection_id: null,
+    input_values: null,
     ...overrides,
   };
 }
@@ -196,6 +197,7 @@ function makeRepo(id: string, sort_order = 0): Repository {
     default_remote: null,
     path_valid: true,
     remote_connection_id: null,
+    required_inputs: null,
   };
 }
 

--- a/src/ui/src/hooks/useQueuedMessageAutoDispatch.test.tsx
+++ b/src/ui/src/hooks/useQueuedMessageAutoDispatch.test.tsx
@@ -32,6 +32,7 @@ function makeWorkspace(id: string, remoteConnectionId: string | null = null): Wo
     status_line: "",
     created_at: baseTime,
     sort_order: 0,
+    input_values: null,
     remote_connection_id: remoteConnectionId,
   };
 }

--- a/src/ui/src/hooks/useViewTogglePersistence.test.ts
+++ b/src/ui/src/hooks/useViewTogglePersistence.test.ts
@@ -25,6 +25,7 @@ function makeWorkspace(
     status_line: "",
     created_at: "2026-01-01T00:00:00Z",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
   };
 }

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
@@ -45,6 +45,7 @@ function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
     status_line: "",
     created_at: "1700000000",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
     ...overrides,
   };

--- a/src/ui/src/services/tauri/repository.ts
+++ b/src/ui/src/services/tauri/repository.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { Repository } from "../../types";
 import type { RepoConfigInfo } from "../../types/repository";
+import type { RepositoryInputField } from "../../types/repositoryInput";
 
 export function addRepository(path: string): Promise<Repository> {
   return invoke("add_repository", { path });
@@ -72,4 +73,15 @@ export function setSetupScriptAutoRun(repoId: string, enabled: boolean): Promise
 
 export function setArchiveScriptAutoRun(repoId: string, enabled: boolean): Promise<void> {
   return invoke("set_archive_script_auto_run", { repoId, enabled });
+}
+
+/** Replace the per-repo declared-input schema. Pass `[]` to clear it (the
+ *  backend treats empty and null identically, so workspace-create stops
+ *  prompting). The backend re-validates env-var-name shape and duplicate
+ *  keys; surfacing a validation error here is a thrown promise rejection. */
+export function updateRepositoryRequiredInputs(
+  repoId: string,
+  schema: RepositoryInputField[],
+): Promise<void> {
+  return invoke("update_repository_required_inputs", { repoId, schema });
 }

--- a/src/ui/src/services/tauri/workspace.ts
+++ b/src/ui/src/services/tauri/workspace.ts
@@ -2,13 +2,22 @@ import { invoke } from "@tauri-apps/api/core";
 import type { Workspace } from "../../types";
 import type { CreateWorkspaceResult, SetupResult } from "../../types/repository";
 import type { WorkspaceEnvTrustNeededPayload } from "../../types/env";
+import type { RepositoryInputValues } from "../../types/repositoryInput";
 
 export function createWorkspace(
   repoId: string,
   name: string,
-  skipSetup?: boolean
+  skipSetup?: boolean,
+  /** Values for the repo's declared `required_inputs`. Omit when the repo
+   *  has no schema (the backend ignores the field in that case). */
+  inputValues?: RepositoryInputValues | null,
 ): Promise<CreateWorkspaceResult> {
-  return invoke("create_workspace", { repoId, name, skipSetup: skipSetup ?? false });
+  return invoke("create_workspace", {
+    repoId,
+    name,
+    skipSetup: skipSetup ?? false,
+    inputValues: inputValues ?? null,
+  });
 }
 
 export interface ForkWorkspaceResult {

--- a/src/ui/src/stores/slices/workspacesSlice.test.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.test.ts
@@ -15,6 +15,7 @@ function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
     status_line: "",
     created_at: "1700000000",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
     ...overrides,
   };

--- a/src/ui/src/stores/useAppStore.persistence.test.ts
+++ b/src/ui/src/stores/useAppStore.persistence.test.ts
@@ -16,6 +16,7 @@ function makeWorkspace(id: string, repoId: string = "r1"): Workspace {
     status_line: "",
     created_at: "2026-01-01T00:00:00Z",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
   };
 }
@@ -57,6 +58,7 @@ function makeRepository(id: string): Repository {
     base_branch: null,
     default_remote: null,
     path_valid: true,
+    required_inputs: null,
     remote_connection_id: null,
   };
 }

--- a/src/ui/src/stores/useAppStore.selectRepository.test.ts
+++ b/src/ui/src/stores/useAppStore.selectRepository.test.ts
@@ -20,6 +20,7 @@ function makeWs(id: string, repoId: string): Workspace {
     status_line: "",
     created_at: "2026-01-01T00:00:00Z",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
   };
 }

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -1416,6 +1416,7 @@ describe("mergeRemoteData / clearRemoteData default branches", () => {
           base_branch: null,
           default_remote: null,
           path_valid: true,
+          required_inputs: null,
           remote_connection_id: null,
         },
       ],
@@ -1472,6 +1473,7 @@ describe("mergeRemoteData / clearRemoteData default branches", () => {
           base_branch: null,
           default_remote: null,
           path_valid: true,
+          required_inputs: null,
           remote_connection_id: null,
         },
         {
@@ -1491,6 +1493,7 @@ describe("mergeRemoteData / clearRemoteData default branches", () => {
           base_branch: null,
           default_remote: null,
           path_valid: true,
+          required_inputs: null,
           remote_connection_id: null,
         },
       ],
@@ -2038,6 +2041,7 @@ function makeWorkspace(id: string, repoId: string = "r1"): Workspace {
     status_line: "",
     created_at: "2026-01-01T00:00:00Z",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
   };
 }

--- a/src/ui/src/types/repository.ts
+++ b/src/ui/src/types/repository.ts
@@ -1,3 +1,5 @@
+import type { RepositoryInputField } from "./repositoryInput";
+
 export interface Repository {
   id: string;
   path: string;
@@ -14,6 +16,10 @@ export interface Repository {
   archive_script_auto_run: boolean;
   base_branch: string | null;
   default_remote: string | null;
+  /** Per-repo declared inputs. New workspaces must supply a value for each
+   *  declared field at creation time; those values become env vars in the
+   *  workspace session. Null/empty means "no prompt on workspace create". */
+  required_inputs: RepositoryInputField[] | null;
   path_valid: boolean;
   /** Non-null when this repo belongs to a remote connection. */
   remote_connection_id: string | null;

--- a/src/ui/src/types/repositoryInput.test.ts
+++ b/src/ui/src/types/repositoryInput.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  coerceInputValue,
+  toPluginSettingField,
+  validateInputKey,
+  type RepositoryInputField,
+} from "./repositoryInput";
+
+describe("validateInputKey", () => {
+  it("accepts typical env var names", () => {
+    expect(validateInputKey("TICKET_ID")).toBeNull();
+    expect(validateInputKey("_internal")).toBeNull();
+    expect(validateInputKey("a1")).toBeNull();
+  });
+
+  it("rejects empty, leading-digit, and bad-character names", () => {
+    expect(validateInputKey("")).toMatch(/cannot be empty/);
+    expect(validateInputKey("1FOO")).toMatch(/must start/);
+    expect(validateInputKey("FOO-BAR")).toMatch(/letters/);
+    expect(validateInputKey("FOO BAR")).toMatch(/letters/);
+  });
+});
+
+describe("coerceInputValue", () => {
+  it("boolean accepts only true/false", () => {
+    const field: RepositoryInputField = {
+      type: "boolean",
+      key: "FLAG",
+      label: "Flag",
+    };
+    expect(coerceInputValue(field, "true")).toEqual({ ok: true, value: "true" });
+    expect(coerceInputValue(field, "false")).toEqual({ ok: true, value: "false" });
+    expect(coerceInputValue(field, "yes").ok).toBe(false);
+    // Casing matters — the renderer always normalizes through onChange.
+    expect(coerceInputValue(field, "True").ok).toBe(false);
+  });
+
+  it("number rejects non-numeric and out-of-range values", () => {
+    const field: RepositoryInputField = {
+      type: "number",
+      key: "RETRIES",
+      label: "Retries",
+      min: 0,
+      max: 10,
+    };
+    expect(coerceInputValue(field, "5")).toEqual({ ok: true, value: "5" });
+    expect(coerceInputValue(field, "  3.5  ")).toEqual({ ok: true, value: "3.5" });
+    expect(coerceInputValue(field, "abc").ok).toBe(false);
+    expect(coerceInputValue(field, "-1").ok).toBe(false);
+    expect(coerceInputValue(field, "11").ok).toBe(false);
+    expect(coerceInputValue(field, "").ok).toBe(false);
+  });
+
+  it("string rejects empty values (every declared input is required)", () => {
+    const field: RepositoryInputField = {
+      type: "string",
+      key: "TICKET_ID",
+      label: "Ticket",
+    };
+    expect(coerceInputValue(field, "PROJ-123")).toEqual({ ok: true, value: "PROJ-123" });
+    expect(coerceInputValue(field, "   ").ok).toBe(false);
+    expect(coerceInputValue(field, "").ok).toBe(false);
+  });
+});
+
+describe("toPluginSettingField", () => {
+  it("maps string → text and preserves shape", () => {
+    const adapted = toPluginSettingField({
+      type: "string",
+      key: "TICKET",
+      label: "Ticket",
+      placeholder: "PROJ-1",
+    });
+    expect(adapted.type).toBe("text");
+    expect(adapted.key).toBe("TICKET");
+    if (adapted.type === "text") {
+      expect(adapted.placeholder).toBe("PROJ-1");
+    }
+  });
+
+  it("passes number bounds through", () => {
+    const adapted = toPluginSettingField({
+      type: "number",
+      key: "N",
+      label: "N",
+      min: 1,
+      max: 10,
+      default: 3,
+    });
+    expect(adapted.type).toBe("number");
+    if (adapted.type === "number") {
+      expect(adapted.min).toBe(1);
+      expect(adapted.max).toBe(10);
+      expect(adapted.default).toBe(3);
+    }
+  });
+});

--- a/src/ui/src/types/repositoryInput.test.ts
+++ b/src/ui/src/types/repositoryInput.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   coerceInputValue,
+  isFieldRequired,
   toPluginSettingField,
   validateInputKey,
   type RepositoryInputField,
@@ -51,7 +52,7 @@ describe("coerceInputValue", () => {
     expect(coerceInputValue(field, "").ok).toBe(false);
   });
 
-  it("string rejects empty values (every declared input is required)", () => {
+  it("string rejects empty values when the field is required", () => {
     const field: RepositoryInputField = {
       type: "string",
       key: "TICKET_ID",
@@ -60,6 +61,68 @@ describe("coerceInputValue", () => {
     expect(coerceInputValue(field, "PROJ-123")).toEqual({ ok: true, value: "PROJ-123" });
     expect(coerceInputValue(field, "   ").ok).toBe(false);
     expect(coerceInputValue(field, "").ok).toBe(false);
+  });
+
+  it("non-required string accepts blank values", () => {
+    const field: RepositoryInputField = {
+      type: "string",
+      key: "NOTES",
+      label: "Notes",
+      required: false,
+    };
+    expect(coerceInputValue(field, "")).toEqual({ ok: true, value: "" });
+    expect(coerceInputValue(field, "   ")).toEqual({ ok: true, value: "   " });
+    expect(coerceInputValue(field, "anything")).toEqual({
+      ok: true,
+      value: "anything",
+    });
+  });
+
+  it("non-required number accepts blank but still validates non-blank input", () => {
+    const field: RepositoryInputField = {
+      type: "number",
+      key: "BUDGET",
+      label: "Budget",
+      min: 0,
+      max: 100,
+      required: false,
+    };
+    // Blank ⇒ "" so scripts can `[ -z "$BUDGET" ]`.
+    expect(coerceInputValue(field, "")).toEqual({ ok: true, value: "" });
+    expect(coerceInputValue(field, "   ")).toEqual({ ok: true, value: "" });
+    // Non-blank still goes through the full numeric path.
+    expect(coerceInputValue(field, "42")).toEqual({ ok: true, value: "42" });
+    expect(coerceInputValue(field, "abc").ok).toBe(false);
+    expect(coerceInputValue(field, "200").ok).toBe(false);
+  });
+});
+
+describe("isFieldRequired", () => {
+  it("defaults to true when `required` is absent (legacy schemas)", () => {
+    expect(isFieldRequired({ type: "string", key: "X", label: "X" })).toBe(true);
+    expect(isFieldRequired({ type: "number", key: "X", label: "X" })).toBe(true);
+  });
+
+  it("honors explicit required: false for string/number", () => {
+    expect(
+      isFieldRequired({ type: "string", key: "X", label: "X", required: false }),
+    ).toBe(false);
+    expect(
+      isFieldRequired({ type: "number", key: "X", label: "X", required: false }),
+    ).toBe(false);
+  });
+
+  it("always returns true for booleans regardless of the flag", () => {
+    // Booleans always carry a value (true / false); the `required` flag is
+    // meaningless for them and the UI/coerce paths treat them as required.
+    expect(
+      isFieldRequired({
+        type: "boolean",
+        key: "FLAG",
+        label: "Flag",
+        required: false,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/src/ui/src/types/repositoryInput.test.ts
+++ b/src/ui/src/types/repositoryInput.test.ts
@@ -157,4 +157,41 @@ describe("toPluginSettingField", () => {
       expect(adapted.default).toBe(3);
     }
   });
+
+  it("boolean without a declared default propagates as undefined", () => {
+    // Used to coerce missing defaults to `false`, which made
+    // "no opinion" indistinguishable from "explicitly off" downstream.
+    // Now `undefined` flows through so renderers can pick their own
+    // initial state.
+    const adapted = toPluginSettingField({
+      type: "boolean",
+      key: "DEBUG",
+      label: "Debug",
+    });
+    expect(adapted.type).toBe("boolean");
+    if (adapted.type === "boolean") {
+      expect(adapted.default).toBeUndefined();
+    }
+  });
+
+  it("boolean with an explicit default preserves the value", () => {
+    const explicitTrue = toPluginSettingField({
+      type: "boolean",
+      key: "DEBUG",
+      label: "Debug",
+      default: true,
+    });
+    if (explicitTrue.type === "boolean") {
+      expect(explicitTrue.default).toBe(true);
+    }
+    const explicitFalse = toPluginSettingField({
+      type: "boolean",
+      key: "DEBUG",
+      label: "Debug",
+      default: false,
+    });
+    if (explicitFalse.type === "boolean") {
+      expect(explicitFalse.default).toBe(false);
+    }
+  });
 });

--- a/src/ui/src/types/repositoryInput.ts
+++ b/src/ui/src/types/repositoryInput.ts
@@ -1,0 +1,157 @@
+/**
+ * Mirrors the Rust `RepositoryInputField` enum (`src/model/repository_input.rs`).
+ *
+ * Shape intentionally parallel to `PluginSettingField` so we can hand instances
+ * off to the shared `PluginSettingInput` renderer with a tiny adapter (see
+ * `toPluginSettingField`). The only divergence is the `string` vs `text`
+ * discriminant — the user-facing wording is "string" and the wire stays
+ * stable; the renderer just needs to know they're the same shape.
+ */
+import type { PluginSettingField } from "./claudettePlugins";
+
+export type RepositoryInputField =
+  | {
+      type: "boolean";
+      key: string;
+      label: string;
+      description?: string | null;
+      default?: boolean | null;
+    }
+  | {
+      type: "string";
+      key: string;
+      label: string;
+      description?: string | null;
+      default?: string | null;
+      placeholder?: string | null;
+    }
+  | {
+      type: "number";
+      key: string;
+      label: string;
+      description?: string | null;
+      default?: number | null;
+      min?: number | null;
+      max?: number | null;
+      step?: number | null;
+      unit?: string | null;
+    };
+
+export type RepositoryInputType = RepositoryInputField["type"];
+
+/** Stringly-coerced map shape persisted on a workspace at create time. */
+export type RepositoryInputValues = Record<string, string>;
+
+/** Validates that `key` is a POSIX-ish env var name. Mirrors the backend
+ *  validator in `src/model/repository_input.rs::validate_input_key` so the
+ *  client rejects bad names before a network round-trip. Returns null on
+ *  success or a human-readable reason on failure.
+ */
+export function validateInputKey(key: string): string | null {
+  if (key.length === 0) return "Input name cannot be empty.";
+  const first = key.charCodeAt(0);
+  const isAlpha =
+    (first >= 65 && first <= 90) || (first >= 97 && first <= 122) || first === 95;
+  if (!isAlpha) {
+    return `Input name "${key}" must start with a letter or underscore.`;
+  }
+  for (let i = 1; i < key.length; i++) {
+    const c = key.charCodeAt(i);
+    const ok =
+      (c >= 48 && c <= 57) ||
+      (c >= 65 && c <= 90) ||
+      (c >= 97 && c <= 122) ||
+      c === 95;
+    if (!ok) {
+      return `Input name "${key}" can only contain letters, digits, and underscores.`;
+    }
+  }
+  return null;
+}
+
+/** Coerce a user-supplied value against its field's type. Returns the
+ *  canonicalized string to send to the backend, or a human-readable error.
+ *  Mirrors `coerce_value` in `src/model/repository_input.rs` — the backend
+ *  re-validates, so this is purely for fast UI feedback.
+ */
+export function coerceInputValue(
+  field: RepositoryInputField,
+  raw: string,
+): { ok: true; value: string } | { ok: false; error: string } {
+  switch (field.type) {
+    case "boolean":
+      if (raw === "true" || raw === "false") return { ok: true, value: raw };
+      return {
+        ok: false,
+        error: `"${field.label}" must be true or false.`,
+      };
+    case "number": {
+      const trimmed = raw.trim();
+      if (trimmed === "") {
+        return { ok: false, error: `"${field.label}" is required.` };
+      }
+      const n = Number(trimmed);
+      if (!Number.isFinite(n)) {
+        return {
+          ok: false,
+          error: `"${field.label}" must be a number.`,
+        };
+      }
+      if (typeof field.min === "number" && n < field.min) {
+        return { ok: false, error: `"${field.label}" must be ≥ ${field.min}.` };
+      }
+      if (typeof field.max === "number" && n > field.max) {
+        return { ok: false, error: `"${field.label}" must be ≤ ${field.max}.` };
+      }
+      return { ok: true, value: trimmed };
+    }
+    case "string":
+      // String inputs always have *some* requirement (the schema field is
+      // declared = the workspace must supply a value). Empty trims block.
+      if (raw.trim() === "") {
+        return { ok: false, error: `"${field.label}" is required.` };
+      }
+      return { ok: true, value: raw };
+  }
+}
+
+/** Adapt a `RepositoryInputField` to the `PluginSettingField` shape so the
+ *  shared `PluginSettingInput` component can render it. Maps `string → text`
+ *  (the only structural difference) and drops the boolean `default` null
+ *  variant to undefined so the renderer's existing logic applies cleanly.
+ */
+export function toPluginSettingField(
+  field: RepositoryInputField,
+): PluginSettingField {
+  switch (field.type) {
+    case "boolean":
+      return {
+        type: "boolean",
+        key: field.key,
+        label: field.label,
+        description: field.description ?? null,
+        default: field.default ?? false,
+      };
+    case "string":
+      return {
+        type: "text",
+        key: field.key,
+        label: field.label,
+        description: field.description ?? null,
+        default: field.default ?? null,
+        placeholder: field.placeholder ?? null,
+      };
+    case "number":
+      return {
+        type: "number",
+        key: field.key,
+        label: field.label,
+        description: field.description ?? null,
+        default: field.default ?? null,
+        min: field.min ?? null,
+        max: field.max ?? null,
+        step: field.step ?? null,
+        unit: field.unit ?? null,
+      };
+  }
+}

--- a/src/ui/src/types/repositoryInput.ts
+++ b/src/ui/src/types/repositoryInput.ts
@@ -16,6 +16,10 @@ export type RepositoryInputField =
       label: string;
       description?: string | null;
       default?: boolean | null;
+      /** Defaults to `true` when absent (legacy schemas predate the field).
+       *  Booleans always carry a value, so this is effectively informational
+       *  for the boolean variant — `isFieldRequired` returns true regardless. */
+      required?: boolean;
     }
   | {
       type: "string";
@@ -24,6 +28,10 @@ export type RepositoryInputField =
       description?: string | null;
       default?: string | null;
       placeholder?: string | null;
+      /** Defaults to `true` when absent. Setting to `false` lets the user
+       *  submit the workspace-create modal without filling this field; the
+       *  env var is still set, but to an empty string. */
+      required?: boolean;
     }
   | {
       type: "number";
@@ -35,6 +43,7 @@ export type RepositoryInputField =
       max?: number | null;
       step?: number | null;
       unit?: string | null;
+      required?: boolean;
     };
 
 export type RepositoryInputType = RepositoryInputField["type"];
@@ -69,6 +78,16 @@ export function validateInputKey(key: string): string | null {
   return null;
 }
 
+/** Whether `field` requires the user to supply a non-blank value at
+ *  workspace-create time. Booleans always have a value so this returns
+ *  `true` for them regardless of the schema flag; for string/number, the
+ *  schema's `required` field controls (defaulting to `true` when absent
+ *  so legacy schemas keep mandatory behavior). */
+export function isFieldRequired(field: RepositoryInputField): boolean {
+  if (field.type === "boolean") return true;
+  return field.required ?? true;
+}
+
 /** Coerce a user-supplied value against its field's type. Returns the
  *  canonicalized string to send to the backend, or a human-readable error.
  *  Mirrors `coerce_value` in `src/model/repository_input.rs` — the backend
@@ -78,6 +97,7 @@ export function coerceInputValue(
   field: RepositoryInputField,
   raw: string,
 ): { ok: true; value: string } | { ok: false; error: string } {
+  const required = isFieldRequired(field);
   switch (field.type) {
     case "boolean":
       if (raw === "true" || raw === "false") return { ok: true, value: raw };
@@ -88,6 +108,11 @@ export function coerceInputValue(
     case "number": {
       const trimmed = raw.trim();
       if (trimmed === "") {
+        // Non-required numeric inputs round-trip as an empty string so
+        // downstream scripts get `$X=""` (uniformly checkable via
+        // `[ -z "$X" ]`) instead of having to know whether the field
+        // was declared.
+        if (!required) return { ok: true, value: "" };
         return { ok: false, error: `"${field.label}" is required.` };
       }
       const n = Number(trimmed);
@@ -106,9 +131,7 @@ export function coerceInputValue(
       return { ok: true, value: trimmed };
     }
     case "string":
-      // String inputs always have *some* requirement (the schema field is
-      // declared = the workspace must supply a value). Empty trims block.
-      if (raw.trim() === "") {
+      if (required && raw.trim() === "") {
         return { ok: false, error: `"${field.label}" is required.` };
       }
       return { ok: true, value: raw };

--- a/src/ui/src/types/repositoryInput.ts
+++ b/src/ui/src/types/repositoryInput.ts
@@ -140,8 +140,11 @@ export function coerceInputValue(
 
 /** Adapt a `RepositoryInputField` to the `PluginSettingField` shape so the
  *  shared `PluginSettingInput` component can render it. Maps `string → text`
- *  (the only structural difference) and drops the boolean `default` null
- *  variant to undefined so the renderer's existing logic applies cleanly.
+ *  (the only structural difference) and propagates `null`/`undefined`
+ *  defaults through as `undefined` so the renderer can distinguish
+ *  "unset" from an explicit `false` — without that, an author who left
+ *  the boolean default blank in the editor would see the toggle render
+ *  as off-on-purpose rather than off-because-no-opinion.
  */
 export function toPluginSettingField(
   field: RepositoryInputField,
@@ -153,7 +156,7 @@ export function toPluginSettingField(
         key: field.key,
         label: field.label,
         description: field.description ?? null,
-        default: field.default ?? false,
+        default: field.default ?? undefined,
       };
     case "string":
       return {

--- a/src/ui/src/types/workspace.ts
+++ b/src/ui/src/types/workspace.ts
@@ -21,6 +21,9 @@ export interface Workspace {
   /** Per-repository display order in the sidebar. Persisted via the
    *  `workspaces.sort_order` column; reassigned by `reorder_workspaces`. */
   sort_order: number;
+  /** Values supplied at workspace-create time for the repo's declared
+   *  `required_inputs`. Null when the repo had no inputs declared. */
+  input_values: Record<string, string> | null;
   /** Non-null when this workspace belongs to a remote connection. */
   remote_connection_id: string | null;
 }

--- a/src/ui/src/utils/sidebarJumpTargets.test.ts
+++ b/src/ui/src/utils/sidebarJumpTargets.test.ts
@@ -25,6 +25,7 @@ function workspace(
     created_at: "2026-01-01T00:00:00Z",
     sort_order: 0,
     remote_connection_id: null,
+    input_values: null,
     ...overrides,
   };
 }

--- a/src/ui/src/utils/textInput.test.ts
+++ b/src/ui/src/utils/textInput.test.ts
@@ -12,6 +12,10 @@ describe("textInput helpers", () => {
 
   it("disables browser typing substitutions for exact-text fields", () => {
     expect(PLAIN_TEXT_INPUT_PROPS).toEqual({
+      // `autoComplete: "off"` suppresses browser-remembered values for
+      // inputs that hold raw content (env var names, scripts, ids) where
+      // autofill is a regression rather than a convenience.
+      autoComplete: "off",
       autoCapitalize: "off",
       autoCorrect: "off",
       spellCheck: false,

--- a/src/ui/src/utils/textInput.ts
+++ b/src/ui/src/utils/textInput.ts
@@ -1,4 +1,11 @@
 export const PLAIN_TEXT_INPUT_PROPS = {
+  // Disable every browser-side text-massaging behavior. These inputs hold
+  // raw content — shell scripts, identifiers, env var names, custom
+  // instructions — where any auto-fix or autofill is a regression, not a
+  // convenience. `autoComplete: "off"` suppresses the browser's
+  // remembered-form suggestions; the others stop iOS/Safari from
+  // capitalizing or "correcting" what the user typed.
+  autoComplete: "off",
   autoCapitalize: "off",
   autoCorrect: "off",
   spellCheck: false,

--- a/src/ui/src/utils/workspaceEnvironment.test.ts
+++ b/src/ui/src/utils/workspaceEnvironment.test.ts
@@ -19,6 +19,7 @@ function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
     status_line: "",
     created_at: "1700000000",
     sort_order: 0,
+    input_values: null,
     remote_connection_id: null,
     ...overrides,
   };

--- a/src/ui/src/utils/workspaceOrdering.test.ts
+++ b/src/ui/src/utils/workspaceOrdering.test.ts
@@ -24,6 +24,7 @@ function workspace(
     status_line: "",
     created_at,
     sort_order,
+    input_values: null,
     remote_connection_id: null,
   };
 }

--- a/src/workspace_alloc.rs
+++ b/src/workspace_alloc.rs
@@ -139,6 +139,7 @@ mod tests {
             archive_script_auto_run: false,
             base_branch: None,
             default_remote: None,
+            required_inputs: None,
             path_valid: true,
         }
     }
@@ -155,6 +156,7 @@ mod tests {
             status_line: String::new(),
             created_at: String::new(),
             sort_order: 0,
+            input_values: None,
         }
     }
 

--- a/src/workspace_sync.rs
+++ b/src/workspace_sync.rs
@@ -194,6 +194,7 @@ mod tests {
             status_line: String::new(),
             created_at: String::new(),
             sort_order: 0,
+            input_values: None,
         }
     }
 
@@ -214,6 +215,7 @@ mod tests {
             archive_script_auto_run: false,
             base_branch: None,
             default_remote: None,
+            required_inputs: None,
             path_valid: true,
         }
     }


### PR DESCRIPTION
## Summary

Adds a per-repo, **optional** declared-inputs feature: a repo maintainer can list named inputs (`string` / `number` / `boolean`) in Repo Settings, and every new workspace must supply a value for each before it can be created. The values become environment variables in that workspace's session — visible to the agent CLI subprocess, the integrated terminal, and the setup/archive scripts.

Useful when a project needs values that nothing on disk can produce: a ticket ID for the agent to reference, an `ENVIRONMENT=staging` flag for scripts, a per-task retry budget. The type discriminator is purely UI/UX (everything serializes to strings at the env boundary) but lets the prompt reject `"abc"` for a number field before the script blows up parsing it.

```mermaid
flowchart LR
  Editor[Repo Settings<br/>RequiredInputsEditor] -- update_repository_required_inputs --> RepoSchema[(repositories.required_inputs<br/>JSON)]
  CreateBtn[Sidebar / Welcome<br/>+ New Workspace] --> Orchestrator[createWorkspaceOrchestrated]
  Orchestrator -- prompt --> Modal[RequiredInputsModal]
  Modal -- values --> Orchestrator
  Orchestrator -- create_workspace --> Backend[validate_workspace_inputs<br/>+ ops_workspace::create]
  Backend -- store --> WsValues[(workspaces.input_values<br/>JSON)]
  WsValues -- merge_workspace_input_env --> Env[ResolvedEnv]
  Env --> Agent[Agent CLI]
  Env --> PTY[Terminal]
  Env --> Scripts[setup / archive]
```

**Storage**: two new JSON columns (one migration, additive only):
- `repositories.required_inputs` — `Vec<RepositoryInputField>` schema
- `workspaces.input_values` — `HashMap<String, String>` values captured at create time

**Env merge order** (low → high precedence): env-provider plugins (direnv, mise, dotenv, nix-devshell) → workspace input values → `CLAUDETTE_*` workspace-context vars (always win). Wired into all four spawn paths: agent (`chat/send.rs`, `chat/remote_control.rs`), PTY (`pty.rs`), and the workspace-warmup resolver in `commands/workspace.rs`. The setup script runs *before* env-provider resolve (intentionally — so it can prime them) but still receives the input values via a synthesized `ResolvedEnv`.

GUI-only for v1. The CLI workspace create + batch manifest will gain `--input KEY=VALUE` in a follow-up.

## Complexity Notes

- **Two workspace-create code paths** — `createWorkspaceOrchestrated` (hook, hotkey, welcome card) and `Sidebar.handleCreateWorkspace`. They were duplicating orchestration before; main consolidated them while this branch was in flight. The new prompt lives in `promptRequiredInputsIfDeclared` so both paths share it via `createWorkspaceOrchestrated`. If either path is reworked, the prompt must continue to gate the `createWorkspace` call.
- **Setup script special case** — `resolve_and_run_setup` runs *before* the env-provider plugin resolve on first create (to allow scripts like `direnv allow` / `mise trust` to prime the providers). The input-values env is merged separately at that site (a synthesized minimal `ResolvedEnv`) rather than via the cached one. Two converging paths, same `Option<&ResolvedEnv>` signature.
- **JSON column on a frequently-loaded table** — `repositories.required_inputs` and `workspaces.input_values` are TEXT JSON. Parse failure degrades to `None` with a `tracing::warn!`, not a SELECT error, so a corrupt row can't kill the sidebar.
- **Tauri command doc-comments on params** — Rust 2024 disallows `///` on function parameters; the `input_values` param uses `//` block comments instead. Trivial but easy to forget.

## Test Steps

1. **Schema editor**:
   - Open `Settings > Repository` for any repo.
   - Scroll to **Required inputs** (between Environment and Custom instructions).
   - Click **+ Add required input**. Add three:
     - String `TICKET_ID`, label "Ticket", description "JIRA key", placeholder "PROJ-123".
     - Number `RETRY_BUDGET`, label "Retries", min 0, max 10, default 3.
     - Boolean `DEBUG`, label "Debug mode".
   - Confirm rows save (~400 ms debounce) — close & reopen settings, schema should persist.
   - Type an invalid name like `1FOO` or `FOO-BAR`; an inline error should appear and the row should not be persisted.

2. **Workspace create prompt**:
   - Click **+ New Workspace** for the repo. The Required Inputs modal opens with the three fields rendered in label-on-left, input-on-right rows.
   - Try `RETRY_BUDGET = "abc"` → submit blocked; try `12` → submit blocked (over max); try `5` → accepted.
   - Click **Cancel** → no worktree allocated, no branch created.
   - Submit with valid values → workspace creates.

3. **Env propagation**:
   - Open the integrated terminal in the new workspace, run `printenv TICKET_ID RETRY_BUDGET DEBUG` — values should print.
   - Configure a setup script `echo "$TICKET_ID" > .ticket` in Repo Settings, create a new workspace, supply inputs → `.ticket` file should contain the value (proves scripts see the env).
   - Send a chat message to the agent; ask it to `printenv TICKET_ID` via a tool call — value should be visible.
   - Restart Claudette, reopen the workspace, repeat the terminal check — values persist (not just in-memory).

4. **Sidebar create path**:
   - From the sidebar's per-repo "+" button (not the welcome card), confirm the modal still opens for repos with declared inputs. Both paths now share `promptRequiredInputsIfDeclared`.

5. **CI gauntlet** (already passing locally):
   - `cargo fmt --all --check`
   - `RUSTFLAGS="-Dwarnings" cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features`
   - `cargo test -p claudette --all-features` (1188 pass; 2 new tests)
   - `cd src/ui && bunx tsc -b`
   - `cd src/ui && bun run lint && bun run lint:css`
   - `cd src/ui && bun run test` (2142 pass; 7 new tests in \`repositoryInput.test.ts\`)

## Checklist

- [x] Tests added/updated (Rust: schema serde + DB roundtrip + input_values roundtrip; TS: validateInputKey, coerceInputValue, toPluginSettingField — 7 new vitest specs; existing test fixtures updated for the two new optional fields)
- [x] Documentation updated (new `site/src/content/docs/features/required-inputs.mdx` registered in `astro.config.mjs`; cross-reference added in `per-repo-settings.mdx`)