### PR TITLE
fix(help): route nightly builds to the rolling GitHub release tag

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -230,10 +230,24 @@ const MACOS_CLOSE_WINDOW_ACCELERATOR: &str = "CmdOrCtrl+Shift+W";
 #[cfg(target_os = "macos")]
 const HELP_DOCS_URL: &str = "https://utensils.io/claudette/getting-started/installation/";
 #[cfg(target_os = "macos")]
-const HELP_RELEASE_URL_BASE: &str = "https://github.com/utensils/claudette/releases/tag/v";
+const HELP_RELEASE_URL_BASE: &str = "https://github.com/utensils/claudette/releases/tag/";
 #[cfg(target_os = "macos")]
 const HELP_ISSUES_URL: &str =
     "https://github.com/utensils/claudette/issues/new?template=bug_report.md";
+
+// Map a `CARGO_PKG_VERSION` string to the GitHub Release tag that actually
+// exists for that build. Nightly versions stamped by `.github/workflows/nightly.yml`
+// (`${NEXT_MINOR}-dev.${COMMITS}.g${SHORT}`) all resolve to the rolling `nightly`
+// tag; stable versions get `v<version>`. Mirrors `releaseTagFor` in
+// `src/ui/src/helpUrls.ts` — update both together.
+#[cfg(target_os = "macos")]
+fn release_tag_for(version: &str) -> String {
+    if version.contains("-dev.") {
+        "nightly".to_string()
+    } else {
+        format!("v{version}")
+    }
+}
 
 fn main() {
     // Install the rustls crypto provider before any TLS usage. Both
@@ -529,7 +543,11 @@ fn main() {
                 // Deep-link to the GitHub Release page for the running
                 // version. Stable URL — doesn't depend on CHANGELOG.md
                 // anchor formatting (which embeds the release date).
-                let url = format!("{}{}", HELP_RELEASE_URL_BASE, env!("CARGO_PKG_VERSION"));
+                let url = format!(
+                    "{}{}",
+                    HELP_RELEASE_URL_BASE,
+                    release_tag_for(env!("CARGO_PKG_VERSION"))
+                );
                 if let Err(e) = commands::shell::opener::open(&url) {
                     tracing::warn!(target: "claudette::ui", url = %url, error = %e, "failed to open changelog URL");
                 }
@@ -1324,6 +1342,8 @@ fn shutdown_runtime_handler(_app: &tauri::AppHandle, _event: tauri::RunEvent) {
 mod tests {
     #[cfg(target_os = "macos")]
     use super::MACOS_CLOSE_WINDOW_ACCELERATOR;
+    #[cfg(target_os = "macos")]
+    use super::release_tag_for;
     use super::migrate_legacy_env_provider_trust;
     use claudette::db::Database;
     use claudette::model::Repository;
@@ -1520,5 +1540,18 @@ mod tests {
         // Positive assertion: we expect the iTerm2 / Safari / Chrome
         // convention so users' muscle memory carries over.
         assert_eq!(MACOS_CLOSE_WINDOW_ACCELERATOR, "CmdOrCtrl+Shift+W");
+    }
+
+    // Nightly builds stamp `CARGO_PKG_VERSION` as
+    // `<x.y.z>-dev.<n>.g<sha>` (see `.github/workflows/nightly.yml`) but
+    // publish to the rolling `nightly` GitHub tag, not a per-build tag.
+    // The Help → "What's New" link must route those to `nightly` instead
+    // of building a `releases/tag/v<dev-version>` URL that 404s.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn release_tag_for_routes_nightly_to_rolling_tag() {
+        assert_eq!(release_tag_for("0.25.0-dev.40.g34ce71e"), "nightly");
+        assert_eq!(release_tag_for("0.24.0"), "v0.24.0");
+        assert_eq!(release_tag_for("1.0.0-rc.1"), "v1.0.0-rc.1");
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1342,9 +1342,9 @@ fn shutdown_runtime_handler(_app: &tauri::AppHandle, _event: tauri::RunEvent) {
 mod tests {
     #[cfg(target_os = "macos")]
     use super::MACOS_CLOSE_WINDOW_ACCELERATOR;
+    use super::migrate_legacy_env_provider_trust;
     #[cfg(target_os = "macos")]
     use super::release_tag_for;
-    use super::migrate_legacy_env_provider_trust;
     use claudette::db::Database;
     use claudette::model::Repository;
     use std::path::Path;

--- a/src/ui/src/components/settings/sections/HelpSettings.tsx
+++ b/src/ui/src/components/settings/sections/HelpSettings.tsx
@@ -8,6 +8,7 @@ import {
   HELP_DOCS_URL,
   HELP_ISSUES_URL,
   HELP_RELEASE_URL_BASE,
+  releaseTagFor,
 } from "../../../helpUrls";
 import styles from "../Settings.module.css";
 
@@ -22,7 +23,9 @@ export function HelpSettings() {
 
   const openChangelog = () => {
     if (!appVersion) return;
-    void openUrl(`${HELP_RELEASE_URL_BASE}${appVersion}`).catch(() => {});
+    void openUrl(`${HELP_RELEASE_URL_BASE}${releaseTagFor(appVersion)}`).catch(
+      () => {},
+    );
   };
 
   return (

--- a/src/ui/src/components/sidebar/HelpMenu.tsx
+++ b/src/ui/src/components/sidebar/HelpMenu.tsx
@@ -12,6 +12,7 @@ import {
   HELP_DOCS_URL,
   HELP_ISSUES_URL,
   HELP_RELEASE_URL_BASE,
+  releaseTagFor,
 } from "../../helpUrls";
 import styles from "./HelpMenu.module.css";
 
@@ -163,7 +164,9 @@ export function HelpMenu({ buttonClassName, triggerLabel }: HelpMenuProps) {
   const handleChangelog = () => {
     setOpen(false);
     if (!appVersion) return;
-    void openUrl(`${HELP_RELEASE_URL_BASE}${appVersion}`).catch(() => {});
+    void openUrl(`${HELP_RELEASE_URL_BASE}${releaseTagFor(appVersion)}`).catch(
+      () => {},
+    );
   };
 
   const handleIssue = () => {

--- a/src/ui/src/helpUrls.test.ts
+++ b/src/ui/src/helpUrls.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { releaseTagFor } from "./helpUrls";
+
+describe("releaseTagFor", () => {
+  // Nightly builds stamp `<x.y.z>-dev.<n>.g<sha>` into CARGO_PKG_VERSION
+  // (see .github/workflows/nightly.yml) but publish to the rolling
+  // `nightly` GitHub tag. The Help → "What's New" link must route those
+  // to `nightly` instead of constructing a tag URL that 404s.
+  it("routes nightly versions to the rolling 'nightly' tag", () => {
+    expect(releaseTagFor("0.25.0-dev.40.g34ce71e")).toBe("nightly");
+    expect(releaseTagFor("0.26.0-dev.1.gabcdef0")).toBe("nightly");
+  });
+
+  it("routes stable versions to v<version>", () => {
+    expect(releaseTagFor("0.24.0")).toBe("v0.24.0");
+    expect(releaseTagFor("1.2.3")).toBe("v1.2.3");
+  });
+
+  it("treats rc / pre-release suffixes (no '-dev.') as stable tags", () => {
+    expect(releaseTagFor("1.0.0-rc.1")).toBe("v1.0.0-rc.1");
+    expect(releaseTagFor("0.25.0-beta.2")).toBe("v0.25.0-beta.2");
+  });
+});

--- a/src/ui/src/helpUrls.ts
+++ b/src/ui/src/helpUrls.ts
@@ -9,10 +9,21 @@
 export const HELP_DOCS_URL =
   "https://utensils.io/claudette/getting-started/installation/";
 
-/** GitHub Releases tag URL. Append `CARGO_PKG_VERSION` to land on the
- * release notes for the running build (e.g. `${BASE}0.23.0`). */
+/** GitHub Releases tag URL prefix. Concatenate with `releaseTagFor(version)`
+ * to land on the release notes for the running build. Stable releases use
+ * `v<x.y.z>` tags; nightly builds all share the rolling `nightly` tag (the
+ * versioned `0.25.0-dev.40.g<sha>` shape stamped by `.github/workflows/nightly.yml`
+ * is not a real GitHub tag). */
 export const HELP_RELEASE_URL_BASE =
-  "https://github.com/utensils/claudette/releases/tag/v";
+  "https://github.com/utensils/claudette/releases/tag/";
+
+/** Map a `CARGO_PKG_VERSION` string to the GitHub Release tag that actually
+ * exists for that build. Nightly versions (which include `-dev.` per the
+ * nightly workflow's `${NEXT_MINOR}-dev.${COMMITS}.g${SHORT}` format) all
+ * resolve to `nightly`; everything else gets `v<version>`. */
+export function releaseTagFor(version: string): string {
+  return version.includes("-dev.") ? "nightly" : `v${version}`;
+}
 
 /** GitHub "new issue" entry point — bug reports / feature requests.
  * The `?template=bug_report.md` query param pre-selects the bug-report


### PR DESCRIPTION
## Summary

- The Help menu's "What's New" link built `releases/tag/v<CARGO_PKG_VERSION>`, which works for stable tags (`v0.24.0`) but 404s for nightlies: the nightly workflow stamps versions as `<x.y.z>-dev.<n>.g<sha>` while publishing all builds to a single rolling `nightly` tag.
- Added a small `releaseTagFor` (TS) / `release_tag_for` (Rust) helper that detects the `-dev.` marker and routes those builds to the `nightly` tag; stable builds keep getting `v<version>`. All three Help surfaces (sidebar dropdown, Settings → Help, macOS native submenu) go through the helper.

## Repro

Open a nightly build (e.g. `v0.25.0-dev.40.g34ce71e`), Help → What's New → 404. After: lands on the rolling [`nightly`](https://github.com/utensils/claudette/releases/tag/nightly) release, which has up-to-date notes per build.

## Trade-offs considered

- **Detection:** chose `version.contains("-dev.")` over a stricter regex — matches the exact format `.github/workflows/nightly.yml` emits (`${NEXT_MINOR}-dev.${COMMITS}.g${SHORT}`), no regex maintenance, and false-positives are bounded to any future build that intentionally embeds `-dev.` (which would be a nightly by convention anyway).
- **Routing target:** chose `releases/tag/nightly` over `releases/latest` because the `nightly` release has per-build notes that match the running binary, whereas `latest` would drop the user on the last stable release with no nightly context.
- **No CI changes:** the existing nightly/release workflows already provide the contract this fix relies on (`-dev.` in the version string, `nightly` as the rolling tag) — `release_tag_for` is purely a consumer.

## Test plan

- [x] `cd src/ui && bunx tsc -b` — clean
- [x] `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` — clean
- [x] `cargo test -p claudette-tauri release_tag_for` — new unit test pins nightly → `nightly`, stable → `v<x.y.z>`, and rc → `v<x.y.z>-rc.N`
- [x] `bun run test` (vitest) — 2162 passed, 6 skipped
- [ ] Manual: in next nightly, open Help → What's New and confirm it lands on `releases/tag/nightly` instead of 404