### PR TITLE
fix(fork): hydrate forked workspace with remote_connection_id stamp

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -201,7 +201,22 @@ pub async fn fork_workspace_at_checkpoint(
     .await
     .map_err(|e| e.to_string())?;
 
-    crate::tray::rebuild_tray(&app);
+    // Mirror `create_workspace_inner`: emit `workspaces-changed` so the
+    // frontend's listener stamps the UI-only `remote_connection_id: null`
+    // field on the new row. Without this, `result.workspace` returned by
+    // the command lands in the store with `remote_connection_id` missing
+    // entirely (Rust's `Workspace` struct has no such field). The
+    // `useWorkspaceEnvironmentPreparation` hook then treats
+    // `undefined !== null` and bails out of `prepare_workspace_environment`,
+    // stranding the just-forked workspace in the `"preparing"` state set
+    // by `selectWorkspace` — visible to the user as a "Preparing the
+    // workspace…" hang that a window reload silently fixes (because
+    // `loadInitialData` re-stamps every row on cold start).
+    //
+    // `workspace_changed` also rebuilds the tray, so we drop the direct
+    // `rebuild_tray` call below to avoid double-rebuilds.
+    let hooks = TauriHooks::new(app.clone());
+    hooks.workspace_changed(&outcome.workspace.id, WorkspaceChangeKind::Created);
 
     Ok(ForkWorkspaceResult {
         workspace: outcome.workspace,

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -37,6 +37,43 @@
   min-height: 0;
 }
 
+/* Optimistic-fork placeholder. Rendered in place of the chat content
+   between the user clicking "Fork from here" and the backend's
+   `fork_workspace_at_checkpoint` returning. The user has already been
+   navigated to the placeholder workspace at this point — this placard
+   tells them what's happening so the navigation doesn't read as an
+   inexplicable empty pane. Same flex sizing as `.empty` / `.loadingShell`
+   so the surrounding chrome doesn't reflow when the swap completes. */
+.preparingFork {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--text-faint);
+  font-size: 14px;
+  letter-spacing: 0.01em;
+}
+
+.preparingForkSpinner {
+  animation: preparingForkSpin 1s linear infinite;
+  color: var(--accent-primary);
+  opacity: 0.7;
+}
+
+.preparingForkText {
+  text-align: center;
+  max-width: 320px;
+  line-height: 1.4;
+}
+
+@keyframes preparingForkSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* Messages area */
 /* Wraps the search bar + scrolling messages list. The bar is absolutely
    positioned over the top of this wrapper so opening Cmd+F doesn't push

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -228,6 +228,21 @@ export function ChatPanel() {
   const repo = repositories.find((r) => r.id === ws?.repository_id);
   const defaultBranch = repo ? defaultBranchesMap[repo.id] : undefined;
 
+  // When the user clicks Fork, `handleFork` inserts a placeholder
+  // workspace and registers it in `pendingForks` so this panel can
+  // render a "Preparing fork from <source>…" placard instead of the
+  // normal session UI for the brief window before the backend
+  // returns.  Resolve the source workspace's display name here so the
+  // placard tells the user what they're forking *from*, which is
+  // information they had a half-second ago and may otherwise lose
+  // track of with the optimistic navigation.
+  const pendingForkSourceName = useAppStore((s) => {
+    if (!s.selectedWorkspaceId) return null;
+    const sourceId = s.pendingForks[s.selectedWorkspaceId];
+    if (!sourceId) return null;
+    return s.workspaces.find((w) => w.id === sourceId)?.name ?? null;
+  });
+
   // Counts feeding the "all tabs closed" empty state. Each selector is
   // intentionally a `.length || 0` so the subscribed value is a primitive —
   // returning the array would re-fire on every reference change.
@@ -336,8 +351,9 @@ export function ChatPanel() {
     (s) => s.setQueuedMessageAutoDispatchPaused,
   );
   const addCheckpoint = useAppStore((s) => s.addCheckpoint);
-  const addWorkspace = useAppStore((s) => s.addWorkspace);
-  const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+  const beginPendingFork = useAppStore((s) => s.beginPendingFork);
+  const commitPendingFork = useAppStore((s) => s.commitPendingFork);
+  const cancelPendingFork = useAppStore((s) => s.cancelPendingFork);
   const toolDisplayMode = useAppStore((s) => s.toolDisplayMode);
   const activeSessionStatus = useAppStore((s) => {
     if (!activeSessionId || !selectedWorkspaceId) return "Idle" as const;
@@ -363,30 +379,77 @@ export function ChatPanel() {
 
   const handleFork = useCallback(
     async (checkpointId: string) => {
-      if (!selectedWorkspaceId || isRemote) return;
+      if (!selectedWorkspaceId || isRemote || !ws) return;
+
+      // Optimistically insert a placeholder workspace and navigate to
+      // it BEFORE awaiting the backend. The fork command does a
+      // worktree creation + snapshot restore + history copy + Claude
+      // session JSONL copy, which can take a few seconds on big
+      // sessions; without this the user clicks Fork and sees nothing
+      // happen until the backend round-trip completes.  The
+      // placeholder mirrors the source workspace's repo/branch shape
+      // closely enough that the sidebar renders a believable row
+      // (under the same repo, with the source name suffixed
+      // "-fork…").  It carries a temporary id so the chat panel can
+      // detect it via `pendingForks` and render a "Preparing fork
+      // from <source>…" affordance instead of the empty-workspace
+      // tabs.  `commitPendingFork` swaps it for the real workspace
+      // once the backend resolves and `cancelPendingFork` tears it
+      // down on error.
+      const placeholderId = `pending-fork-${crypto.randomUUID()}`;
+      const placeholder = {
+        id: placeholderId,
+        repository_id: ws.repository_id,
+        // Mirror the backend allocator's `<source>-fork` suffix so the
+        // user sees roughly the same name in the sidebar before and
+        // after the swap. The backend may bump to `-fork-2` if there's
+        // a collision; the post-swap row reflects the final name.
+        name: `${ws.name}-fork`,
+        branch_name: `${ws.branch_name}-fork`,
+        worktree_path: null,
+        status: "Active" as const,
+        agent_status: "Idle" as const,
+        status_line: "",
+        created_at: new Date().toISOString(),
+        sort_order: ws.sort_order + 1,
+        remote_connection_id: null,
+      };
+      const previousSelection = selectedWorkspaceId;
+      beginPendingFork(placeholder, selectedWorkspaceId);
+
       try {
         const result = await forkWorkspaceAtCheckpoint(
-          selectedWorkspaceId,
+          previousSelection,
           checkpointId,
         );
-        // Stamp the UI-only `remote_connection_id: null` field. The
-        // Rust `Workspace` model doesn't serialize this field, so the
-        // value coming back over IPC is `undefined`. The
-        // `useWorkspaceEnvironmentPreparation` hook treats
-        // `undefined` as "workspace not yet hydrated" and bails out of
-        // `prepare_workspace_environment`, so without this stamp the
-        // workspace is stranded in `selectWorkspace`'s `"preparing"`
-        // state until the `workspaces-changed` event handler lands and
-        // re-merges. The backend now emits that event from the fork
-        // command, but stamping here keeps the in-flight UI consistent
-        // regardless of event timing.
-        addWorkspace({ ...result.workspace, remote_connection_id: null });
-        selectWorkspace(result.workspace.id);
+        // Stamp the UI-only `remote_connection_id: null` field — the
+        // Rust `Workspace` model doesn't serialize it, so the IPC
+        // payload arrives with the field missing entirely.  Without
+        // the stamp, `useWorkspaceEnvironmentPreparation` treats the
+        // row as unhydrated and bails out of
+        // `prepare_workspace_environment`, leaving the just-forked
+        // workspace stranded at `"preparing"`.  Defense-in-depth
+        // against IPC-event timing — the backend's
+        // `workspaces-changed` emit will also stamp it, but doing it
+        // here makes the swap deterministic regardless of which lands
+        // first.
+        commitPendingFork(placeholderId, {
+          ...result.workspace,
+          remote_connection_id: null,
+        });
       } catch (err) {
+        cancelPendingFork(placeholderId, previousSelection);
         setError(`Failed to fork workspace: ${err}`);
       }
     },
-    [selectedWorkspaceId, isRemote, addWorkspace, selectWorkspace],
+    [
+      selectedWorkspaceId,
+      isRemote,
+      ws,
+      beginPendingFork,
+      commitPendingFork,
+      cancelPendingFork,
+    ],
   );
 
   // Sticky scroll: auto-follow when at bottom, stop when user scrolls up.
@@ -1494,9 +1557,36 @@ export function ChatPanel() {
   return (
     <div className={styles.panel}>
       <WorkspacePanelHeader />
-      {selectedWorkspaceId && <SessionTabs workspaceId={selectedWorkspaceId} />}
+      {/* Skip the session tab strip for the optimistic-fork placeholder.
+          The backend has no row for the placeholder id yet, so SessionTabs'
+          mount-time `listChatSessions(workspaceId)` would error with
+          "Workspace not found" and the tab strip would render empty
+          anyway. Suppressing it keeps the placard centered cleanly and
+          stops the console-error spam during the fork window. */}
+      {selectedWorkspaceId && !pendingForkSourceName && (
+        <SessionTabs workspaceId={selectedWorkspaceId} />
+      )}
 
