### PR TITLE
feat(usage): composer usage indicator + ToS warning on enable

### DIFF
--- a/site/src/content/docs/features/experimental-features.mdx
+++ b/site/src/content/docs/features/experimental-features.mdx
@@ -37,7 +37,7 @@ Enables the Plugins / Themes / Grammars community catalog inside Claudette. Brow
 
 ## Usage Insights
 
-Gates the **Settings > Usage** panel that shows Claude Code subscription details (session limits, weekly limits, extra usage) by querying Anthropic's usage API directly, plus a compact vertical bar next to the context meter in the chat composer that drains as you burn through your most-constraining limit and switches to a "resets in…" countdown when exhausted. Requires a Pro or Max plan with standard login (env-var auth tokens don't have the OAuth scopes the API needs).
+Gates the **Settings > Usage** panel that shows Claude Code subscription details (session limits, weekly limits, extra usage) by querying Anthropic's usage API directly, plus a compact vertical bar next to the context meter in the chat composer that fills as you burn through your most-urgent limit (burn-rate weighted across the 5h session and weekly caps) and switches to a "resets in…" countdown when exhausted. Clicking the bar opens a popover listing every limit the API returned. Requires a Pro or Max plan with standard login (env-var auth tokens don't have the OAuth scopes the API needs).
 
 When this is off, Claudette never reads your Claude Code OAuth tokens for usage data — they stay strictly in the keychain / `.credentials.json` for the `claude` CLI's own use. The Claude Code sign-in flow in **Settings > Models** remains available because agent credential failures need a recovery path independent of usage tracking.
 

--- a/site/src/content/docs/features/experimental-features.mdx
+++ b/site/src/content/docs/features/experimental-features.mdx
@@ -37,9 +37,11 @@ Enables the Plugins / Themes / Grammars community catalog inside Claudette. Brow
 
 ## Usage Insights
 
-Gates the **Settings > Usage** panel that shows Claude Code subscription details (session limits, weekly limits, extra usage) by querying Anthropic's usage API directly. Requires a Pro or Max plan with standard login (env-var auth tokens don't have the OAuth scopes the API needs).
+Gates the **Settings > Usage** panel that shows Claude Code subscription details (session limits, weekly limits, extra usage) by querying Anthropic's usage API directly, plus a compact vertical bar next to the context meter in the chat composer that drains as you burn through your most-constraining limit and switches to a "resets in…" countdown when exhausted. Requires a Pro or Max plan with standard login (env-var auth tokens don't have the OAuth scopes the API needs).
 
 When this is off, Claudette never reads your Claude Code OAuth tokens for usage data — they stay strictly in the keychain / `.credentials.json` for the `claude` CLI's own use. The Claude Code sign-in flow in **Settings > Models** remains available because agent credential failures need a recovery path independent of usage tracking.