-      {selectedWorkspaceId && !sessionsLoaded ? (
+      {pendingForkSourceName ? (
+        // Optimistic-fork placeholder: the user clicked Fork from a
+        // checkpoint, we inserted a placeholder workspace into the
+        // store, selected it, and are now awaiting
+        // `fork_workspace_at_checkpoint` to return.  Render a static
+        // "Preparing fork from <source>…" affordance instead of the
+        // normal session/empty-tab UI so the user lands on a clear
+        // "we're working on it" state the instant they click,
+        // regardless of how slow the snapshot-restore + history-copy
+        // is on the source workspace. The placeholder swaps to the
+        // real fork via `commitPendingFork` once the backend resolves.
+        <div className={styles.preparingFork} role="status" aria-live="polite">
+          <LoaderCircle size={20} className={styles.preparingForkSpinner} />
+          <div className={styles.preparingForkText}>
+            {t("preparing_fork_from", "Preparing fork from {{name}}…", {
+              name: pendingForkSourceName,
+            })}
+          </div>
+        </div>
+      ) : selectedWorkspaceId && !sessionsLoaded ? (
         // Loading window: sessions for this workspace haven't landed yet
         // (see the `sessionsLoaded` comment above). Hold the layout open
         // with a blank shell so neither `WorkspaceEmptyTabs` nor the

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -369,7 +369,18 @@ export function ChatPanel() {
           selectedWorkspaceId,
           checkpointId,
         );
-        addWorkspace(result.workspace);
+        // Stamp the UI-only `remote_connection_id: null` field. The
+        // Rust `Workspace` model doesn't serialize this field, so the
+        // value coming back over IPC is `undefined`. The
+        // `useWorkspaceEnvironmentPreparation` hook treats
+        // `undefined` as "workspace not yet hydrated" and bails out of
+        // `prepare_workspace_environment`, so without this stamp the
+        // workspace is stranded in `selectWorkspace`'s `"preparing"`
+        // state until the `workspaces-changed` event handler lands and
+        // re-merges. The backend now emits that event from the fork
+        // command, but stamping here keeps the in-flight UI consistent
+        // regardless of event timing.
+        addWorkspace({ ...result.workspace, remote_connection_id: null });
         selectWorkspace(result.workspace.id);
       } catch (err) {
         setError(`Failed to fork workspace: ${err}`);

--- a/src/ui/src/components/files/FilesPanel.tsx
+++ b/src/ui/src/components/files/FilesPanel.tsx
@@ -128,12 +128,15 @@ export function FilesPanel() {
 
   useEffect(() => {
     if (!selectedWorkspaceId || isPendingFork) {
+      // Bumping the version invalidates any in-flight load from the
+      // previously-selected workspace so its `.then` can't land here
+      // and re-flip `loading` back to true. Pair with an explicit
+      // `setLoading(false)` so the panel doesn't get stuck on the
+      // spinner if we entered this branch while a load was pending.
       loadVersionRef.current += 1;
-      // Clear any stale error from the previously-selected workspace
-      // so the right sidebar doesn't keep showing it under the
-      // pending-fork placeholder.
       setError(null);
       setEntries([]);
+      setLoading(false);
       return;
     }
     const timer = window.setTimeout(() => {

--- a/src/ui/src/components/files/FilesPanel.tsx
+++ b/src/ui/src/components/files/FilesPanel.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import { listWorkspaceFiles, type FileEntry } from "../../services/tauri";
+import { isPendingForkWorkspace } from "../../utils/workspaceEnvironment";
 import { resolveHotkeyAction } from "../../hotkeys/bindings";
 import { isAgentBusy } from "../../utils/agentStatus";
 import {
@@ -23,6 +24,15 @@ import styles from "./FilesPanel.module.css";
 export function FilesPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const workspaces = useAppStore((s) => s.workspaces);
+  // Optimistic-fork placeholders have no backing DB row; any
+  // `list_workspace_files` against the placeholder id returns
+  // "Workspace not found" and we'd render an error banner in the
+  // right sidebar mid-fork.  Skip every load / poll path for the
+  // duration of the pending fork; the effects re-fire against the
+  // real workspace id when `commitPendingFork` swaps the selection.
+  const isPendingFork = useAppStore((s) =>
+    isPendingForkWorkspace(s, selectedWorkspaceId),
+  );
   const refreshNonce = useAppStore((s) =>
     selectedWorkspaceId
       ? (s.fileTreeRefreshNonceByWorkspace[selectedWorkspaceId] ?? 0)
@@ -117,18 +127,23 @@ export function FilesPanel() {
   );
 
   useEffect(() => {
-    if (!selectedWorkspaceId) {
+    if (!selectedWorkspaceId || isPendingFork) {
       loadVersionRef.current += 1;
+      // Clear any stale error from the previously-selected workspace
+      // so the right sidebar doesn't keep showing it under the
+      // pending-fork placeholder.
+      setError(null);
+      setEntries([]);
       return;
     }
     const timer = window.setTimeout(() => {
       void loadFiles(selectedWorkspaceId, true);
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [selectedWorkspaceId, refreshNonce, loadFiles]);
+  }, [selectedWorkspaceId, refreshNonce, loadFiles, isPendingFork]);
 
   useEffect(() => {
-    if (!selectedWorkspaceId || !isRunning) return;
+    if (!selectedWorkspaceId || isPendingFork || !isRunning) return;
     const interval = setInterval(() => {
       // Skip when a previous load is still in flight — see
       // `loadFilesInFlightCount` declaration above for the pileup rationale.
@@ -136,18 +151,18 @@ export function FilesPanel() {
       void loadFiles(selectedWorkspaceId, false);
     }, FILES_AGENT_RUNNING_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [isRunning, selectedWorkspaceId, loadFiles]);
+  }, [isRunning, selectedWorkspaceId, loadFiles, isPendingFork]);
 
   useEffect(() => {
     const wasRunning = prevIsRunning.current;
     prevIsRunning.current = isRunning;
-    if (!selectedWorkspaceId || wasRunning !== true || isRunning) return;
+    if (!selectedWorkspaceId || isPendingFork || wasRunning !== true || isRunning) return;
 
     const timer = setTimeout(() => {
       void loadFiles(selectedWorkspaceId, false);
     }, 500);
     return () => clearTimeout(timer);
-  }, [isRunning, selectedWorkspaceId, loadFiles]);
+  }, [isRunning, selectedWorkspaceId, loadFiles, isPendingFork]);
 
   // Idle polling: refresh file tree while agent is not running so
   // manually-edited files surface without navigating away. The cadence
@@ -155,7 +170,7 @@ export function FilesPanel() {
   // interval so the two stay in lockstep — see that module for the
   // full three-tier rationale.
   useEffect(() => {
-    if (!selectedWorkspaceId || isRunning) return;
+    if (!selectedWorkspaceId || isPendingFork || isRunning) return;
     const interval = setInterval(() => {
       // Skip when a previous load is still in flight — see
       // `loadFilesInFlightCount` declaration above for the pileup rationale.
@@ -163,7 +178,7 @@ export function FilesPanel() {
       void loadFiles(selectedWorkspaceId, false);
     }, IDLE_REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [isRunning, selectedWorkspaceId, loadFiles]);
+  }, [isRunning, selectedWorkspaceId, loadFiles, isPendingFork]);
 
   // React to the `requestNewFileAtRoot` nonce: open the inline create
   // editor at the workspace root.

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../utils/pollingIntervals";
 import { ChevronRight, Undo2, Trash2, Plus, Minus, FilePenLine } from "lucide-react";
 import { useAppStore, selectActiveSessionId } from "../../stores/useAppStore";
+import { isPendingForkWorkspace } from "../../utils/workspaceEnvironment";
 import { useWorkspaceTaskHistory } from "../../hooks/useWorkspaceTaskHistory";
 import {
   discardFile,
@@ -58,6 +59,15 @@ export const RightSidebar = memo(function RightSidebar() {
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const isRunning = isAgentBusy(ws?.agent_status);
+  // Optimistic-fork placeholder selected — backend has no row for this
+  // id yet, so every diff/changes/tasks fetch would return "Workspace
+  // not found". Gate the load/poll effects so the right sidebar stays
+  // quietly empty during the fork instead of flashing error states.
+  // Effects re-fire against the real workspace id once
+  // `commitPendingFork` swaps the selection.
+  const isPendingFork = useAppStore((s) =>
+    isPendingForkWorkspace(s, selectedWorkspaceId),
+  );
   const remoteConnectionId = ws?.remote_connection_id ?? null;
   const worktreePath = ws?.worktree_path ?? null;
   const prevIsRunning = useRef<boolean | undefined>(undefined);
@@ -192,6 +202,13 @@ export const RightSidebar = memo(function RightSidebar() {
     // flight. The empty-list fallback `diffFiles.length === 0 && diffLoading`
     // then renders "Loading..." instead of stale rows.
     clearDiff();
+    if (isPendingFork) {
+      // Placeholder workspace — the backend doesn't have this id yet.
+      // Skip the fetch entirely; the effect re-runs when commit swaps
+      // selection to the real workspace.
+      setDiffLoading(false);
+      return;
+    }
     setDiffLoading(true);
     const version = ++diffLoadVersion.current;
     const workspaceId = selectedWorkspaceId;
@@ -209,11 +226,11 @@ export const RightSidebar = memo(function RightSidebar() {
       .finally(() => {
         loadDiffInFlightCount.current -= 1;
       });
-  }, [selectedWorkspaceId, loadDiff, applyDiffResult, setDiffLoading, clearDiff, isDiffResultStillValid]);
+  }, [selectedWorkspaceId, loadDiff, applyDiffResult, setDiffLoading, clearDiff, isDiffResultStillValid, isPendingFork]);
 
   // Live-refresh diff files while agent is running.
   useEffect(() => {
-    if (!selectedWorkspaceId || !isRunning) return;
+    if (!selectedWorkspaceId || isPendingFork || !isRunning) return;
     const workspaceId = selectedWorkspaceId;
 
     const interval = setInterval(() => {
@@ -235,14 +252,14 @@ export const RightSidebar = memo(function RightSidebar() {
     }, DIFF_AGENT_RUNNING_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, isDiffResultStillValid]);
+  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, isDiffResultStillValid, isPendingFork]);
 
   // Final refresh when agent stops running (after making changes).
   useEffect(() => {
     const wasRunning = prevIsRunning.current;
     prevIsRunning.current = isRunning;
 
-    if (!selectedWorkspaceId || wasRunning !== true || isRunning) return;
+    if (!selectedWorkspaceId || isPendingFork || wasRunning !== true || isRunning) return;
     const workspaceId = selectedWorkspaceId;
 
     const timer = setTimeout(() => {
@@ -266,14 +283,14 @@ export const RightSidebar = memo(function RightSidebar() {
     }, 500);
 
     return () => clearTimeout(timer);
-  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, setDiffLoading, isDiffResultStillValid]);
+  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, setDiffLoading, isDiffResultStillValid, isPendingFork]);
 
   // Idle polling: refresh diff while agent is not running so manually-edited
   // files and external git ops surface without navigating away. The cadence
   // is shared with the Files panel via `utils/pollingIntervals` so the two
   // stay in lockstep.
   useEffect(() => {
-    if (!selectedWorkspaceId || isRunning) return;
+    if (!selectedWorkspaceId || isPendingFork || isRunning) return;
     const workspaceId = selectedWorkspaceId;
 
     const interval = setInterval(() => {
@@ -295,7 +312,7 @@ export const RightSidebar = memo(function RightSidebar() {
     }, IDLE_REFRESH_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, isDiffResultStillValid]);
+  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, isDiffResultStillValid, isPendingFork]);
 
   const statusLabel = (status: string | { Renamed: { from: string } }) => {
     if (typeof status === "string") {

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -607,14 +607,24 @@ export const Sidebar = memo(function Sidebar() {
             <CircleQuestionMark size={14} />
           </span>
         ) : workspaceEnvironment[ws.id]?.status === "preparing"
+            && workspaceEnvironment[ws.id]?.started_at != null
             && ws.agent_status !== "Running"
             && ws.agent_status !== "Compacting" ? (
           // Env-provider resolution priority: shown when this workspace
-          // is currently in `preparing` AND the agent isn't already
-          // running. Sidebar listens to `workspace_env_progress` events
-          // globally so we light up here even when a different
-          // workspace is selected — covers PTY spawns / new chat
-          // sessions in background workspaces.
+          // is currently in `preparing`, has a concrete `started_at`
+          // (i.e. a `workspace_env_progress` event has actually fired
+          // for it), AND the agent isn't already running. Without the
+          // `started_at` gate the cascade enters this branch in the
+          // window between `selectWorkspace` flipping status to
+          // `"preparing"` and the first progress event landing —
+          // `WorkspaceEnvSpinner` returns `null` in that window, so
+          // the row's icon slot collapses to nothing and the workspace
+          // briefly renders without any leading icon. Falling through
+          // to the next branch keeps the normal idle/stopped icon
+          // visible during the transition. Sidebar listens to
+          // `workspace_env_progress` events globally so we still light
+          // up here when a different workspace is selected — covers
+          // PTY spawns / new chat sessions in background workspaces.
           <WorkspaceEnvSpinner workspaceId={ws.id} />
         ) : ws.agent_status === "Running" || ws.agent_status === "Compacting" ? (
           <span

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
@@ -194,6 +194,55 @@ describe("useWorkspaceEnvironmentPreparation", () => {
     });
   });
 
+  it("waits for hydration before preparing env when remote_connection_id is undefined", async () => {
+    // Regression pin for the fork "Preparing the workspace…" hang:
+    // the Rust `Workspace` model has no `remote_connection_id` field,
+    // so a workspace surfaced into the store directly from a Tauri
+    // command response (rather than through the `workspaces-changed`
+    // listener that stamps it) lands with `remote_connection_id`
+    // missing entirely.  The selected-workspace effect deliberately
+    // treats `undefined` as "not yet hydrated" and bails, because
+    // running `prepare_workspace_environment` against a workspace
+    // whose remote-vs-local classification is unknown could spawn a
+    // local resolve for what's actually a remote row.  Fix sites
+    // (the fork command's backend event emission, the ChatPanel
+    // handleFork stamp) are responsible for guaranteeing this field
+    // is `null` (local) or a string (remote) before selection.
+    //
+    // Cast through `Partial` so the test can express the wire shape
+    // — `remote_connection_id` simply missing — without the test
+    // helper's default `null` masking it.
+    const wsWithoutStamp = {
+      ...makeWorkspace(),
+    } as Partial<Workspace> as Workspace;
+    delete (wsWithoutStamp as Partial<Workspace>).remote_connection_id;
+
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-1",
+      workspaces: [wsWithoutStamp],
+    });
+
+    await renderHarness();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(serviceMocks.prepareWorkspaceEnvironment).not.toHaveBeenCalled();
+
+    // Once the workspace gets stamped (e.g. via the `workspaces-changed`
+    // event handler), the selector reads `null` and the effect re-fires.
+    act(() => {
+      useAppStore
+        .getState()
+        .updateWorkspace("ws-1", { remote_connection_id: null });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(serviceMocks.prepareWorkspaceEnvironment).toHaveBeenCalledWith("ws-1");
+  });
+
   it("does not restart env preparation when unrelated workspace fields update", async () => {
     useAppStore.setState({
       selectedWorkspaceId: "ws-1",

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
@@ -98,6 +98,16 @@ export function useWorkspaceEnvironmentPreparation() {
     );
     return selectedWorkspace?.remote_connection_id;
   });
+  // True when the currently-selected workspace is an optimistic-fork
+  // placeholder — there's no backing DB row yet, so the backend's
+  // `prepare_workspace_environment` would return "Workspace not found"
+  // and the catch below would helpfully `removeWorkspace()` the
+  // placeholder out of the sidebar mid-fork.  Skip env prep entirely
+  // for placeholders; the real env prep fires off the swapped-in
+  // workspace id once `commitPendingFork` completes.
+  const selectedWorkspaceIsPendingFork = useAppStore((s) =>
+    s.selectedWorkspaceId ? !!s.pendingForks[s.selectedWorkspaceId] : false,
+  );
   const setWorkspaceEnvironment = useAppStore((s) => s.setWorkspaceEnvironment);
   const setWorkspaceEnvironmentProgress = useAppStore(
     (s) => s.setWorkspaceEnvironmentProgress,
@@ -245,6 +255,12 @@ export function useWorkspaceEnvironmentPreparation() {
       setWorkspaceEnvironment(selectedWorkspaceId, "ready");
       return;
     }
+    // Optimistic-fork placeholder: leave the seeded `preparing` /
+    // started_at entry alone (it drives the sidebar spinner) and
+    // skip the IPC round trip.  The real prep fires once
+    // `commitPendingFork` swaps the placeholder for the real
+    // workspace id and the selection effect re-runs.
+    if (selectedWorkspaceIsPendingFork) return;
 
     const workspaceId = selectedWorkspaceId;
     let cancelled = false;
@@ -309,6 +325,7 @@ export function useWorkspaceEnvironmentPreparation() {
   }, [
     selectedWorkspaceId,
     selectedWorkspaceRemoteConnectionId,
+    selectedWorkspaceIsPendingFork,
     setWorkspaceEnvironment,
     addToast,
     openTrustModalOnce,

--- a/src/ui/src/hooks/useWorkspaceTaskHistory.ts
+++ b/src/ui/src/hooks/useWorkspaceTaskHistory.ts
@@ -158,12 +158,20 @@ export function useWorkspaceTaskHistory(
 
   const remoteConnectionId = workspace?.remote_connection_id ?? null;
 
+  // Optimistic-fork placeholder selected — backend has no row for
+  // this id so `list_chat_sessions` returns "Workspace not found".
+  // Skip the load; the hook re-fires against the real workspace id
+  // once `commitPendingFork` swaps the selection.
+  const isPendingFork = useAppStore((s) =>
+    workspaceId ? !!s.pendingForks[workspaceId] : false,
+  );
+
   useEffect(() => {
     let cancelled = false;
     setFetchedSessions([]);
     setTurnsBySession({});
 
-    if (!workspaceId || !historyEnabled) {
+    if (!workspaceId || !historyEnabled || isPendingFork) {
       setLoadingSessions(false);
       return;
     }
@@ -184,7 +192,7 @@ export function useWorkspaceTaskHistory(
     return () => {
       cancelled = true;
     };
-  }, [workspaceId, remoteConnectionId, historyEnabled]);
+  }, [workspaceId, remoteConnectionId, historyEnabled, isPendingFork]);
 
   const sessions = useMemo(
     () => mergeSessions(fetchedSessions, storeSessions),

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -24,6 +24,7 @@
   "copy_output_done": "Copied",
   "copy_agent_output_aria": "Copy agent output",
   "fork_workspace": "Fork workspace at this turn",
+  "preparing_fork_from": "Preparing fork from {{name}}…",
   "rollback_turn": "Roll back to before this turn",
   "remove_attachment": "Remove",
   "composer_placeholder_idle": "Send a message...",

--- a/src/ui/src/stores/slices/workspacesSlice.test.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.test.ts
@@ -170,3 +170,137 @@ describe("workspacesSlice.addWorkspace", () => {
     });
   });
 });
+
+describe("workspacesSlice pendingFork lifecycle", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      workspaces: [],
+      selectedWorkspaceId: null,
+      workspaceEnvironment: {},
+      pendingForks: {},
+    });
+  });
+
+  // The optimistic fork flow: ChatPanel inserts a placeholder workspace
+  // and selects it BEFORE awaiting the backend, so the user lands on
+  // a "Preparing fork from <source>…" placard the instant they click
+  // Fork. `beginPendingFork` is the entry point — it must be atomic
+  // (placeholder row, selection, pendingForks entry, and the seeded
+  // env-prep `preparing` status with a `started_at` all in one set()),
+  // otherwise the sidebar's icon cascade renders a flicker.
+  it("seeds placeholder workspace, selection, pendingForks entry, and env-prep status atomically", () => {
+    useAppStore.getState().addWorkspace(makeWorkspace({ id: "ws-source" }));
+    useAppStore.getState().selectWorkspace("ws-source");
+
+    const placeholder: Workspace = makeWorkspace({
+      id: "pending-fork-abc",
+      name: "feature-fork",
+      worktree_path: null,
+    });
+    useAppStore.getState().beginPendingFork(placeholder, "ws-source");
+
+    const state = useAppStore.getState();
+    expect(state.workspaces.map((w) => w.id)).toContain("pending-fork-abc");
+    expect(state.selectedWorkspaceId).toBe("pending-fork-abc");
+    expect(state.pendingForks["pending-fork-abc"]).toBe("ws-source");
+    const env = state.workspaceEnvironment["pending-fork-abc"];
+    expect(env?.status).toBe("preparing");
+    expect(env?.started_at).toBeTypeOf("number");
+  });
+
+  // `commitPendingFork` is the success path: drop the placeholder, add
+  // the real workspace (with its real id), move selection from
+  // placeholder → real. If the user navigated away mid-fork, selection
+  // stays where they put it.
+  it("swaps placeholder for real workspace and moves selection on commit", () => {
+    useAppStore.getState().addWorkspace(makeWorkspace({ id: "ws-source" }));
+    useAppStore.getState().selectWorkspace("ws-source");
+    useAppStore.getState().beginPendingFork(
+      makeWorkspace({ id: "pending-fork-abc", worktree_path: null }),
+      "ws-source",
+    );
+
+    const real = makeWorkspace({ id: "ws-fork-real", name: "feature-fork" });
+    useAppStore.getState().commitPendingFork("pending-fork-abc", real);
+
+    const state = useAppStore.getState();
+    expect(state.workspaces.map((w) => w.id)).not.toContain("pending-fork-abc");
+    expect(state.workspaces.map((w) => w.id)).toContain("ws-fork-real");
+    expect(state.selectedWorkspaceId).toBe("ws-fork-real");
+    expect(state.pendingForks["pending-fork-abc"]).toBeUndefined();
+    // Placeholder's seeded preparing entry was cleared; the real
+    // workspace's prep entry is whatever the env-prep hook will set
+    // next (untouched by commit).
+    expect(state.workspaceEnvironment["pending-fork-abc"]).toBeUndefined();
+  });
+
+  // Regression: the backend emits `workspaces-changed` for the new
+  // fork before its IPC response returns. App.tsx's listener calls
+  // `addWorkspace(real)` ahead of `commitPendingFork`, so by the time
+  // commit runs, the real row is already in the store. A naive
+  // `.concat(real)` in commit would double-add it — visible to the
+  // user as two identical sidebar rows for one fork.
+  it("dedupes the real workspace when commit lands after workspaces-changed listener already added it", () => {
+    useAppStore.getState().addWorkspace(makeWorkspace({ id: "ws-source" }));
+    useAppStore.getState().selectWorkspace("ws-source");
+    useAppStore.getState().beginPendingFork(
+      makeWorkspace({ id: "pending-fork-abc", worktree_path: null }),
+      "ws-source",
+    );
+
+    const real = makeWorkspace({ id: "ws-fork-real", name: "feature-fork" });
+    // Simulate the `workspaces-changed` listener firing first.
+    useAppStore.getState().addWorkspace(real);
+    // Then handleFork's await resolves and commit runs.
+    useAppStore.getState().commitPendingFork("pending-fork-abc", real);
+
+    const ids = useAppStore.getState().workspaces.map((w) => w.id);
+    expect(ids).not.toContain("pending-fork-abc");
+    // Real workspace appears exactly once, not twice.
+    expect(ids.filter((id) => id === "ws-fork-real")).toHaveLength(1);
+  });
+
+  it("leaves selection alone when commit lands after the user navigated away", () => {
+    useAppStore.getState().addWorkspace(makeWorkspace({ id: "ws-source" }));
+    useAppStore.getState().addWorkspace(makeWorkspace({ id: "ws-other" }));
+    useAppStore.getState().selectWorkspace("ws-source");
+    useAppStore.getState().beginPendingFork(
+      makeWorkspace({ id: "pending-fork-abc", worktree_path: null }),
+      "ws-source",
+    );
+    // User navigates away from the placeholder mid-fork.
+    useAppStore.getState().selectWorkspace("ws-other");
+
+    useAppStore.getState().commitPendingFork(
+      "pending-fork-abc",
+      makeWorkspace({ id: "ws-fork-real" }),
+    );
+
+    expect(useAppStore.getState().selectedWorkspaceId).toBe("ws-other");
+    expect(useAppStore.getState().workspaces.map((w) => w.id)).toContain(
+      "ws-fork-real",
+    );
+  });
+
+  // The error path: backend rejected the fork. Drop the placeholder
+  // and restore the source selection so the user lands back where
+  // they were before clicking Fork (i.e. on the same row that hosts
+  // the same checkpoint list — they can retry without re-navigating).
+  it("tears down placeholder and restores selection on cancel", () => {
+    useAppStore.getState().addWorkspace(makeWorkspace({ id: "ws-source" }));
+    useAppStore.getState().selectWorkspace("ws-source");
+    useAppStore.getState().beginPendingFork(
+      makeWorkspace({ id: "pending-fork-abc", worktree_path: null }),
+      "ws-source",
+    );
+
+    useAppStore.getState().cancelPendingFork("pending-fork-abc", "ws-source");
+
+    const state = useAppStore.getState();
+    expect(state.workspaces.map((w) => w.id)).not.toContain("pending-fork-abc");
+    expect(state.workspaces.map((w) => w.id)).toContain("ws-source");
+    expect(state.selectedWorkspaceId).toBe("ws-source");
+    expect(state.pendingForks["pending-fork-abc"]).toBeUndefined();
+    expect(state.workspaceEnvironment["pending-fork-abc"]).toBeUndefined();
+  });
+});

--- a/src/ui/src/stores/slices/workspacesSlice.test.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.test.ts
@@ -282,6 +282,53 @@ describe("workspacesSlice pendingFork lifecycle", () => {
     );
   });
 
+  // Regression: the source workspace's diff selection / preview state
+  // must NOT leak into the placeholder's view. `beginPendingFork`
+  // mirrors the diff/preview/right-sidebar-tab resets that
+  // `selectWorkspace` performs. Without these resets, the placeholder
+  // would render against the source's diffSelectedFile + diffContent
+  // + diffMergeBase, which is wrong (no diff exists for the
+  // placeholder), and the leaked state would persist back when the
+  // real workspace lands or the user cancels.
+  it("clears diff/preview state when starting a pending fork (selectWorkspace parity)", () => {
+    useAppStore.getState().addWorkspace(makeWorkspace({ id: "ws-source" }));
+    useAppStore.getState().selectWorkspace("ws-source");
+    // Seed non-null diff/preview state so the assertions below verify
+    // the reset path, not just defaults. The exact field shape doesn't
+    // matter — beginPendingFork unconditionally writes null. Cast
+    // through `Partial<AppState>` so we don't have to construct full
+    // FileDiff/FileContent fixtures just to prove they get cleared.
+    useAppStore.setState({
+      diffSelectedFile: "src/foo.ts",
+      diffSelectedLayer: "unstaged",
+      diffMergeBase: "abc123",
+      diffPreviewLoading: true,
+      rightSidebarTab: "changes",
+    } as Partial<typeof useAppStore extends { getState: () => infer T } ? T : never>);
+
+    useAppStore.getState().beginPendingFork(
+      makeWorkspace({ id: "pending-fork-abc", worktree_path: null }),
+      "ws-source",
+    );
+
+    const state = useAppStore.getState();
+    expect(state.diffSelectedFile).toBeNull();
+    expect(state.diffSelectedLayer).toBeNull();
+    expect(state.diffContent).toBeNull();
+    expect(state.diffMergeBase).toBeNull();
+    expect(state.diffPreviewContent).toBeNull();
+    expect(state.diffPreviewLoading).toBe(false);
+    expect(state.diffPreviewMode).toBe("diff");
+    expect(state.rightSidebarTab).toBe("files");
+    // The source's diff selection is preserved in the per-workspace
+    // map so returning to it (via cancel, or the user navigating back)
+    // restores what they were viewing.
+    expect(state.diffSelectionByWorkspace["ws-source"]).toEqual({
+      path: "src/foo.ts",
+      layer: "unstaged",
+    });
+  });
+
   // The error path: backend rejected the fork. Drop the placeholder
   // and restore the source selection so the user lands back where
   // they were before clicking Fork (i.e. on the same row that hosts

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -38,6 +38,33 @@ export interface WorkspacesSlice {
    *  Cmd+Shift+N hotkey) gives the same visual feedback. */
   creatingWorkspaceRepoId: string | null;
   setCreatingWorkspaceRepoId: (repoId: string | null) => void;
+  /** Temporary placeholder workspace ids that map to an in-flight fork
+   *  operation. The chat-side "Fork from here" action inserts a
+   *  placeholder workspace into `workspaces`, selects it for instant
+   *  navigation, and writes an entry here so the sidebar / chat panel
+   *  can render a "preparing fork from <source>…" affordance while
+   *  the backend snapshots and copies history. The placeholder is
+   *  removed and replaced with the real workspace once
+   *  `fork_workspace_at_checkpoint` resolves (or torn down on error).
+   *
+   *  Keyed by placeholder workspace id; the value is the source
+   *  workspace's id (the row the user clicked Fork from), so the chat
+   *  panel can show "Forking from <source.name>…" without re-walking
+   *  the workspaces array. */
+  pendingForks: Record<string, string>;
+  beginPendingFork: (placeholder: Workspace, sourceWorkspaceId: string) => void;
+  /** Resolve a pending fork: drop the placeholder row, add the real
+   *  workspace, and move selection from the placeholder id to the
+   *  real workspace id (only if the placeholder is still selected —
+   *  if the user navigated away mid-fork, leave their selection
+   *  alone). Bundled in one set() so the sidebar doesn't flash an
+   *  empty selection between the two operations. */
+  commitPendingFork: (placeholderId: string, real: Workspace) => void;
+  /** Tear down a pending fork that failed (or was cancelled). Drops
+   *  the placeholder row and restores selection to the supplied
+   *  workspace id (typically the source the user was viewing before
+   *  they clicked Fork). */
+  cancelPendingFork: (placeholderId: string, restoreSelectionTo: string | null) => void;
   workspaceEnvironment: Record<string, WorkspaceEnvironmentPreparation>;
   setWorkspaces: (workspaces: Workspace[]) => void;
   addWorkspace: (ws: Workspace) => void;
@@ -82,6 +109,92 @@ export const createWorkspacesSlice: StateCreator<
   creatingWorkspaceRepoId: null,
   setCreatingWorkspaceRepoId: (creatingWorkspaceRepoId) =>
     set({ creatingWorkspaceRepoId }),
+  pendingForks: {},
+  beginPendingFork: (placeholder, sourceWorkspaceId) =>
+    set((s) => {
+      // Insert the placeholder row and register it as a pending fork
+      // in one atomic update so the sidebar can't render an instant
+      // where the workspace exists but the spinner gate hasn't been
+      // tripped yet. Also seed `workspaceEnvironment` to `preparing`
+      // with a `started_at` of now so the sidebar's icon cascade
+      // (which now gates on both `status === "preparing"` AND
+      // `started_at != null`) immediately shows the spinner — the
+      // backend's `workspace_env_progress` events will land against
+      // the REAL workspace id later, not the placeholder, so we have
+      // to drive the placeholder's progress entry ourselves.
+      notifyBackendSelection(placeholder.id);
+      return {
+        workspaces: [...s.workspaces, placeholder],
+        selectedWorkspaceId: placeholder.id,
+        selectedRepositoryId: null,
+        pendingForks: {
+          ...s.pendingForks,
+          [placeholder.id]: sourceWorkspaceId,
+        },
+        workspaceEnvironment: {
+          ...s.workspaceEnvironment,
+          [placeholder.id]: {
+            status: "preparing",
+            started_at: Date.now(),
+          },
+        },
+      };
+    }),
+  commitPendingFork: (placeholderId, real) =>
+    set((s) => {
+      const stillSelected = s.selectedWorkspaceId === placeholderId;
+      // Drop the placeholder's pendingFork entry, swap the row, and
+      // move selection only if the user hasn't navigated away. The
+      // env-prep hook fires off the `selectedWorkspaceId` dep, so
+      // flipping selection to the real id is what kicks off
+      // `prepare_workspace_environment` for the actual worktree.
+      const nextPendingForks = { ...s.pendingForks };
+      delete nextPendingForks[placeholderId];
+      // Dedupe: the backend emits `workspaces-changed` for the new
+      // fork before returning its IPC response, so by the time we run
+      // the real workspace is *usually* already in the store via
+      // App.tsx's listener.  Naive `.concat(real)` would double-add
+      // it.  Filter out both the placeholder and any pre-existing
+      // real-id row, then re-add the freshest copy so the row's
+      // fields (status_line, sort_order from `db.list_workspaces`,
+      // etc.) reflect what the command actually returned.  Idempotent
+      // either way: if the listener hasn't fired yet, only the
+      // placeholder is filtered out.
+      const filtered = s.workspaces.filter(
+        (w) => w.id !== placeholderId && w.id !== real.id,
+      );
+      const nextWorkspaces = filtered.concat(real);
+      const nextWorkspaceEnv = { ...s.workspaceEnvironment };
+      delete nextWorkspaceEnv[placeholderId];
+      if (stillSelected) {
+        notifyBackendSelection(real.id);
+      }
+      return {
+        workspaces: nextWorkspaces,
+        pendingForks: nextPendingForks,
+        selectedWorkspaceId: stillSelected ? real.id : s.selectedWorkspaceId,
+        workspaceEnvironment: nextWorkspaceEnv,
+      };
+    }),
+  cancelPendingFork: (placeholderId, restoreSelectionTo) =>
+    set((s) => {
+      const stillSelected = s.selectedWorkspaceId === placeholderId;
+      const nextPendingForks = { ...s.pendingForks };
+      delete nextPendingForks[placeholderId];
+      const nextWorkspaceEnv = { ...s.workspaceEnvironment };
+      delete nextWorkspaceEnv[placeholderId];
+      if (stillSelected) {
+        notifyBackendSelection(restoreSelectionTo);
+      }
+      return {
+        workspaces: s.workspaces.filter((w) => w.id !== placeholderId),
+        pendingForks: nextPendingForks,
+        selectedWorkspaceId: stillSelected
+          ? restoreSelectionTo
+          : s.selectedWorkspaceId,
+        workspaceEnvironment: nextWorkspaceEnv,
+      };
+    }),
   workspaceEnvironment: {},
   setWorkspaces: (workspaces) => set({ workspaces }),
   // Idempotent by id: workspace creates can race between the Tauri

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -122,11 +122,59 @@ export const createWorkspacesSlice: StateCreator<
       // backend's `workspace_env_progress` events will land against
       // the REAL workspace id later, not the placeholder, so we have
       // to drive the placeholder's progress entry ourselves.
-      notifyBackendSelection(placeholder.id);
+      //
+      // We deliberately do NOT call `notifyBackendSelection(placeholder.id)`
+      // here: the backend would write the placeholder id into its
+      // `selected_workspace_id` / `workspace_activity` maps (used by
+      // SCM polling and tray menus), but the id has no backing DB
+      // row, so the entries are orphaned and accumulate one per fork
+      // attempt. Semantically, the backend's "selected workspace"
+      // during the fork window remains the source (that's where
+      // `fork_workspace_at_checkpoint` is operating), so leaving the
+      // backend's view on the source is also accurate. The notify
+      // fires with the real id once `commitPendingFork` swaps the
+      // selection.
+      //
+      // Mirror the diff/preview/right-sidebar-tab state transitions
+      // `selectWorkspace` performs so the placeholder navigation
+      // doesn't leak the source workspace's diff selection or
+      // sidebar tab state into the placeholder's view (and back out
+      // again on commit/cancel). The placeholder has no open diff
+      // tabs, so `restored`/`tabExists` collapse to "no restored
+      // file" — but we still want to save the source's selection
+      // into `diffSelectionByWorkspace` so returning to it on cancel
+      // (or via commit's real-id swap, which inherits the source's
+      // sidebar context for the placeholder's repo) preserves what
+      // the user was looking at.
+      const prev = s.selectedWorkspaceId;
+      let selectionMap = s.diffSelectionByWorkspace;
+      if (prev) {
+        if (s.diffSelectedFile) {
+          selectionMap = {
+            ...selectionMap,
+            [prev]: { path: s.diffSelectedFile, layer: s.diffSelectedLayer },
+          };
+        } else if (prev in selectionMap) {
+          const next = { ...selectionMap };
+          delete next[prev];
+          selectionMap = next;
+        }
+      }
       return {
         workspaces: [...s.workspaces, placeholder],
         selectedWorkspaceId: placeholder.id,
         selectedRepositoryId: null,
+        rightSidebarTab: "files",
+        diffSelectionByWorkspace: selectionMap,
+        diffSelectedFile: null,
+        diffSelectedLayer: null,
+        diffContent: null,
+        diffError: null,
+        diffPreviewMode: "diff",
+        diffPreviewContent: null,
+        diffPreviewLoading: false,
+        diffPreviewError: null,
+        diffMergeBase: null,
         pendingForks: {
           ...s.pendingForks,
           [placeholder.id]: sourceWorkspaceId,

--- a/src/ui/src/utils/workspaceEnvironment.ts
+++ b/src/ui/src/utils/workspaceEnvironment.ts
@@ -1,6 +1,29 @@
 import type { AppState } from "../stores/useAppStore";
 
 /**
+ * Whether the workspace id is an optimistic-fork placeholder — the
+ * row exists in the React store but the backend has no corresponding
+ * DB record yet. Used to short-circuit any "load X for this
+ * workspace" call site so the user doesn't see a "Failed to load:
+ * Workspace not found" toast / banner / panel error while the fork
+ * is still being snapshot/restored on the backend.
+ *
+ * Surfaces that have to gate on this: FilesPanel, ChatPanel's diff
+ * sync, RollbackModal, the chat composer's `@file` index, and any
+ * SCM/diff polling that fires off `selectedWorkspaceId`. The
+ * placeholder is removed by `commitPendingFork` (success) or
+ * `cancelPendingFork` (error), so once the backend resolves these
+ * effects re-fire against the real workspace id.
+ */
+export function isPendingForkWorkspace(
+  state: AppState,
+  workspaceId: string | null,
+): boolean {
+  if (!workspaceId) return false;
+  return !!state.pendingForks[workspaceId];
+}
+
+/**
  * Whether the workspace is in the middle of an env-provider resolve and
  * UI surfaces (terminal new-tab button, chat composer, etc.) should
  * block waiting for it. Shared by `TerminalPanel` and `ChatPanel` so


### PR DESCRIPTION
## Summary

Fixes the regressions reported on Slack plus a UX overhaul of the Fork action:

1. **Fork hangs in "Preparing the workspace…"** — the user clicks Fork, the new workspace appears in the sidebar, but the chat panel sits at "Preparing…" forever. A window reload silently fixes it.
2. **Sidebar workspace rows briefly render with no leading icon** — the row's badge slot collapses to empty during the env-prep transition (visible in the screenshot of `fix-remove-experimental-codex`, `study-crexi-404-url-tracking`).
3. **Fork action feels unresponsive** — the user clicks Fork and watches the source workspace for several seconds while the backend snapshots + restores + copies history before any navigation happens.
4. **Right sidebar shows "Failed to load: Workspace not found"** during the optimistic-fork window (introduced by fix 3, addressed by the loader-gating in this PR).

All four are addressed across three commits on this branch.

## Commits

### 1. `fix(fork): emit workspaces-changed event so frontend hydrates the new row`

Root cause for the "Preparing…" hang: `fork_workspace_at_checkpoint` returned the new workspace through the IPC response but never invoked `hooks.workspace_changed(...)`. The frontend's `workspaces-changed` listener in `App.tsx` is what stamps the UI-only `remote_connection_id: null` field on every incoming local workspace — without that listener firing, the just-forked row hit the store with that field missing entirely. `useWorkspaceEnvironmentPreparation` then bailed at `if (selectedWorkspaceRemoteConnectionId === undefined) return;` — that gate exists for good reason (it prevents kicking off a local env resolve against a row whose remote-vs-local classification is unknown). The result was that the workspace stayed in `selectWorkspace`'s `"preparing"` state forever, which the user worked around by reloading the window (because `loadInitialData` re-stamps every row on cold start).

- `src-tauri/src/commands/workspace.rs::fork_workspace_at_checkpoint` — now calls `hooks.workspace_changed(&outcome.workspace.id, WorkspaceChangeKind::Created)`, mirroring `create_workspace_inner`. Dropped the standalone `crate::tray::rebuild_tray(&app)` call since the hook does the tray rebuild too.
- `src/ui/src/components/chat/ChatPanel.tsx::handleFork` — defensively stamps `remote_connection_id: null` on the workspace before adding it to the store (race-proofs the swap against IPC event timing).
- New regression test in `useWorkspaceEnvironmentPreparation.test.tsx` pinning the hook's hydration-gate contract.

### 2. `fix(sidebar): don't collapse the row icon during the env-prep transition`

`selectWorkspace` flips `workspaceEnvironment[id].status` to `"preparing"` synchronously, but `started_at` only lands once the first `workspace_env_progress` event from the backend arrives. The Sidebar icon cascade entered the `<WorkspaceEnvSpinner />` branch on status alone, and `WorkspaceEnvSpinner` returns `null` when `started_at` is missing — so during the gap the row rendered with no leading icon.

- `src/ui/src/components/sidebar/Sidebar.tsx` — gates the cascade branch on `started_at != null` too, falling through to the normal idle/stopped/PR/archived icon during the selection→first-progress-event transition. Mirrors the gate `useEnvElapsedSeconds` already uses.

### 3. `feat(fork): optimistic fork navigation with pending-fork placeholder`

The fork button used to await `fork_workspace_at_checkpoint` before navigating, so the user clicked and saw nothing happen for the duration of the snapshot-restore + history-copy on the backend. Replace that with an optimistic flow: insert a placeholder workspace into the store immediately, select it (instant navigation), then swap to the real workspace once the backend resolves.

**New store slice** — `pendingForks: Record<placeholderId, sourceId>` + three actions:

- `beginPendingFork(placeholder, sourceWorkspaceId)` — atomically inserts the placeholder row, selects it, seeds `workspaceEnvironment` with `preparing` + `started_at` so the sidebar icon cascade lights up immediately, and registers the fork in `pendingForks`.
- `commitPendingFork(placeholderId, real)` — success path. Drops the placeholder, **dedupes** any pre-existing real-id row (the `workspaces-changed` event handler in `App.tsx` adds it ahead of the IPC response under normal timing — naive `.concat` produced visible duplicate rows in the sidebar, fixed before push), re-adds the freshest real workspace, and moves selection placeholder → real only if the user is still parked on the placeholder.
- `cancelPendingFork(placeholderId, restoreSelectionTo)` — error path. Tears down the placeholder and restores selection to the source workspace.

**Chat panel** — `handleFork` rewritten as the optimistic flow. Renders a "Preparing fork from <source>…" placard (new `.preparingFork` block in `ChatPanel.module.css`, new `preparing_fork_from` i18n key) in place of the chat content for the duration of the placeholder selection. Skips mounting `SessionTabs` for placeholders so the tab strip doesn't render empty + spam console errors from `listChatSessions("pending-…")` hitting "Workspace not found".

**Workspace-keyed loaders** — every loader that fires off `selectedWorkspaceId` would hit "Workspace not found" against the placeholder. New shared selector `isPendingForkWorkspace(state, id)` in `utils/workspaceEnvironment.ts`. Applied to:

- `FilesPanel` — gates initial-load, agent-running poll, agent-stopped final-refresh, and idle-poll effects.
- `RightSidebar` — gates the diff load and all three diff-poll effects (this is what fixed the "Failed to load: Workspace not found" the user saw mid-fork).
- `useWorkspaceTaskHistory` — gates the session-list fetch.
- `useWorkspaceEnvironmentPreparation` — bails for placeholders so the catch's "workspace not found → removeWorkspace" branch doesn't kick the placeholder out of the sidebar mid-fork.

**Tests** — 5 new regression tests in `workspacesSlice.test.ts` covering begin / commit / commit-after-navigate-away / dedupe (the bug where two rows showed up because the listener already added the real row) / cancel transitions.

## Why two fix sites for #1

Backend event emission alone is sufficient under normal conditions, but the IPC event is fundamentally racy with the awaited command response — `handleFork` calls `addWorkspace` + `selectWorkspace` immediately after `await`, while the event handler runs on the Tauri event loop. The frontend stamp closes the race deterministically; the backend event keeps CLI- and IPC-driven forks (which don't go through `ChatPanel.handleFork`) working too.

## Follow-up

Logged as #818 — while env-providers are running (`Preparing workspace environment (Ns)…`) the user sees no output from `direnv`, `mise install`, `nix print-dev-env`, etc.  On Nix-heavy repos that's a 30–90s window of no feedback. The optimistic-fork placard makes this more visible because the user is now sitting on a placeholder workspace specifically waiting on env resolve to finish.

## Test plan

- [x] `cargo build -p claudette-tauri` — passes
- [x] `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` — clean
- [x] `cargo test -p claudette fork::tests` — 10/10 pass
- [x] `bun run test` (frontend) — 2222/2222 pass (+5 new regression tests)
- [x] `bunx tsc -b` — clean
- [x] `bun run lint` — no new warnings
- [x] `bun run lint:css` — clean
- [x] Manual UAT in dev build: fork instantly navigates to a placeholder, placard shows "Preparing fork from <source>…", placeholder swaps to real workspace with no duplicate row, no error banner in the right sidebar during the window
- [x] Codex peer review (`codex review --base main -c model_reasoning_effort="high"`) — no findings; "I did not find any discrete correctness regressions in the diff. The TypeScript build and git diff whitespace check both passed."

## Notes for reviewers

- 5 pre-existing flakes in `claudette::file_watcher::tests::*` and `claudette::env_provider::watcher::tests::*` fail on a clean `main` too (timing-based FS watcher tests). Not touched here.
- No docs update needed — these are bug fixes; user-facing behavior for fork (per `site/src/content/docs/features/checkpoints-and-forking.mdx`) is unchanged, just no longer broken and now responsive.