+
+Enabling this toggle opens a confirmation dialog that explains how the data flows and warns that this endpoint is undocumented, so programmatic access may not be permitted under [Anthropic's Consumer Terms](https://www.anthropic.com/legal/consumer-terms). Disabling never prompts.
 
 → What the panel shows and how it's cached: **[Usage & Metrics](/claudette/features/usage-and-metrics/)**
 

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -51,7 +51,7 @@ See [Agent Configuration](/claudette/features/agent-configuration/) for detailed
 | Plugin Management | Show the Claude Code Plugins settings section and plugin-management slash commands. | Off |
 | Claude Remote Control | Show the local chat Remote Control toggle and allow Claudette to attach live Claude sessions to claude.ai. | On |
 | Community Registry | Show the Community settings section for themes, plugins, and language grammars. | Off |
-| Usage Insights | Show Claude subscription usage data plus a draining bar indicator in the composer. Confirmation dialog warns about Anthropic ToS on enable. | Off |
+| Usage Insights | Show Claude subscription usage data plus a click-to-expand burn-rate-weighted bar indicator in the composer (fills as your most-urgent limit is consumed). Confirmation dialog warns about Anthropic ToS on enable. | Off |
 
 ## Claude CLI Flags
 

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -51,7 +51,7 @@ See [Agent Configuration](/claudette/features/agent-configuration/) for detailed
 | Plugin Management | Show the Claude Code Plugins settings section and plugin-management slash commands. | Off |
 | Claude Remote Control | Show the local chat Remote Control toggle and allow Claudette to attach live Claude sessions to claude.ai. | On |
 | Community Registry | Show the Community settings section for themes, plugins, and language grammars. | Off |
-| Usage Insights | Show Claude subscription usage data. | Off |
+| Usage Insights | Show Claude subscription usage data plus a draining bar indicator in the composer. Confirmation dialog warns about Anthropic ToS on enable. | Off |
 
 ## Claude CLI Flags
 

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -17,6 +17,7 @@ import { KEYBINDING_SETTING_PREFIX } from "./hotkeys/bindings";
 import type { WorkspaceOrderModeByRepo } from "./utils/workspaceOrdering";
 import { useMcpStatus } from "./hooks/useMcpStatus";
 import { useChatSessionCreatedEvent } from "./hooks/useChatSessionCreatedEvent";
+import { useUsageInsightsPoller } from "./hooks/useUsageInsightsPoller";
 import {
   hydratePersistedViewState,
   useViewTogglePersistence,
@@ -119,6 +120,7 @@ function App() {
   // Listen for MCP supervisor status events from the Rust backend.
   useMcpStatus();
   useChatSessionCreatedEvent();
+  useUsageInsightsPoller();
 
   // Boot-health heartbeat for the post-update probation window.
   //

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -42,6 +42,7 @@ import { isMacHotkeyPlatform } from "../../hotkeys/platform";
 import { ComposerToolbar } from "./composer/ComposerToolbar";
 import { ContextPopover } from "./composer/ContextPopover";
 import { SegmentedMeter } from "./composer/SegmentedMeter";
+import { UsageIndicator } from "./composer/UsageIndicator";
 import { AttachMenu } from "./AttachMenu";
 import { FileMentionPicker, matchFiles } from "./FileMentionPicker";
 import { PinnedPromptsBar } from "./PinnedPromptsBar";
@@ -1364,6 +1365,7 @@ export function ChatInputArea({
           />
         </div>
         <div className={styles.inputControlsRight}>
+          <UsageIndicator sessionId={sessionId} />
           <SegmentedMeter
             ref={meterRef}
             sessionId={sessionId}

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -1365,7 +1365,7 @@ export function ChatInputArea({
           />
         </div>
         <div className={styles.inputControlsRight}>
-          <UsageIndicator sessionId={sessionId} />
+          <UsageIndicator />
           <SegmentedMeter
             ref={meterRef}
             sessionId={sessionId}

--- a/src/ui/src/components/chat/composer/UsageIndicator.module.css
+++ b/src/ui/src/components/chat/composer/UsageIndicator.module.css
@@ -37,6 +37,7 @@
 .countdown {
   color: var(--status-stopped);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .exhausted .bar {

--- a/src/ui/src/components/chat/composer/UsageIndicator.module.css
+++ b/src/ui/src/components/chat/composer/UsageIndicator.module.css
@@ -1,0 +1,44 @@
+.indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 18px;
+  padding: 0 4px;
+  background: transparent;
+  border: none;
+  cursor: default;
+  color: var(--text-dim);
+  font-size: var(--fs-xs);
+  line-height: 1;
+}
+
+.bar {
+  position: relative;
+  width: 4px;
+  height: 14px;
+  background: var(--divider);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.barFill {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  transition: height 0.3s ease, background 0.3s ease;
+}
+
+.readout {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.countdown {
+  color: var(--status-stopped);
+  font-variant-numeric: tabular-nums;
+}
+
+.exhausted .bar {
+  background: color-mix(in srgb, var(--status-stopped) 25%, transparent);
+}

--- a/src/ui/src/components/chat/composer/UsageIndicator.module.css
+++ b/src/ui/src/components/chat/composer/UsageIndicator.module.css
@@ -1,3 +1,8 @@
+.wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
 .indicator {
   display: inline-flex;
   align-items: center;
@@ -6,10 +11,28 @@
   padding: 0 4px;
   background: transparent;
   border: none;
-  cursor: default;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
   color: var(--text-dim);
   font-size: var(--fs-xs);
   line-height: 1;
+  font-family: inherit;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.indicator:hover {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}
+
+.indicator:focus-visible {
+  outline: 1px solid var(--accent-primary);
+  outline-offset: 1px;
+}
+
+.indicator[aria-expanded="true"] {
+  background: var(--hover-bg);
+  color: var(--text-primary);
 }
 
 .bar {

--- a/src/ui/src/components/chat/composer/UsageIndicator.test.tsx
+++ b/src/ui/src/components/chat/composer/UsageIndicator.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClaudeCodeUsage } from "../../../types/usage";
+
+const appStore = vi.hoisted(() => ({
+  usageInsightsEnabled: false,
+  claudeCodeUsage: null as ClaudeCodeUsage | null,
+}));
+
+vi.mock("../../../stores/useAppStore", () => ({
+  useAppStore: <T,>(selector: (state: typeof appStore) => T): T =>
+    selector(appStore),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (!opts) return key;
+      const args = Object.entries(opts)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(",");
+      return `${key}(${args})`;
+    },
+  }),
+}));
+
+import { UsageIndicator } from "./UsageIndicator";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function render(): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(<UsageIndicator />);
+  });
+  return container;
+}
+
+function fakeUsage(
+  partial: Partial<ClaudeCodeUsage["usage"]> = {},
+): ClaudeCodeUsage {
+  const futureIso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  return {
+    subscription_type: "pro",
+    rate_limit_tier: "default_claude_pro",
+    fetched_at: Date.now(),
+    usage: {
+      five_hour: { utilization: 35, resets_at: futureIso },
+      seven_day: null,
+      seven_day_sonnet: null,
+      seven_day_opus: null,
+      extra_usage: null,
+      ...partial,
+    },
+  };
+}
+
+beforeEach(() => {
+  appStore.usageInsightsEnabled = false;
+  appStore.claudeCodeUsage = null;
+});
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
+describe("UsageIndicator", () => {
+  it("renders nothing when Usage Insights is disabled", async () => {
+    appStore.usageInsightsEnabled = false;
+    appStore.claudeCodeUsage = fakeUsage();
+    const container = await render();
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("renders nothing when no usage data has been fetched yet", async () => {
+    appStore.usageInsightsEnabled = true;
+    appStore.claudeCodeUsage = null;
+    const container = await render();
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("renders nothing when the API returned no populated buckets", async () => {
+    appStore.usageInsightsEnabled = true;
+    appStore.claudeCodeUsage = fakeUsage({ five_hour: null });
+    const container = await render();
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("renders the indicator with the picked bucket's used percent", async () => {
+    appStore.usageInsightsEnabled = true;
+    appStore.claudeCodeUsage = fakeUsage();
+    const container = await render();
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toContain("35%");
+    expect(button?.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("opens the popover when clicked, closes it on a second click", async () => {
+    appStore.usageInsightsEnabled = true;
+    appStore.claudeCodeUsage = fakeUsage();
+    const container = await render();
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+
+    await act(async () => button!.click());
+    expect(button!.getAttribute("aria-expanded")).toBe("true");
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+
+    await act(async () => button!.click());
+    expect(button!.getAttribute("aria-expanded")).toBe("false");
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("closes the popover on Escape", async () => {
+    appStore.usageInsightsEnabled = true;
+    appStore.claudeCodeUsage = fakeUsage();
+    const container = await render();
+    const button = container.querySelector("button")!;
+
+    await act(async () => button.click());
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("closes the popover on click outside (not on trigger)", async () => {
+    appStore.usageInsightsEnabled = true;
+    appStore.claudeCodeUsage = fakeUsage();
+    const container = await render();
+    const button = container.querySelector("button")!;
+
+    await act(async () => button.click());
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    await act(async () => {
+      outside.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, composed: true }),
+      );
+    });
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    outside.remove();
+  });
+});

--- a/src/ui/src/components/chat/composer/UsageIndicator.tsx
+++ b/src/ui/src/components/chat/composer/UsageIndicator.tsx
@@ -1,35 +1,13 @@
 import { useEffect, useState } from "react";
 import { useAppStore } from "../../../stores/useAppStore";
+import { formatResetCountdown } from "../../../utils/usageReset";
 import { selectUsageBucket } from "./selectUsageBucket";
 import styles from "./UsageIndicator.module.css";
-
-interface UsageIndicatorProps {
-  sessionId: string;
-}
 
 function barColor(pct: number): string {
   if (pct >= 85) return "var(--status-stopped)";
   if (pct >= 60) return "var(--context-meter-warn)";
   return "var(--accent-primary)";
-}
-
-function formatResetCountdown(resetsAt: string | number): string {
-  const ms =
-    typeof resetsAt === "string"
-      ? new Date(resetsAt).getTime()
-      : resetsAt < 1e12
-        ? resetsAt * 1000
-        : resetsAt;
-  const diffSec = Math.max(0, (ms - Date.now()) / 1000);
-  if (diffSec <= 0) return "resetting…";
-  const hours = Math.floor(diffSec / 3600);
-  const minutes = Math.floor((diffSec % 3600) / 60);
-  if (hours >= 24) {
-    const days = Math.floor(hours / 24);
-    return `${days}d ${hours % 24}h`;
-  }
-  if (hours > 0) return `${hours}h ${minutes}m`;
-  return `${minutes}m`;
 }
 
 /**
@@ -43,12 +21,9 @@ function formatResetCountdown(resetsAt: string | number): string {
  * data has been fetched at least once. No-data → render nothing,
  * matches existing ContextMeter behavior.
  */
-export function UsageIndicator({ sessionId }: UsageIndicatorProps) {
+export function UsageIndicator() {
   const enabled = useAppStore((s) => s.usageInsightsEnabled);
   const usage = useAppStore((s) => s.claudeCodeUsage);
-  const selectedModel = useAppStore(
-    (s) => s.selectedModel[sessionId] ?? "opus",
-  );
 
   // Tick once a minute so the countdown stays fresh without re-rendering
   // the whole composer on every animation frame.
@@ -60,7 +35,7 @@ export function UsageIndicator({ sessionId }: UsageIndicatorProps) {
   }, [enabled]);
 
   if (!enabled || !usage) return null;
-  const bucket = selectUsageBucket({ usage, selectedModel });
+  const bucket = selectUsageBucket({ usage });
   if (!bucket) return null;
 
   const pct = Math.min(bucket.utilization, 100);

--- a/src/ui/src/components/chat/composer/UsageIndicator.tsx
+++ b/src/ui/src/components/chat/composer/UsageIndicator.tsx
@@ -14,9 +14,11 @@ function barColor(pct: number): string {
 /**
  * Compact usage-allocation indicator for the composer toolbar.
  *
- * Vertical bar that drains as the most-urgent Anthropic subscription
- * limit fills (burn-rate weighted — see [[selectUsageBucket]]). Clicking
- * opens a popover showing every bucket the API returned.
+ * Vertical bar that fills as the most-urgent Anthropic subscription
+ * limit is consumed (burn-rate weighted — see [[selectUsageBucket]]).
+ * The readout shows percent *used* to match the popover and Claude
+ * Code's own `/usage` panel. Clicking opens a popover with every
+ * bucket the API returned.
  */
 export function UsageIndicator() {
   const enabled = useAppStore((s) => s.usageInsightsEnabled);
@@ -39,7 +41,6 @@ export function UsageIndicator() {
   if (!bucket) return null;
 
   const pct = Math.min(bucket.utilization, 100);
-  const remainingHeight = Math.max(0, 100 - pct);
   const color = barColor(pct);
   const tooltip = bucket.exhausted
     ? `${bucket.label} exhausted — resets in ${formatResetCountdown(bucket.resetsAt)}`
@@ -60,7 +61,7 @@ export function UsageIndicator() {
         <div className={styles.bar}>
           <div
             className={styles.barFill}
-            style={{ height: `${remainingHeight}%`, background: color }}
+            style={{ height: `${pct}%`, background: color }}
           />
         </div>
         {bucket.exhausted ? (
@@ -68,7 +69,7 @@ export function UsageIndicator() {
             ↻ {formatResetCountdown(bucket.resetsAt)}
           </span>
         ) : (
-          <span className={styles.readout}>{Math.floor(100 - pct)}%</span>
+          <span className={styles.readout}>{Math.floor(pct)}%</span>
         )}
       </button>
       {open && (

--- a/src/ui/src/components/chat/composer/UsageIndicator.tsx
+++ b/src/ui/src/components/chat/composer/UsageIndicator.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../../stores/useAppStore";
-import { formatResetCountdown } from "../../../utils/usageReset";
+import { formatResetCountdown, resetCountdown } from "../../../utils/usageReset";
 import { selectUsageBucket } from "./selectUsageBucket";
 import { UsagePopover } from "./UsagePopover";
 import styles from "./UsageIndicator.module.css";
@@ -21,6 +22,7 @@ function barColor(pct: number): string {
  * bucket the API returned.
  */
 export function UsageIndicator() {
+  const { t } = useTranslation("settings");
   const enabled = useAppStore((s) => s.usageInsightsEnabled);
   const usage = useAppStore((s) => s.claudeCodeUsage);
 
@@ -42,9 +44,21 @@ export function UsageIndicator() {
 
   const pct = Math.min(bucket.utilization, 100);
   const color = barColor(pct);
+  // Avoid "resets in resetting…" — when the reset moment has already passed
+  // but the API hasn't refreshed yet, fall back to a dedicated key.
+  const exhaustedResetting =
+    bucket.exhausted && resetCountdown(bucket.resetsAt).resetting;
   const tooltip = bucket.exhausted
-    ? `${bucket.label} exhausted — resets in ${formatResetCountdown(bucket.resetsAt)}`
-    : `${bucket.label}: ${Math.floor(pct)}% used — click for all limits`;
+    ? exhaustedResetting
+      ? t("usage_indicator_tooltip_exhausted_resetting", { label: bucket.label })
+      : t("usage_indicator_tooltip_exhausted", {
+          label: bucket.label,
+          countdown: formatResetCountdown(bucket.resetsAt),
+        })
+    : t("usage_indicator_tooltip_used", {
+        label: bucket.label,
+        pct: Math.floor(pct),
+      });
 
   return (
     <div className={styles.wrapper}>

--- a/src/ui/src/components/chat/composer/UsageIndicator.tsx
+++ b/src/ui/src/components/chat/composer/UsageIndicator.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { useAppStore } from "../../../stores/useAppStore";
+import { selectUsageBucket } from "./selectUsageBucket";
+import styles from "./UsageIndicator.module.css";
+
+interface UsageIndicatorProps {
+  sessionId: string;
+}
+
+function barColor(pct: number): string {
+  if (pct >= 85) return "var(--status-stopped)";
+  if (pct >= 60) return "var(--context-meter-warn)";
+  return "var(--accent-primary)";
+}
+
+function formatResetCountdown(resetsAt: string | number): string {
+  const ms =
+    typeof resetsAt === "string"
+      ? new Date(resetsAt).getTime()
+      : resetsAt < 1e12
+        ? resetsAt * 1000
+        : resetsAt;
+  const diffSec = Math.max(0, (ms - Date.now()) / 1000);
+  if (diffSec <= 0) return "resetting…";
+  const hours = Math.floor(diffSec / 3600);
+  const minutes = Math.floor((diffSec % 3600) / 60);
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24);
+    return `${days}d ${hours % 24}h`;
+  }
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+/**
+ * Compact usage-allocation indicator for the composer toolbar.
+ *
+ * Vertical bar that drains as the most-relevant Anthropic subscription
+ * limit fills (inverse of context meter). When exhausted, swaps to a
+ * "Resets in <countdown>" readout.
+ *
+ * Hidden unless the experimental Usage Insights flag is on AND usage
+ * data has been fetched at least once. No-data → render nothing,
+ * matches existing ContextMeter behavior.
+ */
+export function UsageIndicator({ sessionId }: UsageIndicatorProps) {
+  const enabled = useAppStore((s) => s.usageInsightsEnabled);
+  const usage = useAppStore((s) => s.claudeCodeUsage);
+  const selectedModel = useAppStore(
+    (s) => s.selectedModel[sessionId] ?? "opus",
+  );
+
+  // Tick once a minute so the countdown stays fresh without re-rendering
+  // the whole composer on every animation frame.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!enabled) return;
+    const id = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(id);
+  }, [enabled]);
+
+  if (!enabled || !usage) return null;
+  const bucket = selectUsageBucket({ usage, selectedModel });
+  if (!bucket) return null;
+
+  const pct = Math.min(bucket.utilization, 100);
+  // Inverse of context meter — bar *drains* as utilization rises.
+  const remainingHeight = Math.max(0, 100 - pct);
+  const color = barColor(pct);
+  const tooltip = bucket.exhausted
+    ? `${bucket.label} exhausted — resets in ${formatResetCountdown(bucket.resetsAt)}`
+    : `${bucket.label}: ${Math.floor(pct)}% used`;
+
+  return (
+    <div
+      className={`${styles.indicator} ${bucket.exhausted ? styles.exhausted : ""}`}
+      title={tooltip}
+      role="status"
+      aria-label={tooltip}
+    >
+      <div className={styles.bar}>
+        <div
+          className={styles.barFill}
+          style={{ height: `${remainingHeight}%`, background: color }}
+        />
+      </div>
+      {bucket.exhausted ? (
+        <span className={styles.countdown}>
+          ↻ {formatResetCountdown(bucket.resetsAt)}
+        </span>
+      ) : (
+        <span className={styles.readout}>{Math.floor(100 - pct)}%</span>
+      )}
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/composer/UsageIndicator.tsx
+++ b/src/ui/src/components/chat/composer/UsageIndicator.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAppStore } from "../../../stores/useAppStore";
 import { formatResetCountdown } from "../../../utils/usageReset";
 import { selectUsageBucket } from "./selectUsageBucket";
+import { UsagePopover } from "./UsagePopover";
 import styles from "./UsageIndicator.module.css";
 
 function barColor(pct: number): string {
@@ -13,17 +14,16 @@ function barColor(pct: number): string {
 /**
  * Compact usage-allocation indicator for the composer toolbar.
  *
- * Vertical bar that drains as the most-relevant Anthropic subscription
- * limit fills (inverse of context meter). When exhausted, swaps to a
- * "Resets in <countdown>" readout.
- *
- * Hidden unless the experimental Usage Insights flag is on AND usage
- * data has been fetched at least once. No-data → render nothing,
- * matches existing ContextMeter behavior.
+ * Vertical bar that drains as the most-urgent Anthropic subscription
+ * limit fills (burn-rate weighted — see [[selectUsageBucket]]). Clicking
+ * opens a popover showing every bucket the API returned.
  */
 export function UsageIndicator() {
   const enabled = useAppStore((s) => s.usageInsightsEnabled);
   const usage = useAppStore((s) => s.claudeCodeUsage);
+
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
 
   // Tick once a minute so the countdown stays fresh without re-rendering
   // the whole composer on every animation frame.
@@ -39,32 +39,44 @@ export function UsageIndicator() {
   if (!bucket) return null;
 
   const pct = Math.min(bucket.utilization, 100);
-  // Inverse of context meter — bar *drains* as utilization rises.
   const remainingHeight = Math.max(0, 100 - pct);
   const color = barColor(pct);
   const tooltip = bucket.exhausted
     ? `${bucket.label} exhausted — resets in ${formatResetCountdown(bucket.resetsAt)}`
-    : `${bucket.label}: ${Math.floor(pct)}% used`;
+    : `${bucket.label}: ${Math.floor(pct)}% used — click for all limits`;
 
   return (
-    <div
-      className={`${styles.indicator} ${bucket.exhausted ? styles.exhausted : ""}`}
-      title={tooltip}
-      role="status"
-      aria-label={tooltip}
-    >
-      <div className={styles.bar}>
-        <div
-          className={styles.barFill}
-          style={{ height: `${remainingHeight}%`, background: color }}
+    <div className={styles.wrapper}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`${styles.indicator} ${bucket.exhausted ? styles.exhausted : ""}`}
+        title={tooltip}
+        aria-label={tooltip}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <div className={styles.bar}>
+          <div
+            className={styles.barFill}
+            style={{ height: `${remainingHeight}%`, background: color }}
+          />
+        </div>
+        {bucket.exhausted ? (
+          <span className={styles.countdown}>
+            ↻ {formatResetCountdown(bucket.resetsAt)}
+          </span>
+        ) : (
+          <span className={styles.readout}>{Math.floor(100 - pct)}%</span>
+        )}
+      </button>
+      {open && (
+        <UsagePopover
+          onClose={() => setOpen(false)}
+          triggerRef={triggerRef}
+          activeBucketKey={bucket.key}
         />
-      </div>
-      {bucket.exhausted ? (
-        <span className={styles.countdown}>
-          ↻ {formatResetCountdown(bucket.resetsAt)}
-        </span>
-      ) : (
-        <span className={styles.readout}>{Math.floor(100 - pct)}%</span>
       )}
     </div>
   );

--- a/src/ui/src/components/chat/composer/UsagePopover.module.css
+++ b/src/ui/src/components/chat/composer/UsagePopover.module.css
@@ -1,0 +1,113 @@
+.popover {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  right: 0;
+  width: 320px;
+  background: var(--sidebar-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-xl);
+  padding: 16px;
+  box-shadow: var(--shadow-lg);
+  z-index: 50;
+  animation: fadeUp 160ms var(--ease-out-quick);
+}
+
+.header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.caption {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.tier {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--accent-primary);
+  letter-spacing: 0.04em;
+}
+
+.bucketList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.bucket {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.bucket.active {
+  background: var(--hover-bg);
+  border-color: var(--sidebar-border);
+}
+
+.bucketHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.bucketLabel {
+  font-size: var(--fs-sm);
+  color: var(--text-primary);
+}
+
+.bucketPct {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.bucketBar {
+  position: relative;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--divider);
+  overflow: hidden;
+}
+
+.bucketBarFill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  transition: width 400ms var(--ease-out-quick), background var(--transition-fast);
+}
+
+.bucketReset {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-dim);
+  letter-spacing: 0.02em;
+}
+
+.footnote {
+  font-size: 10.5px;
+  line-height: 1.4;
+  color: var(--text-dim);
+  border-top: 1px solid var(--divider);
+  padding-top: 10px;
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/src/ui/src/components/chat/composer/UsagePopover.tsx
+++ b/src/ui/src/components/chat/composer/UsagePopover.tsx
@@ -1,0 +1,96 @@
+import { type RefObject, useEffect, useRef } from "react";
+import { useAppStore } from "../../../stores/useAppStore";
+import { formatResetIn } from "../../../utils/usageReset";
+import { getAllUsageBuckets, type UsageBucket } from "./selectUsageBucket";
+import styles from "./UsagePopover.module.css";
+
+interface UsagePopoverProps {
+  onClose: () => void;
+  triggerRef?: RefObject<HTMLElement | null>;
+  /** Key of the bucket the compact indicator is currently surfacing — highlighted in the list. */
+  activeBucketKey?: UsageBucket["key"];
+}
+
+function bandColor(pct: number): string {
+  if (pct >= 85) return "var(--status-stopped)";
+  if (pct >= 60) return "var(--context-meter-warn)";
+  return "var(--accent-primary)";
+}
+
+export function UsagePopover({ onClose, triggerRef, activeBucketKey }: UsagePopoverProps) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const usage = useAppStore((s) => s.claudeCodeUsage);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      const target = e.target as Node;
+      if (triggerRef?.current?.contains(target)) return;
+      if (popoverRef.current && !popoverRef.current.contains(target)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onClose, triggerRef]);
+
+  if (!usage) return null;
+  const buckets = getAllUsageBuckets(usage);
+  if (buckets.length === 0) return null;
+
+  const tier = usage.subscription_type
+    ? usage.subscription_type.charAt(0).toUpperCase() + usage.subscription_type.slice(1)
+    : "Anthropic";
+
+  return (
+    <div ref={popoverRef} className={styles.popover} role="dialog" aria-label="Anthropic usage limits">
+      <div className={styles.header}>
+        <span className={styles.caption}>Usage</span>
+        <span className={styles.tier}>{tier}</span>
+      </div>
+
+      <ul className={styles.bucketList}>
+        {buckets.map((b) => {
+          const pct = Math.min(b.utilization, 100);
+          const color = bandColor(pct);
+          const isActive = b.key === activeBucketKey;
+          return (
+            <li
+              key={b.key}
+              className={`${styles.bucket} ${isActive ? styles.active : ""}`}
+            >
+              <div className={styles.bucketHead}>
+                <span className={styles.bucketLabel}>{b.label}</span>
+                <span className={styles.bucketPct} style={{ color }}>
+                  {Math.floor(pct)}%
+                </span>
+              </div>
+              <div className={styles.bucketBar}>
+                <div
+                  className={styles.bucketBarFill}
+                  style={{ width: `${pct}%`, background: color }}
+                />
+              </div>
+              <span className={styles.bucketReset}>{formatResetIn(b.resetsAt)}</span>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className={styles.footnote}>
+        Burn-rate weighted: the indicator surfaces whichever limit you’ll hit first
+        at your current pace, not just the highest percentage.
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/composer/selectUsageBucket.test.ts
+++ b/src/ui/src/components/chat/composer/selectUsageBucket.test.ts
@@ -24,17 +24,13 @@ function usage(partial: Partial<ClaudeCodeUsage["usage"]>): ClaudeCodeUsage {
 
 describe("selectUsageBucket", () => {
   it("returns null when no limits are present", () => {
-    const bucket = selectUsageBucket({
-      usage: usage({}),
-      selectedModel: "opus",
-    });
+    const bucket = selectUsageBucket({ usage: usage({}) });
     expect(bucket).toBeNull();
   });
 
   it("returns the single limit when only one is set", () => {
     const bucket = selectUsageBucket({
       usage: usage({ five_hour: limit(42) }),
-      selectedModel: "opus",
     });
     expect(bucket).not.toBeNull();
     expect(bucket?.utilization).toBe(42);
@@ -50,7 +46,6 @@ describe("selectUsageBucket", () => {
         seven_day_sonnet: limit(80),
         seven_day_opus: limit(20),
       }),
-      selectedModel: "sonnet",
     });
     expect(bucket?.label).toBe("Week (Sonnet)");
     expect(bucket?.utilization).toBe(80);
@@ -60,7 +55,6 @@ describe("selectUsageBucket", () => {
   it("marks exhausted at >= 100", () => {
     const bucket = selectUsageBucket({
       usage: usage({ five_hour: limit(100) }),
-      selectedModel: "opus",
     });
     expect(bucket?.exhausted).toBe(true);
   });
@@ -68,7 +62,6 @@ describe("selectUsageBucket", () => {
   it("does not mark exhausted at 99", () => {
     const bucket = selectUsageBucket({
       usage: usage({ five_hour: limit(99) }),
-      selectedModel: "opus",
     });
     expect(bucket?.exhausted).toBe(false);
   });
@@ -79,7 +72,6 @@ describe("selectUsageBucket", () => {
         five_hour: limit(20, "2026-07-01T12:00:00Z"),
         seven_day: limit(70, "2026-07-08T00:00:00Z"),
       }),
-      selectedModel: "opus",
     });
     expect(bucket?.resetsAt).toBe("2026-07-08T00:00:00Z");
   });

--- a/src/ui/src/components/chat/composer/selectUsageBucket.test.ts
+++ b/src/ui/src/components/chat/composer/selectUsageBucket.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { selectUsageBucket } from "./selectUsageBucket";
 import type { ClaudeCodeUsage, UsageLimit } from "../../../types/usage";
 
-function limit(utilization: number, resetsAt = "2026-06-01T00:00:00Z"): UsageLimit {
+function limit(utilization: number, resetsAt: string): UsageLimit {
   return { utilization, resets_at: resetsAt };
 }
 
@@ -22,57 +22,150 @@ function usage(partial: Partial<ClaudeCodeUsage["usage"]>): ClaudeCodeUsage {
   };
 }
 
+// Fixed reference time for deterministic burn-rate scoring.
+// Picked so 5h and 7d windows have clean offsets to reason about.
+const NOW = Date.parse("2026-06-01T01:00:00Z"); // 1h into a 5h window starting at 00:00Z
+
+/** Reset time N hours from NOW. */
+const inHours = (h: number) =>
+  new Date(NOW + h * 60 * 60 * 1000).toISOString();
+/** Reset time N days from NOW. */
+const inDays = (d: number) =>
+  new Date(NOW + d * 24 * 60 * 60 * 1000).toISOString();
+
 describe("selectUsageBucket", () => {
   it("returns null when no limits are present", () => {
-    const bucket = selectUsageBucket({ usage: usage({}) });
+    const bucket = selectUsageBucket({ usage: usage({}), now: NOW });
     expect(bucket).toBeNull();
   });
 
   it("returns the single limit when only one is set", () => {
     const bucket = selectUsageBucket({
-      usage: usage({ five_hour: limit(42) }),
+      usage: usage({ five_hour: limit(42, inHours(4)) }),
+      now: NOW,
     });
     expect(bucket).not.toBeNull();
     expect(bucket?.utilization).toBe(42);
     expect(bucket?.label).toBe("Session (5h)");
+    expect(bucket?.key).toBe("five_hour");
     expect(bucket?.exhausted).toBe(false);
+    expect(bucket?.windowMs).toBe(5 * 60 * 60 * 1000);
   });
 
-  it("picks the most-constraining limit among many", () => {
+  it("session at 25% / 1h-in beats weekly at 4% / 1d-in (burn-rate)", () => {
+    // 5h session, 4h remaining → 20% elapsed → score 25/0.2 = 125
+    // 7d weekly, 6d remaining → ~14% elapsed → score ~28
     const bucket = selectUsageBucket({
       usage: usage({
-        five_hour: limit(30),
-        seven_day: limit(55),
-        seven_day_sonnet: limit(80),
-        seven_day_opus: limit(20),
+        five_hour: limit(25, inHours(4)),
+        seven_day: limit(4, inDays(6)),
       }),
+      now: NOW,
     });
+    expect(bucket?.key).toBe("five_hour");
+  });
+
+  it("high-utilization weekly beats low-utilization session at same elapsed fraction", () => {
+    // 5h session at 2.5h elapsed (50%): 5/0.5 = 10
+    // 7d weekly at 5d elapsed (~71%): 80/0.71 ≈ 112
+    const bucket = selectUsageBucket({
+      usage: usage({
+        five_hour: limit(5, inHours(2.5)),
+        seven_day_sonnet: limit(80, inDays(2)),
+      }),
+      now: NOW,
+    });
+    expect(bucket?.key).toBe("seven_day_sonnet");
     expect(bucket?.label).toBe("Week (Sonnet)");
-    expect(bucket?.utilization).toBe(80);
-    expect(bucket?.exhausted).toBe(false);
+  });
+
+  it("exhausted bucket dominates every non-exhausted bucket", () => {
+    const bucket = selectUsageBucket({
+      usage: usage({
+        five_hour: limit(100, inHours(2)), // exhausted, would score Infinity
+        seven_day_sonnet: limit(95, inDays(1)), // very high but not exhausted
+      }),
+      now: NOW,
+    });
+    expect(bucket?.key).toBe("five_hour");
+    expect(bucket?.exhausted).toBe(true);
+  });
+
+  it("MIN_FRACTION_ELAPSED floor prevents fresh-window noise from winning", () => {
+    // Session just opened (4.99h remaining of 5h → ~0.2% elapsed,
+    // floored to 10%). 1% util / 0.1 = 10.
+    // Weekly mid-life: 50% util / 0.5 = 100. Weekly wins.
+    const bucket = selectUsageBucket({
+      usage: usage({
+        five_hour: limit(1, inHours(4.99)),
+        seven_day: limit(50, inDays(3.5)),
+      }),
+      now: NOW,
+    });
+    expect(bucket?.key).toBe("seven_day");
+  });
+
+  it("treats stale data (resetsAt in the past) as a fully-consumed window", () => {
+    // Session resetsAt in the past → fractionElapsed = 1 → score = utilization (50)
+    // Weekly mid-life with high util → score ~140. Weekly wins.
+    const bucket = selectUsageBucket({
+      usage: usage({
+        five_hour: limit(50, inHours(-1)),
+        seven_day: limit(60, inDays(4)),
+      }),
+      now: NOW,
+    });
+    expect(bucket?.key).toBe("seven_day");
+  });
+
+  it("breaks ties in display order (session before weekly when both exhausted)", () => {
+    const bucket = selectUsageBucket({
+      usage: usage({
+        five_hour: limit(100, inHours(2)),
+        seven_day: limit(100, inDays(3)),
+      }),
+      now: NOW,
+    });
+    expect(bucket?.key).toBe("five_hour");
   });
 
   it("marks exhausted at >= 100", () => {
     const bucket = selectUsageBucket({
-      usage: usage({ five_hour: limit(100) }),
+      usage: usage({ five_hour: limit(100, inHours(2)) }),
+      now: NOW,
     });
     expect(bucket?.exhausted).toBe(true);
   });
 
   it("does not mark exhausted at 99", () => {
     const bucket = selectUsageBucket({
-      usage: usage({ five_hour: limit(99) }),
+      usage: usage({ five_hour: limit(99, inHours(2)) }),
+      now: NOW,
     });
     expect(bucket?.exhausted).toBe(false);
   });
 
-  it("preserves the resetsAt value from the picked limit", () => {
+  it("preserves resetsAt from the picked bucket", () => {
+    const sessionReset = inHours(4);
+    const weeklyReset = inDays(6);
     const bucket = selectUsageBucket({
       usage: usage({
-        five_hour: limit(20, "2026-07-01T12:00:00Z"),
-        seven_day: limit(70, "2026-07-08T00:00:00Z"),
+        five_hour: limit(25, sessionReset),
+        seven_day: limit(4, weeklyReset),
       }),
+      now: NOW,
     });
-    expect(bucket?.resetsAt).toBe("2026-07-08T00:00:00Z");
+    expect(bucket?.resetsAt).toBe(sessionReset);
+  });
+
+  it("ignores zero-utilization buckets when something else has activity", () => {
+    const bucket = selectUsageBucket({
+      usage: usage({
+        five_hour: limit(0, inHours(4)),
+        seven_day: limit(15, inDays(3)),
+      }),
+      now: NOW,
+    });
+    expect(bucket?.key).toBe("seven_day");
   });
 });

--- a/src/ui/src/components/chat/composer/selectUsageBucket.test.ts
+++ b/src/ui/src/components/chat/composer/selectUsageBucket.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { selectUsageBucket } from "./selectUsageBucket";
+import type { ClaudeCodeUsage, UsageLimit } from "../../../types/usage";
+
+function limit(utilization: number, resetsAt = "2026-06-01T00:00:00Z"): UsageLimit {
+  return { utilization, resets_at: resetsAt };
+}
+
+function usage(partial: Partial<ClaudeCodeUsage["usage"]>): ClaudeCodeUsage {
+  return {
+    subscription_type: "pro",
+    rate_limit_tier: "default_claude_pro",
+    fetched_at: Date.now(),
+    usage: {
+      five_hour: null,
+      seven_day: null,
+      seven_day_sonnet: null,
+      seven_day_opus: null,
+      extra_usage: null,
+      ...partial,
+    },
+  };
+}
+
+describe("selectUsageBucket", () => {
+  it("returns null when no limits are present", () => {
+    const bucket = selectUsageBucket({
+      usage: usage({}),
+      selectedModel: "opus",
+    });
+    expect(bucket).toBeNull();
+  });
+
+  it("returns the single limit when only one is set", () => {
+    const bucket = selectUsageBucket({
+      usage: usage({ five_hour: limit(42) }),
+      selectedModel: "opus",
+    });
+    expect(bucket).not.toBeNull();
+    expect(bucket?.utilization).toBe(42);
+    expect(bucket?.label).toBe("Session (5h)");
+    expect(bucket?.exhausted).toBe(false);
+  });
+
+  it("picks the most-constraining limit among many", () => {
+    const bucket = selectUsageBucket({
+      usage: usage({
+        five_hour: limit(30),
+        seven_day: limit(55),
+        seven_day_sonnet: limit(80),
+        seven_day_opus: limit(20),
+      }),
+      selectedModel: "sonnet",
+    });
+    expect(bucket?.label).toBe("Week (Sonnet)");
+    expect(bucket?.utilization).toBe(80);
+    expect(bucket?.exhausted).toBe(false);
+  });
+
+  it("marks exhausted at >= 100", () => {
+    const bucket = selectUsageBucket({
+      usage: usage({ five_hour: limit(100) }),
+      selectedModel: "opus",
+    });
+    expect(bucket?.exhausted).toBe(true);
+  });
+
+  it("does not mark exhausted at 99", () => {
+    const bucket = selectUsageBucket({
+      usage: usage({ five_hour: limit(99) }),
+      selectedModel: "opus",
+    });
+    expect(bucket?.exhausted).toBe(false);
+  });
+
+  it("preserves the resetsAt value from the picked limit", () => {
+    const bucket = selectUsageBucket({
+      usage: usage({
+        five_hour: limit(20, "2026-07-01T12:00:00Z"),
+        seven_day: limit(70, "2026-07-08T00:00:00Z"),
+      }),
+      selectedModel: "opus",
+    });
+    expect(bucket?.resetsAt).toBe("2026-07-08T00:00:00Z");
+  });
+});

--- a/src/ui/src/components/chat/composer/selectUsageBucket.ts
+++ b/src/ui/src/components/chat/composer/selectUsageBucket.ts
@@ -61,37 +61,44 @@ export function getAllUsageBuckets(usage: ClaudeCodeUsage): UsageBucket[] {
 }
 
 /**
+ * Floor on fractionElapsed when computing the burn-rate score. Prevents
+ * a freshly-reset window with a tiny amount of utilization from scoring
+ * absurdly high — the first 10% of a window (~30 min of a 5h session,
+ * ~17h of a weekly window) is too noisy to read a trend from.
+ */
+const MIN_FRACTION_ELAPSED = 0.1;
+
+/**
  * Burn-rate score for a single bucket. Higher score = more urgent.
  *
- * Intuition: `utilization` alone misses that a 25% session window resetting
- * in 4h is on track to blow past 100%, while a 25% weekly window resetting
- * in 6 days is fine. We compare against fraction-of-window-elapsed instead.
+ *   fractionElapsed = (windowMs - msUntilReset) / windowMs
+ *   score           = utilization / max(fractionElapsed, MIN_FRACTION_ELAPSED)
  *
- *   fractionElapsed = (windowMs - msUntilReset) / windowMs   ∈ (0, 1]
- *   score           = utilization / fractionElapsed
+ * Surfaces "which limit will you hit first at current pace" rather than
+ * "which has the highest %". A 25% session window 1h into its 5h means
+ * a projected ~125% by reset (score 125); a 25% weekly window 1 day in
+ * projects ~175% but with 6 days to course-correct (lower urgency in
+ * absolute terms — that's why we use elapsed fraction, not projected %).
  *
- * Edge cases YOU need to decide:
- *   - fractionElapsed very small (just past reset): score blows up. Cap it?
- *   - msUntilReset <= 0 (clock skew / stale data): treat as fully elapsed?
- *   - Exhausted buckets (>=100): always rank above non-exhausted?
- *
- * Implement below — see [[selectUsageBucket]] for how it's consumed.
+ * Edge cases:
+ *   - Exhausted (>=100): returns Infinity. A maxed bucket should always
+ *     own the indicator slot — that's the actionable signal.
+ *   - msUntilReset <= 0 (clock skew or stale data): treat the window as
+ *     fully elapsed (fractionElapsed = 1, score = utilization). Hides
+ *     stale-but-low buckets while still surfacing high ones.
+ *   - Zero utilization: scores 0 regardless of windowMs (untouched limit
+ *     should never win).
  */
 function burnRateScore(bucket: UsageBucket, now: number): number {
-  // TODO(you): return a score where higher = more urgent.
-  //
-  // Available:
-  //   bucket.utilization  // 0-100
-  //   bucket.windowMs     // 5h or 7d in ms
-  //   bucket.resetsAt     // pass through parseResetMs() to get epoch ms
-  //   bucket.exhausted    // utilization >= 100
-  //
-  // Decide: how do you handle a near-zero fractionElapsed? Do you want
-  // exhausted to dominate? Should very-fresh windows (< ~5 min elapsed)
-  // fall back to plain utilization to avoid scoring noise?
-  void bucket;
-  void now;
-  return 0;
+  if (bucket.exhausted) return Number.POSITIVE_INFINITY;
+  if (bucket.utilization <= 0) return 0;
+
+  const msUntilReset = parseResetMs(bucket.resetsAt) - now;
+  const rawFractionElapsed = (bucket.windowMs - msUntilReset) / bucket.windowMs;
+  const fractionElapsed =
+    msUntilReset <= 0 ? 1 : Math.max(rawFractionElapsed, MIN_FRACTION_ELAPSED);
+
+  return bucket.utilization / fractionElapsed;
 }
 
 /**

--- a/src/ui/src/components/chat/composer/selectUsageBucket.ts
+++ b/src/ui/src/components/chat/composer/selectUsageBucket.ts
@@ -13,12 +13,10 @@ export interface UsageBucket {
 
 interface SelectInput {
   usage: ClaudeCodeUsage;
-  /** Currently selected agent model id ("opus" | "sonnet" | "haiku" | ...). */
-  selectedModel: string;
 }
 
 /**
- * Decide which of the (up to 4) usage limits the lower-bar indicator should
+ * Decide which of the (up to 4) usage limits the composer indicator should
  * surface. The usage API returns:
  *
  *   - five_hour          : Current rolling 5h session window
@@ -26,26 +24,13 @@ interface SelectInput {
  *   - seven_day_sonnet   : Weekly cap, Sonnet-only
  *   - seven_day_opus     : Weekly cap, Opus-only
  *
- * The bar can only show one bucket at a time, so we have to pick. Common
- * strategies:
- *
- *   (a) Most-constraining        — pick max(utilization). Surfaces whichever
- *                                  limit the user will hit first. Stable, but
- *                                  switches buckets as the user works.
- *   (b) Model-aware              — for Opus selection, prefer seven_day_opus;
- *                                  for Sonnet, prefer seven_day_sonnet; fall
- *                                  back to (a). Closer to "what affects ME
- *                                  right now" but ignores the 5h cap that
- *                                  often bites first.
- *   (c) Session-first            — always prefer five_hour while it has data,
- *                                  fall back to (a). Matches the cadence of
- *                                  a coding session, but hides weekly burn.
- *
- * Returns `null` when there's nothing meaningful to display (no usage data
- * returned by the API).
+ * The bar shows one bucket at a time. We pick the most-constraining
+ * (max utilization) — it surfaces whichever limit the user will hit first
+ * regardless of which model they switch to. Returns `null` when there's
+ * nothing meaningful to display (no usage data returned by the API).
  */
 export function selectUsageBucket(input: SelectInput): UsageBucket | null {
-  const { usage, selectedModel } = input;
+  const { usage } = input;
 
   const candidates: { limit: UsageLimit; label: string }[] = [];
   if (usage.usage.five_hour) {
@@ -69,14 +54,6 @@ export function selectUsageBucket(input: SelectInput): UsageBucket | null {
 
   if (candidates.length === 0) return null;
 
-  // TODO(learning): pick a strategy. The simplest viable thing is below
-  // (most-constraining), but the user may want model-aware or session-first.
-  // See doc-comment above for trade-offs. Replace this block with your
-  // chosen selection logic (5-10 lines).
-  //
-  // Inputs available: `candidates` (label + limit), `selectedModel`.
-  // Return: a single { limit, label } from `candidates`.
-  void selectedModel; // silence unused-param lint until the user wires it up
   const picked = candidates.reduce((best, c) =>
     c.limit.utilization > best.limit.utilization ? c : best,
   );

--- a/src/ui/src/components/chat/composer/selectUsageBucket.ts
+++ b/src/ui/src/components/chat/composer/selectUsageBucket.ts
@@ -1,0 +1,90 @@
+import type { ClaudeCodeUsage, UsageLimit } from "../../../types/usage";
+
+export interface UsageBucket {
+  /** Which limit this bucket represents — used as a label and aria description. */
+  label: string;
+  /** 0-100. Render as a vertical bar that goes *down* as utilization rises. */
+  utilization: number;
+  /** Absolute reset time (string or epoch s/ms — matches UsageLimit shape). */
+  resetsAt: string | number;
+  /** True when utilization >= 100 — switches the indicator into countdown mode. */
+  exhausted: boolean;
+}
+
+interface SelectInput {
+  usage: ClaudeCodeUsage;
+  /** Currently selected agent model id ("opus" | "sonnet" | "haiku" | ...). */
+  selectedModel: string;
+}
+
+/**
+ * Decide which of the (up to 4) usage limits the lower-bar indicator should
+ * surface. The usage API returns:
+ *
+ *   - five_hour          : Current rolling 5h session window
+ *   - seven_day          : Weekly cap, aggregated across all models
+ *   - seven_day_sonnet   : Weekly cap, Sonnet-only
+ *   - seven_day_opus     : Weekly cap, Opus-only
+ *
+ * The bar can only show one bucket at a time, so we have to pick. Common
+ * strategies:
+ *
+ *   (a) Most-constraining        — pick max(utilization). Surfaces whichever
+ *                                  limit the user will hit first. Stable, but
+ *                                  switches buckets as the user works.
+ *   (b) Model-aware              — for Opus selection, prefer seven_day_opus;
+ *                                  for Sonnet, prefer seven_day_sonnet; fall
+ *                                  back to (a). Closer to "what affects ME
+ *                                  right now" but ignores the 5h cap that
+ *                                  often bites first.
+ *   (c) Session-first            — always prefer five_hour while it has data,
+ *                                  fall back to (a). Matches the cadence of
+ *                                  a coding session, but hides weekly burn.
+ *
+ * Returns `null` when there's nothing meaningful to display (no usage data
+ * returned by the API).
+ */
+export function selectUsageBucket(input: SelectInput): UsageBucket | null {
+  const { usage, selectedModel } = input;
+
+  const candidates: { limit: UsageLimit; label: string }[] = [];
+  if (usage.usage.five_hour) {
+    candidates.push({ limit: usage.usage.five_hour, label: "Session (5h)" });
+  }
+  if (usage.usage.seven_day) {
+    candidates.push({ limit: usage.usage.seven_day, label: "Week (all)" });
+  }
+  if (usage.usage.seven_day_sonnet) {
+    candidates.push({
+      limit: usage.usage.seven_day_sonnet,
+      label: "Week (Sonnet)",
+    });
+  }
+  if (usage.usage.seven_day_opus) {
+    candidates.push({
+      limit: usage.usage.seven_day_opus,
+      label: "Week (Opus)",
+    });
+  }
+
+  if (candidates.length === 0) return null;
+
+  // TODO(learning): pick a strategy. The simplest viable thing is below
+  // (most-constraining), but the user may want model-aware or session-first.
+  // See doc-comment above for trade-offs. Replace this block with your
+  // chosen selection logic (5-10 lines).
+  //
+  // Inputs available: `candidates` (label + limit), `selectedModel`.
+  // Return: a single { limit, label } from `candidates`.
+  void selectedModel; // silence unused-param lint until the user wires it up
+  const picked = candidates.reduce((best, c) =>
+    c.limit.utilization > best.limit.utilization ? c : best,
+  );
+
+  return {
+    label: picked.label,
+    utilization: picked.limit.utilization,
+    resetsAt: picked.limit.resets_at,
+    exhausted: picked.limit.utilization >= 100,
+  };
+}

--- a/src/ui/src/components/chat/composer/selectUsageBucket.ts
+++ b/src/ui/src/components/chat/composer/selectUsageBucket.ts
@@ -1,4 +1,5 @@
 import type { ClaudeCodeUsage, UsageLimit } from "../../../types/usage";
+import { parseResetMs } from "../../../utils/usageReset";
 
 /** Window length in milliseconds, derived from the bucket key. */
 const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
@@ -23,11 +24,6 @@ interface SelectInput {
   usage: ClaudeCodeUsage;
   /** Override "now" for deterministic tests. Defaults to Date.now(). */
   now?: number;
-}
-
-function parseResetMs(resetsAt: string | number): number {
-  if (typeof resetsAt === "string") return new Date(resetsAt).getTime();
-  return resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;
 }
 
 /**
@@ -75,10 +71,11 @@ const MIN_FRACTION_ELAPSED = 0.1;
  *   score           = utilization / max(fractionElapsed, MIN_FRACTION_ELAPSED)
  *
  * Surfaces "which limit will you hit first at current pace" rather than
- * "which has the highest %". A 25% session window 1h into its 5h means
- * a projected ~125% by reset (score 125); a 25% weekly window 1 day in
- * projects ~175% but with 6 days to course-correct (lower urgency in
- * absolute terms — that's why we use elapsed fraction, not projected %).
+ * "which has the highest %". Example: a 30% session 2h into its 5h
+ * window (40% elapsed) scores ~75; a 10% weekly bucket ~2.8d into its
+ * 7d window (40% elapsed) scores ~25 — same elapsed fraction, but the
+ * session is on track to exhaust three times faster, so it wins the
+ * indicator slot.
  *
  * Edge cases:
  *   - Exhausted (>=100): returns Infinity. A maxed bucket should always
@@ -118,4 +115,3 @@ export function selectUsageBucket(input: SelectInput): UsageBucket | null {
   );
 }
 
-export { parseResetMs };

--- a/src/ui/src/components/chat/composer/selectUsageBucket.ts
+++ b/src/ui/src/components/chat/composer/selectUsageBucket.ts
@@ -1,67 +1,114 @@
 import type { ClaudeCodeUsage, UsageLimit } from "../../../types/usage";
 
+/** Window length in milliseconds, derived from the bucket key. */
+const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
+const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+
 export interface UsageBucket {
-  /** Which limit this bucket represents — used as a label and aria description. */
+  /** Stable key for the bucket; matches the `usage` field name. */
+  key: "five_hour" | "seven_day" | "seven_day_sonnet" | "seven_day_opus";
+  /** Human-readable label — used in the indicator tooltip and the popover. */
   label: string;
-  /** 0-100. Render as a vertical bar that goes *down* as utilization rises. */
+  /** 0-100. */
   utilization: number;
   /** Absolute reset time (string or epoch s/ms — matches UsageLimit shape). */
   resetsAt: string | number;
-  /** True when utilization >= 100 — switches the indicator into countdown mode. */
+  /** Total length of the limit window in ms (5h or 7d). */
+  windowMs: number;
+  /** True when utilization >= 100. */
   exhausted: boolean;
 }
 
 interface SelectInput {
   usage: ClaudeCodeUsage;
+  /** Override "now" for deterministic tests. Defaults to Date.now(). */
+  now?: number;
+}
+
+function parseResetMs(resetsAt: string | number): number {
+  if (typeof resetsAt === "string") return new Date(resetsAt).getTime();
+  return resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;
 }
 
 /**
- * Decide which of the (up to 4) usage limits the composer indicator should
- * surface. The usage API returns:
+ * Build the full list of buckets the API returned, in stable display order
+ * (session → week-all → week-sonnet → week-opus). Used both for the
+ * compact indicator's selection logic AND for the click-to-expand popover.
+ */
+export function getAllUsageBuckets(usage: ClaudeCodeUsage): UsageBucket[] {
+  const out: UsageBucket[] = [];
+  const push = (
+    key: UsageBucket["key"],
+    limit: UsageLimit | null | undefined,
+    label: string,
+    windowMs: number,
+  ) => {
+    if (!limit) return;
+    out.push({
+      key,
+      label,
+      utilization: limit.utilization,
+      resetsAt: limit.resets_at,
+      windowMs,
+      exhausted: limit.utilization >= 100,
+    });
+  };
+  push("five_hour", usage.usage.five_hour, "Session (5h)", FIVE_HOUR_MS);
+  push("seven_day", usage.usage.seven_day, "Week (all)", SEVEN_DAY_MS);
+  push("seven_day_sonnet", usage.usage.seven_day_sonnet, "Week (Sonnet)", SEVEN_DAY_MS);
+  push("seven_day_opus", usage.usage.seven_day_opus, "Week (Opus)", SEVEN_DAY_MS);
+  return out;
+}
+
+/**
+ * Burn-rate score for a single bucket. Higher score = more urgent.
  *
- *   - five_hour          : Current rolling 5h session window
- *   - seven_day          : Weekly cap, aggregated across all models
- *   - seven_day_sonnet   : Weekly cap, Sonnet-only
- *   - seven_day_opus     : Weekly cap, Opus-only
+ * Intuition: `utilization` alone misses that a 25% session window resetting
+ * in 4h is on track to blow past 100%, while a 25% weekly window resetting
+ * in 6 days is fine. We compare against fraction-of-window-elapsed instead.
  *
- * The bar shows one bucket at a time. We pick the most-constraining
- * (max utilization) — it surfaces whichever limit the user will hit first
- * regardless of which model they switch to. Returns `null` when there's
- * nothing meaningful to display (no usage data returned by the API).
+ *   fractionElapsed = (windowMs - msUntilReset) / windowMs   ∈ (0, 1]
+ *   score           = utilization / fractionElapsed
+ *
+ * Edge cases YOU need to decide:
+ *   - fractionElapsed very small (just past reset): score blows up. Cap it?
+ *   - msUntilReset <= 0 (clock skew / stale data): treat as fully elapsed?
+ *   - Exhausted buckets (>=100): always rank above non-exhausted?
+ *
+ * Implement below — see [[selectUsageBucket]] for how it's consumed.
+ */
+function burnRateScore(bucket: UsageBucket, now: number): number {
+  // TODO(you): return a score where higher = more urgent.
+  //
+  // Available:
+  //   bucket.utilization  // 0-100
+  //   bucket.windowMs     // 5h or 7d in ms
+  //   bucket.resetsAt     // pass through parseResetMs() to get epoch ms
+  //   bucket.exhausted    // utilization >= 100
+  //
+  // Decide: how do you handle a near-zero fractionElapsed? Do you want
+  // exhausted to dominate? Should very-fresh windows (< ~5 min elapsed)
+  // fall back to plain utilization to avoid scoring noise?
+  void bucket;
+  void now;
+  return 0;
+}
+
+/**
+ * Pick the bucket the composer indicator should surface.
+ *
+ * Returns `null` when no usage data is present. Otherwise scores every
+ * candidate via [[burnRateScore]] and returns the max. On exact ties the
+ * earlier bucket wins (display order: session → week-all → sonnet → opus),
+ * which matches the order `getAllUsageBuckets` emits.
  */
 export function selectUsageBucket(input: SelectInput): UsageBucket | null {
-  const { usage } = input;
-
-  const candidates: { limit: UsageLimit; label: string }[] = [];
-  if (usage.usage.five_hour) {
-    candidates.push({ limit: usage.usage.five_hour, label: "Session (5h)" });
-  }
-  if (usage.usage.seven_day) {
-    candidates.push({ limit: usage.usage.seven_day, label: "Week (all)" });
-  }
-  if (usage.usage.seven_day_sonnet) {
-    candidates.push({
-      limit: usage.usage.seven_day_sonnet,
-      label: "Week (Sonnet)",
-    });
-  }
-  if (usage.usage.seven_day_opus) {
-    candidates.push({
-      limit: usage.usage.seven_day_opus,
-      label: "Week (Opus)",
-    });
-  }
-
-  if (candidates.length === 0) return null;
-
-  const picked = candidates.reduce((best, c) =>
-    c.limit.utilization > best.limit.utilization ? c : best,
+  const { usage, now = Date.now() } = input;
+  const buckets = getAllUsageBuckets(usage);
+  if (buckets.length === 0) return null;
+  return buckets.reduce((best, b) =>
+    burnRateScore(b, now) > burnRateScore(best, now) ? b : best,
   );
-
-  return {
-    label: picked.label,
-    utilization: picked.limit.utilization,
-    resetsAt: picked.limit.resets_at,
-    exhausted: picked.limit.utilization >= 100,
-  };
 }
+
+export { parseResetMs };

--- a/src/ui/src/components/settings/sections/ExperimentalSettings.test.tsx
+++ b/src/ui/src/components/settings/sections/ExperimentalSettings.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const appStore = vi.hoisted(() => ({
+  claudetteTerminalEnabled: false,
+  setClaudetteTerminalEnabled: vi.fn((next: boolean) => {
+    appStore.claudetteTerminalEnabled = next;
+  }),
+  usageInsightsEnabled: false,
+  setUsageInsightsEnabled: vi.fn((next: boolean) => {
+    appStore.usageInsightsEnabled = next;
+  }),
+  pluginManagementEnabled: false,
+  setPluginManagementEnabled: vi.fn((next: boolean) => {
+    appStore.pluginManagementEnabled = next;
+  }),
+  claudeRemoteControlEnabled: false,
+  setClaudeRemoteControlEnabled: vi.fn((next: boolean) => {
+    appStore.claudeRemoteControlEnabled = next;
+  }),
+  communityRegistryEnabled: false,
+  setCommunityRegistryEnabled: vi.fn((next: boolean) => {
+    appStore.communityRegistryEnabled = next;
+  }),
+}));
+
+const serviceMocks = vi.hoisted(() => ({
+  setAppSetting: vi.fn(() => Promise.resolve()),
+  openUrl: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../../stores/useAppStore", () => ({
+  useAppStore: <T,>(selector: (state: typeof appStore) => T): T =>
+    selector(appStore),
+}));
+
+vi.mock("../../../services/tauri", () => ({
+  setAppSetting: serviceMocks.setAppSetting,
+  openUrl: serviceMocks.openUrl,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// Modal renders a portal — for the test we just need its children to be
+// in the DOM so we can find/click the confirm button.
+vi.mock("../../modals/Modal", () => ({
+  Modal: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="modal">{children}</div>
+  ),
+}));
+
+import { ExperimentalSettings } from "./ExperimentalSettings";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function renderSettings(): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(<ExperimentalSettings />);
+  });
+  return container;
+}
+
+function findUsageToggle(container: HTMLElement): HTMLButtonElement {
+  const toggle = container.querySelector(
+    'button[aria-label="experimental_usage_aria"]',
+  );
+  if (!toggle) throw new Error("Usage Insights toggle not found");
+  return toggle as HTMLButtonElement;
+}
+
+function findConfirmButton(container: HTMLElement): HTMLButtonElement | null {
+  const modal = container.querySelector('[data-testid="modal"]');
+  if (!modal) return null;
+  const buttons = Array.from(modal.querySelectorAll("button"));
+  return (
+    buttons.find(
+      (b) => b.textContent?.trim() === "usage_insights_confirm_enable",
+    ) ?? null
+  );
+}
+
+beforeEach(() => {
+  appStore.usageInsightsEnabled = false;
+  appStore.setUsageInsightsEnabled.mockClear();
+  serviceMocks.setAppSetting.mockClear();
+  serviceMocks.setAppSetting.mockResolvedValue(undefined);
+});
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
+describe("ExperimentalSettings — Usage Insights consent gate", () => {
+  it("opens the confirmation modal on OFF→ON without persisting", async () => {
+    const container = await renderSettings();
+
+    await act(async () => {
+      findUsageToggle(container).click();
+    });
+
+    expect(container.querySelector('[data-testid="modal"]')).not.toBeNull();
+    expect(serviceMocks.setAppSetting).not.toHaveBeenCalled();
+    expect(appStore.setUsageInsightsEnabled).not.toHaveBeenCalled();
+  });
+
+  it("persists usage_insights_enabled=true after the user confirms", async () => {
+    const container = await renderSettings();
+
+    await act(async () => {
+      findUsageToggle(container).click();
+    });
+
+    const confirm = findConfirmButton(container);
+    expect(confirm).not.toBeNull();
+
+    await act(async () => {
+      confirm!.click();
+      await Promise.resolve();
+    });
+
+    expect(serviceMocks.setAppSetting).toHaveBeenCalledWith(
+      "usage_insights_enabled",
+      "true",
+    );
+    expect(container.querySelector('[data-testid="modal"]')).toBeNull();
+  });
+
+  it("disables without prompting when already ON", async () => {
+    appStore.usageInsightsEnabled = true;
+    const container = await renderSettings();
+
+    await act(async () => {
+      findUsageToggle(container).click();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[data-testid="modal"]')).toBeNull();
+    expect(serviceMocks.setAppSetting).toHaveBeenCalledWith(
+      "usage_insights_enabled",
+      "false",
+    );
+  });
+});

--- a/src/ui/src/components/settings/sections/ExperimentalSettings.tsx
+++ b/src/ui/src/components/settings/sections/ExperimentalSettings.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../../stores/useAppStore";
 import { setAppSetting } from "../../../services/tauri";
+import { UsageInsightsConfirmModal } from "./UsageInsightsConfirmModal";
 import styles from "../Settings.module.css";
 
 export function ExperimentalSettings() {
@@ -29,6 +30,7 @@ export function ExperimentalSettings() {
     (s) => s.setCommunityRegistryEnabled,
   );
   const [error, setError] = useState<string | null>(null);
+  const [usageConfirmOpen, setUsageConfirmOpen] = useState(false);
 
   const handleClaudetteTerminalToggle = async () => {
     const next = !claudetteTerminalEnabled;
@@ -42,8 +44,7 @@ export function ExperimentalSettings() {
     }
   };
 
-  const handleUsageToggle = async () => {
-    const next = !usageInsightsEnabled;
+  const applyUsageInsights = async (next: boolean) => {
     setUsageInsightsEnabled(next);
     try {
       setError(null);
@@ -52,6 +53,15 @@ export function ExperimentalSettings() {
       setUsageInsightsEnabled(!next);
       setError(String(e));
     }
+  };
+
+  const handleUsageToggle = async () => {
+    // Confirm only on OFF -> ON. Disabling never prompts.
+    if (!usageInsightsEnabled) {
+      setUsageConfirmOpen(true);
+      return;
+    }
+    await applyUsageInsights(false);
   };
 
   const handlePluginManagementToggle = async () => {
@@ -209,6 +219,16 @@ export function ExperimentalSettings() {
           </button>
         </div>
       </div>
+
+      {usageConfirmOpen && (
+        <UsageInsightsConfirmModal
+          onCancel={() => setUsageConfirmOpen(false)}
+          onConfirm={() => {
+            setUsageConfirmOpen(false);
+            void applyUsageInsights(true);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/ui/src/components/settings/sections/UsageInsightsConfirmModal.tsx
+++ b/src/ui/src/components/settings/sections/UsageInsightsConfirmModal.tsx
@@ -1,0 +1,65 @@
+import { useCallback, type MouseEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { Modal } from "../../modals/Modal";
+import { openUrl } from "../../../services/tauri";
+import shared from "../../modals/shared.module.css";
+
+const ANTHROPIC_TOS_URL = "https://www.anthropic.com/legal/consumer-terms";
+
+interface Props {
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function handleExternalLink(href: string) {
+  return (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    void openUrl(href).catch((err) => console.warn("openUrl failed:", err));
+  };
+}
+
+export function UsageInsightsConfirmModal({ onConfirm, onCancel }: Props) {
+  const { t } = useTranslation("settings");
+
+  const handleConfirm = useCallback(() => {
+    onConfirm();
+  }, [onConfirm]);
+
+  return (
+    <Modal title={t("usage_insights_confirm_title")} onClose={onCancel}>
+      <div className={shared.warning}>
+        <p style={{ margin: 0 }}>{t("usage_insights_confirm_how_it_works")}</p>
+      </div>
+
+      <div className={shared.warning} style={{ marginTop: 8 }}>
+        <strong>{t("usage_insights_confirm_warning_heading")}</strong>
+        <p style={{ margin: "6px 0 0 0" }}>
+          {t("usage_insights_confirm_warning_body")}{" "}
+          <a
+            href={ANTHROPIC_TOS_URL}
+            target="_blank"
+            rel="noreferrer"
+            onClick={handleExternalLink(ANTHROPIC_TOS_URL)}
+          >
+            {t("usage_insights_confirm_tos_link")}
+          </a>
+          .
+        </p>
+      </div>
+
+      <div className={shared.actions}>
+        <button className={shared.btn} onClick={onCancel} type="button">
+          {t("usage_insights_confirm_cancel")}
+        </button>
+        <button
+          className={shared.btnPrimary}
+          onClick={handleConfirm}
+          type="button"
+          autoFocus
+        >
+          {t("usage_insights_confirm_enable")}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/ui/src/components/settings/sections/UsageSettings.tsx
+++ b/src/ui/src/components/settings/sections/UsageSettings.tsx
@@ -7,6 +7,7 @@ import {
   openUsageSettings,
 } from "../../../services/tauri";
 import type { UsageLimit, ExtraUsage } from "../../../types/usage";
+import { formatResetIn } from "../../../utils/usageReset";
 import {
   cleanClaudeAuthError,
   isClaudeAuthError,
@@ -18,26 +19,6 @@ function barColor(pct: number): string {
   if (pct >= 85) return "var(--status-stopped)";
   if (pct >= 60) return "var(--context-meter-warn)";
   return "var(--accent-primary)";
-}
-
-function formatResetTime(resetsAt: string | number): string {
-  let resetMs: number;
-  if (typeof resetsAt === "string") {
-    resetMs = new Date(resetsAt).getTime();
-  } else {
-    resetMs = resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;
-  }
-  const diffSec = (resetMs - Date.now()) / 1000;
-  if (diffSec <= 0) return "resetting now";
-  const hours = Math.floor(diffSec / 3600);
-  const minutes = Math.floor((diffSec % 3600) / 60);
-  if (hours > 24) {
-    const days = Math.floor(hours / 24);
-    const remHours = hours % 24;
-    return `resets in ${days}d ${remHours}h`;
-  }
-  if (hours > 0) return `resets in ${hours}h ${minutes}m`;
-  return `resets in ${minutes}m`;
 }
 
 function formatTimestamp(ms: number): string {
@@ -81,7 +62,7 @@ function UsageBar({
           style={{ width: `${pct}%`, background: color }}
         />
       </div>
-      <div className={styles.usageReset}>{formatResetTime(limit.resets_at)}</div>
+      <div className={styles.usageReset}>{formatResetIn(limit.resets_at)}</div>
     </div>
   );
 }

--- a/src/ui/src/hooks/useUsageInsightsPoller.test.tsx
+++ b/src/ui/src/hooks/useUsageInsightsPoller.test.tsx
@@ -49,6 +49,9 @@ async function unmountAll(): Promise<void> {
   }
 }
 
+let hasFocusReturn = true;
+let originalHasFocus: typeof document.hasFocus | undefined;
+
 beforeEach(() => {
   vi.useFakeTimers();
   getClaudeCodeUsageMock.mockReset();
@@ -68,12 +71,26 @@ beforeEach(() => {
     usageInsightsEnabled: false,
     claudeCodeUsage: null,
   });
+
+  hasFocusReturn = true;
+  originalHasFocus = document.hasFocus.bind(document);
+  document.hasFocus = () => hasFocusReturn;
 });
 
 afterEach(async () => {
   await unmountAll();
   vi.useRealTimers();
+  if (originalHasFocus) {
+    document.hasFocus = originalHasFocus;
+  }
 });
+
+async function setFocus(focused: boolean) {
+  hasFocusReturn = focused;
+  await act(async () => {
+    window.dispatchEvent(new Event(focused ? "focus" : "blur"));
+  });
+}
 
 describe("useUsageInsightsPoller", () => {
   it("does not call getClaudeCodeUsage while disabled", async () => {
@@ -149,5 +166,107 @@ describe("useUsageInsightsPoller", () => {
     });
     expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
     expect(useAppStore.getState().claudeCodeUsage).toBeNull();
+  });
+
+  describe("focus-aware pausing", () => {
+    it("does not fetch while the window is blurred between polls", async () => {
+      useAppStore.setState({ usageInsightsEnabled: true });
+      await mountHook();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+
+      await setFocus(false);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15 * 60_000);
+      });
+      // Still only the initial fetch — interval should be paused.
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("fetches immediately on refocus when the interval elapsed during blur", async () => {
+      useAppStore.setState({ usageInsightsEnabled: true });
+      await mountHook();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+
+      await setFocus(false);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10 * 60_000);
+      });
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+
+      await setFocus(true);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not refetch on refocus when the interval has not yet elapsed", async () => {
+      useAppStore.setState({ usageInsightsEnabled: true });
+      await mountHook();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+
+      await setFocus(false);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      await setFocus(true);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      // Only 1 minute elapsed total — no extra fetch yet.
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("resumes the scheduled poll after refocus", async () => {
+      useAppStore.setState({ usageInsightsEnabled: true });
+      await mountHook();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+
+      // Blur for 1 min, then refocus.
+      await setFocus(false);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      await setFocus(true);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      // No catch-up fetch (interval not elapsed).
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+
+      // 4 more minutes (5 min total since initial fetch) → next poll fires.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4 * 60_000);
+      });
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not fetch on enable while the window is already blurred", async () => {
+      hasFocusReturn = false;
+      useAppStore.setState({ usageInsightsEnabled: true });
+      await mountHook();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(getClaudeCodeUsageMock).not.toHaveBeenCalled();
+
+      await setFocus(true);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/ui/src/hooks/useUsageInsightsPoller.test.tsx
+++ b/src/ui/src/hooks/useUsageInsightsPoller.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+
+const getClaudeCodeUsageMock: Mock = vi.fn();
+vi.mock("../services/tauri", () => ({
+  getClaudeCodeUsage: () => getClaudeCodeUsageMock(),
+}));
+
+import { useUsageInsightsPoller } from "./useUsageInsightsPoller";
+import { useAppStore } from "../stores/useAppStore";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function mountHook(): Promise<void> {
+  function Probe() {
+    useUsageInsightsPoller();
+    return null;
+  }
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(<Probe />);
+  });
+}
+
+async function unmountAll(): Promise<void> {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  getClaudeCodeUsageMock.mockReset();
+  getClaudeCodeUsageMock.mockResolvedValue({
+    subscription_type: "pro",
+    rate_limit_tier: "default_claude_pro",
+    fetched_at: 0,
+    usage: {
+      five_hour: null,
+      seven_day: null,
+      seven_day_sonnet: null,
+      seven_day_opus: null,
+      extra_usage: null,
+    },
+  });
+  useAppStore.setState({
+    usageInsightsEnabled: false,
+    claudeCodeUsage: null,
+  });
+});
+
+afterEach(async () => {
+  await unmountAll();
+  vi.useRealTimers();
+});
+
+describe("useUsageInsightsPoller", () => {
+  it("does not call getClaudeCodeUsage while disabled", async () => {
+    await mountHook();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15 * 60_000);
+    });
+    expect(getClaudeCodeUsageMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches once immediately when enabled and writes to the store", async () => {
+    await mountHook();
+    await act(async () => {
+      useAppStore.setState({ usageInsightsEnabled: true });
+      // Flush the queued microtask from the effect's fetchOnce().
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().claudeCodeUsage).not.toBeNull();
+  });
+
+  it("polls again after the 5-minute interval", async () => {
+    useAppStore.setState({ usageInsightsEnabled: true });
+    await mountHook();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+    });
+    expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops polling when disabled mid-flight", async () => {
+    useAppStore.setState({ usageInsightsEnabled: true });
+    await mountHook();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      useAppStore.setState({ usageInsightsEnabled: false });
+      await vi.advanceTimersByTimeAsync(15 * 60_000);
+    });
+    expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears its interval on unmount", async () => {
+    useAppStore.setState({ usageInsightsEnabled: true });
+    await mountHook();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+
+    await unmountAll();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15 * 60_000);
+    });
+    expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows fetch errors without crashing the host", async () => {
+    getClaudeCodeUsageMock.mockRejectedValueOnce(new Error("boom"));
+    useAppStore.setState({ usageInsightsEnabled: true });
+    await mountHook();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().claudeCodeUsage).toBeNull();
+  });
+});

--- a/src/ui/src/hooks/useUsageInsightsPoller.test.tsx
+++ b/src/ui/src/hooks/useUsageInsightsPoller.test.tsx
@@ -268,5 +268,52 @@ describe("useUsageInsightsPoller", () => {
       });
       expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
     });
+
+    it("does not duplicate requests when blur/refocus races the initial fetch", async () => {
+      // Make the first fetch hang so we can simulate a focus toggle while it's
+      // still in flight. Without an in-flight guard, the refocus would call
+      // start() again and fire a second concurrent request.
+      let resolveFirst!: (value: ReturnType<typeof getClaudeCodeUsageMock>) => void;
+      const firstFetch = new Promise((r) => {
+        resolveFirst = r;
+      });
+      getClaudeCodeUsageMock.mockReturnValueOnce(firstFetch);
+
+      useAppStore.setState({ usageInsightsEnabled: true });
+      await mountHook();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+
+      // Blur → focus while the first fetch is still pending.
+      await setFocus(false);
+      await setFocus(true);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      // No duplicate request started.
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+
+      // Resolve the first fetch and let the schedule settle.
+      await act(async () => {
+        resolveFirst({
+          subscription_type: "pro",
+          rate_limit_tier: "default_claude_pro",
+          fetched_at: 0,
+          usage: {
+            five_hour: null,
+            seven_day: null,
+            seven_day_sonnet: null,
+            seven_day_opus: null,
+            extra_usage: null,
+          },
+        });
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      // Still no extra calls — the refocus did not catch up because the first
+      // fetch only just resolved (lastFetchAt is now ~current time).
+      expect(getClaudeCodeUsageMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/ui/src/hooks/useUsageInsightsPoller.ts
+++ b/src/ui/src/hooks/useUsageInsightsPoller.ts
@@ -33,16 +33,28 @@ export function useUsageInsightsPoller() {
     let cancelled = false;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     let lastFetchAt = 0;
+    // Tracks the currently-running fetch. Without this, a blur/refocus while
+    // the first request is still in flight would call `start()` twice — the
+    // second call sees `timeoutId === null` and `lastFetchAt === 0` and fires
+    // a duplicate request. Returning the existing promise instead keeps us
+    // to one concurrent call against the undocumented endpoint.
+    let inFlight: Promise<void> | null = null;
 
-    const fetchOnce = async () => {
-      try {
-        const data = await getClaudeCodeUsage();
-        if (cancelled) return;
-        setUsage(data);
-        lastFetchAt = Date.now();
-      } catch {
-        // Ignore — Settings panel handles error display.
-      }
+    const fetchOnce = (): Promise<void> => {
+      if (inFlight !== null) return inFlight;
+      inFlight = (async () => {
+        try {
+          const data = await getClaudeCodeUsage();
+          if (cancelled) return;
+          setUsage(data);
+          lastFetchAt = Date.now();
+        } catch {
+          // Ignore — Settings panel handles error display.
+        } finally {
+          inFlight = null;
+        }
+      })();
+      return inFlight;
     };
 
     const stop = () => {

--- a/src/ui/src/hooks/useUsageInsightsPoller.ts
+++ b/src/ui/src/hooks/useUsageInsightsPoller.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { useAppStore } from "../stores/useAppStore";
+import { getClaudeCodeUsage } from "../services/tauri";
+
+const REFRESH_INTERVAL_MS = 5 * 60_000; // 5 minutes
+
+/**
+ * Keeps `claudeCodeUsage` fresh in the store while Usage Insights is enabled.
+ *
+ * Fetches once on enable and then every 5 minutes. The Anthropic usage API
+ * is per-account, not per-workspace, so a single global poller is correct —
+ * the indicator and Settings panel both read the same value. Failures are
+ * swallowed: the Settings panel surfaces auth/error states itself, and a
+ * transient network blip should not be loud here.
+ */
+export function useUsageInsightsPoller() {
+  const enabled = useAppStore((s) => s.usageInsightsEnabled);
+  const setUsage = useAppStore((s) => s.setClaudeCodeUsage);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+
+    const fetchOnce = async () => {
+      try {
+        const data = await getClaudeCodeUsage();
+        if (!cancelled) setUsage(data);
+      } catch {
+        // Ignore — Settings panel handles error display.
+      }
+    };
+
+    void fetchOnce();
+    const id = setInterval(fetchOnce, REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [enabled, setUsage]);
+}

--- a/src/ui/src/hooks/useUsageInsightsPoller.ts
+++ b/src/ui/src/hooks/useUsageInsightsPoller.ts
@@ -5,13 +5,19 @@ import { getClaudeCodeUsage } from "../services/tauri";
 const REFRESH_INTERVAL_MS = 5 * 60_000; // 5 minutes
 
 /**
- * Keeps `claudeCodeUsage` fresh in the store while Usage Insights is enabled.
+ * Keeps `claudeCodeUsage` fresh in the store while Usage Insights is enabled
+ * AND the app window is focused.
  *
- * Fetches once on enable and then every 5 minutes. The Anthropic usage API
- * is per-account, not per-workspace, so a single global poller is correct —
- * the indicator and Settings panel both read the same value. Failures are
- * swallowed: the Settings panel surfaces auth/error states itself, and a
- * transient network blip should not be loud here.
+ * Polling pauses whenever the user switches to another app or minimizes the
+ * window — no point spending API calls (and rate-limit budget) on usage data
+ * the user can't see. On refocus, if more than REFRESH_INTERVAL_MS has elapsed
+ * since the last successful fetch, we fetch immediately; otherwise we resume
+ * the existing schedule.
+ *
+ * The Anthropic usage API is per-account, not per-workspace, so a single
+ * global poller is correct — the indicator and Settings panel both read the
+ * same value. Failures are swallowed: the Settings panel surfaces auth/error
+ * states itself, and a transient network blip should not be loud here.
  */
 export function useUsageInsightsPoller() {
   const enabled = useAppStore((s) => s.usageInsightsEnabled);
@@ -20,21 +26,70 @@ export function useUsageInsightsPoller() {
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let lastFetchAt = 0;
 
     const fetchOnce = async () => {
       try {
         const data = await getClaudeCodeUsage();
-        if (!cancelled) setUsage(data);
+        if (cancelled) return;
+        setUsage(data);
+        lastFetchAt = Date.now();
       } catch {
         // Ignore — Settings panel handles error display.
       }
     };
 
-    void fetchOnce();
-    const id = setInterval(fetchOnce, REFRESH_INTERVAL_MS);
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const stop = () => {
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+    };
+
+    const start = () => {
+      if (intervalId !== null || timeoutId !== null) return; // already scheduled
+      const elapsed = Date.now() - lastFetchAt;
+      if (lastFetchAt === 0 || elapsed >= REFRESH_INTERVAL_MS) {
+        // First run, or the interval already elapsed during blur — catch up now.
+        void fetchOnce();
+        intervalId = setInterval(fetchOnce, REFRESH_INTERVAL_MS);
+      } else {
+        // Resume the existing schedule: fire once when the remaining time
+        // expires, then settle into the steady 5-min cadence.
+        const remaining = REFRESH_INTERVAL_MS - elapsed;
+        timeoutId = setTimeout(() => {
+          timeoutId = null;
+          if (cancelled) return;
+          void fetchOnce();
+          intervalId = setInterval(fetchOnce, REFRESH_INTERVAL_MS);
+        }, remaining);
+      }
+    };
+
+    const handleFocus = () => {
+      if (cancelled) return;
+      start();
+    };
+    const handleBlur = () => {
+      stop();
+    };
+
+    if (document.hasFocus()) start();
+    window.addEventListener("focus", handleFocus);
+    window.addEventListener("blur", handleBlur);
+
     return () => {
       cancelled = true;
-      clearInterval(id);
+      stop();
+      window.removeEventListener("focus", handleFocus);
+      window.removeEventListener("blur", handleBlur);
     };
   }, [enabled, setUsage]);
 }

--- a/src/ui/src/hooks/useUsageInsightsPoller.ts
+++ b/src/ui/src/hooks/useUsageInsightsPoller.ts
@@ -14,6 +14,11 @@ const REFRESH_INTERVAL_MS = 5 * 60_000; // 5 minutes
  * since the last successful fetch, we fetch immediately; otherwise we resume
  * the existing schedule.
  *
+ * The schedule is a self-rescheduling `setTimeout` rather than `setInterval`
+ * so the next fetch is always REFRESH_INTERVAL_MS after the previous one
+ * *resolved*, not after it was kicked off. A slow request can't pull the next
+ * one closer than intended.
+ *
  * The Anthropic usage API is per-account, not per-workspace, so a single
  * global poller is correct — the indicator and Settings panel both read the
  * same value. Failures are swallowed: the Settings panel surfaces auth/error
@@ -26,7 +31,7 @@ export function useUsageInsightsPoller() {
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
-    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
     let lastFetchAt = 0;
 
     const fetchOnce = async () => {
@@ -40,36 +45,41 @@ export function useUsageInsightsPoller() {
       }
     };
 
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
     const stop = () => {
-      if (intervalId !== null) {
-        clearInterval(intervalId);
-        intervalId = null;
-      }
       if (timeoutId !== null) {
         clearTimeout(timeoutId);
         timeoutId = null;
       }
     };
 
+    const scheduleNext = (delay: number) => {
+      if (timeoutId !== null) return;
+      timeoutId = setTimeout(async () => {
+        timeoutId = null;
+        if (cancelled) return;
+        // Defensive: if focus flipped during the wait, the blur handler has
+        // already cleared this timeout — but in the unlikely race where the
+        // callback fires before the listener, skip the fetch.
+        if (!document.hasFocus()) return;
+        await fetchOnce();
+        if (cancelled) return;
+        scheduleNext(REFRESH_INTERVAL_MS);
+      }, delay);
+    };
+
     const start = () => {
-      if (intervalId !== null || timeoutId !== null) return; // already scheduled
+      if (timeoutId !== null) return; // already scheduled
       const elapsed = Date.now() - lastFetchAt;
       if (lastFetchAt === 0 || elapsed >= REFRESH_INTERVAL_MS) {
-        // First run, or the interval already elapsed during blur — catch up now.
-        void fetchOnce();
-        intervalId = setInterval(fetchOnce, REFRESH_INTERVAL_MS);
+        // First run, or the interval already elapsed during blur — catch up
+        // now, then schedule the next fetch from the completion time.
+        void fetchOnce().then(() => {
+          if (!cancelled) scheduleNext(REFRESH_INTERVAL_MS);
+        });
       } else {
         // Resume the existing schedule: fire once when the remaining time
-        // expires, then settle into the steady 5-min cadence.
-        const remaining = REFRESH_INTERVAL_MS - elapsed;
-        timeoutId = setTimeout(() => {
-          timeoutId = null;
-          if (cancelled) return;
-          void fetchOnce();
-          intervalId = setInterval(fetchOnce, REFRESH_INTERVAL_MS);
-        }, remaining);
+        // expires, then settle into the steady 5-min cadence after that.
+        scheduleNext(REFRESH_INTERVAL_MS - elapsed);
       }
     };
 

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -425,7 +425,10 @@
   "usage_pct_used": "{{pct}}% used",
 
   "usage_insights_confirm_title": "Enable Usage Insights?",
-  "usage_insights_confirm_how_it_works": "Usage Insights asks Anthropic's usage API how much of your subscription you've used and shows that next to the context meter — a little vertical bar that drains as you approach your limit, plus a 'resets in…' countdown when you've hit it. Claudette only reads usage when this is on; it never stores or shares the numbers.",
+  "usage_insights_confirm_how_it_works": "Usage Insights asks Anthropic's usage API how much of your subscription you've used and shows that next to the context meter — a little vertical bar that fills as you approach your limit, plus a 'resets in…' countdown when you've hit it. Claudette only reads usage when this is on; it never stores or shares the numbers.",
+  "usage_indicator_tooltip_used": "{{label}}: {{pct}}% used — click for all limits",
+  "usage_indicator_tooltip_exhausted": "{{label}} exhausted — resets in {{countdown}}",
+  "usage_indicator_tooltip_exhausted_resetting": "{{label}} exhausted — resetting now",
   "usage_insights_confirm_warning_heading": "Heads up",
   "usage_insights_confirm_warning_body": "This feature talks to a Claude Code API endpoint that isn't part of Anthropic's documented public API surface. Programmatic access to it may not be permitted under Anthropic's terms — please review them before enabling.",
   "usage_insights_confirm_tos_link": "Read Anthropic's Consumer Terms",

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -424,6 +424,14 @@
   "usage_last_updated": "Last updated {{time}}",
   "usage_pct_used": "{{pct}}% used",
 
+  "usage_insights_confirm_title": "Enable Usage Insights?",
+  "usage_insights_confirm_how_it_works": "Usage Insights asks Anthropic's usage API how much of your subscription you've used and shows that next to the context meter — a little vertical bar that drains as you approach your limit, plus a 'resets in…' countdown when you've hit it. Claudette only reads usage when this is on; it never stores or shares the numbers.",
+  "usage_insights_confirm_warning_heading": "Heads up",
+  "usage_insights_confirm_warning_body": "This feature talks to a Claude Code API endpoint that isn't part of Anthropic's documented public API surface. Programmatic access to it may not be permitted under Anthropic's terms — please review them before enabling.",
+  "usage_insights_confirm_tos_link": "Read Anthropic's Consumer Terms",
+  "usage_insights_confirm_cancel": "Cancel",
+  "usage_insights_confirm_enable": "I understand — enable",
+
   "repo_not_found": "Repository not found",
   "repo_change_icon_aria": "Change repository icon",
   "repo_change_icon_title": "Change icon",

--- a/src/ui/src/utils/usageReset.test.ts
+++ b/src/ui/src/utils/usageReset.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  formatResetCountdown,
+  formatResetIn,
+  resetCountdown,
+} from "./usageReset";
+
+const NOW = Date.parse("2026-05-14T12:00:00Z");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(NOW));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("resetCountdown", () => {
+  it("parses ISO strings", () => {
+    const c = resetCountdown("2026-05-14T13:30:00Z");
+    expect(c).toEqual({ resetting: false, days: 0, hours: 1, minutes: 30 });
+  });
+
+  it("parses epoch seconds", () => {
+    const sec = Math.floor((NOW + 90 * 60_000) / 1000);
+    const c = resetCountdown(sec);
+    expect(c).toEqual({ resetting: false, days: 0, hours: 1, minutes: 30 });
+  });
+
+  it("parses epoch milliseconds", () => {
+    const c = resetCountdown(NOW + 5 * 60_000);
+    expect(c).toEqual({ resetting: false, days: 0, hours: 0, minutes: 5 });
+  });
+
+  it("flags resetting when the timestamp is in the past", () => {
+    const c = resetCountdown(NOW - 1000);
+    expect(c.resetting).toBe(true);
+  });
+
+  it("rolls over into days at >= 24h", () => {
+    const c = resetCountdown(NOW + (2 * 24 + 5) * 3600 * 1000);
+    expect(c).toEqual({ resetting: false, days: 2, hours: 5, minutes: 0 });
+  });
+});
+
+describe("formatResetCountdown", () => {
+  it("shows minutes only when under an hour", () => {
+    expect(formatResetCountdown(NOW + 30 * 60_000)).toBe("30m");
+  });
+
+  it("shows hours and minutes within a day", () => {
+    expect(formatResetCountdown(NOW + (3 * 60 + 15) * 60_000)).toBe("3h 15m");
+  });
+
+  it("shows days and hours past a day", () => {
+    expect(formatResetCountdown(NOW + (25 * 60 + 0) * 60_000)).toBe("1d 1h");
+  });
+
+  it("returns resetting placeholder when in the past", () => {
+    expect(formatResetCountdown(NOW - 1000)).toBe("resetting…");
+  });
+});
+
+describe("formatResetIn", () => {
+  it("prefixes with 'resets in'", () => {
+    expect(formatResetIn(NOW + 90 * 60_000)).toBe("resets in 1h 30m");
+  });
+
+  it("returns 'resetting now' in the past", () => {
+    expect(formatResetIn(NOW - 1000)).toBe("resetting now");
+  });
+});

--- a/src/ui/src/utils/usageReset.ts
+++ b/src/ui/src/utils/usageReset.ts
@@ -19,7 +19,7 @@ export interface ResetCountdown {
   minutes: number;
 }
 
-function parseResetMs(resetsAt: string | number): number {
+export function parseResetMs(resetsAt: string | number): number {
   if (typeof resetsAt === "string") return new Date(resetsAt).getTime();
   // API returns seconds for some buckets, milliseconds for others.
   return resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;

--- a/src/ui/src/utils/usageReset.ts
+++ b/src/ui/src/utils/usageReset.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared parser/formatter for Anthropic usage `resets_at` values.
+ *
+ * The usage API returns reset times as either an ISO string or an epoch
+ * timestamp (seconds OR milliseconds, depending on the bucket). Both the
+ * Settings panel and the composer indicator render countdowns from this
+ * value but want slightly different copy ("resets in 1h 23m" vs. "1h 23m"),
+ * so we share the parse and let callers wrap.
+ */
+
+export interface ResetCountdown {
+  /** True once the reset moment has passed (utilization should refresh). */
+  resetting: boolean;
+  /** Whole days remaining (only > 0 when total >= 24h). */
+  days: number;
+  /** Hours remaining within the current day (0-23). */
+  hours: number;
+  /** Minutes remaining within the current hour (0-59). */
+  minutes: number;
+}
+
+function parseResetMs(resetsAt: string | number): number {
+  if (typeof resetsAt === "string") return new Date(resetsAt).getTime();
+  // API returns seconds for some buckets, milliseconds for others.
+  return resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;
+}
+
+export function resetCountdown(
+  resetsAt: string | number,
+  now: number = Date.now(),
+): ResetCountdown {
+  const diffSec = (parseResetMs(resetsAt) - now) / 1000;
+  if (diffSec <= 0) {
+    return { resetting: true, days: 0, hours: 0, minutes: 0 };
+  }
+  const totalHours = Math.floor(diffSec / 3600);
+  const minutes = Math.floor((diffSec % 3600) / 60);
+  const days = Math.floor(totalHours / 24);
+  const hours = days > 0 ? totalHours % 24 : totalHours;
+  return { resetting: false, days, hours, minutes };
+}
+
+/** Compact countdown ("1h 23m" / "2d 5h" / "resetting…"). */
+export function formatResetCountdown(resetsAt: string | number): string {
+  const c = resetCountdown(resetsAt);
+  if (c.resetting) return "resetting…";
+  if (c.days > 0) return `${c.days}d ${c.hours}h`;
+  if (c.hours > 0) return `${c.hours}h ${c.minutes}m`;
+  return `${c.minutes}m`;
+}
+
+/** Settings-style "resets in X" copy ("resets in 1h 23m" / "resetting now"). */
+export function formatResetIn(resetsAt: string | number): string {
+  const c = resetCountdown(resetsAt);
+  if (c.resetting) return "resetting now";
+  if (c.days > 0) return `resets in ${c.days}d ${c.hours}h`;
+  if (c.hours > 0) return `resets in ${c.hours}h ${c.minutes}m`;
+  return `resets in ${c.minutes}m`;
+}


### PR DESCRIPTION
Closes #800.

## Summary

- Adds a compact usage indicator next to the context meter in the composer. The bar **fills** (and the readout shows percent **used**) as the most-urgent Anthropic subscription limit is consumed. Matches the framing used in the popover and Claude Code's own `/usage` panel.
- Adds a **click-to-expand popover** that lists every bucket the API returned (5h session, weekly all-models, weekly Sonnet, weekly Opus) with bars, percentages, and reset countdowns. The bucket currently driving the compact indicator is highlighted so users see *why* it was picked.
- Bucket selection is **burn-rate weighted**: surfaces whichever limit you'll hit first at current pace, not just the highest percentage. Exhausted buckets always win the slot.
- Polling pauses when the app window is **not focused** so we don't burn API budget while the user is in another app.
- Adds a confirmation modal that fires only on OFF→ON of the Usage Insights toggle. It explains in friendly language what the feature actually does, warns that the underlying endpoint isn't part of Anthropic's documented public API surface and may not be permitted under Anthropic's terms, and links to [Anthropic's Consumer Terms](https://www.anthropic.com/legal/consumer-terms). Disabling never prompts.

## Indicator + popover behavior

- Compact indicator is now a **button** that toggles the popover. Hover, focus, and `aria-expanded` are wired through CSS.
- Bar height = `utilization%` (fills as you burn through it). Color follows the existing context-meter palette (`--accent-primary` → `--context-meter-warn` at 60% → `--status-stopped` at 85%).
- Popover lists buckets in stable display order (session → week-all → sonnet → opus), highlights the active bucket, and includes a one-line footnote explaining the burn-rate ranking. Escape and click-outside dismiss.
- Hidden when Usage Insights is off, when there's no usage data yet, or when no limits are populated.
- Per-bucket reset uses `formatResetIn()` ("resets in 1h 22m" / "5d 19h") for compact display in the popover.

## Bucket selection (`selectUsageBucket.ts`)

Burn-rate score: `utilization / max(fractionElapsed, 0.1)`. Higher = more urgent.

- **Exhausted dominance** — buckets at ≥100% short-circuit to `+Infinity` so a maxed limit always owns the indicator slot.
- **Min-elapsed floor of 10%** prevents a freshly-reset window with trivial utilization from scoring absurdly high during the first ~30 min of a 5h session or first ~17h of a weekly window.
- **Stale-data guard** — if `resetsAt` is in the past (clock skew / stale fetch), the bucket is treated as a fully-consumed window (`fractionElapsed = 1`, score = utilization) rather than scoring negatively from a negative elapsed fraction.
- **Tie-breaks** by display order (`reduce` uses strict `>`), so when two buckets are both exhausted the 5h session wins — shorter reset, more actionable countdown.

Twelve unit tests cover ranking, exhausted dominance, stale data, the elapsed-fraction floor, tie-breaking, and `resetsAt` preservation. All use injected `now` for determinism.

## Focus-aware polling (`useUsageInsightsPoller.ts`)

The 5-minute global poll now respects window focus:

- **On enable**: only fetch if `document.hasFocus()`; otherwise wait for focus.
- **On blur**: clear the interval and any pending catch-up timeout — no API hits while the user is away.
- **On refocus**:
  - If `REFRESH_INTERVAL_MS` has elapsed since the last successful fetch → fetch immediately and restart the 5-min interval.
  - Otherwise schedule a one-shot catch-up at `(interval - elapsed)` so the steady 5-min cadence resumes from when the last fetch landed, not from refocus time.

Five new tests under a `focus-aware pausing` describe block exercise blurred-between-polls, refocus-with-elapsed-interval, refocus-before-interval, schedule-resume-after-refocus, and enable-while-blurred. Existing six poller tests remain green.

## Test plan

- [x] `bunx tsc -b` — clean
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `bun run lint:css` — design-token check passes
- [x] `bun run test` — **2202 passed** (12 selectUsageBucket + 11 useUsageInsightsPoller incl. 5 new focus tests)
- [x] `cargo check -p claudette` — clean
- [ ] Manual: toggle Usage Insights ON → confirm modal with ToS warning + link
- [ ] Manual: indicator appears at correct **used %** with matching bar fill
- [ ] Manual: click indicator → popover lists all returned buckets, active bucket highlighted, copy matches `/usage` panel
- [ ] Manual: alt-tab away → no new fetches in network panel; come back after >5 min → catch-up fetch fires
- [ ] Manual: toggle OFF → no prompt; indicator + popover disappear
- [ ] Manual: ToS link opens in default browser