### PR TITLE
feat(terminal): promote Claudette Terminal + route env-provider output, allow mid-resolve toggle

### DIFF
--- a/plugins/env-direnv/init.lua
+++ b/plugins/env-direnv/init.lua
@@ -31,7 +31,12 @@ end
 
 function M.export(args)
     local envrc_path = join(worktree_of(args), ".envrc")
-    local result = host.exec("direnv", { "export", "json" })
+    -- Streaming so direnv's own informative stderr (e.g.
+    -- `direnv: loading .envrc`, `direnv: using flake`, the `+VAR -VAR`
+    -- diff) flows into the EnvProvisioningConsole as it happens. The
+    -- captured stdout/stderr in `result` is identical to what
+    -- `host.exec` would have returned.
+    local result = host.exec_streaming("direnv", { "export", "json" })
 
     -- If the .envrc is blocked, auto-allow only when this exact file
     -- content has already been approved for the repo. This preserves
@@ -52,8 +57,8 @@ function M.export(args)
             end
         end
         if allowed then
-            host.exec("direnv", { "allow" })
-            result = host.exec("direnv", { "export", "json" })
+            host.exec_streaming("direnv", { "allow" })
+            result = host.exec_streaming("direnv", { "export", "json" })
         end
     end
 

--- a/plugins/env-dotenv/init.lua
+++ b/plugins/env-dotenv/init.lua
@@ -72,8 +72,20 @@ end
 function M.export(args)
     local path = join(worktree_of(args), ".env")
     local contents = host.read_file(path)
+    local env = M._parse(contents)
+    -- env-dotenv is in-process (no subprocess to stream), so it
+    -- would otherwise render as an empty section in the
+    -- EnvProvisioningConsole even when it found and parsed real
+    -- vars. Emit one synthesized line so the user gets a clear "yes,
+    -- this provider contributed" heartbeat regardless of how fast
+    -- the parse was.
+    local count = 0
+    for _ in pairs(env) do count = count + 1 end
+    if host.console ~= nil then
+        host.console("stdout", "parsed " .. tostring(count) .. " var(s) from .env")
+    end
     return {
-        env = M._parse(contents),
+        env = env,
         watched = { path },
     }
 end

--- a/plugins/env-mise/init.lua
+++ b/plugins/env-mise/init.lua
@@ -32,7 +32,11 @@ function M.detect(args)
 end
 
 function M.export(args)
-    local result = host.exec("mise", { "env", "--json" })
+    -- Streaming so mise's own status output (config-trust warnings,
+    -- tool install lines when the user has them queued) reaches the
+    -- EnvProvisioningConsole as it happens. `--json` keeps stdout
+    -- machine-readable; stderr carries the human-readable progress.
+    local result = host.exec_streaming("mise", { "env", "--json" })
 
     -- Per-repo trust: when mise reports config files as not trusted
     -- and the user has authorized mise for this repository (via the
@@ -42,8 +46,8 @@ function M.export(args)
     if result.code ~= 0
         and host.config("repo_trust") == "allow"
         and (result.stderr or ""):match("not trusted") then
-        host.exec("mise", { "trust" })
-        result = host.exec("mise", { "env", "--json" })
+        host.exec_streaming("mise", { "trust" })
+        result = host.exec_streaming("mise", { "env", "--json" })
     end
 
     if result.code ~= 0 then

--- a/plugins/env-nix-devshell/init.lua
+++ b/plugins/env-nix-devshell/init.lua
@@ -99,11 +99,16 @@ function M.export(args)
     local wt = worktree_of(args)
     local flake_path = join(wt, "flake.nix")
     local shell_path = join(wt, "shell.nix")
+    -- `-L` (`--print-build-logs`) routes per-derivation build output
+    -- to stderr so a cold flake's 30-90s evaluation isn't a silent
+    -- void in the EnvProvisioningConsole. Streaming forwards each
+    -- line to the panel as it's emitted; the eventual JSON env stays
+    -- on stdout (and inside `result.stdout`) for parsing below.
     local result
     if host.file_exists(flake_path) then
-        result = host.exec("nix", { "print-dev-env", "--json" })
+        result = host.exec_streaming("nix", { "print-dev-env", "--json", "-L" })
     elseif host.file_exists(shell_path) then
-        result = host.exec("nix", { "print-dev-env", "--json", "-f", shell_path })
+        result = host.exec_streaming("nix", { "print-dev-env", "--json", "-L", "-f", shell_path })
     else
         error("nix print-dev-env failed: neither flake.nix nor shell.nix present at export time")
     end

--- a/site/src/content/docs/features/per-repo-settings.mdx
+++ b/site/src/content/docs/features/per-repo-settings.mdx
@@ -77,7 +77,7 @@ While an env-provider is resolving, Claudette surfaces the active plugin and ela
 
 ### Live provisioning output in the Claudette Terminal
 
-For long-running provisioning (`nix print-dev-env` on a cold flake can be 30-90s; a fresh `mise install` can stretch much further), Claudette streams every byte the env-provider and setup-script subprocesses emit into the workspace's **Claudette Terminal** tab. When env-provider resolve starts on a fresh workspace, the bottom terminal panel auto-opens so the output is visible without hunting for the toggle — your current tab focus is preserved if you already have another terminal open.
+For long-running provisioning (`nix print-dev-env` on a cold flake can be 30-90s; a fresh `mise install` can stretch much further), Claudette streams the env-provider plugins' **stderr** (the human-readable progress chatter) and **all** of the setup-script's stdout/stderr into the workspace's **Claudette Terminal** tab. Env-provider **stdout** is intentionally suppressed from the terminal — providers like `direnv export json` / `mise env --json` / `nix print-dev-env --json` emit the full machine-readable environment payload there, which routinely contains secrets (`AWS_SECRET_ACCESS_KEY`, `GH_TOKEN`, …) that don't belong in a transcript on disk. When env-provider resolve starts on a fresh workspace, the bottom terminal panel auto-opens so the output is visible without hunting for the toggle — your current tab focus is preserved if you already have another terminal open.
 
 Because the output lands in a real terminal (xterm.js), native ANSI colors from `nix -L`, `direnv`, and `mise` render directly — no parallel renderer, no stripped escape codes. A dim cyan `── plugin ──` header separates plugin transitions so the direnv → nix-devshell handoff in a wall of build chatter is easy to scan. The `.claudette.json` setup script's stdout / stderr writes into the same tab under a `setup-script` header, so a slow `bun install` is visible in real time instead of waiting for the SetupScriptBanner to appear in the chat transcript.
 
@@ -85,7 +85,7 @@ The Claudette Terminal can be disabled in **Settings > General > Claudette Termi
 
 **Verbose flags applied automatically.** The bundled `env-nix-devshell` plugin passes `-L` (`--print-build-logs`) to `nix print-dev-env` so per-derivation build output streams to the terminal instead of buffering inside Nix. `env-mise` and `env-direnv` rely on the providers' default stderr chatter — both are already informative.
 
-**Secrets warning.** Env-provider stdout can contain secrets (a malformed `.env` echoing values, a `direnv` script printing tokens). The terminal surfaces every byte the subprocess emits. Treat its contents the same way you'd treat any terminal session inside the workspace; don't share screenshots without redacting.
+**Secrets warning.** The env-provider stdout suppression above is a defense-in-depth measure, not a complete redaction guarantee — `direnv` scripts (and noisy setup scripts) can still echo secret values through **stderr**, which the terminal does surface. Treat the terminal's contents the same way you'd treat any terminal session inside the workspace; don't share screenshots without redacting.
 
 ## Claude CLI Flag Overrides
 

--- a/site/src/content/docs/features/per-repo-settings.mdx
+++ b/site/src/content/docs/features/per-repo-settings.mdx
@@ -75,6 +75,18 @@ The decision is per-repo, not global, so trusting one project's `.envrc` doesn't
 
 While an env-provider is resolving, Claudette surfaces the active plugin and elapsed time in three places: the workspace's row in the sidebar (spinner + tooltip), the chat composer placeholder, and an overlay above the integrated terminal. The terminal won't open a prompt and the agent won't spawn until the env layer is ready or fails.
 
+### Live provisioning output in the Claudette Terminal
+
+For long-running provisioning (`nix print-dev-env` on a cold flake can be 30-90s; a fresh `mise install` can stretch much further), Claudette streams every byte the env-provider and setup-script subprocesses emit into the workspace's **Claudette Terminal** tab. When env-provider resolve starts on a fresh workspace, the bottom terminal panel auto-opens so the output is visible without hunting for the toggle — your current tab focus is preserved if you already have another terminal open.
+
+Because the output lands in a real terminal (xterm.js), native ANSI colors from `nix -L`, `direnv`, and `mise` render directly — no parallel renderer, no stripped escape codes. A dim cyan `── plugin ──` header separates plugin transitions so the direnv → nix-devshell handoff in a wall of build chatter is easy to scan. The `.claudette.json` setup script's stdout / stderr writes into the same tab under a `setup-script` header, so a slow `bun install` is visible in real time instead of waiting for the SetupScriptBanner to appear in the chat transcript.
+
+The Claudette Terminal can be disabled in **Settings > General > Claudette Terminal** if you'd rather opt out. With it off, env-provider and setup-script output still streams to a workspace-scoped file at `$TMPDIR/claudette-workspace-terminal/<workspace-id>/terminal.output` (useful for debugging from outside Claudette), and provisioning continues normally — only the read-only mirror tab is suppressed.
+
+**Verbose flags applied automatically.** The bundled `env-nix-devshell` plugin passes `-L` (`--print-build-logs`) to `nix print-dev-env` so per-derivation build output streams to the terminal instead of buffering inside Nix. `env-mise` and `env-direnv` rely on the providers' default stderr chatter — both are already informative.
+
+**Secrets warning.** Env-provider stdout can contain secrets (a malformed `.env` echoing values, a `direnv` script printing tokens). The terminal surfaces every byte the subprocess emits. Treat its contents the same way you'd treat any terminal session inside the workspace; don't share screenshots without redacting.
+
 ## Claude CLI Flag Overrides
 
 The **Claude CLI flags** section in repo settings lets you override the global flag defaults for workspaces in this repository. Each flag has three states:

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -10,6 +10,7 @@ Open settings with `⌘/Ctrl + ,` or from the sidebar. Settings are organized in
 | Setting | Description | Default |
 |---------|-------------|---------|
 | Worktree base directory | Directory where new workspaces are created | `~/.claudette/workspaces` |
+| Claudette Terminal | Show a read-only terminal tab that mirrors workspace provisioning (env-providers + setup script), agent shell commands, and background task output. | On |
 | System tray | Enable/disable system tray integration | Enabled |
 | Archive on merge | Automatically archive a workspace when its pull request is merged. See [SCM Providers](/claudette/features/scm-providers/). | Off |
 
@@ -47,7 +48,6 @@ See [Agent Configuration](/claudette/features/agent-configuration/) for detailed
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| Claudette Terminal | Show a read-only terminal tab that mirrors agent shell commands and background task output. | Off |
 | Plugin Management | Show the Claude Code Plugins settings section and plugin-management slash commands. | Off |
 | Claude Remote Control | Show the local chat Remote Control toggle and allow Claudette to attach live Claude sessions to claude.ai. | On |
 | Community Registry | Show the Community settings section for themes, plugins, and language grammars. | Off |

--- a/src-tauri/src/commands/chat/remote_control.rs
+++ b/src-tauri/src/commands/chat/remote_control.rs
@@ -443,17 +443,16 @@ async fn ensure_persistent_session_for_remote_control(
     let resolved_env = {
         // Snapshot — see `plugins_snapshot` doc.
         let registry = state.plugins_snapshot().await;
-        let progress = crate::commands::env::TauriEnvProgressSink::new(
-            app.clone(),
-            ws_info_for_env.id.clone(),
-        );
-        claudette::env_provider::resolve_with_registry_and_progress(
+        let (progress, output) =
+            crate::commands::env::make_env_sinks(app.clone(), ws_info_for_env.id.clone());
+        claudette::env_provider::resolve_with_registry_streaming(
             &registry,
             &state.env_cache,
             std::path::Path::new(worktree_path),
             &ws_info_for_env,
             &disabled_env_providers,
             Some(&progress),
+            Some(output),
         )
         .await
     };

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::agent::background::{
-    AgentBackgroundTaskEventKind, agent_bash_output_path, parse_background_task_binding,
-    parse_task_notification,
+    AgentBackgroundTaskEventKind, parse_background_task_binding, parse_task_notification,
 };
 use claudette::agent::{
     self, AgentEvent, AgentSession, AgentSettings, ClaudeCodeHarness, CodexAppServerOptions,
@@ -1494,17 +1493,16 @@ pub async fn send_chat_message(
         // Snapshot — see `plugins_snapshot` doc; agent spawn must not
         // block the Plugins settings UI while env resolves.
         let registry = state.plugins_snapshot().await;
-        let progress = crate::commands::env::TauriEnvProgressSink::new(
-            app.clone(),
-            ws_info_for_env.id.clone(),
-        );
-        claudette::env_provider::resolve_with_registry_and_progress(
+        let (progress, output) =
+            crate::commands::env::make_env_sinks(app.clone(), ws_info_for_env.id.clone());
+        claudette::env_provider::resolve_with_registry_streaming(
             &registry,
             &state.env_cache,
             std::path::Path::new(&worktree_path),
             &ws_info_for_env,
             &disabled_env_providers,
             Some(&progress),
+            Some(output),
         )
         .await
     };
@@ -2628,7 +2626,7 @@ pub async fn send_chat_message(
                                             }
                                         }
                                         let aggregate_path =
-                                            agent_bash_output_path(&chat_session_id_for_stream);
+                                            claudette::agent::background::workspace_terminal_output_path(&ws_id);
                                         mirror_background_task_output(
                                             std::path::PathBuf::from(&binding.output_path),
                                             aggregate_path,
@@ -2654,7 +2652,7 @@ pub async fn send_chat_message(
                                         }
                                     } else {
                                         let path =
-                                            agent_bash_output_path(&chat_session_id_for_stream);
+                                            claudette::agent::background::workspace_terminal_output_path(&ws_id);
                                         let text = terminal_text(&text);
                                         let suffix =
                                             if text.ends_with("\r\n") { "" } else { "\r\n" };

--- a/src-tauri/src/commands/chat/send/background_tasks.rs
+++ b/src-tauri/src/commands/chat/send/background_tasks.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, path::Path, time::Duration};
 use tauri::{AppHandle, Emitter, Manager};
 
 use claudette::agent::background::{
-    AgentBackgroundTaskEvent, AgentBackgroundTaskEventKind, agent_bash_output_path,
-    parse_bash_start, parse_task_notification,
+    AgentBackgroundTaskEvent, AgentBackgroundTaskEventKind, parse_bash_start,
+    parse_task_notification, workspace_terminal_output_path,
 };
 use claudette::agent::{AgentEvent, InnerStreamEvent, StartContentBlock, StreamEvent};
 use claudette::chat::{
@@ -63,13 +63,6 @@ pub(super) async fn append_agent_bash_output(
         .open(path)
         .await?;
     file.write_all(text.as_bytes()).await
-}
-
-pub(super) async fn truncate_agent_bash_output(path: &std::path::Path) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent).await?;
-    }
-    tokio::fs::File::create(path).await.map(|_| ())
 }
 
 pub(super) fn mirror_background_task_output(
@@ -142,11 +135,16 @@ pub(super) fn get_or_create_agent_shell_terminal_tab(
     workspace_id: &str,
     chat_session_id: &str,
 ) -> Option<TerminalTab> {
+    // Workspace-scoped path: env-provider provisioning, setup-script,
+    // and agent shell all append to the same file so the Claudette
+    // Terminal tab shows one unified transcript per workspace. The
+    // chat-session id still drives `agent_chat_session_id` so
+    // background-task lookups by session find this tab.
     let db = Database::open(db_path).ok()?;
+    let output_path = workspace_terminal_output_path(workspace_id)
+        .to_string_lossy()
+        .into_owned();
     if let Ok(Some(mut tab)) = db.get_agent_shell_terminal_tab_by_workspace(workspace_id) {
-        let output_path = agent_bash_output_path(chat_session_id)
-            .to_string_lossy()
-            .into_owned();
         let _ = db.update_agent_shell_terminal_tab_session(tab.id, chat_session_id, &output_path);
         tab.title = CLAUDETTE_TERMINAL_TITLE.to_string();
         tab.agent_chat_session_id = Some(chat_session_id.to_string());
@@ -158,7 +156,6 @@ pub(super) fn get_or_create_agent_shell_terminal_tab(
         return Some(tab);
     }
     let max_id = db.max_terminal_tab_id().ok()?;
-    let output_path = agent_bash_output_path(chat_session_id);
     let tab = TerminalTab {
         id: max_id + 1,
         workspace_id: workspace_id.to_string(),
@@ -170,7 +167,7 @@ pub(super) fn get_or_create_agent_shell_terminal_tab(
         agent_chat_session_id: Some(chat_session_id.to_string()),
         agent_tool_use_id: None,
         agent_task_id: None,
-        output_path: Some(output_path.to_string_lossy().into_owned()),
+        output_path: Some(output_path),
         task_status: None,
         task_summary: None,
     };
@@ -257,13 +254,6 @@ impl BackgroundTaskInputTracker {
         };
 
         let command = start.command.as_deref();
-        let had_running_background_tasks = {
-            let app_state = app.state::<AppState>();
-            let agents = app_state.agents.read().await;
-            agents
-                .get(chat_session_id)
-                .is_some_and(|s| !s.running_background_tasks.is_empty())
-        };
         if start.run_in_background {
             let app_state = app.state::<AppState>();
             let mut agents = app_state.agents.write().await;
@@ -271,10 +261,14 @@ impl BackgroundTaskInputTracker {
                 session.running_background_tasks.insert(tool_use_id.clone());
             }
         }
-        let path = agent_bash_output_path(chat_session_id);
-        if !had_running_background_tasks && let Err(err) = truncate_agent_bash_output(&path).await {
-            tracing::warn!(target: "claudette::chat", error = %err, "failed to reset agent bash output");
-        }
+        // Workspace-scoped path: every agent shell command across every
+        // chat session appends to the same workspace transcript. The
+        // truncate-on-no-running-tasks behavior the chat-session-scoped
+        // path used to do is intentionally gone — env-provider
+        // provisioning + prior session history must survive into the
+        // new command's view, otherwise the user loses the unified
+        // Claudette Terminal transcript the moment they hit Bash again.
+        let path = workspace_terminal_output_path(workspace_id);
         let echo = command
             .map(|cmd| format!("\r\n$ {}\r\n", terminal_text(cmd)))
             .unwrap_or_else(|| "\r\n$ Bash\r\n".to_string());

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -140,6 +140,15 @@ pub struct WorkspaceTerminalFileSink {
     /// Last plugin name we emitted a header for. We don't lock for
     /// reads — the worst case on a torn read is a duplicate header.
     last_plugin: std::sync::Mutex<Option<String>>,
+    /// Cached append-mode file handle so the hot streaming path
+    /// (potentially 100k+ lines from `nix print-dev-env -L`) doesn't
+    /// pay an `OpenOptions::open` + `create_dir_all` syscall per line.
+    /// Lazily initialized on first append; subsequent appends only
+    /// pay one `write_all` per line. No `BufWriter` here on purpose:
+    /// xterm.js tails the file, so we want every line to land on
+    /// disk immediately rather than coalesce in a userspace buffer
+    /// the reader can't see.
+    file: std::sync::Mutex<Option<std::fs::File>>,
 }
 
 impl WorkspaceTerminalFileSink {
@@ -147,6 +156,7 @@ impl WorkspaceTerminalFileSink {
         Self {
             output_path: workspace_terminal_output_path(workspace_id),
             last_plugin: std::sync::Mutex::new(None),
+            file: std::sync::Mutex::new(None),
         }
     }
 
@@ -155,14 +165,21 @@ impl WorkspaceTerminalFileSink {
     /// full), dropping a line is preferable to spamming logs from the
     /// hot streaming path.
     fn append(&self, bytes: &[u8]) {
-        if let Some(parent) = self.output_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+        let mut guard = match self.file.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if guard.is_none() {
+            if let Some(parent) = self.output_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            *guard = std::fs::OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(&self.output_path)
+                .ok();
         }
-        if let Ok(mut file) = std::fs::OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(&self.output_path)
-        {
+        if let Some(file) = guard.as_mut() {
             use std::io::Write;
             let _ = file.write_all(bytes);
         }

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -407,6 +407,11 @@ pub async fn get_env_sources(
     )
     .await;
 
+    // Mid-resolve disable safety — see [`evict_newly_disabled`] doc.
+    // Cheap DB read; covers the case where the user toggled a plugin
+    // off while this resolve was already in flight.
+    evict_newly_disabled(&state, &worktree, &repo_id, &disabled);
+
     // Subscribe the fs watcher to every freshly-cached plugin's
     // watched paths. Must happen BEFORE `filter_globally_disabled`
     // moves `resolved.sources` — we want to register even hidden
@@ -774,6 +779,14 @@ pub async fn prepare_workspace_environment(
         Some(output),
     )
     .await;
+    // Mid-resolve disable: the user may have toggled a plugin off
+    // between the `disabled` snapshot above and the resolve's
+    // completion. `set_env_provider_enabled` invalidates the cache
+    // when it runs, but a still-running `export` would then re-populate
+    // via `cache.put` after the invalidation — re-evict any newly
+    // disabled plugin's cache entry so the user's "disable" intent
+    // survives the late completion. See evict_newly_disabled.
+    evict_newly_disabled(&state, &worktree, &repo_id, &disabled);
     register_resolved_with_watcher(&state, Path::new(&worktree), &resolved.sources).await;
     let trust_payload = build_trust_needed_payload(&ws_info.id, &repo_id, &resolved);
     if let Some(payload) = trust_payload.clone() {
@@ -786,6 +799,46 @@ pub async fn prepare_workspace_environment(
         return Err(error);
     }
     Ok(trust_payload)
+}
+
+/// Re-read the disabled set and evict cache entries for any plugins
+/// newly disabled since the supplied baseline. Defends against the
+/// race where the user clicked Disable mid-resolve: the disable
+/// itself invalidates the cache, but a still-running `export`
+/// completing after the invalidation calls `cache.put` and re-
+/// populates a stale entry. Calling this after `resolve_with_registry_*`
+/// ensures the user's "disable" intent persists across that race.
+///
+/// Silent on DB read failure — the worst case is we miss the
+/// invalidation, the cache holds the stale entry for one TTL, and
+/// the next mtime change clears it anyway.
+fn evict_newly_disabled(
+    state: &AppState,
+    worktree: &str,
+    repo_id: &str,
+    baseline: &HashSet<String>,
+) {
+    let after = match Database::open(&state.db_path) {
+        Ok(db) => load_disabled_providers(&db, repo_id),
+        Err(_) => return,
+    };
+    for plugin in newly_disabled(baseline, &after) {
+        state
+            .env_cache
+            .invalidate(Path::new(worktree), Some(&plugin));
+    }
+}
+
+/// Pure helper: the set of plugin names disabled in `after` but not in
+/// `baseline`. Factored out so the diff logic can be unit-tested
+/// without spinning up an [`AppState`] / DB / cache. Returns owned
+/// `String`s so the caller can drop the borrows on the input sets
+/// before iterating (the cache invalidation borrows mutably otherwise).
+fn newly_disabled(baseline: &HashSet<String>, after: &HashSet<String>) -> Vec<String> {
+    after
+        .difference(baseline)
+        .map(|s| s.to_string())
+        .collect()
 }
 
 /// Toggle whether an env-provider plugin runs for the target's repo.
@@ -1801,5 +1854,114 @@ mod tests {
         // Ellipsis is one of [..3 bytes] depending on UTF-8 encoding;
         // the truncated body is at most 60 bytes pre-ellipsis.
         assert!(out.len() <= 60 + '…'.len_utf8());
+    }
+
+    #[test]
+    fn newly_disabled_returns_diff_only() {
+        // The mid-resolve-disable race: the user clicked Disable on a
+        // plugin while a resolve was already running. `newly_disabled`
+        // names only plugins that were absent from the baseline (the
+        // set captured before the resolve started) but present in the
+        // refreshed read after it finished. Plugins already disabled
+        // before the resolve don't need re-eviction — the dispatcher
+        // skipped them entirely.
+        let mut baseline = HashSet::new();
+        baseline.insert("env-mise".to_string());
+        let mut after = HashSet::new();
+        after.insert("env-mise".to_string());
+        after.insert("env-direnv".to_string());
+
+        let diff = newly_disabled(&baseline, &after);
+
+        assert_eq!(diff, vec!["env-direnv".to_string()]);
+    }
+
+    #[test]
+    fn newly_disabled_handles_no_changes() {
+        // Common case: the resolve completed with no concurrent disable
+        // click. Returning an empty vec lets the caller skip the
+        // invalidate loop entirely.
+        let mut both = HashSet::new();
+        both.insert("env-mise".to_string());
+
+        assert!(newly_disabled(&both, &both).is_empty());
+    }
+
+    #[test]
+    fn newly_disabled_ignores_re_enabled_plugins() {
+        // If a plugin was disabled at baseline and re-enabled mid-
+        // resolve (rare, but possible), it's gone from `after` —
+        // we should NOT re-evict its cache. (We also shouldn't surface
+        // it as "newly enabled" — that's not this function's job; the
+        // dispatcher already populated the cache for any provider that
+        // actually ran.) Pin the contract so a future refactor doesn't
+        // accidentally swap the difference direction.
+        let mut baseline = HashSet::new();
+        baseline.insert("env-direnv".to_string());
+        baseline.insert("env-mise".to_string());
+        let mut after = HashSet::new();
+        after.insert("env-direnv".to_string());
+
+        assert!(newly_disabled(&baseline, &after).is_empty());
+    }
+
+    #[tokio::test]
+    async fn set_env_provider_enabled_persists_and_invalidates_cache() {
+        // End-to-end check of the "disable a plugin" path: the DB
+        // setting must persist with the right key + value, AND the
+        // cache for the plugin must be evicted so a still-running
+        // resolve's late `cache.put` is the only way a stale entry
+        // could come back (handled by [`evict_newly_disabled`]).
+        //
+        // This is the contract the EnvPanel toggle depends on: when
+        // a user disables a slow provider mid-resolve, the
+        // `set_env_provider_enabled` IPC alone must leave the cache
+        // empty for that plugin so a fresh spawn doesn't pick up
+        // stale env after the user's intent change.
+        use claudette::db::Database;
+        use claudette::env_provider::cache::EnvCache;
+        use claudette::env_provider::types::ProviderExport;
+        use std::collections::HashMap;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        let cache = EnvCache::new();
+        let worktree = dir.path();
+
+        // Seed the cache as if a resolve had completed.
+        let mut env = HashMap::new();
+        env.insert("FOO".to_string(), Some("bar".to_string()));
+        cache
+            .put(
+                worktree,
+                "env-direnv",
+                &ProviderExport {
+                    env,
+                    watched: vec![],
+                },
+            )
+            .expect("put");
+        assert!(cache.get_fresh(worktree, "env-direnv").is_some());
+
+        // Persist the disable directly via load_disabled_providers'
+        // sibling write — mirrors what `set_env_provider_enabled` does
+        // (we exercise the helper rather than the full Tauri command
+        // because the command takes `State<'_, AppState>` which can't
+        // be constructed in a unit test). The cache eviction the
+        // command performs is exercised separately by the explicit
+        // `cache.invalidate` call below — the two together are the
+        // command's full behavior.
+        db.set_app_setting(&enabled_key("repo-1", "env-direnv"), "false")
+            .unwrap();
+        cache.invalidate(worktree, Some("env-direnv"));
+
+        // Persistence: load_disabled_providers reflects the new state.
+        let disabled = load_disabled_providers(&db, "repo-1");
+        assert!(disabled.contains("env-direnv"));
+
+        // Cache: the entry is gone.
+        assert!(cache.get_fresh(worktree, "env-direnv").is_none());
     }
 }

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -408,9 +408,24 @@ pub async fn get_env_sources(
     .await;
 
     // Mid-resolve disable safety — see [`evict_newly_disabled`] doc.
-    // Cheap DB read; covers the case where the user toggled a plugin
-    // off while this resolve was already in flight.
-    evict_newly_disabled(&state, &worktree, &repo_id, &disabled);
+    // Re-read the disabled set once and use it for BOTH the cache
+    // eviction and the per-row `enabled` field below. Without the
+    // re-read, a slow `nix print-dev-env` whose `get_env_sources` call
+    // started before the user clicked Disable would land back at the
+    // panel with `enabled = true` (the pre-resolve snapshot value),
+    // overwriting the EnvPanel's optimistic flip until another
+    // refresh. The toggle is now actionable mid-resolve, so the
+    // response payload has to honor any toggles applied during the
+    // resolve window.
+    let disabled_after = {
+        let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+        load_disabled_providers(&db, &repo_id)
+    };
+    for plugin in newly_disabled(&disabled, &disabled_after) {
+        state
+            .env_cache
+            .invalidate(Path::new(&worktree), Some(&plugin));
+    }
 
     // Subscribe the fs watcher to every freshly-cached plugin's
     // watched paths. Must happen BEFORE `filter_globally_disabled`
@@ -426,7 +441,7 @@ pub async fn get_env_sources(
                 .get(&s.plugin_name)
                 .cloned()
                 .unwrap_or_else(|| s.plugin_name.clone());
-            let enabled = !disabled.contains(&s.plugin_name);
+            let enabled = !disabled_after.contains(&s.plugin_name);
             // The dispatcher writes `error: Some("unavailable")` to
             // signal "required CLI isn't on PATH". Promote that to a
             // dedicated flag and clear the error string so the UI
@@ -1903,6 +1918,36 @@ mod tests {
         after.insert("env-direnv".to_string());
 
         assert!(newly_disabled(&baseline, &after).is_empty());
+    }
+
+    #[test]
+    fn newly_disabled_diff_drives_get_env_sources_enabled_field() {
+        // Pin the contract the get_env_sources fix depends on: when a
+        // user disables a plugin mid-resolve, the post-resolve
+        // `load_disabled_providers` read returns a set whose
+        // `!contains(plugin_name)` lookup matches the new toggle
+        // state — i.e. `enabled = false` for the disabled plugin.
+        //
+        // Codex iter (post-squash) flagged: without using
+        // `disabled_after` here, a slow resolve's response would
+        // overwrite the EnvPanel's optimistic disable flip with the
+        // pre-resolve snapshot value. The fix re-reads disabled after
+        // the resolve and feeds that set into both the eviction loop
+        // and the per-row `enabled` field. This test asserts the set
+        // logic at the boundary the command actually uses
+        // (`!disabled.contains(&plugin_name)`) so the contract is
+        // explicit even though the command itself can't be exercised
+        // without a Tauri AppState.
+        let mut disabled_after = HashSet::new();
+        disabled_after.insert("env-direnv".to_string());
+
+        // env-direnv was just disabled.
+        let direnv_enabled = !disabled_after.contains("env-direnv");
+        // env-mise was never touched.
+        let mise_enabled = !disabled_after.contains("env-mise");
+
+        assert!(!direnv_enabled);
+        assert!(mise_enabled);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -856,6 +856,26 @@ fn newly_disabled(baseline: &HashSet<String>, after: &HashSet<String>) -> Vec<St
         .collect()
 }
 
+/// List the env-provider plugin names that are disabled for the
+/// target's repo. Cheap DB-only read — does NOT run any resolves and
+/// does NOT consult the registry. Designed for the EnvPanel's
+/// placeholder hydration so the user-visible toggle state matches the
+/// persisted setting even before the (potentially slow) initial
+/// `get_env_sources` resolve returns.
+#[tauri::command]
+pub async fn list_env_provider_disabled(
+    target: EnvTarget,
+    state: State<'_, AppState>,
+) -> Result<Vec<String>, String> {
+    let (_, _, repo_id) = resolve_target(&state, &target).await?;
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let mut names: Vec<String> = load_disabled_providers(&db, &repo_id)
+        .into_iter()
+        .collect();
+    names.sort();
+    Ok(names)
+}
+
 /// Toggle whether an env-provider plugin runs for the target's repo.
 /// The toggle is persisted per-repo, so the change applies to every
 /// worktree under that repo. This evicts the cache for the repo's

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -17,9 +17,10 @@ use std::time::Duration;
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, State};
 
+use claudette::agent::background::workspace_terminal_output_path;
 use claudette::db::Database;
 use claudette::env_provider::EnvWatcher;
-use claudette::plugin_runtime::host_api::WorkspaceInfo;
+use claudette::plugin_runtime::host_api::{OutputStream, StreamingSink, WorkspaceInfo};
 use claudette::plugin_runtime::manifest::PluginKind;
 
 use crate::state::AppState;
@@ -114,6 +115,128 @@ impl claudette::env_provider::EnvProgressSink for TauriEnvProgressSink {
             },
         );
     }
+}
+
+/// Workspace-scoped sink that funnels env-provider stdout/stderr and
+/// setup-script stdout/stderr into a single line-oriented file at
+/// [`workspace_terminal_output_path`]. The Claudette Terminal tab created
+/// during workspace provisioning tails that file via the existing
+/// `start_agent_task_tail` plumbing, so xterm.js renders nix's `-L`
+/// build chatter, direnv's status spam, and `bun install` progress with
+/// their native ANSI colors — no parallel React renderer, no event
+/// serialization tax, no stripped escape codes.
+///
+/// One instance implements **both** [`StreamingSink`] (env-provider
+/// host.exec_streaming) and [`claudette::ops::workspace::SetupOutputSink`]
+/// (setup-script runner) so a single Arc can be cloned into both call
+/// sites and produce a coherent transcript.
+///
+/// A subtle bit: we emit a dim cyan section header (`── plugin ──`)
+/// whenever the plugin name changes between consecutive lines. Without
+/// this the user can't tell where direnv stops and nix-devshell starts
+/// — both stream the same kind of build chatter to the same buffer.
+pub struct WorkspaceTerminalFileSink {
+    output_path: std::path::PathBuf,
+    /// Last plugin name we emitted a header for. We don't lock for
+    /// reads — the worst case on a torn read is a duplicate header.
+    last_plugin: std::sync::Mutex<Option<String>>,
+}
+
+impl WorkspaceTerminalFileSink {
+    pub fn new(workspace_id: &str) -> Self {
+        Self {
+            output_path: workspace_terminal_output_path(workspace_id),
+            last_plugin: std::sync::Mutex::new(None),
+        }
+    }
+
+    /// Best-effort append to the workspace terminal file. The destination
+    /// lives in `temp_dir()` — if a write fails (permissions, disk
+    /// full), dropping a line is preferable to spamming logs from the
+    /// hot streaming path.
+    fn append(&self, bytes: &[u8]) {
+        if let Some(parent) = self.output_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&self.output_path)
+        {
+            use std::io::Write;
+            let _ = file.write_all(bytes);
+        }
+    }
+
+    /// Emit a `── <plugin> ──` header when the plugin name changes
+    /// between two consecutive lines. Bold cyan so it's easy to scan in
+    /// a wall of build output but doesn't compete with whatever ANSI
+    /// the plugin's own tool emits (nix uses yellow/blue; direnv uses
+    /// magenta).
+    fn maybe_emit_header(&self, plugin: &str) {
+        let mut last = match self.last_plugin.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if last.as_deref() == Some(plugin) {
+            return;
+        }
+        *last = Some(plugin.to_string());
+        let header = format!("\r\n\x1b[1;36m── {plugin} ──\x1b[0m\r\n");
+        self.append(header.as_bytes());
+    }
+}
+
+impl StreamingSink for WorkspaceTerminalFileSink {
+    fn line(&self, plugin: &str, _stream: OutputStream, line: String) {
+        self.maybe_emit_header(plugin);
+        // xterm wants CRLF line endings. Lua's host.exec_streaming reader
+        // hands us a `line` already stripped of the trailing newline.
+        let mut bytes = line.into_bytes();
+        bytes.extend_from_slice(b"\r\n");
+        self.append(&bytes);
+    }
+}
+
+impl claudette::ops::workspace::SetupOutputSink for WorkspaceTerminalFileSink {
+    fn line(&self, _stream: claudette::ops::workspace::SetupOutputStream, line: String) {
+        self.maybe_emit_header("setup-script");
+        let mut bytes = line.into_bytes();
+        bytes.extend_from_slice(b"\r\n");
+        self.append(&bytes);
+    }
+}
+
+/// Build the matched pair of sinks every Tauri-side env-resolve call
+/// site needs: a [`TauriEnvProgressSink`] (for per-plugin loading
+/// state) and an [`Arc<dyn StreamingSink>`] (for live stdout/stderr
+/// from `host.exec_streaming`). The progress sink fans out via Tauri
+/// events for the spinner; the streaming sink writes line-oriented
+/// bytes into the workspace's Claudette Terminal output file.
+///
+/// Callers feed them into [`resolve_with_registry_streaming`]:
+/// ```ignore
+/// let (progress, output) = make_env_sinks(app.clone(), ws_id.clone());
+/// resolve_with_registry_streaming(
+///     &registry, &cache, &worktree, &ws_info, &disabled,
+///     Some(&progress), Some(output),
+/// ).await;
+/// ```
+pub fn make_env_sinks(
+    app: AppHandle,
+    workspace_id: String,
+) -> (TauriEnvProgressSink, Arc<dyn StreamingSink>) {
+    let progress = TauriEnvProgressSink::new(app, workspace_id.clone());
+    let output: Arc<dyn StreamingSink> = Arc::new(WorkspaceTerminalFileSink::new(&workspace_id));
+    (progress, output)
+}
+
+/// Shared constructor for the setup-script + env-provider sink. Returned
+/// as a concrete `Arc<WorkspaceTerminalFileSink>` because both call
+/// sites (workspace.rs setup runner; env.rs resolve loop) coerce it into
+/// their respective trait object on demand.
+pub fn make_workspace_terminal_sink(workspace_id: &str) -> Arc<WorkspaceTerminalFileSink> {
+    Arc::new(WorkspaceTerminalFileSink::new(workspace_id))
 }
 
 /// Emit a `Complete` event whenever the sink is dropped. This is the
@@ -272,14 +395,15 @@ pub async fn get_env_sources(
         .iter()
         .map(|(name, p)| (name.clone(), p.manifest.display_name.clone()))
         .collect();
-    let progress = TauriEnvProgressSink::new(app, ws_info.id.clone());
-    let resolved = claudette::env_provider::resolve_with_registry_and_progress(
+    let (progress, output) = make_env_sinks(app, ws_info.id.clone());
+    let resolved = claudette::env_provider::resolve_with_registry_streaming(
         &registry,
         &state.env_cache,
         Path::new(&worktree),
         &ws_info,
         &disabled,
         Some(&progress),
+        Some(output),
     )
     .await;
 
@@ -639,14 +763,15 @@ pub async fn prepare_workspace_environment(
     // Snapshot — see `plugins_snapshot` doc; this command can run
     // ~120s on cold env-providers and must not stall the Plugins UI.
     let registry = state.plugins_snapshot().await;
-    let progress = TauriEnvProgressSink::new(app.clone(), ws_info.id.clone());
-    let resolved = claudette::env_provider::resolve_with_registry_and_progress(
+    let (progress, output) = make_env_sinks(app.clone(), ws_info.id.clone());
+    let resolved = claudette::env_provider::resolve_with_registry_streaming(
         &registry,
         &state.env_cache,
         Path::new(&worktree),
         &ws_info,
         &disabled,
         Some(&progress),
+        Some(output),
     )
     .await;
     register_resolved_with_watcher(&state, Path::new(&worktree), &resolved.sources).await;
@@ -1108,12 +1233,17 @@ async fn maybe_emit_trust_needed_for_changed_env(
             disabled.insert(name.clone());
         }
     }
-    let resolved = claudette::env_provider::resolve_with_registry_and_progress(
+    // Watcher-driven invalidation: pass `None` for both sinks. The
+    // progress spinner stays silent so a transient mtime bump doesn't
+    // flash the UI, and the streaming output is also suppressed since
+    // there's no panel listening for an off-screen re-resolve.
+    let resolved = claudette::env_provider::resolve_with_registry_streaming(
         &registry,
         &state.env_cache,
         Path::new(&worktree),
         &ws_info,
         &disabled,
+        None,
         None,
     )
     .await;
@@ -1271,14 +1401,15 @@ pub fn spawn_repo_env_warmup(app: AppHandle, repo_id: String) {
         // Best-effort warmup — snapshot so the resolve doesn't stall
         // any concurrent Plugins/SCM commands.
         let registry = state.plugins_snapshot().await;
-        let progress = TauriEnvProgressSink::new(app.clone(), ws_info.id.clone());
-        let resolved = claudette::env_provider::resolve_with_registry_and_progress(
+        let (progress, output) = make_env_sinks(app.clone(), ws_info.id.clone());
+        let resolved = claudette::env_provider::resolve_with_registry_streaming(
             &registry,
             &state.env_cache,
             Path::new(&repo.path),
             &ws_info,
             &disabled,
             Some(&progress),
+            Some(output),
         )
         .await;
         register_resolved_with_watcher(&state, Path::new(&repo.path), &resolved.sources).await;

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -850,10 +850,7 @@ fn evict_newly_disabled(
 /// `String`s so the caller can drop the borrows on the input sets
 /// before iterating (the cache invalidation borrows mutably otherwise).
 fn newly_disabled(baseline: &HashSet<String>, after: &HashSet<String>) -> Vec<String> {
-    after
-        .difference(baseline)
-        .map(|s| s.to_string())
-        .collect()
+    after.difference(baseline).map(|s| s.to_string()).collect()
 }
 
 /// List the env-provider plugin names that are disabled for the
@@ -869,9 +866,7 @@ pub async fn list_env_provider_disabled(
 ) -> Result<Vec<String>, String> {
     let (_, _, repo_id) = resolve_target(&state, &target).await?;
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    let mut names: Vec<String> = load_disabled_providers(&db, &repo_id)
-        .into_iter()
-        .collect();
+    let mut names: Vec<String> = load_disabled_providers(&db, &repo_id).into_iter().collect();
     names.sort();
     Ok(names)
 }

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
-use claudette::agent::background::agent_bash_output_path;
+use claudette::agent::background::workspace_terminal_output_path;
 use claudette::db::{CLAUDETTE_TERMINAL_TITLE, Database};
 use claudette::model::{TerminalTab, TerminalTabKind};
 
@@ -56,21 +56,97 @@ pub async fn create_terminal_tab(
     Ok(tab)
 }
 
+/// Synchronously ensure the Claudette Terminal tab exists for a
+/// workspace, bound to the workspace-scoped provisioning output file.
+/// Called from `create_workspace` / `fork_workspace_at_checkpoint` /
+/// `run_workspace_setup` *before* env-provider + setup-script sinks
+/// start appending — the tab needs to be in the database when the
+/// frontend's `workspaces-changed` listener queries `list_terminal_tabs`
+/// for the new row, or the tail won't start.
+///
+/// If a tab already exists for this workspace (manual setup rerun, or
+/// re-fork onto the same workspace id), re-stamp its `output_path` to
+/// the workspace-scoped file. A stale tab might still point at the
+/// legacy `agent_bash_output_path(chat_session_id)` from before the
+/// unified-transcript refactor, or at a different workspace's path if
+/// the DB row was migrated — either way, the live env/setup sinks are
+/// writing to `workspace_terminal_output_path(workspace_id)` and the
+/// visible tab must follow. The `agent_chat_session_id` binding is
+/// preserved so background-task lookups by session still resolve.
+pub fn ensure_workspace_provisioning_terminal_tab(
+    db_path: &std::path::Path,
+    workspace_id: &str,
+) -> Result<TerminalTab, String> {
+    let db = Database::open(db_path).map_err(|e| e.to_string())?;
+    let output_path = workspace_terminal_output_path(workspace_id)
+        .to_string_lossy()
+        .into_owned();
+
+    if let Some(mut tab) = db
+        .get_agent_shell_terminal_tab_by_workspace(workspace_id)
+        .map_err(|e| e.to_string())?
+    {
+        // Rebind to the workspace-scoped file. The DB helper requires
+        // a session id; reuse whatever the tab already had, falling
+        // back to empty string when this is a fresh provisioning tab
+        // with no session yet (the typical workspace-create case).
+        let session_id = tab.agent_chat_session_id.clone().unwrap_or_default();
+        db.update_agent_shell_terminal_tab_session(tab.id, &session_id, &output_path)
+            .map_err(|e| e.to_string())?;
+        tab.title = CLAUDETTE_TERMINAL_TITLE.to_string();
+        tab.output_path = Some(output_path);
+        tab.task_status = None;
+        tab.task_summary = None;
+        return Ok(tab);
+    }
+
+    let tab = TerminalTab {
+        id: db.max_terminal_tab_id().map_err(|e| e.to_string())? + 1,
+        workspace_id: workspace_id.to_string(),
+        title: CLAUDETTE_TERMINAL_TITLE.to_string(),
+        kind: TerminalTabKind::AgentTask,
+        is_script_output: false,
+        // sort_order < 0 so the Claudette Terminal sorts before any
+        // user-created `Terminal 1/2/3...` tabs, matching the
+        // chat-session ensure path's convention.
+        sort_order: -1,
+        created_at: now_iso(),
+        agent_chat_session_id: None,
+        agent_tool_use_id: None,
+        agent_task_id: None,
+        output_path: Some(output_path),
+        task_status: None,
+        task_summary: None,
+    };
+    db.insert_terminal_tab(&tab).map_err(|e| e.to_string())?;
+    Ok(tab)
+}
+
 #[tauri::command]
 pub async fn ensure_claudette_terminal_tab(
     workspace_id: String,
     chat_session_id: String,
     state: State<'_, AppState>,
 ) -> Result<TerminalTab, String> {
+    // The Claudette Terminal tab is workspace-scoped now, not
+    // chat-session-scoped: env-provider provisioning writes here,
+    // setup-script writes here, and (per the refactor below) the
+    // agent shell tool writes here. Binding to the chat-session
+    // agent-shell file would lose the provisioning transcript the
+    // moment the first chat session is materialized, which defeats
+    // the whole reason this tab exists.
+    //
+    // We still update `agent_chat_session_id` so background-task
+    // code that looks up the tab by session can find it.
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let output_path = workspace_terminal_output_path(&workspace_id)
+        .to_string_lossy()
+        .into_owned();
 
     if let Some(mut tab) = db
         .get_agent_shell_terminal_tab_by_workspace(&workspace_id)
         .map_err(|e| e.to_string())?
     {
-        let output_path = agent_bash_output_path(&chat_session_id)
-            .to_string_lossy()
-            .into_owned();
         db.update_agent_shell_terminal_tab_session(tab.id, &chat_session_id, &output_path)
             .map_err(|e| e.to_string())?;
         tab.title = CLAUDETTE_TERMINAL_TITLE.to_string();
@@ -91,14 +167,10 @@ pub async fn ensure_claudette_terminal_tab(
         is_script_output: false,
         sort_order: -1,
         created_at: now_iso(),
-        agent_chat_session_id: Some(chat_session_id.clone()),
+        agent_chat_session_id: Some(chat_session_id),
         agent_tool_use_id: None,
         agent_task_id: None,
-        output_path: Some(
-            agent_bash_output_path(&chat_session_id)
-                .to_string_lossy()
-                .into_owned(),
-        ),
+        output_path: Some(output_path),
         task_status: None,
         task_summary: None,
     };

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -120,10 +120,58 @@ pub(crate) async fn create_workspace_inner(
         .find(|r| r.id == repo_id)
         .ok_or("Repository not found")?;
 
+    // Ensure the workspace's Claudette Terminal tab exists before any
+    // env-provider or setup-script line is written — the tab points at
+    // the workspace-scoped output file the sinks below append to, and
+    // we want it visible in the bottom panel the moment provisioning
+    // starts so the user can open the panel and watch live.
+    let _ = crate::commands::terminal::ensure_workspace_provisioning_terminal_tab(
+        &state.db_path,
+        &out.workspace.id,
+    );
+
+    // Emit `workspaces-changed` *before* env-provider + setup-script
+    // run so the frontend can hydrate the workspace row (and its
+    // pre-seeded Claudette Terminal tab) immediately. The post-
+    // provisioning emit at the end of this function re-stamps the row
+    // — both emits are idempotent in the frontend's `addWorkspace`.
+    let early_hooks = TauriHooks::new(app.clone());
+    early_hooks.workspace_changed(&out.workspace.id, WorkspaceChangeKind::Created);
+
+    // Signal the start of the create-time warmup (setup script + env
+    // resolve) via a synthetic `workspace_env_progress (started)`
+    // event. The frontend's progress listener seeds
+    // `workspaceEnvironment[wsId] = preparing` with a `started_at`,
+    // which locks chat / terminal interaction until the matching
+    // `Complete` event from the env-sink's Drop terminates it. Forks
+    // intentionally skip this — they don't run env warmup at this
+    // stage, and a permanent preparing state would strand them. IPC /
+    // CLI / remote creates ride the same signal so they don't expose
+    // an unprimed worktree.
+    let _ = app.emit(
+        "workspace_env_progress",
+        crate::commands::env::WorkspaceEnvProgressPayload {
+            workspace_id: out.workspace.id.clone(),
+            plugin: "provisioning".to_string(),
+            phase: crate::commands::env::EnvProgressPhase::Started,
+            elapsed_ms: 0,
+            ok: None,
+        },
+    );
+
     let setup_result = if skip_setup {
         None
     } else {
-        ops_workspace::resolve_and_run_setup(
+        // Stream setup-script output into the workspace's Claudette
+        // Terminal so the user watches `bun install` / `cargo build`
+        // chatter live in a real terminal rather than a frozen elapsed
+        // timer. The sink also feeds the chat-transcript
+        // SetupScriptBanner via the accumulated `SetupResult.output`
+        // after the script returns.
+        let sink: Option<std::sync::Arc<dyn ops_workspace::SetupOutputSink>> = Some(
+            crate::commands::env::make_workspace_terminal_sink(&out.workspace.id),
+        );
+        ops_workspace::resolve_and_run_setup_streaming(
             &out.workspace,
             Path::new(&repo.path),
             Path::new(&out.worktree_path),
@@ -131,6 +179,7 @@ pub(crate) async fn create_workspace_inner(
             repo.base_branch.as_deref(),
             repo.default_remote.as_deref(),
             None,
+            sink,
         )
         .await
     };
@@ -201,6 +250,16 @@ pub async fn fork_workspace_at_checkpoint(
     .await
     .map_err(|e| e.to_string())?;
 
+    // Pre-create the fork's Claudette Terminal tab pointing at the
+    // workspace-scoped provisioning output file. The fork itself doesn't
+    // run an env-provider resolve here (that fires lazily on first
+    // agent / PTY spawn), but the tab needs to exist so the lazy
+    // resolve's output is visible if the user is watching the panel.
+    let _ = crate::commands::terminal::ensure_workspace_provisioning_terminal_tab(
+        &state.db_path,
+        &outcome.workspace.id,
+    );
+
     // Mirror `create_workspace_inner`: emit `workspaces-changed` so the
     // frontend's listener stamps the UI-only `remote_connection_id: null`
     // field on the new row. Without this, `result.workspace` returned by
@@ -248,8 +307,17 @@ pub async fn run_workspace_setup(
         .find(|r| r.id == ws.repository_id)
         .ok_or("Repository not found")?;
 
+    // Manual setup re-run reuses the workspace-scoped Claudette
+    // Terminal output file so the user can re-watch a failed setup
+    // without losing the prior provisioning transcript.
+    let _ = crate::commands::terminal::ensure_workspace_provisioning_terminal_tab(
+        &state.db_path,
+        &ws.id,
+    );
     let resolved_env = resolve_env_for_workspace(&state, ws, &repo.path, Some(&app)).await;
-    let result = ops_workspace::resolve_and_run_setup(
+    let sink: Option<std::sync::Arc<dyn ops_workspace::SetupOutputSink>> =
+        Some(crate::commands::env::make_workspace_terminal_sink(&ws.id));
+    let result = ops_workspace::resolve_and_run_setup_streaming(
         ws,
         Path::new(&repo.path),
         Path::new(worktree_path),
@@ -257,6 +325,7 @@ pub async fn run_workspace_setup(
         repo.base_branch.as_deref(),
         repo.default_remote.as_deref(),
         resolved_env.as_ref(),
+        sink,
     )
     .await;
 
@@ -299,9 +368,12 @@ async fn resolve_env_for_workspace(
     // resolve can run ~120s. Holding the outer RwLock that long
     // stalls the Plugins settings page; see `plugins_snapshot`.
     let registry = state.plugins_snapshot().await;
-    let progress =
-        app.map(|h| crate::commands::env::TauriEnvProgressSink::new(h.clone(), ws.id.clone()));
-    let resolved = claudette::env_provider::resolve_with_registry_and_progress(
+    let sinks = app.map(|h| crate::commands::env::make_env_sinks(h.clone(), ws.id.clone()));
+    let (progress, output) = match sinks {
+        Some((p, o)) => (Some(p), Some(o)),
+        None => (None, None),
+    };
+    let resolved = claudette::env_provider::resolve_with_registry_streaming(
         &registry,
         &state.env_cache,
         Path::new(worktree),
@@ -310,6 +382,7 @@ async fn resolve_env_for_workspace(
         progress
             .as_ref()
             .map(|p| p as &dyn claudette::env_provider::EnvProgressSink),
+        output,
     )
     .await;
     crate::commands::env::register_resolved_with_watcher(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1141,6 +1141,7 @@ fn main() {
             commands::env::prepare_workspace_environment,
             commands::env::reload_env,
             commands::env::set_env_provider_enabled,
+            commands::env::list_env_provider_disabled,
             commands::env::run_env_trust,
             commands::env::get_host_env_flags,
             // Claudette Lua plugins (SCM + env-provider) settings surface

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -142,15 +142,16 @@ pub async fn spawn_pty(
         // settings page (which awaits `list_claudette_plugins`) is
         // never blocked by a slow PTY-spawn env resolve.
         let registry = state.plugins_snapshot().await;
-        let progress =
-            crate::commands::env::TauriEnvProgressSink::new(app.clone(), workspace_id.clone());
-        claudette::env_provider::resolve_with_registry_and_progress(
+        let (progress, output) =
+            crate::commands::env::make_env_sinks(app.clone(), workspace_id.clone());
+        claudette::env_provider::resolve_with_registry_streaming(
             &registry,
             &state.env_cache,
             std::path::Path::new(&working_dir),
             &ws_info,
             &disabled_env_providers,
             Some(&progress),
+            Some(output),
         )
         .await
     };

--- a/src/agent/background.rs
+++ b/src/agent/background.rs
@@ -1,10 +1,19 @@
 use serde::{Deserialize, Serialize};
 
-pub fn agent_bash_output_path(chat_session_id: &str) -> std::path::PathBuf {
+/// Workspace-scoped output file for the Claudette Terminal tab. This is
+/// the single destination for the workspace's unified provisioning +
+/// agent-shell transcript: env-provider stdout/stderr, the
+/// `.claudette.json` setup script, every chat session's Bash tool
+/// commands (foreground and the mirror of background tasks). xterm.js
+/// tails this one file; the tab created on workspace create/fork
+/// points here from the start and never rebinds, so the user can
+/// scroll back through the full history of everything that ever ran
+/// in the workspace.
+pub fn workspace_terminal_output_path(workspace_id: &str) -> std::path::PathBuf {
     std::env::temp_dir()
-        .join("claudette-agent-bash")
-        .join(chat_session_id)
-        .join("agent-shell.output")
+        .join("claudette-workspace-terminal")
+        .join(workspace_id)
+        .join("terminal.output")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/env_provider/backend.rs
+++ b/src/env_provider/backend.rs
@@ -11,8 +11,9 @@
 
 use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use crate::plugin_runtime::host_api::WorkspaceInfo;
+use crate::plugin_runtime::host_api::{StreamingSink, WorkspaceInfo};
 use crate::plugin_runtime::manifest::PluginKind;
 use crate::plugin_runtime::{PluginError, PluginRegistry};
 
@@ -74,11 +75,28 @@ pub trait EnvProviderBackend: Send + Sync {
 /// Production backend wrapping a [`PluginRegistry`].
 pub struct PluginRegistryBackend<'a> {
     pub registry: &'a PluginRegistry,
+    /// Optional sink forwarded into every `call_operation_streaming`
+    /// invocation. When set, env-provider plugins that call
+    /// `host.exec_streaming` (and `host.console`) emit their stdout
+    /// and stderr lines through here — typically wired to the
+    /// `workspace_env_output` Tauri event in the GUI.
+    streaming_sink: Option<Arc<dyn StreamingSink>>,
 }
 
 impl<'a> PluginRegistryBackend<'a> {
     pub fn new(registry: &'a PluginRegistry) -> Self {
-        Self { registry }
+        Self {
+            registry,
+            streaming_sink: None,
+        }
+    }
+
+    /// Builder-style attach of a [`StreamingSink`] so the dispatcher
+    /// can hand the same sink to every plugin invocation without each
+    /// `detect`/`export` having to thread it through manually.
+    pub fn with_streaming_sink(mut self, sink: Option<Arc<dyn StreamingSink>>) -> Self {
+        self.streaming_sink = sink;
+        self
     }
 }
 
@@ -121,7 +139,13 @@ impl EnvProviderBackend for PluginRegistryBackend<'_> {
         });
         let result = self
             .registry
-            .call_operation(plugin, "detect", args, ws_info.clone())
+            .call_operation_streaming(
+                plugin,
+                "detect",
+                args,
+                ws_info.clone(),
+                self.streaming_sink.clone(),
+            )
             .await?;
         Ok(result.as_bool().unwrap_or(false))
     }
@@ -137,7 +161,13 @@ impl EnvProviderBackend for PluginRegistryBackend<'_> {
         });
         let result = self
             .registry
-            .call_operation(plugin, "export", args, ws_info.clone())
+            .call_operation_streaming(
+                plugin,
+                "export",
+                args,
+                ws_info.clone(),
+                self.streaming_sink.clone(),
+            )
             .await?;
 
         // Expected shape: { env: { KEY: "value" | nil, ... }, watched: ["path", ...] }

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -68,7 +68,26 @@ pub async fn resolve_with_registry_and_progress(
     disabled: &std::collections::HashSet<String>,
     progress: Option<&dyn EnvProgressSink>,
 ) -> ResolvedEnv {
-    let backend = PluginRegistryBackend::new(registry);
+    resolve_with_registry_streaming(registry, cache, worktree, ws_info, disabled, progress, None)
+        .await
+}
+
+/// Variant of [`resolve_with_registry_and_progress`] that *also*
+/// attaches a [`crate::plugin_runtime::host_api::StreamingSink`] so
+/// any plugin that calls `host.exec_streaming` (or `host.console`)
+/// forwards each stdout/stderr line through the sink. Used by Tauri
+/// command handlers to broadcast a `workspace_env_output` event for
+/// the EnvProvisioningConsole. Cache hits still bypass both sinks.
+pub async fn resolve_with_registry_streaming(
+    registry: &crate::plugin_runtime::PluginRegistry,
+    cache: &EnvCache,
+    worktree: &Path,
+    ws_info: &WorkspaceInfo,
+    disabled: &std::collections::HashSet<String>,
+    progress: Option<&dyn EnvProgressSink>,
+    streaming: Option<std::sync::Arc<dyn crate::plugin_runtime::host_api::StreamingSink>>,
+) -> ResolvedEnv {
+    let backend = PluginRegistryBackend::new(registry).with_streaming_sink(streaming);
     resolve_for_workspace_with_progress(&backend, cache, worktree, ws_info, disabled, progress)
         .await
 }

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -40,7 +40,28 @@ fn make_vm(plugin: &str, allowed: &[&str], worktree: &Path) -> Lua {
         },
         ..Default::default()
     };
-    create_lua_vm(ctx).expect("create vm")
+    let lua = create_lua_vm(ctx).expect("create vm");
+    // Tests stub `host.exec` with a Lua closure to inject canned
+    // subprocess output. After the migration to `host.exec_streaming`
+    // for env-provider plugins, those same stubs need to fire when
+    // the plugin calls the streaming variant — otherwise the plugin
+    // would try to spawn the real binary, which panics under `#[test]`
+    // (no multi-thread tokio runtime) and breaks every plugin test.
+    //
+    // Proxy `host.exec_streaming` to `host.exec` at the Lua level. The
+    // closure re-reads `host.exec` on each call, so a later
+    // `host.exec = function(...)` override is picked up automatically
+    // — no per-test bookkeeping needed.
+    lua.load(
+        r#"
+            host.exec_streaming = function(cmd, args)
+                return host.exec(cmd, args)
+            end
+        "#,
+    )
+    .exec()
+    .expect("install host.exec_streaming proxy");
+    lua
 }
 
 #[cfg(has_direnv)]
@@ -1293,11 +1314,15 @@ fn nix_export_shell_nix_uses_file_arg_and_watches_shell_nix() {
         r#"
         host.exec = function(cmd, args)
             if cmd ~= "nix" then error("expected cmd='nix', got: " .. tostring(cmd)) end
+            -- `-L` (print-build-logs) was added so streaming surfaces
+            -- per-derivation build output in the EnvProvisioningConsole.
+            -- The shell.nix path slides to args[5] as a result.
             if type(args) ~= "table"
                 or args[1] ~= "print-dev-env"
                 or args[2] ~= "--json"
-                or args[3] ~= "-f"
-                or args[4] ~= "{expected_shell}" then
+                or args[3] ~= "-L"
+                or args[4] ~= "-f"
+                or args[5] ~= "{expected_shell}" then
                 error("expected shell.nix args")
             end
             return {{ stdout = [==[{payload_json}]==], stderr = "", code = 0 }}

--- a/src/ops/workspace.rs
+++ b/src/ops/workspace.rs
@@ -320,9 +320,13 @@ impl SetupOutputStream {
 }
 
 /// Callback receiver for streamed setup-script output. The Tauri-side
-/// caller wraps this around a `workspace_setup_output` event emitter
-/// so the EnvProvisioningConsole can render setup-script chatter
-/// alongside the env-provider plugins' output.
+/// implementor is [`WorkspaceTerminalFileSink`] in
+/// `src-tauri/src/commands/env.rs`, which appends each line to the
+/// workspace-scoped output file under a `── setup-script ──` header
+/// so xterm.js (tailing the file in the Claudette Terminal tab) shows
+/// the setup output inline with the env-provider transcript. The
+/// previous `workspace_setup_output` Tauri event and the
+/// `EnvProvisioningConsole` React component are gone.
 pub trait SetupOutputSink: Send + Sync {
     fn line(&self, stream: SetupOutputStream, line: String);
 }

--- a/src/ops/workspace.rs
+++ b/src/ops/workspace.rs
@@ -15,9 +15,11 @@
 //! [`ResolvedEnv`] in; callers that don't (the WS server today) pass `None`.
 
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::Serialize;
+use tokio::io::AsyncBufReadExt;
 use tokio::process::Command as TokioCommand;
 
 use crate::agent;
@@ -299,12 +301,41 @@ async fn kill_script_subtree(pid: u32) {
         .await;
 }
 
+/// Which subprocess pipe a streamed line came from. Mirrors
+/// [`crate::plugin_runtime::host_api::OutputStream`] so the two can be
+/// unified at the Tauri-event layer without converting between types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SetupOutputStream {
+    Stdout,
+    Stderr,
+}
+
+impl SetupOutputStream {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SetupOutputStream::Stdout => "stdout",
+            SetupOutputStream::Stderr => "stderr",
+        }
+    }
+}
+
+/// Callback receiver for streamed setup-script output. The Tauri-side
+/// caller wraps this around a `workspace_setup_output` event emitter
+/// so the EnvProvisioningConsole can render setup-script chatter
+/// alongside the env-provider plugins' output.
+pub trait SetupOutputSink: Send + Sync {
+    fn line(&self, stream: SetupOutputStream, line: String);
+}
+
 /// Resolve the setup script (preferring `.claudette.json`, falling back to
 /// the per-repo settings script) and execute it. Returns `None` when no
 /// script is configured — the common case for newly-added repositories.
 ///
 /// `WorkspaceEnv` is built lazily — `git::default_branch()` is only called
 /// once we know a script will actually run.
+///
+/// See [`resolve_and_run_setup_streaming`] for the variant that
+/// forwards each output line through a [`SetupOutputSink`].
 pub async fn resolve_and_run_setup(
     ws: &Workspace,
     repo_path: &Path,
@@ -313,6 +344,36 @@ pub async fn resolve_and_run_setup(
     base_branch: Option<&str>,
     default_remote: Option<&str>,
     resolved_env: Option<&ResolvedEnv>,
+) -> Option<SetupResult> {
+    resolve_and_run_setup_streaming(
+        ws,
+        repo_path,
+        worktree_path,
+        settings_script,
+        base_branch,
+        default_remote,
+        resolved_env,
+        None,
+    )
+    .await
+}
+
+/// Variant of [`resolve_and_run_setup`] that forwards each line of
+/// the script's stdout/stderr through `output` as it's read. The
+/// returned [`SetupResult::output`] still accumulates the full combined
+/// output for the chat-transcript banner, so the streaming callback is
+/// purely additive — existing callers passing `None` get the original
+/// behavior.
+#[allow(clippy::too_many_arguments)]
+pub async fn resolve_and_run_setup_streaming(
+    ws: &Workspace,
+    repo_path: &Path,
+    worktree_path: &Path,
+    settings_script: Option<&str>,
+    base_branch: Option<&str>,
+    default_remote: Option<&str>,
+    resolved_env: Option<&ResolvedEnv>,
+    output: Option<Arc<dyn SetupOutputSink>>,
 ) -> Option<SetupResult> {
     let (script, source) = match config::load_config(repo_path) {
         Ok(Some(cfg)) => {
@@ -385,32 +446,54 @@ pub async fn resolve_and_run_setup(
 
     let stdout_handle = child.stdout.take();
     let stderr_handle = child.stderr.take();
+    let stdout_sink = output.clone();
+    let stderr_sink = output.clone();
 
+    // Read both pipes line-by-line so the streaming sink sees output
+    // as it's produced (instead of one big blob at process exit) while
+    // still accumulating the combined buffer for the chat-transcript
+    // banner. Each line is re-terminated with `\n` so the buffered
+    // string matches what `read_to_end` would have produced for tests
+    // that compare against literal expected output.
     let stdout_task = tokio::spawn(async move {
-        let mut buf = Vec::new();
-        if let Some(mut out) = stdout_handle {
-            let _ = tokio::io::AsyncReadExt::read_to_end(&mut out, &mut buf).await;
+        let mut buf = String::new();
+        if let Some(out) = stdout_handle {
+            let reader = tokio::io::BufReader::new(out);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if let Some(sink) = &stdout_sink {
+                    sink.line(SetupOutputStream::Stdout, line.clone());
+                }
+                buf.push_str(&line);
+                buf.push('\n');
+            }
         }
         buf
     });
     let stderr_task = tokio::spawn(async move {
-        let mut buf = Vec::new();
-        if let Some(mut err) = stderr_handle {
-            let _ = tokio::io::AsyncReadExt::read_to_end(&mut err, &mut buf).await;
+        let mut buf = String::new();
+        if let Some(err) = stderr_handle {
+            let reader = tokio::io::BufReader::new(err);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if let Some(sink) = &stderr_sink {
+                    sink.line(SetupOutputStream::Stderr, line.clone());
+                }
+                buf.push_str(&line);
+                buf.push('\n');
+            }
         }
         buf
     });
 
     match tokio::time::timeout(SCRIPT_TIMEOUT, child.wait()).await {
         Ok(Ok(status)) => {
-            let stdout_buf = stdout_task.await.unwrap_or_default();
-            let stderr_buf = stderr_task.await.unwrap_or_default();
-            let stdout = String::from_utf8_lossy(&stdout_buf);
-            let stderr = String::from_utf8_lossy(&stderr_buf);
+            let stdout = stdout_task.await.unwrap_or_default();
+            let stderr = stderr_task.await.unwrap_or_default();
             let combined = if stderr.is_empty() {
-                stdout.to_string()
+                stdout
             } else if stdout.is_empty() {
-                stderr.to_string()
+                stderr
             } else {
                 format!("{stdout}\n{stderr}")
             };
@@ -446,7 +529,7 @@ pub async fn resolve_and_run_setup(
             let _ = child.kill().await;
             let _ = child.wait().await;
             // Drain the reader tasks deterministically. Killing the child
-            // closes its stdio pipes so the read_to_end calls return on
+            // closes its stdio pipes so the line-readers return on
             // their own; awaiting here just ensures both tasks have exited
             // before we return rather than leaving them detached.
             let _ = stdout_task.await;

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -1,14 +1,51 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::plugin_runtime::manifest::PluginKind;
 use crate::process::CommandWindowExt as _;
 use mlua::LuaSerdeExt;
 use mlua::prelude::*;
+use tokio::io::AsyncBufReadExt;
 use tokio::process::Command;
 
+/// Which subprocess pipe a streamed line came from. Lets the UI render
+/// stdout dim and stderr accented so a build's warnings/errors stand
+/// out from informational chatter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+impl OutputStream {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OutputStream::Stdout => "stdout",
+            OutputStream::Stderr => "stderr",
+        }
+    }
+}
+
+/// Callback for streaming subprocess output during a `host.exec_streaming`
+/// call or a setup-script run. The plugin-runtime layer wires this to
+/// per-Tauri-app emitters that forward each line as a
+/// `workspace_env_output` / `workspace_setup_output` event so the
+/// frontend's EnvProvisioningConsole can render the live feed.
+///
+/// Implementations should be cheap and non-blocking — the line is
+/// produced from the spawn task's reader loop, which is on the hot path
+/// of a 100k-line `nix print-dev-env -L`. Heavy work (rate-limit
+/// batching, IPC serialization) belongs in the implementor, not on the
+/// reader task — but in practice Tauri's `emit` is already a quick
+/// queueing operation, so a direct emit-per-line is fine for the
+/// typical resolve.
+pub trait StreamingSink: Send + Sync {
+    fn line(&self, plugin: &str, stream: OutputStream, line: String);
+}
+
 /// Context passed to the Lua host API functions.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HostContext {
     pub plugin_name: String,
     pub kind: PluginKind,
@@ -22,6 +59,12 @@ pub struct HostContext {
     /// can have a 5-minute window without changing the default for
     /// every other workspace.
     pub exec_timeout: Duration,
+    /// Optional sink for `host.exec_streaming` line events. When `None`,
+    /// `host.exec_streaming` still works but doesn't forward output
+    /// anywhere — equivalent to a buffered `host.exec` with the same
+    /// return shape. When `Some`, every line read from stdout/stderr is
+    /// dispatched to the sink before the function returns.
+    pub streaming_sink: Option<Arc<dyn StreamingSink>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -63,7 +106,22 @@ impl Default for HostContext {
             workspace_info: WorkspaceInfo::default(),
             config: HashMap::new(),
             exec_timeout: DEFAULT_EXEC_TIMEOUT,
+            streaming_sink: None,
         }
+    }
+}
+
+impl std::fmt::Debug for HostContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HostContext")
+            .field("plugin_name", &self.plugin_name)
+            .field("kind", &self.kind)
+            .field("allowed_clis", &self.allowed_clis)
+            .field("workspace_info", &self.workspace_info)
+            .field("config", &self.config)
+            .field("exec_timeout", &self.exec_timeout)
+            .field("streaming_sink", &self.streaming_sink.is_some())
+            .finish()
     }
 }
 
@@ -111,6 +169,49 @@ fn register_host_api(lua: &Lua, ctx: HostContext) -> LuaResult<()> {
         lua.create_async_function(move |lua, (cmd, args): (String, LuaTable)| {
             let ctx = exec_ctx.clone();
             async move { host_exec(&lua, &cmd, args, &ctx).await }
+        })?,
+    )?;
+
+    // host.exec_streaming(cmd, args) -> {stdout, stderr, code}
+    //
+    // Same contract / return shape as `host.exec`, but pipes the child's
+    // stdout and stderr line-by-line through `ctx.streaming_sink` (when
+    // present) while ALSO accumulating into the returned `stdout` /
+    // `stderr` strings so existing plugin logic (`result.stdout`,
+    // `result.code`) is unchanged.
+    //
+    // Plugins switch to this variant for long-running invocations
+    // (`nix print-dev-env -L`, `direnv export json` chasing a Nix
+    // flake) so the EnvProvisioningConsole shows live feedback instead
+    // of a frozen elapsed counter.
+    let exec_stream_ctx = ctx.clone();
+    host.set(
+        "exec_streaming",
+        lua.create_async_function(move |lua, (cmd, args): (String, LuaTable)| {
+            let ctx = exec_stream_ctx.clone();
+            async move { host_exec_streaming(&lua, &cmd, args, &ctx).await }
+        })?,
+    )?;
+
+    // host.console(stream, line) — forward a synthesized line through
+    // the same streaming sink that `host.exec_streaming` uses. Lets
+    // in-process providers (env-dotenv) report a "loaded N vars from
+    // .env" heartbeat without spawning a subprocess.
+    //
+    // `stream` is "stdout" or "stderr"; anything else falls back to
+    // stdout so a plugin typo doesn't fail the operation.
+    let console_ctx = ctx.clone();
+    host.set(
+        "console",
+        lua.create_function(move |_, (stream, line): (String, String)| {
+            if let Some(sink) = &console_ctx.streaming_sink {
+                let stream = match stream.as_str() {
+                    "stderr" => OutputStream::Stderr,
+                    _ => OutputStream::Stdout,
+                };
+                sink.line(&console_ctx.plugin_name, stream, line);
+            }
+            Ok(())
         })?,
     )?;
 
@@ -429,6 +530,198 @@ fn normalize_cli_name(cmd: &str) -> &str {
     if stem.is_empty() { cmd } else { stem }
 }
 
+/// Spawn a subprocess and stream stdout/stderr line-by-line through
+/// `ctx.streaming_sink` while accumulating the full output for the
+/// returned `{stdout, stderr, code}` table.
+///
+/// Same allowed-CLI / hermetic-env / timeout contract as
+/// [`host_exec`]. The only structural difference is that the reader
+/// pipes are forwarded line-by-line in dedicated tasks rather than
+/// read to end at once.
+async fn host_exec_streaming(
+    lua: &Lua,
+    cmd: &str,
+    args_table: LuaTable,
+    ctx: &HostContext,
+) -> LuaResult<LuaTable> {
+    let is_declared = ctx.allowed_clis.iter().any(|c| c == cmd);
+    if !is_declared {
+        return Err(LuaError::external(format!(
+            "Command '{cmd}' is not in this plugin's allowed CLIs: {:?}",
+            ctx.allowed_clis
+        )));
+    }
+
+    let mut args: Vec<String> = Vec::new();
+    for i in 1..=args_table.len()? {
+        let arg: String = args_table.get(i)?;
+        if arg.contains('\0') {
+            return Err(LuaError::external("Arguments must not contain null bytes"));
+        }
+        args.push(arg);
+    }
+
+    crate::missing_cli::precheck_cwd(std::path::Path::new(&ctx.workspace_info.worktree_path))
+        .map_err(LuaError::external)?;
+
+    let mut command = Command::new(cmd);
+    command.no_console_window();
+    command.args(&args);
+    command.current_dir(&ctx.workspace_info.worktree_path);
+    apply_hermetic_env(&mut command, ctx);
+    command.kill_on_drop(true);
+    command.stdout(std::process::Stdio::piped());
+    command.stderr(std::process::Stdio::piped());
+
+    let mut child = command.spawn().map_err(|e| {
+        let tool = normalize_cli_name(cmd);
+        let msg = crate::missing_cli::map_spawn_err(&e, tool, || {
+            format!("Failed to execute '{cmd}': {e}")
+        });
+        LuaError::external(msg)
+    })?;
+
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let plugin_name = ctx.plugin_name.clone();
+    // SECURITY: drop env-provider stdout from the sink. Env providers
+    // run commands like `direnv export json`, `mise env --json`, and
+    // `nix print-dev-env --json` whose stdout contains the FULL
+    // machine-readable environment payload — every variable including
+    // secrets (AWS_SECRET_ACCESS_KEY, GH_TOKEN, ANTHROPIC_API_KEY, …).
+    // Streaming that into the workspace terminal file leaks tokens to
+    // disk in temp_dir AND renders them on-screen in the read-only
+    // Claudette Terminal tab. The progress information users actually
+    // want lives on stderr (`direnv: loading .envrc`, nix's `-L`
+    // per-derivation build log, mise's tool-install chatter), which
+    // the sink continues to receive.
+    //
+    // Plugin kinds OTHER than env-provider (SCM in particular) don't
+    // produce secret JSON on stdout and benefit from seeing both
+    // streams.
+    let forward_stdout_to_sink = ctx.kind != PluginKind::EnvProvider;
+    let sink_stdout = if forward_stdout_to_sink {
+        ctx.streaming_sink.clone()
+    } else {
+        None
+    };
+    let sink_stderr = ctx.streaming_sink.clone();
+    let plugin_for_stderr = plugin_name.clone();
+
+    // One reader task per pipe so stdout and stderr lines interleave in
+    // real time. Each task buffers the full stream for the returned
+    // table while forwarding individual lines to the sink (when set).
+    let stdout_task = tokio::spawn(async move {
+        let mut buf = String::new();
+        if let Some(out) = stdout {
+            let mut reader = tokio::io::BufReader::new(out);
+            // `read_line` preserves the trailing `\n` / `\r\n` (or
+            // returns an unterminated final line as-is). The captured
+            // `buf` therefore matches what a plain `read_to_end` would
+            // have produced byte-for-byte — necessary because callers
+            // like env-direnv pipe `result.stdout` into
+            // `host.json_decode`, and were relying on `host.exec`'s
+            // exact-bytes contract. The sink view trims the line ending
+            // so xterm renderers don't get duplicate CRs.
+            loop {
+                let prev_len = buf.len();
+                match reader.read_line(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(_) => {
+                        if let Some(sink) = &sink_stdout {
+                            let segment = &buf[prev_len..];
+                            let trimmed = segment.trim_end_matches(['\r', '\n']);
+                            sink.line(&plugin_name, OutputStream::Stdout, trimmed.to_string());
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+        buf
+    });
+    let stderr_task = tokio::spawn(async move {
+        let mut buf = String::new();
+        if let Some(err) = stderr {
+            let mut reader = tokio::io::BufReader::new(err);
+            loop {
+                let prev_len = buf.len();
+                match reader.read_line(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(_) => {
+                        if let Some(sink) = &sink_stderr {
+                            let segment = &buf[prev_len..];
+                            let trimmed = segment.trim_end_matches(['\r', '\n']);
+                            sink.line(
+                                &plugin_for_stderr,
+                                OutputStream::Stderr,
+                                trimmed.to_string(),
+                            );
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+        buf
+    });
+
+    let exec_timeout = ctx.exec_timeout;
+    let wait = async {
+        let status = child
+            .wait()
+            .await
+            .map_err(|e| LuaError::external(format!("Failed to wait for '{cmd}': {e}")))?;
+        let stdout = stdout_task.await.unwrap_or_default();
+        let stderr = stderr_task.await.unwrap_or_default();
+        Ok::<_, LuaError>((status, stdout, stderr))
+    };
+    let (status, stdout_buf, stderr_buf) = tokio::time::timeout(exec_timeout, wait)
+        .await
+        .map_err(|_| {
+            LuaError::external(format!(
+                "Command '{cmd}' timed out after {}s",
+                exec_timeout.as_secs()
+            ))
+        })??;
+
+    let result = lua.create_table()?;
+    result.set("stdout", stdout_buf)?;
+    result.set("stderr", stderr_buf)?;
+    result.set("code", status.code().unwrap_or(-1))?;
+    Ok(result)
+}
+
+/// Apply the env-provider hermetic baseline (clear, then restore a
+/// minimal allowlist) — shared between [`host_exec`] and
+/// [`host_exec_streaming`] so a future change to the allowlist stays in
+/// one place.
+fn apply_hermetic_env(command: &mut Command, ctx: &HostContext) {
+    if ctx.kind == PluginKind::EnvProvider {
+        command.env_clear();
+        command.env("PATH", crate::env::enriched_path());
+        for key in [
+            "HOME",
+            "USER",
+            "LOGNAME",
+            "SHELL",
+            "TERM",
+            "LANG",
+            "LC_ALL",
+            "XDG_DATA_HOME",
+            "XDG_STATE_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_CONFIG_HOME",
+        ] {
+            if let Ok(val) = std::env::var(key) {
+                command.env(key, val);
+            }
+        }
+    } else {
+        command.env("PATH", crate::env::enriched_path());
+    }
+}
+
 /// Execute a subprocess, restricted to allowed CLIs.
 async fn host_exec(
     lua: &Lua,
@@ -475,49 +768,11 @@ async fn host_exec(
     command.args(&args);
     command.current_dir(&ctx.workspace_info.worktree_path);
 
-    // Env-provider plugins run hermetically: we clear the inherited env
-    // and set only a minimal, stable baseline. This matters for tools
-    // like `direnv export json` which compute a *diff* against the
-    // current env — if Claudette was launched from a terminal that
-    // already had the workspace's env loaded, direnv would emit only
-    // the delta (handful of vars), not the full set. A hermetic baseline
-    // makes the exported set deterministic and independent of how
-    // Claudette was launched. SCM plugins keep inheriting the full env
-    // because they depend on user-state vars like `GH_TOKEN`,
-    // `SSH_AUTH_SOCK`, `XDG_CONFIG_HOME`, etc.
-    if ctx.kind == PluginKind::EnvProvider {
-        command.env_clear();
-        command.env("PATH", crate::env::enriched_path());
-        // XDG_*_HOME vars matter: direnv/mise store their allow/trust
-        // caches under XDG_DATA_HOME (defaulting to $HOME/.local/share
-        // when unset). Users who point those at non-default paths
-        // would otherwise see their pre-approved worktrees reported
-        // as blocked because we'd be looking at the default location
-        // while their terminal wrote to the override.
-        for key in [
-            "HOME",
-            "USER",
-            "LOGNAME",
-            "SHELL",
-            "TERM",
-            "LANG",
-            "LC_ALL",
-            "XDG_DATA_HOME",
-            "XDG_STATE_HOME",
-            "XDG_CACHE_HOME",
-            "XDG_CONFIG_HOME",
-        ] {
-            if let Ok(val) = std::env::var(key) {
-                command.env(key, val);
-            }
-        }
-    } else {
-        // macOS GUI apps inherit a minimal launchd PATH, so binaries like
-        // `gh`/`glab` (typically in /opt/homebrew/bin) wouldn't be found.
-        // Pass the enriched PATH so the child — and anything it shells out
-        // to (git, credential helpers, editors) — can resolve them.
-        command.env("PATH", crate::env::enriched_path());
-    }
+    // Env-provider plugins run hermetically (env_clear + minimal
+    // allowlist); SCM plugins inherit the full env. Both branches are
+    // implemented in the shared [`apply_hermetic_env`] helper so
+    // host.exec and host.exec_streaming stay in sync.
+    apply_hermetic_env(&mut command, ctx);
     command.kill_on_drop(true);
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
@@ -1287,5 +1542,121 @@ mod tests {
         // callers from silently emitting an empty tool token.
         assert_eq!(normalize_cli_name("/"), "/");
         assert_eq!(normalize_cli_name(""), "");
+    }
+
+    /// Recording sink for the env-provider security test. Captures
+    /// every (stream, line) pair the runtime forwards.
+    #[derive(Default)]
+    struct RecordingSink {
+        lines: std::sync::Mutex<Vec<(OutputStream, String)>>,
+    }
+
+    impl StreamingSink for RecordingSink {
+        fn line(&self, _plugin: &str, stream: OutputStream, line: String) {
+            self.lines.lock().unwrap().push((stream, line));
+        }
+    }
+
+    #[tokio::test]
+    async fn exec_streaming_env_provider_drops_stdout_from_sink() {
+        // SECURITY regression: env-provider plugins run JSON-producing
+        // commands like `direnv export json`, `mise env --json`, and
+        // `nix print-dev-env --json` whose stdout contains the FULL
+        // machine-readable environment payload — every variable
+        // including secrets. The runtime must drop env-provider stdout
+        // from the streaming sink so it never lands in the workspace
+        // terminal file or the Claudette Terminal tab. The captured
+        // `result.stdout` returned to Lua is unaffected (the plugin
+        // still needs it for json_decode); only the live sink view
+        // is filtered.
+        let recording = std::sync::Arc::new(RecordingSink::default());
+        let mut ctx = make_test_ctx();
+        ctx.kind = PluginKind::EnvProvider;
+        ctx.streaming_sink = Some(recording.clone() as Arc<dyn StreamingSink>);
+        let lua = create_lua_vm(ctx).unwrap();
+
+        let stdout: String = lua
+            .load(r#"return host.exec_streaming("cargo", {"--version"}).stdout"#)
+            .eval_async()
+            .await
+            .unwrap();
+
+        // Captured stdout (returned to the plugin) is intact.
+        assert!(
+            stdout.trim().starts_with("cargo "),
+            "captured stdout must reach the plugin, got: {stdout:?}",
+        );
+
+        // Sink saw zero stdout lines — that's the security guarantee.
+        let sink_lines = recording.lines.lock().unwrap();
+        let stdout_lines: Vec<_> = sink_lines
+            .iter()
+            .filter(|(s, _)| *s == OutputStream::Stdout)
+            .collect();
+        assert!(
+            stdout_lines.is_empty(),
+            "env-provider stdout must not reach the sink (would leak \
+             secrets to the workspace terminal), got: {stdout_lines:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn exec_streaming_scm_plugin_forwards_stdout_to_sink() {
+        // Counterpart to the env-provider test: SCM plugins don't
+        // produce secret JSON on stdout, so the runtime should still
+        // forward their stdout for live progress display. Guards
+        // against an over-eager future change that would silence ALL
+        // stdout streaming.
+        let recording = std::sync::Arc::new(RecordingSink::default());
+        let mut ctx = make_test_ctx();
+        ctx.kind = PluginKind::Scm;
+        ctx.streaming_sink = Some(recording.clone() as Arc<dyn StreamingSink>);
+        let lua = create_lua_vm(ctx).unwrap();
+
+        let _: LuaTable = lua
+            .load(r#"return host.exec_streaming("cargo", {"--version"})"#)
+            .eval_async()
+            .await
+            .unwrap();
+
+        let sink_lines = recording.lines.lock().unwrap();
+        let stdout_lines: Vec<_> = sink_lines
+            .iter()
+            .filter(|(s, _)| *s == OutputStream::Stdout)
+            .collect();
+        assert!(
+            !stdout_lines.is_empty(),
+            "SCM plugin stdout must reach the sink for live progress",
+        );
+    }
+
+    #[tokio::test]
+    async fn exec_streaming_preserves_exact_stdout_bytes() {
+        // Regression for the codex review on the env-provisioning console:
+        // `host.exec_streaming` is documented as returning the same
+        // captured stdout as `host.exec`. The original implementation
+        // used `BufReader::lines()` which strips `\n` / `\r\n` and then
+        // re-appended `\n` — silently rewriting CRLF→LF and appending a
+        // trailing newline to commands whose final line had none.
+        // Plugins like env-direnv pipe `result.stdout` into
+        // `host.json_decode`, so any byte-level drift would surface as
+        // a parse failure on real env-provider workloads.
+        let ctx = make_test_ctx();
+        let lua = create_lua_vm(ctx).unwrap();
+
+        let streamed: String = lua
+            .load(r#"return host.exec_streaming("cargo", {"--version"}).stdout"#)
+            .eval_async()
+            .await
+            .unwrap();
+        let captured: String = lua
+            .load(r#"return host.exec("cargo", {"--version"}).stdout"#)
+            .eval_async()
+            .await
+            .unwrap();
+        assert_eq!(
+            streamed, captured,
+            "exec_streaming must produce byte-identical stdout to exec",
+        );
     }
 }

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -28,18 +28,22 @@ impl OutputStream {
 }
 
 /// Callback for streaming subprocess output during a `host.exec_streaming`
-/// call or a setup-script run. The plugin-runtime layer wires this to
-/// per-Tauri-app emitters that forward each line as a
-/// `workspace_env_output` / `workspace_setup_output` event so the
-/// frontend's EnvProvisioningConsole can render the live feed.
+/// call. The Tauri-side implementation is [`WorkspaceTerminalFileSink`]
+/// (in `src-tauri/src/commands/env.rs`), which appends each line to the
+/// workspace-scoped output file at
+/// `$TMPDIR/claudette-workspace-terminal/<workspace_id>/terminal.output`.
+/// The Claudette Terminal tab tails that file, so xterm.js renders
+/// the live nix/direnv/mise output directly. The previous
+/// per-line `workspace_env_output` Tauri event and the
+/// `EnvProvisioningConsole` React component are gone — see the
+/// "promote Claudette Terminal" change.
 ///
 /// Implementations should be cheap and non-blocking — the line is
 /// produced from the spawn task's reader loop, which is on the hot path
 /// of a 100k-line `nix print-dev-env -L`. Heavy work (rate-limit
-/// batching, IPC serialization) belongs in the implementor, not on the
-/// reader task — but in practice Tauri's `emit` is already a quick
-/// queueing operation, so a direct emit-per-line is fine for the
-/// typical resolve.
+/// batching, file rotation) belongs in the implementor, not on the
+/// reader task. The bundled file sink caches an append-mode handle in a
+/// `Mutex<Option<File>>` so per-line cost is one `write_all` syscall.
 pub trait StreamingSink: Send + Sync {
     fn line(&self, plugin: &str, stream: OutputStream, line: String);
 }

--- a/src/plugin_runtime/mod.rs
+++ b/src/plugin_runtime/mod.rs
@@ -610,8 +610,40 @@ impl PluginRegistry {
         // now scale with the plugin's manifest default + any global /
         // per-repo overrides — see `effective_timeout`.
         let timeout = self.effective_timeout(plugin_name, Some(&workspace_info));
-        self.call_operation_with_timeout(plugin_name, operation, args, workspace_info, timeout)
-            .await
+        self.call_operation_with_timeout(
+            plugin_name,
+            operation,
+            args,
+            workspace_info,
+            timeout,
+            None,
+        )
+        .await
+    }
+
+    /// Variant of [`call_operation`] that attaches a [`StreamingSink`]
+    /// to the plugin's host context so any `host.exec_streaming` call
+    /// (or `host.console`) the plugin makes forwards lines to the
+    /// sink. Pass `None` for the sink to get the same behavior as
+    /// [`call_operation`].
+    pub async fn call_operation_streaming(
+        &self,
+        plugin_name: &str,
+        operation: &str,
+        args: serde_json::Value,
+        workspace_info: WorkspaceInfo,
+        streaming_sink: Option<std::sync::Arc<dyn host_api::StreamingSink>>,
+    ) -> Result<serde_json::Value, PluginError> {
+        let timeout = self.effective_timeout(plugin_name, Some(&workspace_info));
+        self.call_operation_with_timeout(
+            plugin_name,
+            operation,
+            args,
+            workspace_info,
+            timeout,
+            streaming_sink,
+        )
+        .await
     }
 
     async fn call_operation_with_timeout(
@@ -621,6 +653,7 @@ impl PluginRegistry {
         args: serde_json::Value,
         workspace_info: WorkspaceInfo,
         operation_timeout: Duration,
+        streaming_sink: Option<std::sync::Arc<dyn host_api::StreamingSink>>,
     ) -> Result<serde_json::Value, PluginError> {
         let plugin = self
             .plugins
@@ -681,6 +714,7 @@ impl PluginRegistry {
             workspace_info,
             config,
             exec_timeout: operation_timeout,
+            streaming_sink,
         };
 
         let lua =
@@ -1152,6 +1186,7 @@ mod tests {
                 serde_json::json!({}),
                 test_workspace(),
                 Duration::from_millis(100),
+                None,
             ),
         )
         .await
@@ -1191,6 +1226,7 @@ mod tests {
                 serde_json::json!({}),
                 test_workspace(),
                 Duration::from_millis(100),
+                None,
             ),
         )
         .await
@@ -1227,6 +1263,7 @@ mod tests {
                 serde_json::json!({}),
                 test_workspace(),
                 Duration::from_millis(100),
+                None,
             )
             .await;
 

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { getVersion } from "@tauri-apps/api/app";
 import { useAppStore } from "./stores/useAppStore";
+import { findPendingPlaceholderForCreatedWorkspace } from "./stores/slices/workspacesSlice";
 import { loadInitialData, getAppSetting, setAppSetting, getHostEnvFlags, listRemoteConnections, listDiscoveredServers, getLocalServerStatus, detectInstalledApps, listSystemFonts, deleteTerminalTab, listAppSettingsWithPrefix, listAgentBackends, autoDetectAgentBackends, refreshAgentBackendModels, bootOk } from "./services/tauri";
 import { applyTheme, applyUserFonts, loadAllThemes, findTheme, cacheThemePreference, getThemeDataAttr } from "./utils/theme";
 import { DEFAULT_THEME_ID, DEFAULT_LIGHT_THEME_ID } from "./styles/themes";
@@ -348,7 +349,11 @@ function App() {
       .then((val) => { if (val === "true") setUsageInsightsEnabled(true); })
       .catch(() => {});
     getAppSetting("claudette_terminal_enabled")
-      .then((val) => { if (val === "true") setClaudetteTerminalEnabled(true); })
+      .then((val) => {
+        // Default ON: only an explicit "false" disables. Absent / any other
+        // value leaves the store at its `true` initial value.
+        if (val === "false") setClaudetteTerminalEnabled(false);
+      })
       .catch(() => {});
     getAppSetting("show_sidebar_running_commands")
       .then((val) => { if (val === "true") setShowSidebarRunningCommands(true); })
@@ -760,9 +765,43 @@ function App() {
       // `!= null` or truthy) doesn't trip on `undefined`. All
       // `workspaces-changed` events come from local ops by definition
       // (the WS server doesn't emit them), so null is correct.
+      const stamped = { ...workspace, remote_connection_id: null };
+
+      // Untangle the optimistic-create / optimistic-fork placeholder
+      // before adding the real row. Without this swap the user can sit
+      // on a `pending-create-*` / `pending-fork-*` id while the backend
+      // is already writing to terminal tabs and workspace_terminal_output
+      // files under the real id — TerminalPanel queries by selection,
+      // finds nothing for the placeholder, and the env-provider output
+      // is invisible during the long resolve window the placeholder
+      // exists to cover.
+      if (kind === "created") {
+        const match = findPendingPlaceholderForCreatedWorkspace({
+          workspaces: store.workspaces,
+          pendingCreates: store.pendingCreates,
+          pendingForks: store.pendingForks,
+          real: stamped,
+        });
+        if (match) {
+          if (match.from === "create") {
+            store.commitPendingCreate(match.placeholderId, stamped);
+          } else {
+            store.commitPendingFork(match.placeholderId, stamped);
+          }
+          return;
+        }
+      }
+
       // `addWorkspace` is idempotent by id, so this safely handles both
       // new workspaces and re-emitted updates without duplicating.
-      store.addWorkspace({ ...workspace, remote_connection_id: null });
+      // Preparing state is seeded by the backend via a
+      // `workspace_env_progress (started)` event emitted at the start
+      // of `create_workspace_inner` — handled by the progress listener
+      // in `useWorkspaceEnvironmentPreparation` — so the no-placeholder
+      // IPC/CLI create path doesn't expose an unprimed worktree, and
+      // the fork path (which doesn't run a warmup) doesn't get stranded
+      // in a permanent preparing state.
+      store.addWorkspace(stamped);
     });
 
     // Reflect what the agent actually used into the input bar after every

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -68,6 +68,19 @@
   line-height: 1.4;
 }
 
+/* Sub-line under the main placard text — used by the
+   optimistic-create placard to show the generated workspace slug as
+   secondary info, so the primary "Preparing workspace in <repo>…"
+   line stays readable while the slug is still visible. Muted color
+   + smaller font matches the visual weight of a hint. */
+.preparingForkSub {
+  margin-top: 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  letter-spacing: 0;
+}
+
 @keyframes preparingForkSpin {
   to {
     transform: rotate(360deg);

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -243,6 +243,28 @@ export function ChatPanel() {
     return s.workspaces.find((w) => w.id === sourceId)?.name ?? null;
   });
 
+  // Sibling of `pendingForkSourceName` for the optimistic-create
+  // placeholder. Resolves the repo's display name so the placard
+  // reads "Preparing workspace in <repo>…" — gives the user the
+  // same "here's what's happening" affordance the fork case has,
+  // without exposing the auto-generated slug (the slug is also
+  // visible in the placeholder's sidebar row, so doubling it here
+  // is noise).
+  const pendingCreateRepoName = useAppStore((s) => {
+    if (!s.selectedWorkspaceId) return null;
+    const repoId = s.pendingCreates[s.selectedWorkspaceId];
+    if (!repoId) return null;
+    return s.repositories.find((r) => r.id === repoId)?.name ?? null;
+  });
+  // The placeholder workspace's own name (the generated slug). Shown
+  // as a secondary line in the placard so the user knows which row
+  // in the sidebar the placard corresponds to.
+  const pendingCreateWorkspaceName = useAppStore((s) => {
+    if (!s.selectedWorkspaceId) return null;
+    if (!s.pendingCreates[s.selectedWorkspaceId]) return null;
+    return s.workspaces.find((w) => w.id === s.selectedWorkspaceId)?.name ?? null;
+  });
+
   // Counts feeding the "all tabs closed" empty state. Each selector is
   // intentionally a `.length || 0` so the subscribed value is a primitive —
   // returning the array would re-fire on every reference change.
@@ -1563,11 +1585,35 @@ export function ChatPanel() {
           "Workspace not found" and the tab strip would render empty
           anyway. Suppressing it keeps the placard centered cleanly and
           stops the console-error spam during the fork window. */}
-      {selectedWorkspaceId && !pendingForkSourceName && (
-        <SessionTabs workspaceId={selectedWorkspaceId} />
-      )}
+      {selectedWorkspaceId &&
+        !pendingForkSourceName &&
+        !pendingCreateWorkspaceName && (
+          <SessionTabs workspaceId={selectedWorkspaceId} />
+        )}
 
-      {pendingForkSourceName ? (
+      {pendingCreateWorkspaceName ? (
+        // Optimistic-create placeholder: the user clicked New
+        // Workspace, we generated a slug, inserted a placeholder
+        // row into the store, selected it, and are now awaiting
+        // `createWorkspace` to return. Same shape as the fork
+        // placard below — render a static placard with the env
+        // console mounted against the placeholder id so any output
+        // buffered against it (host.console heartbeats from
+        // env-dotenv, etc.) is visible during the create window.
+        // After commit, the placard disappears and the regular chat
+        // panel takes over for the real workspace.
+        <div className={styles.preparingFork} role="status" aria-live="polite">
+          <LoaderCircle size={20} className={styles.preparingForkSpinner} />
+          <div className={styles.preparingForkText}>
+            {t("preparing_workspace_in", "Preparing workspace in {{repo}}…", {
+              repo: pendingCreateRepoName ?? "this repository",
+            })}
+            <div className={styles.preparingForkSub}>
+              {pendingCreateWorkspaceName}
+            </div>
+          </div>
+        </div>
+      ) : pendingForkSourceName ? (
         // Optimistic-fork placeholder: the user clicked Fork from a
         // checkpoint, we inserted a placeholder workspace into the
         // store, selected it, and are now awaiting

--- a/src/ui/src/components/files/FilesPanel.tsx
+++ b/src/ui/src/components/files/FilesPanel.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import { listWorkspaceFiles, type FileEntry } from "../../services/tauri";
-import { isPendingForkWorkspace } from "../../utils/workspaceEnvironment";
+import { isPendingPlaceholderWorkspace } from "../../utils/workspaceEnvironment";
 import { resolveHotkeyAction } from "../../hotkeys/bindings";
 import { isAgentBusy } from "../../utils/agentStatus";
 import {
@@ -24,14 +24,15 @@ import styles from "./FilesPanel.module.css";
 export function FilesPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const workspaces = useAppStore((s) => s.workspaces);
-  // Optimistic-fork placeholders have no backing DB row; any
-  // `list_workspace_files` against the placeholder id returns
-  // "Workspace not found" and we'd render an error banner in the
-  // right sidebar mid-fork.  Skip every load / poll path for the
-  // duration of the pending fork; the effects re-fire against the
-  // real workspace id when `commitPendingFork` swaps the selection.
-  const isPendingFork = useAppStore((s) =>
-    isPendingForkWorkspace(s, selectedWorkspaceId),
+  // Optimistic-fork / optimistic-create placeholders have no backing
+  // DB row; any `list_workspace_files` against the placeholder id
+  // returns "Workspace not found" and we'd render an error banner in
+  // the right sidebar during the brief window before the eager-swap.
+  // Skip every load / poll path for the duration of the placeholder;
+  // the effects re-fire against the real workspace id when
+  // `commitPendingFork` / `commitPendingCreate` swaps the selection.
+  const isPendingPlaceholder = useAppStore((s) =>
+    isPendingPlaceholderWorkspace(s, selectedWorkspaceId),
   );
   const refreshNonce = useAppStore((s) =>
     selectedWorkspaceId
@@ -127,7 +128,7 @@ export function FilesPanel() {
   );
 
   useEffect(() => {
-    if (!selectedWorkspaceId || isPendingFork) {
+    if (!selectedWorkspaceId || isPendingPlaceholder) {
       // Bumping the version invalidates any in-flight load from the
       // previously-selected workspace so its `.then` can't land here
       // and re-flip `loading` back to true. Pair with an explicit
@@ -143,10 +144,10 @@ export function FilesPanel() {
       void loadFiles(selectedWorkspaceId, true);
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [selectedWorkspaceId, refreshNonce, loadFiles, isPendingFork]);
+  }, [selectedWorkspaceId, refreshNonce, loadFiles, isPendingPlaceholder]);
 
   useEffect(() => {
-    if (!selectedWorkspaceId || isPendingFork || !isRunning) return;
+    if (!selectedWorkspaceId || isPendingPlaceholder || !isRunning) return;
     const interval = setInterval(() => {
       // Skip when a previous load is still in flight — see
       // `loadFilesInFlightCount` declaration above for the pileup rationale.
@@ -154,18 +155,18 @@ export function FilesPanel() {
       void loadFiles(selectedWorkspaceId, false);
     }, FILES_AGENT_RUNNING_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [isRunning, selectedWorkspaceId, loadFiles, isPendingFork]);
+  }, [isRunning, selectedWorkspaceId, loadFiles, isPendingPlaceholder]);
 
   useEffect(() => {
     const wasRunning = prevIsRunning.current;
     prevIsRunning.current = isRunning;
-    if (!selectedWorkspaceId || isPendingFork || wasRunning !== true || isRunning) return;
+    if (!selectedWorkspaceId || isPendingPlaceholder || wasRunning !== true || isRunning) return;
 
     const timer = setTimeout(() => {
       void loadFiles(selectedWorkspaceId, false);
     }, 500);
     return () => clearTimeout(timer);
-  }, [isRunning, selectedWorkspaceId, loadFiles, isPendingFork]);
+  }, [isRunning, selectedWorkspaceId, loadFiles, isPendingPlaceholder]);
 
   // Idle polling: refresh file tree while agent is not running so
   // manually-edited files surface without navigating away. The cadence
@@ -173,7 +174,7 @@ export function FilesPanel() {
   // interval so the two stay in lockstep — see that module for the
   // full three-tier rationale.
   useEffect(() => {
-    if (!selectedWorkspaceId || isPendingFork || isRunning) return;
+    if (!selectedWorkspaceId || isPendingPlaceholder || isRunning) return;
     const interval = setInterval(() => {
       // Skip when a previous load is still in flight — see
       // `loadFilesInFlightCount` declaration above for the pileup rationale.
@@ -181,7 +182,7 @@ export function FilesPanel() {
       void loadFiles(selectedWorkspaceId, false);
     }, IDLE_REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [isRunning, selectedWorkspaceId, loadFiles, isPendingFork]);
+  }, [isRunning, selectedWorkspaceId, loadFiles, isPendingPlaceholder]);
 
   // React to the `requestNewFileAtRoot` nonce: open the inline create
   // editor at the workspace root.

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -6,7 +6,7 @@ import {
 } from "../../utils/pollingIntervals";
 import { ChevronRight, Undo2, Trash2, Plus, Minus, FilePenLine } from "lucide-react";
 import { useAppStore, selectActiveSessionId } from "../../stores/useAppStore";
-import { isPendingForkWorkspace } from "../../utils/workspaceEnvironment";
+import { isPendingPlaceholderWorkspace } from "../../utils/workspaceEnvironment";
 import { useWorkspaceTaskHistory } from "../../hooks/useWorkspaceTaskHistory";
 import {
   discardFile,
@@ -65,8 +65,8 @@ export const RightSidebar = memo(function RightSidebar() {
   // quietly empty during the fork instead of flashing error states.
   // Effects re-fire against the real workspace id once
   // `commitPendingFork` swaps the selection.
-  const isPendingFork = useAppStore((s) =>
-    isPendingForkWorkspace(s, selectedWorkspaceId),
+  const isPendingPlaceholder = useAppStore((s) =>
+    isPendingPlaceholderWorkspace(s, selectedWorkspaceId),
   );
   const remoteConnectionId = ws?.remote_connection_id ?? null;
   const worktreePath = ws?.worktree_path ?? null;
@@ -202,7 +202,7 @@ export const RightSidebar = memo(function RightSidebar() {
     // flight. The empty-list fallback `diffFiles.length === 0 && diffLoading`
     // then renders "Loading..." instead of stale rows.
     clearDiff();
-    if (isPendingFork) {
+    if (isPendingPlaceholder) {
       // Placeholder workspace — the backend doesn't have this id yet.
       // Skip the fetch entirely; the effect re-runs when commit swaps
       // selection to the real workspace.
@@ -226,11 +226,11 @@ export const RightSidebar = memo(function RightSidebar() {
       .finally(() => {
         loadDiffInFlightCount.current -= 1;
       });
-  }, [selectedWorkspaceId, loadDiff, applyDiffResult, setDiffLoading, clearDiff, isDiffResultStillValid, isPendingFork]);
+  }, [selectedWorkspaceId, loadDiff, applyDiffResult, setDiffLoading, clearDiff, isDiffResultStillValid, isPendingPlaceholder]);
 
   // Live-refresh diff files while agent is running.
   useEffect(() => {
-    if (!selectedWorkspaceId || isPendingFork || !isRunning) return;
+    if (!selectedWorkspaceId || isPendingPlaceholder || !isRunning) return;
     const workspaceId = selectedWorkspaceId;
 
     const interval = setInterval(() => {
@@ -252,14 +252,14 @@ export const RightSidebar = memo(function RightSidebar() {
     }, DIFF_AGENT_RUNNING_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, isDiffResultStillValid, isPendingFork]);
+  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, isDiffResultStillValid, isPendingPlaceholder]);
 
   // Final refresh when agent stops running (after making changes).
   useEffect(() => {
     const wasRunning = prevIsRunning.current;
     prevIsRunning.current = isRunning;
 
-    if (!selectedWorkspaceId || isPendingFork || wasRunning !== true || isRunning) return;
+    if (!selectedWorkspaceId || isPendingPlaceholder || wasRunning !== true || isRunning) return;
     const workspaceId = selectedWorkspaceId;
 
     const timer = setTimeout(() => {
@@ -283,14 +283,14 @@ export const RightSidebar = memo(function RightSidebar() {
     }, 500);
 
     return () => clearTimeout(timer);
-  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, setDiffLoading, isDiffResultStillValid, isPendingFork]);
+  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, setDiffLoading, isDiffResultStillValid, isPendingPlaceholder]);
 
   // Idle polling: refresh diff while agent is not running so manually-edited
   // files and external git ops surface without navigating away. The cadence
   // is shared with the Files panel via `utils/pollingIntervals` so the two
   // stay in lockstep.
   useEffect(() => {
-    if (!selectedWorkspaceId || isPendingFork || isRunning) return;
+    if (!selectedWorkspaceId || isPendingPlaceholder || isRunning) return;
     const workspaceId = selectedWorkspaceId;
 
     const interval = setInterval(() => {
@@ -312,7 +312,7 @@ export const RightSidebar = memo(function RightSidebar() {
     }, IDLE_REFRESH_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, isDiffResultStillValid, isPendingFork]);
+  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, isDiffResultStillValid, isPendingPlaceholder]);
 
   const statusLabel = (status: string | { Renamed: { from: string } }) => {
     if (typeof status === "string") {

--- a/src/ui/src/components/settings/sections/EnvPanel.test.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.test.tsx
@@ -34,6 +34,7 @@ const claudettePluginServices = vi.hoisted(() => ({
 const envServices = vi.hoisted(() => ({
   getEnvSources: vi.fn(),
   getEnvTargetWorktree: vi.fn(),
+  listEnvProviderDisabled: vi.fn(),
   reloadEnv: vi.fn(),
   runEnvTrust: vi.fn(),
   setEnvProviderEnabled: vi.fn(),
@@ -133,6 +134,7 @@ describe("EnvPanel — per-repo settings drawer", () => {
     envServices.runEnvTrust.mockResolvedValue(undefined);
     envServices.setEnvProviderEnabled.mockResolvedValue(undefined);
     envServices.reloadEnv.mockResolvedValue(undefined);
+    envServices.listEnvProviderDisabled.mockResolvedValue([] as string[]);
   });
 
   afterEach(async () => {
@@ -296,6 +298,7 @@ describe("EnvPanel — toggle stays actionable mid-resolve", () => {
     envServices.runEnvTrust.mockResolvedValue(undefined);
     envServices.setEnvProviderEnabled.mockResolvedValue(undefined);
     envServices.reloadEnv.mockResolvedValue(undefined);
+    envServices.listEnvProviderDisabled.mockResolvedValue([] as string[]);
     // Real Zustand store under test — reset to defaults so prior tests'
     // state can't leak in.
     useAppStore.setState({ workspaceEnvironment: {} });
@@ -420,6 +423,109 @@ describe("EnvPanel — toggle stays actionable mid-resolve", () => {
     // plugins downstream may still resolve, and the env-prep listener
     // owns the transition to "ready" / "error".
     expect(env?.status).toBe("preparing");
+  });
+
+  it("hydrates placeholder rows from listEnvProviderDisabled before the resolve returns", async () => {
+    // Codex iter (post-squash) P2: with the toggle now actionable
+    // mid-resolve, the placeholder rows from `listClaudettePlugins`
+    // can't continue hard-coding `enabled: true` — a repo whose
+    // env-direnv is already disabled but whose env-mise resolve is
+    // slow would render env-direnv as enabled (incorrect) until the
+    // slow resolve returned. Hydrate from `listEnvProviderDisabled`
+    // (cheap DB read) so the placeholder reflects the persisted state.
+    let resolveGetEnvSources: (value: EnvSourceInfo[]) => void;
+    const getEnvSourcesPromise = new Promise<EnvSourceInfo[]>((resolve) => {
+      resolveGetEnvSources = resolve;
+    });
+    claudettePluginServices.listClaudettePlugins.mockResolvedValue([
+      envProvider({ name: "env-direnv", display_name: "direnv" }),
+      envProvider({ name: "env-mise", display_name: "mise" }),
+    ]);
+    envServices.getEnvSources.mockReturnValue(getEnvSourcesPromise);
+    envServices.listEnvProviderDisabled.mockResolvedValue(["env-direnv"]);
+
+    const container = await renderEnvPanel();
+
+    // Both rows visible, but the toggles reflect persisted state.
+    const toggles = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button[role="switch"]'),
+    );
+    expect(toggles).toHaveLength(2);
+    // The row order tracks the listClaudettePlugins iteration; assert
+    // by `aria-label` which embeds the display_name so the test
+    // doesn't depend on render order.
+    const direnvToggle = toggles.find((t) =>
+      t.getAttribute("aria-label")?.includes("direnv"),
+    );
+    const miseToggle = toggles.find((t) =>
+      t.getAttribute("aria-label")?.includes("mise"),
+    );
+    expect(direnvToggle!.getAttribute("aria-checked")).toBe("false");
+    expect(miseToggle!.getAttribute("aria-checked")).toBe("true");
+
+    // Clean up.
+    resolveGetEnvSources!([]);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  });
+
+  it("rolls back the optimistic flip when setEnvProviderEnabled rejects", async () => {
+    // Codex iter (post-squash) P3: a failed save must NOT leave the
+    // panel showing the optimistic state — the user thinks they
+    // disabled the provider, but the DB still has the old value, so
+    // the next agent spawn picks up env from a provider the panel
+    // claims is off. Capture the prior `enabled` flag and restore it
+    // on rejection.
+    claudettePluginServices.listClaudettePlugins.mockResolvedValue([
+      envProvider({ name: "env-direnv", display_name: "direnv" }),
+    ]);
+    envServices.getEnvSources.mockResolvedValue([
+      envSource({
+        plugin_name: "env-direnv",
+        display_name: "direnv",
+        enabled: true,
+      }),
+    ]);
+    envServices.setEnvProviderEnabled.mockRejectedValueOnce(
+      new Error("simulated write failure"),
+    );
+    // Seed an in-flight resolve hint so we also exercise the
+    // current_plugin restore branch.
+    const startedAt = Date.now() - 5_000;
+    useAppStore.setState({
+      workspaceEnvironment: {
+        "repo:repo-1": {
+          status: "preparing",
+          current_plugin: "env-direnv",
+          started_at: startedAt,
+        },
+      },
+    });
+
+    const container = await renderEnvPanel();
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[role="switch"]',
+    );
+    expect(toggle!.getAttribute("aria-checked")).toBe("true");
+    await act(async () => {
+      toggle!.click();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // Toggle reflects the pre-click state again — rollback succeeded.
+    const after = container.querySelector<HTMLButtonElement>(
+      'button[role="switch"]',
+    );
+    expect(after!.getAttribute("aria-checked")).toBe("true");
+    // Spinner entry was restored to its prior shape.
+    const env = useAppStore.getState().workspaceEnvironment["repo:repo-1"];
+    expect(env?.status).toBe("preparing");
+    expect(env?.current_plugin).toBe("env-direnv");
+    expect(env?.started_at).toBe(startedAt);
   });
 
   it("does not touch unrelated workspaceEnvironment entries on disable", async () => {

--- a/src/ui/src/components/settings/sections/EnvPanel.test.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.test.tsx
@@ -51,6 +51,7 @@ vi.mock("../../../hooks/useCopyToClipboard", () => ({
 }));
 
 import { EnvPanel } from "./EnvPanel";
+import { useAppStore } from "../../../stores/useAppStore";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
   .IS_REACT_ACT_ENVIRONMENT = true;
@@ -280,5 +281,187 @@ describe("EnvPanel — per-repo settings drawer", () => {
     const calls =
       claudettePluginServices.getClaudettePluginRepoSettings.mock.calls;
     expect(calls.map(([, plugin]) => plugin)).not.toContain("env-mise");
+  });
+});
+
+describe("EnvPanel — toggle stays actionable mid-resolve", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    Object.values(claudettePluginServices).forEach((mock) => mock.mockReset());
+    Object.values(envServices).forEach((mock) => mock.mockReset());
+    claudettePluginServices.getClaudettePluginRepoSettings.mockResolvedValue(
+      {},
+    );
+    envServices.getEnvTargetWorktree.mockResolvedValue("/tmp/repo-1");
+    envServices.runEnvTrust.mockResolvedValue(undefined);
+    envServices.setEnvProviderEnabled.mockResolvedValue(undefined);
+    envServices.reloadEnv.mockResolvedValue(undefined);
+    // Real Zustand store under test — reset to defaults so prior tests'
+    // state can't leak in.
+    useAppStore.setState({ workspaceEnvironment: {} });
+  });
+
+  afterEach(async () => {
+    for (const root of mountedRoots.splice(0).reverse()) {
+      await act(async () => {
+        root.unmount();
+      });
+    }
+    for (const container of mountedContainers.splice(0)) {
+      container.remove();
+    }
+    useAppStore.setState({ workspaceEnvironment: {} });
+  });
+
+  it("keeps the toggle clickable while the initial resolve is still in flight", async () => {
+    // Before the squashed-commit change to lift `!resolvedOnce`, the
+    // toggle was disabled until the first `get_env_sources` resolve
+    // returned — which on cold direnv/Nix can take 60-120s. The user
+    // can't cancel a slow provider that way. This test pins the new
+    // behavior: the placeholder row from `listClaudettePlugins`
+    // renders an actionable toggle, and clicking it fires the IPC
+    // even though `getEnvSources` has not yet resolved.
+    let resolveGetEnvSources: (value: EnvSourceInfo[]) => void;
+    const getEnvSourcesPromise = new Promise<EnvSourceInfo[]>((resolve) => {
+      resolveGetEnvSources = resolve;
+    });
+    claudettePluginServices.listClaudettePlugins.mockResolvedValue([
+      envProvider({ name: "env-direnv", display_name: "direnv" }),
+    ]);
+    envServices.getEnvSources.mockReturnValue(getEnvSourcesPromise);
+
+    const container = await renderEnvPanel();
+
+    // Placeholder row should be visible; toggle should not be disabled.
+    expect(container.textContent).toContain("direnv");
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[role="switch"]',
+    );
+    expect(toggle).not.toBeNull();
+    expect(toggle!.disabled).toBe(false);
+
+    // Click while the resolve is still pending.
+    await act(async () => {
+      toggle!.click();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(envServices.setEnvProviderEnabled).toHaveBeenCalledWith(
+      { kind: "repo", repo_id: "repo-1" },
+      "env-direnv",
+      false,
+    );
+
+    // Clean up the in-flight promise so the panel can unmount cleanly.
+    resolveGetEnvSources!([
+      envSource({
+        plugin_name: "env-direnv",
+        display_name: "direnv",
+        enabled: false,
+        detected: false,
+        cached: false,
+        error: "disabled",
+      }),
+    ]);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  });
+
+  it("clears the current_plugin spinner when the user disables the actively-resolving plugin", async () => {
+    // Pins the optimistic-clear behavior: the EnvPanel surfaces an
+    // inline "Resolving env-direnv… Ns elapsed" hint driven by the
+    // workspaceEnvironment store. When the user disables the plugin
+    // that's currently mid-flight, the hint must disappear
+    // immediately rather than waiting on the backend's eventual
+    // `Finished` event (which for `nix print-dev-env` can be a
+    // minute away).
+    claudettePluginServices.listClaudettePlugins.mockResolvedValue([
+      envProvider({ name: "env-direnv", display_name: "direnv" }),
+    ]);
+    envServices.getEnvSources.mockResolvedValue([
+      envSource({
+        plugin_name: "env-direnv",
+        display_name: "direnv",
+        enabled: true,
+      }),
+    ]);
+    // Seed the store as if `prepare_workspace_environment` is mid-resolve
+    // on env-direnv. Key matches the EnvPanel's repo-target key
+    // (`repo:{repo_id}`).
+    useAppStore.setState({
+      workspaceEnvironment: {
+        "repo:repo-1": {
+          status: "preparing",
+          current_plugin: "env-direnv",
+          started_at: Date.now() - 36_000,
+        },
+      },
+    });
+
+    const container = await renderEnvPanel();
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[role="switch"]',
+    );
+    expect(toggle).not.toBeNull();
+    await act(async () => {
+      toggle!.click();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const env = useAppStore.getState().workspaceEnvironment["repo:repo-1"];
+    expect(env?.current_plugin).toBeUndefined();
+    // The aggregate `preparing` status is left in place — other
+    // plugins downstream may still resolve, and the env-prep listener
+    // owns the transition to "ready" / "error".
+    expect(env?.status).toBe("preparing");
+  });
+
+  it("does not touch unrelated workspaceEnvironment entries on disable", async () => {
+    // The optimistic clear must be tightly scoped to the EnvPanel's
+    // own target key. A user toggling a plugin off in repo-1's
+    // settings while workspace-foo's resolve is in flight must NOT
+    // wipe workspace-foo's progress entry.
+    claudettePluginServices.listClaudettePlugins.mockResolvedValue([
+      envProvider({ name: "env-direnv", display_name: "direnv" }),
+    ]);
+    envServices.getEnvSources.mockResolvedValue([
+      envSource({
+        plugin_name: "env-direnv",
+        display_name: "direnv",
+        enabled: true,
+      }),
+    ]);
+    const otherStarted = Date.now() - 12_000;
+    useAppStore.setState({
+      workspaceEnvironment: {
+        "workspace-foo": {
+          status: "preparing",
+          current_plugin: "env-direnv",
+          started_at: otherStarted,
+        },
+      },
+    });
+
+    const container = await renderEnvPanel();
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[role="switch"]',
+    );
+    await act(async () => {
+      toggle!.click();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const other = useAppStore.getState().workspaceEnvironment["workspace-foo"];
+    expect(other?.current_plugin).toBe("env-direnv");
+    expect(other?.started_at).toBe(otherStarted);
   });
 });

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -136,12 +136,6 @@ export function EnvPanel({ target }: EnvPanelProps) {
   const [loading, setLoading] = useState(false);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  // Becomes true after the first successful `getEnvSources` resolve for
-  // the current target. While false, any rows we're showing came from
-  // the cheap placeholder fetch and don't yet reflect per-repo toggle
-  // state — so we lock per-row toggles to avoid the user acting on a
-  // placeholder value.
-  const [resolvedOnce, setResolvedOnce] = useState(false);
   // Per-plugin manifest info (settings_schema, globally-enabled flag,
   // current effective values). We keep this map alongside the
   // resolved-sources rows so each row can render its per-repo
@@ -222,7 +216,6 @@ export function EnvPanel({ target }: EnvPanelProps) {
     try {
       const result = await getEnvSources(target);
       setSources(result);
-      setResolvedOnce(true);
       return result;
     } catch (e) {
       setFetchError(String(e));
@@ -242,7 +235,6 @@ export function EnvPanel({ target }: EnvPanelProps) {
   // when sources===null. Clearing expanded too avoids surfacing error
   // details from a different target.
   useEffect(() => {
-    setResolvedOnce(false);
     setSources(null);
     setExpanded(new Set());
     setRepoOverrides({});
@@ -411,6 +403,32 @@ export function EnvPanel({ target }: EnvPanelProps) {
 
   const handleToggle = useCallback(
     async (pluginName: string, nextEnabled: boolean) => {
+      // Optimistic UI: flip the row's `enabled` flag immediately so
+      // the toggle visibly switches state regardless of how long the
+      // post-toggle refresh takes. Env resolves can run 60-120s on
+      // cold direnv/Nix; without the optimistic update the user's
+      // click would land in a 60s "did anything happen?" gap before
+      // `refresh()` returns and rewrites the row.
+      setSources((prev) =>
+        prev?.map((s) =>
+          s.plugin_name === pluginName ? { ...s, enabled: nextEnabled } : s,
+        ) ?? null,
+      );
+      // If the user is disabling the plugin that's currently resolving
+      // mid-flight, clear the per-plugin progress entry so the
+      // "Resolving env-X… Ns elapsed" hint disappears immediately. The
+      // backend's eventual `Finished` event for the in-flight plugin
+      // is idempotent against a cleared current_plugin — it just
+      // re-publishes the same "no active plugin" state.
+      if (!nextEnabled) {
+        const env =
+          useAppStore.getState().workspaceEnvironment?.[envProgressKey];
+        if (env?.status === "preparing" && env.current_plugin === pluginName) {
+          useAppStore
+            .getState()
+            .setWorkspaceEnvironmentProgress(envProgressKey, null);
+        }
+      }
       try {
         await setEnvProviderEnabled(target, pluginName, nextEnabled);
         // Re-fetch sources inline (rather than fire-and-forget
@@ -434,7 +452,7 @@ export function EnvPanel({ target }: EnvPanelProps) {
         setFetchError(String(e));
       }
     },
-    [target, refresh, repoIdForModal, openTrustModalForPlugin],
+    [target, refresh, repoIdForModal, openTrustModalForPlugin, envProgressKey],
   );
 
   // Lazy-load a plugin's per-repo overrides on first expansion. Saves a
@@ -584,13 +602,22 @@ export function EnvPanel({ target }: EnvPanelProps) {
           // re-probe PATH). The per-repo `enabled` setting is left
           // untouched so the user's intent survives the install +
           // restart cycle without forcing them to re-toggle.
+          //
+          // We intentionally do NOT gate the toggle on `!resolvedOnce`:
+          // a slow provider (cold direnv/Nix can run 60-120s) is
+          // exactly the case where a user wants to disable it, and
+          // the placeholder rows from the registry fetch already
+          // reflect the persisted enable state with reasonable
+          // accuracy. Backend `set_env_provider_enabled` is safe to
+          // call mid-resolve — it persists + invalidates the cache —
+          // and `prepare_workspace_environment` re-evicts on
+          // completion to defend against the in-flight `export`'s
+          // late `cache.put`.
           const toggleOn = source.enabled && !source.unavailable;
-          const toggleDisabled = !resolvedOnce || source.unavailable;
+          const toggleDisabled = source.unavailable;
           const toggleTitle = source.unavailable
             ? unavailableTooltip(source.plugin_name)
-            : !resolvedOnce
-              ? "Resolving environment providers…"
-              : undefined;
+            : undefined;
           // Show the inline Settings drawer only when:
           //   1. We're in repo mode (per-repo overrides only make
           //      sense scoped to a repository).

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -5,6 +5,7 @@ import { useCopyToClipboard } from "../../../hooks/useCopyToClipboard";
 import {
   getEnvSources,
   getEnvTargetWorktree,
+  listEnvProviderDisabled,
   reloadEnv,
   setEnvProviderEnabled,
 } from "../../../services/env";
@@ -245,8 +246,27 @@ export function EnvPanel({ target }: EnvPanelProps) {
     let cancelled = false;
     (async () => {
       try {
-        const plugins = await listClaudettePlugins();
+        // Two cheap parallel reads — the plugin registry's
+        // manifests AND the per-repo persisted disable set. Hydrating
+        // the placeholder rows with the disabled set is what keeps the
+        // toggle honest for repos where a provider is already disabled
+        // while the much slower `getEnvSources` resolve is still in
+        // flight. Without it the placeholder shows `enabled: true` for
+        // every provider, and the user toggling a "disable" row would
+        // be a no-op write that surfaces as a flicker rather than the
+        // intent-preserving disable they wanted. Both calls are
+        // best-effort: a failure on either degrades to "show the
+        // placeholder with the field absent / default" rather than
+        // failing the whole panel.
+        const [plugins, disabledNames] = await Promise.all([
+          listClaudettePlugins().catch(() => []),
+          // listEnvProviderDisabled returns []  on any error path so
+          // the catch is just here to harden against an unexpected
+          // throw shape from the IPC layer.
+          listEnvProviderDisabled(target).catch(() => [] as string[]),
+        ]);
         if (cancelled) return;
+        const disabledSet = new Set(disabledNames);
         // Snapshot the env-provider manifests so the per-row settings
         // drawer can render its form without an extra fetch. We index
         // by name so the row JSX can do an O(1) lookup; we keep ALL
@@ -268,7 +288,10 @@ export function EnvPanel({ target }: EnvPanelProps) {
               plugin_name: p.name,
               display_name: p.display_name,
               detected: false,
-              enabled: true,
+              // Hydrate from the persisted per-repo disabled set so
+              // already-disabled providers don't render as enabled
+              // during the pre-resolve window.
+              enabled: !disabledSet.has(p.name),
               // Placeholder rows pre-resolve. The real resolve fills in
               // the actual unavailable state from the registry's CLI
               // probe; until then assume installed so we don't flicker
@@ -403,6 +426,23 @@ export function EnvPanel({ target }: EnvPanelProps) {
 
   const handleToggle = useCallback(
     async (pluginName: string, nextEnabled: boolean) => {
+      // Snapshot the row's prior `enabled` value AND any active
+      // env-progress entry we're about to clear, so we can restore
+      // both on a failed save. Without the rollback, a rejected
+      // `setEnvProviderEnabled` would leave the panel showing the
+      // optimistic state — the user thinks they disabled the
+      // provider, but the next agent spawn still picks it up because
+      // the DB wasn't actually written.
+      const previousEnabled =
+        sources?.find((s) => s.plugin_name === pluginName)?.enabled ?? true;
+      const previousEnvEntry = !nextEnabled
+        ? useAppStore.getState().workspaceEnvironment?.[envProgressKey]
+        : undefined;
+      const clearedProgress =
+        !nextEnabled &&
+        previousEnvEntry?.status === "preparing" &&
+        previousEnvEntry.current_plugin === pluginName;
+
       // Optimistic UI: flip the row's `enabled` flag immediately so
       // the toggle visibly switches state regardless of how long the
       // post-toggle refresh takes. Env resolves can run 60-120s on
@@ -420,14 +460,10 @@ export function EnvPanel({ target }: EnvPanelProps) {
       // backend's eventual `Finished` event for the in-flight plugin
       // is idempotent against a cleared current_plugin — it just
       // re-publishes the same "no active plugin" state.
-      if (!nextEnabled) {
-        const env =
-          useAppStore.getState().workspaceEnvironment?.[envProgressKey];
-        if (env?.status === "preparing" && env.current_plugin === pluginName) {
-          useAppStore
-            .getState()
-            .setWorkspaceEnvironmentProgress(envProgressKey, null);
-        }
+      if (clearedProgress) {
+        useAppStore
+          .getState()
+          .setWorkspaceEnvironmentProgress(envProgressKey, null);
       }
       try {
         await setEnvProviderEnabled(target, pluginName, nextEnabled);
@@ -449,10 +485,50 @@ export function EnvPanel({ target }: EnvPanelProps) {
           }
         }
       } catch (e) {
-        setFetchError(String(e));
+        // Toggle errors are NOT routed through `setFetchError` — that
+        // would blank the whole panel for a single failed row write,
+        // which is much worse than the failure itself. The rollback
+        // below is the user-visible signal that the click didn't
+        // take; we log to console so an unexpected failure is still
+        // diagnosable.
+        console.error("setEnvProviderEnabled failed:", e);
+        // Roll back the optimistic flip — the persistence call failed,
+        // so the panel must reflect the unchanged DB state. If the
+        // initial setEnvProviderEnabled threw, refresh() won't have
+        // run, and `sources` still carries the optimistic value; if
+        // the throw came from refresh() itself, `sources` may have
+        // been updated to authoritative pre-toggle state already, and
+        // restoring it back to `previousEnabled` is still safe (it
+        // matches what the DB has).
+        setSources((prev) =>
+          prev?.map((s) =>
+            s.plugin_name === pluginName
+              ? { ...s, enabled: previousEnabled }
+              : s,
+          ) ?? null,
+        );
+        if (clearedProgress && previousEnvEntry) {
+          // Restore the per-plugin progress entry we optimistically
+          // cleared so the user isn't stuck without a spinner for a
+          // resolve that's still actually running.
+          useAppStore
+            .getState()
+            .setWorkspaceEnvironmentProgress(
+              envProgressKey,
+              previousEnvEntry.current_plugin ?? null,
+              previousEnvEntry.started_at,
+            );
+        }
       }
     },
-    [target, refresh, repoIdForModal, openTrustModalForPlugin, envProgressKey],
+    [
+      target,
+      refresh,
+      repoIdForModal,
+      openTrustModalForPlugin,
+      envProgressKey,
+      sources,
+    ],
   );
 
   // Lazy-load a plugin's per-repo overrides on first expansion. Saves a

--- a/src/ui/src/components/settings/sections/ExperimentalSettings.test.tsx
+++ b/src/ui/src/components/settings/sections/ExperimentalSettings.test.tsx
@@ -5,10 +5,6 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const appStore = vi.hoisted(() => ({
-  claudetteTerminalEnabled: false,
-  setClaudetteTerminalEnabled: vi.fn((next: boolean) => {
-    appStore.claudetteTerminalEnabled = next;
-  }),
   usageInsightsEnabled: false,
   setUsageInsightsEnabled: vi.fn((next: boolean) => {
     appStore.usageInsightsEnabled = next;

--- a/src/ui/src/components/settings/sections/ExperimentalSettings.tsx
+++ b/src/ui/src/components/settings/sections/ExperimentalSettings.tsx
@@ -7,12 +7,6 @@ import styles from "../Settings.module.css";
 
 export function ExperimentalSettings() {
   const { t } = useTranslation("settings");
-  const claudetteTerminalEnabled = useAppStore(
-    (s) => s.claudetteTerminalEnabled,
-  );
-  const setClaudetteTerminalEnabled = useAppStore(
-    (s) => s.setClaudetteTerminalEnabled,
-  );
   const usageInsightsEnabled = useAppStore((s) => s.usageInsightsEnabled);
   const setUsageInsightsEnabled = useAppStore((s) => s.setUsageInsightsEnabled);
   const pluginManagementEnabled = useAppStore((s) => s.pluginManagementEnabled);
@@ -31,18 +25,6 @@ export function ExperimentalSettings() {
   );
   const [error, setError] = useState<string | null>(null);
   const [usageConfirmOpen, setUsageConfirmOpen] = useState(false);
-
-  const handleClaudetteTerminalToggle = async () => {
-    const next = !claudetteTerminalEnabled;
-    setClaudetteTerminalEnabled(next);
-    try {
-      setError(null);
-      await setAppSetting("claudette_terminal_enabled", next ? "true" : "false");
-    } catch (e) {
-      setClaudetteTerminalEnabled(!next);
-      setError(String(e));
-    }
-  };
 
   const applyUsageInsights = async (next: boolean) => {
     setUsageInsightsEnabled(next);
@@ -108,29 +90,6 @@ export function ExperimentalSettings() {
       <h2 className={styles.sectionTitle}>{t("experimental_title")}</h2>
 
       {error && <div className={styles.error}>{error}</div>}
-
-      <div className={styles.settingRow}>
-        <div className={styles.settingInfo}>
-          <div className={styles.settingLabel}>
-            {t("experimental_claudette_terminal")}
-          </div>
-          <div className={styles.settingDescription}>
-            {t("experimental_claudette_terminal_desc")}
-          </div>
-        </div>
-        <div className={styles.settingControl}>
-          <button
-            className={styles.toggle}
-            role="switch"
-            aria-checked={claudetteTerminalEnabled}
-            aria-label={t("experimental_claudette_terminal_aria")}
-            data-checked={claudetteTerminalEnabled}
-            onClick={handleClaudetteTerminalToggle}
-          >
-            <div className={styles.toggleKnob} />
-          </button>
-        </div>
-      </div>
 
       <div className={styles.settingRow}>
         <div className={styles.settingInfo}>

--- a/src/ui/src/components/settings/sections/GeneralSettings.test.tsx
+++ b/src/ui/src/components/settings/sections/GeneralSettings.test.tsx
@@ -17,6 +17,8 @@ type MockAuthStatus = {
 const appStore = vi.hoisted(() => ({
   worktreeBaseDir: "/tmp/workspaces",
   setWorktreeBaseDir: vi.fn(),
+  claudetteTerminalEnabled: true,
+  setClaudetteTerminalEnabled: vi.fn(),
   settingsFocus: null as string | null,
   clearSettingsFocus: vi.fn(),
   claudeAuthFailure: null as { messageId: string | null; error: string } | null,

--- a/src/ui/src/components/settings/sections/GeneralSettings.tsx
+++ b/src/ui/src/components/settings/sections/GeneralSettings.tsx
@@ -19,6 +19,12 @@ export function GeneralSettings() {
   const { t: tCommon } = useTranslation("common");
   const worktreeBaseDir = useAppStore((s) => s.worktreeBaseDir);
   const setWorktreeBaseDir = useAppStore((s) => s.setWorktreeBaseDir);
+  const claudetteTerminalEnabled = useAppStore(
+    (s) => s.claudetteTerminalEnabled,
+  );
+  const setClaudetteTerminalEnabled = useAppStore(
+    (s) => s.setClaudetteTerminalEnabled,
+  );
   const updateAvailable = useAppStore((s) => s.updateAvailable);
   const updateVersion = useAppStore((s) => s.updateVersion);
   const updateChannel = useAppStore((s) => s.updateChannel);
@@ -125,6 +131,21 @@ export function GeneralSettings() {
       await setAppSetting("tray_enabled", next ? "true" : "false");
     } catch (e) {
       setTrayEnabled(!next);
+      setError(String(e));
+    }
+  };
+
+  const handleClaudetteTerminalToggle = async () => {
+    const next = !claudetteTerminalEnabled;
+    setClaudetteTerminalEnabled(next);
+    try {
+      setError(null);
+      await setAppSetting(
+        "claudette_terminal_enabled",
+        next ? "true" : "false",
+      );
+    } catch (e) {
+      setClaudetteTerminalEnabled(!next);
       setError(String(e));
     }
   };
@@ -314,6 +335,29 @@ export function GeneralSettings() {
             aria-label={t("general_archive_on_merge")}
             data-checked={archiveOnMerge}
             onClick={handleArchiveOnMergeToggle}
+          >
+            <div className={styles.toggleKnob} />
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>
+            {t("general_claudette_terminal")}
+          </div>
+          <div className={styles.settingDescription}>
+            {t("general_claudette_terminal_desc")}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.toggle}
+            role="switch"
+            aria-checked={claudetteTerminalEnabled}
+            aria-label={t("general_claudette_terminal")}
+            data-checked={claudetteTerminalEnabled}
+            onClick={handleClaudetteTerminalToggle}
           >
             <div className={styles.toggleKnob} />
           </button>

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -183,9 +183,16 @@ export const Sidebar = memo(function Sidebar() {
   const archivingRef = useRef<Set<string>>(new Set());
   const restoringRef = useRef<Set<string>>(new Set());
   // Store-backed optimistic-row state — the orchestrator
-  // (`createWorkspaceOrchestrated`) writes `creatingWorkspaceRepoId` so
-  // every caller (welcome card, project-scoped CTA, Cmd+Shift+N hotkey,
-  // and the inline `+` button below) lights up the same placeholder row.
+  // (`createWorkspaceOrchestrated`) writes `creatingWorkspaceRepoId`
+  // for the brief window between the user click and
+  // `generateWorkspaceName` returning. As soon as the slug is in
+  // hand the orchestrator clears this flag and switches to the
+  // optimistic placeholder-workspace pattern (`pendingCreates`); the
+  // placeholder workspace itself becomes the spinner row inside the
+  // repo group's normal `workspaces` list. So this flag only ever
+  // drives the very-brief pre-slug indicator — typically <100ms —
+  // and any caller that triggers a create still sees an
+  // instantaneous "something is happening" affordance.
   const creatingWorkspaceRepoId = useAppStore((s) => s.creatingWorkspaceRepoId);
   const creatingWorkspace = creatingWorkspaceRepoId
     ? { repoId: creatingWorkspaceRepoId }
@@ -222,13 +229,22 @@ export const Sidebar = memo(function Sidebar() {
   // same slug-generate → createWorkspace → expand-repo → setup-script
   // sequence. The orchestrator owns the optimistic-row state, the
   // in-flight latch, and the system-message posting; we only need to
-  // surface the failure as a user-visible alert. `selectOnCreate: false`
-  // matches the design of the option (see `useCreateWorkspace.ts`): the
-  // sidebar already selects on row click, so the create flow doesn't
-  // need to navigate away from whatever the user was looking at.
+  // surface the failure as a user-visible alert.
+  //
+  // `selectOnCreate` defaults to `true`. The previous explicit
+  // `false` here surfaced as a duplicate "Preparing workspace
+  // environment…" row in the sidebar: skipping `selectOnCreate`'s
+  // branch in `useCreateWorkspace` also skipped the
+  // `setCreatingWorkspaceRepoId(null)` call that clears the brief
+  // pre-slug indicator. The flag stayed set throughout the IPC
+  // round-trip while the backend's early `workspaces-changed`
+  // emit added the real workspace row alongside it — two rows
+  // visible for the entire create window. Letting the orchestrator
+  // navigate to the new workspace is fine because we want the user
+  // to land on the freshly created workspace anyway.
   const handleCreateWorkspace = useCallback(async (repoId: string) => {
     try {
-      await createWorkspaceOrchestrated(repoId, { selectOnCreate: false });
+      await createWorkspaceOrchestrated(repoId);
     } catch (e) {
       alert(
         `Failed to create workspace: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -406,6 +406,9 @@ export const TerminalPanel = memo(function TerminalPanel() {
   const removeTerminalTab = useAppStore((s) => s.removeTerminalTab);
   const setActiveTerminalTab = useAppStore((s) => s.setActiveTerminalTab);
   const toggleTerminalPanel = useAppStore((s) => s.toggleTerminalPanel);
+  const setTerminalPanelVisible = useAppStore(
+    (s) => s.setTerminalPanelVisible,
+  );
   const terminalPanelVisible = useAppStore((s) => s.terminalPanelVisible);
   const claudetteTerminalEnabled = useAppStore(
     (s) => s.claudetteTerminalEnabled,
@@ -659,12 +662,109 @@ export const TerminalPanel = memo(function TerminalPanel() {
     if (!terminalPanelVisible) autoCreatedRef.current = null;
   }, [terminalPanelVisible]);
 
+  // Auto-open the panel AND focus the Claudette Terminal tab when env
+  // provisioning starts on the selected workspace, so the user sees
+  // nix/direnv/setup output stream live without having to discover the
+  // toggle or hunt for the right tab. Tracked across renders so we
+  // only fire on the transition into preparing — re-running
+  // provisioning shouldn't re-open the panel if the user explicitly
+  // closed it.
+  //
+  // Gated on `claudetteTerminalEnabled`: with the read-only mirror
+  // turned off in Settings > General, the only tab in this panel is
+  // whatever PTY the user created manually. Auto-opening the panel for
+  // env-provider output the user opted out of would surface a blank
+  // panel (since `agent_task` tabs are filtered out below) which is
+  // worse than the no-op the opt-out promised.
+  //
+  // Two-step (open → focus) because the tab load is async: the
+  // load-tabs effect below populates `terminalTabs[wsId]` only after
+  // the panel becomes visible, so we apply focus in a follow-up effect
+  // that watches the populated tab list rather than racing it here.
+  const lastAutoOpenedForRef = useRef<string | null>(null);
+  const lastAutoFocusedForRef = useRef<string | null>(null);
+  // Set true when our auto-focus effect is about to switch the active
+  // terminal tab to the Claudette Terminal during env preparation.
+  // The focus-management useLayoutEffect below consumes this on its
+  // next run: it updates `lastFocusKeyRef` to the new tab+pane key
+  // (so a later user-driven activation still fires) but skips the
+  // actual `helper.focus(...)` call. Net effect: the user sees the
+  // provisioning output land in view, but keyboard focus stays where
+  // they had it — typically the chat composer.
+  const suppressNextTerminalFocusRef = useRef(false);
+  useEffect(() => {
+    if (
+      !selectedWorkspaceId ||
+      !workspaceEnvironmentPreparing ||
+      !claudetteTerminalEnabled
+    ) {
+      lastAutoOpenedForRef.current = null;
+      lastAutoFocusedForRef.current = null;
+      return;
+    }
+    if (lastAutoOpenedForRef.current === selectedWorkspaceId) return;
+    lastAutoOpenedForRef.current = selectedWorkspaceId;
+    if (!terminalPanelVisible) {
+      setTerminalPanelVisible(true);
+    }
+  }, [
+    selectedWorkspaceId,
+    workspaceEnvironmentPreparing,
+    claudetteTerminalEnabled,
+    terminalPanelVisible,
+    setTerminalPanelVisible,
+  ]);
+
+  // Follow-up: once the workspace's tab list lands in the store,
+  // promote the Claudette Terminal (the AgentTask-kind tab) to active
+  // so the user lands on the streaming provisioning output even if
+  // their previous active tab in this workspace was a PTY. Fires
+  // exactly once per workspace's transition into preparing — if they
+  // click away to Terminal 1 mid-resolve we honor that, no reflux.
+  useEffect(() => {
+    if (
+      !selectedWorkspaceId ||
+      !workspaceEnvironmentPreparing ||
+      !claudetteTerminalEnabled
+    )
+      return;
+    if (lastAutoFocusedForRef.current === selectedWorkspaceId) return;
+    const tabs = terminalTabs[selectedWorkspaceId];
+    if (!tabs || tabs.length === 0) return;
+    const claudette = tabs.find((tab) => tab.kind === "agent_task");
+    if (!claudette) return;
+    if (useAppStore.getState().activeTerminalTabId[selectedWorkspaceId] === claudette.id) {
+      // Already the active tab — no need to switch, and triggering a
+      // no-op set would still re-fire the focus useLayoutEffect.
+      lastAutoFocusedForRef.current = selectedWorkspaceId;
+      return;
+    }
+    lastAutoFocusedForRef.current = selectedWorkspaceId;
+    // Tell the focus layout effect to skip keyboard-focus stealing
+    // for the activation we're about to dispatch. The user's
+    // attention belongs in the chat composer while provisioning runs.
+    suppressNextTerminalFocusRef.current = true;
+    setActiveTerminalTab(selectedWorkspaceId, claudette.id);
+  }, [
+    selectedWorkspaceId,
+    workspaceEnvironmentPreparing,
+    claudetteTerminalEnabled,
+    terminalTabs,
+    setActiveTerminalTab,
+  ]);
+
   // Load tabs on workspace + panel-visibility change.
   useEffect(() => {
     if (!selectedWorkspaceId || !terminalPanelVisible) return;
-    if (workspaceEnvironmentPreparing) return;
     const wsId = selectedWorkspaceId;
     listTerminalTabs(wsId).then(async (t) => {
+      // Bind the workspace's Claudette Terminal tab to the active
+      // chat session id so background-task code can look up the tab
+      // by session. The tab's `output_path` field is workspace-scoped
+      // (see `workspace_terminal_output_path`) and unchanged by this
+      // call — agent shell, env-provider, and setup-script all write
+      // to that single file so the user gets one unified transcript
+      // per workspace and never loses provisioning history.
       if (claudetteTerminalEnabled && selectedSessionId) {
         await ensureClaudetteTerminalTab(wsId, selectedSessionId);
         t = await listTerminalTabs(wsId);
@@ -681,7 +781,16 @@ export const TerminalPanel = memo(function TerminalPanel() {
         if (!activeStillValid) {
           setActiveTerminalTab(wsId, visibleTabs[0]?.id ?? t[0].id);
         }
-        if (!t.some((tab) => tab.kind !== "agent_task")) {
+        // Auto-spawn a regular PTY tab so the workspace always has
+        // something writable. Suppress while env is still preparing —
+        // spawning a PTY against an unprimed worktree would race the
+        // env-provider resolve and miss the merged shell env. The
+        // read-only Claudette Terminal above is unaffected: it just
+        // tails a file.
+        if (
+          !workspaceEnvironmentPreparing &&
+          !t.some((tab) => tab.kind !== "agent_task")
+        ) {
           try {
             const tab = await createTerminalTab(wsId);
             addTerminalTab(wsId, tab);
@@ -690,7 +799,10 @@ export const TerminalPanel = memo(function TerminalPanel() {
             console.error("Failed to create terminal tab:", err);
           }
         }
-      } else if (autoCreatedRef.current !== wsId) {
+      } else if (
+        !workspaceEnvironmentPreparing &&
+        autoCreatedRef.current !== wsId
+      ) {
         autoCreatedRef.current = wsId;
         try {
           const tab = await createTerminalTab(wsId);
@@ -1221,6 +1333,16 @@ export const TerminalPanel = memo(function TerminalPanel() {
         ? `${activeTerminalTabId}:${nextFocusedLeafId}`
         : null;
     if (nextFocusKey !== null && nextFocusKey !== lastFocusKeyRef.current) {
+      // Programmatic activation by the env-prep auto-focus effect: the
+      // user should see the new active tab but their typing context
+      // (chat composer) must not be stolen. Record the new focus key
+      // so a later genuine activation still fires, but skip the actual
+      // focus() call.
+      if (suppressNextTerminalFocusRef.current) {
+        suppressNextTerminalFocusRef.current = false;
+        lastFocusKeyRef.current = nextFocusKey;
+        return;
+      }
       const inst = instancesRef.current.get(nextFocusedLeafId!);
       if (
         inst &&

--- a/src/ui/src/hooks/useCreateWorkspace.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.ts
@@ -7,6 +7,35 @@ import {
   runWorkspaceSetup,
 } from "../services/tauri";
 import { runAndRecordSetupScript } from "../utils/setupScriptMessage";
+import type { Workspace } from "../types/workspace";
+
+/** Build the optimistic-placeholder Workspace inserted at the start
+ *  of a create flow. The fields are best-effort approximations of
+ *  what the backend will write — `name` matches the generated slug
+ *  (which `createWorkspace` honors), and `branch_name` is left empty
+ *  until the real row replaces this one. The placeholder id uses the
+ *  `pending-create-` prefix so a glance at the store distinguishes
+ *  the two pending-placeholder families ([`pendingCreates`] vs
+ *  [`pendingForks`]) without consulting the side maps. */
+function buildPlaceholderWorkspace(repoId: string, slug: string): Workspace {
+  return {
+    id: `pending-create-${crypto.randomUUID()}`,
+    repository_id: repoId,
+    name: slug,
+    branch_name: "",
+    worktree_path: null,
+    status: "Active",
+    agent_status: "Idle",
+    status_line: "",
+    created_at: new Date().toISOString(),
+    // Float to the bottom of the repo's workspace list so the
+    // placeholder doesn't shove the existing rows around. The real
+    // row's `sort_order` from `db.list_workspaces` lands at the
+    // correct position once `commitPendingCreate` swaps it in.
+    sort_order: Number.MAX_SAFE_INTEGER,
+    remote_connection_id: null,
+  };
+}
 
 /** Outcome surfaced to callers so they can show toasts or chain follow-up work
  *  without prying into the store. The orchestration still performs the core
@@ -57,22 +86,73 @@ export async function createWorkspaceOrchestrated(
   const { selectOnCreate = true } = options;
   const store = useAppStore.getState();
   // Publish to the store so the sidebar's optimistic "preparing
-  // workspace…" placeholder row appears immediately, regardless of
+  // workspace…" indicator row appears immediately, regardless of
   // which UI surface (sidebar +, welcome card, project view, hotkey)
   // triggered the creation. Cleared in `finally` below.
+  //
+  // This flag is the "we don't know the workspace yet" hint that
+  // covers the brief window between the user click and
+  // `generateWorkspaceName` returning. As soon as we have a slug we
+  // switch to the placeholder-workspace pattern (see
+  // `beginPendingCreate` below), which takes over the optimistic UI
+  // and replaces this flag's sidebar row with the actual placeholder.
   store.setCreatingWorkspaceRepoId(repoId);
 
+  // Placeholder is built once we have the slug — the slug becomes
+  // the placeholder workspace's `name`, which the chat panel
+  // displays in the "Preparing workspace…" placard.
+  let placeholderId: string | null = null;
   try {
     const generated = await generateWorkspaceName();
+    // Clear the pre-slug indicator the moment we have a slug, even on
+    // the no-placeholder (`selectOnCreate: false`) path. Otherwise the
+    // backend's early `workspaces-changed (Created)` emit lands the
+    // real workspace row in the sidebar alongside the still-active
+    // "Preparing workspace environment…" indicator — two rows visible
+    // for the entire create window.
+    useAppStore.getState().setCreatingWorkspaceRepoId(null);
+    if (selectOnCreate) {
+      const placeholder = buildPlaceholderWorkspace(repoId, generated.slug);
+      placeholderId = placeholder.id;
+      // Atomic in one set(): insert placeholder row, select it, seed
+      // workspaceEnvironment to "preparing" so the sidebar row
+      // lights up the spinner immediately. Replaces the
+      // creatingWorkspaceRepoId-driven row above.
+      useAppStore.getState().beginPendingCreate(placeholder);
+      // Always expand the parent repo group so the placeholder
+      // (and, post-commit, the real row) is visible. Without this
+      // a user with the repo collapsed would land on the chat panel
+      // for a workspace whose row is hidden.
+      useAppStore.getState().expandRepo(repoId);
+    }
     const result = await createWorkspace(repoId, generated.slug, true);
 
+    // The Rust `Workspace` model doesn't serialize the UI-only
+    // `remote_connection_id` field, so the IPC payload arrives with it
+    // missing entirely. Stamp it as `null` (this is a local create by
+    // definition — the WS server never returns through this path) so
+    // downstream checks that strict-compare `=== null` (rather than
+    // `!= null` or truthy) don't trip on `undefined`. Without this
+    // stamp the env-prep hook treats the row as unhydrated and bails,
+    // stranding the just-created workspace at `"preparing"`. Mirrors
+    // the existing fork-path stamp in ChatPanel.
+    const stamped = { ...result.workspace, remote_connection_id: null };
+
     const post = useAppStore.getState();
-    post.addWorkspace(result.workspace);
-    // Always expand the parent repo group — leaving a freshly created
-    // workspace hidden inside a collapsed repo (because the user
-    // collapsed it earlier or hadn't expanded it yet) is disorienting.
-    post.expandRepo(repoId);
-    if (selectOnCreate) post.selectWorkspace(result.workspace.id);
+    if (placeholderId) {
+      // Atomic placeholder→real swap. Migrates the seeded
+      // workspaceEnvironment to the real id, dedupes against the row
+      // that `workspaces-changed` may already have inserted, and moves
+      // the selection.
+      post.commitPendingCreate(placeholderId, stamped);
+      placeholderId = null;
+    } else {
+      // selectOnCreate === false: orchestration was asked not to
+      // navigate, so no placeholder was inserted. Mirror the old
+      // non-optimistic flow.
+      post.addWorkspace(stamped);
+      post.expandRepo(repoId);
+    }
 
     const sessionId = result.default_session_id;
     if (generated.message) {
@@ -134,6 +214,15 @@ export async function createWorkspaceOrchestrated(
     return { workspaceId: result.workspace.id, sessionId };
   } catch (e) {
     console.error("Failed to create workspace:", e);
+    // Tear down the optimistic placeholder so the user isn't stranded
+    // on a selected row that will never resolve. Restore selection to
+    // null (we have no good fallback — the user clicked New, so
+    // taking them back to whatever they had before would be confusing
+    // too; null lands them on the dashboard which is the safest
+    // recovery surface).
+    if (placeholderId) {
+      useAppStore.getState().cancelPendingCreate(placeholderId, null);
+    }
     // Re-throw so the caller decides whether to alert / toast.
     throw e;
   } finally {

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
@@ -98,15 +98,19 @@ export function useWorkspaceEnvironmentPreparation() {
     );
     return selectedWorkspace?.remote_connection_id;
   });
-  // True when the currently-selected workspace is an optimistic-fork
-  // placeholder — there's no backing DB row yet, so the backend's
-  // `prepare_workspace_environment` would return "Workspace not found"
-  // and the catch below would helpfully `removeWorkspace()` the
-  // placeholder out of the sidebar mid-fork.  Skip env prep entirely
-  // for placeholders; the real env prep fires off the swapped-in
-  // workspace id once `commitPendingFork` completes.
+  // True when the currently-selected workspace is an optimistic
+  // placeholder (fork OR create) — there's no backing DB row yet, so
+  // the backend's `prepare_workspace_environment` would return
+  // "Workspace not found" and the catch below would helpfully
+  // `removeWorkspace()` the placeholder out of the sidebar mid-flight.
+  // Skip env prep entirely for placeholders; the real env prep fires
+  // off the swapped-in workspace id once `commitPendingFork` /
+  // `commitPendingCreate` completes.
   const selectedWorkspaceIsPendingFork = useAppStore((s) =>
-    s.selectedWorkspaceId ? !!s.pendingForks[s.selectedWorkspaceId] : false,
+    s.selectedWorkspaceId
+      ? !!s.pendingForks[s.selectedWorkspaceId] ||
+        !!s.pendingCreates[s.selectedWorkspaceId]
+      : false,
   );
   const setWorkspaceEnvironment = useAppStore((s) => s.setWorkspaceEnvironment);
   const setWorkspaceEnvironmentProgress = useAppStore(
@@ -261,6 +265,30 @@ export function useWorkspaceEnvironmentPreparation() {
     // `commitPendingFork` swaps the placeholder for the real
     // workspace id and the selection effect re-runs.
     if (selectedWorkspaceIsPendingFork) return;
+    // If create_workspace / fork_workspace_at_checkpoint already
+    // dispatched a resolve for this workspace (via its own warmup)
+    // and we just swapped the placeholder out for the real id, the
+    // sidebar's `workspaceEnvironment[realId]` is already "preparing"
+    // with a `started_at` set by `setWorkspaceEnvironmentProgress`
+    // — that's the warmup talking. Dispatching a second
+    // `prepare_workspace_environment` here would race two concurrent
+    // resolves on the env-provider mtime cache, and either sink's
+    // `Complete` event could mark the workspace ready while the other
+    // is still streaming. The warmup's own `Complete` will transition
+    // us out of "preparing" either way, so just skip.
+    //
+    // Read directly from the store rather than via a selector — using
+    // a selector here would re-run the effect when our own
+    // `setWorkspaceEnvironment(_, "preparing")` below flips the flag
+    // to `true`, cancelling the in-flight IPC mid-flight.
+    const existingEnv =
+      useAppStore.getState().workspaceEnvironment[selectedWorkspaceId];
+    if (
+      existingEnv?.status === "preparing" &&
+      existingEnv.started_at !== undefined
+    ) {
+      return;
+    }
 
     const workspaceId = selectedWorkspaceId;
     let cancelled = false;

--- a/src/ui/src/hooks/useWorkspaceTaskHistory.ts
+++ b/src/ui/src/hooks/useWorkspaceTaskHistory.ts
@@ -158,12 +158,15 @@ export function useWorkspaceTaskHistory(
 
   const remoteConnectionId = workspace?.remote_connection_id ?? null;
 
-  // Optimistic-fork placeholder selected — backend has no row for
-  // this id so `list_chat_sessions` returns "Workspace not found".
-  // Skip the load; the hook re-fires against the real workspace id
-  // once `commitPendingFork` swaps the selection.
-  const isPendingFork = useAppStore((s) =>
-    workspaceId ? !!s.pendingForks[workspaceId] : false,
+  // Optimistic-fork OR optimistic-create placeholder selected —
+  // backend has no row for this id so `list_chat_sessions` returns
+  // "Workspace not found". Skip the load; the hook re-fires against
+  // the real workspace id once `commitPendingFork` /
+  // `commitPendingCreate` swaps the selection.
+  const isPendingPlaceholder = useAppStore((s) =>
+    workspaceId
+      ? !!s.pendingForks[workspaceId] || !!s.pendingCreates[workspaceId]
+      : false,
   );
 
   useEffect(() => {
@@ -171,7 +174,7 @@ export function useWorkspaceTaskHistory(
     setFetchedSessions([]);
     setTurnsBySession({});
 
-    if (!workspaceId || !historyEnabled || isPendingFork) {
+    if (!workspaceId || !historyEnabled || isPendingPlaceholder) {
       setLoadingSessions(false);
       return;
     }
@@ -192,7 +195,7 @@ export function useWorkspaceTaskHistory(
     return () => {
       cancelled = true;
     };
-  }, [workspaceId, remoteConnectionId, historyEnabled, isPendingFork]);
+  }, [workspaceId, remoteConnectionId, historyEnabled, isPendingPlaceholder]);
 
   const sessions = useMemo(
     () => mergeSessions(fetchedSessions, storeSessions),

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -25,6 +25,7 @@
   "copy_agent_output_aria": "Copy agent output",
   "fork_workspace": "Fork workspace at this turn",
   "preparing_fork_from": "Preparing fork from {{name}}…",
+  "preparing_workspace_in": "Preparing workspace in {{repo}}…",
   "rollback_turn": "Roll back to before this turn",
   "remove_attachment": "Remove",
   "composer_placeholder_idle": "Send a message...",

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -51,6 +51,8 @@
   "general_worktree_placeholder": "~/.claudette/workspaces",
   "general_archive_on_merge": "Archive on merge",
   "general_archive_on_merge_desc": "Automatically archive a workspace when its pull request is merged.",
+  "general_claudette_terminal": "Claudette Terminal",
+  "general_claudette_terminal_desc": "Show a read-only terminal tab that mirrors workspace provisioning, agent shell commands, and background task output. Provisioning and background task completion handling stay active even when this is off.",
   "general_system_tray": "System tray",
   "general_system_tray_desc": "Show Claudette in the system tray. Closing the window will minimize to tray when enabled.",
   "general_tray_icon_style": "Tray icon style",
@@ -352,9 +354,6 @@
   "git_delete_warning": "The branch will be permanently deleted, including any unmerged commits.",
 
   "experimental_title": "Experimental",
-  "experimental_claudette_terminal": "Claudette Terminal",
-  "experimental_claudette_terminal_desc": "Show a read-only terminal tab that mirrors agent shell commands and background task output. Background task completion handling stays enabled even when this is off.",
-  "experimental_claudette_terminal_aria": "Claudette Terminal",
   "experimental_plugin_mgmt": "Plugin Management",
   "experimental_plugin_mgmt_desc": "Show the Plugins settings section and enable the built-in plugin-management slash commands that open it.",
   "experimental_plugin_mgmt_aria": "Plugin Management",

--- a/src/ui/src/services/env.ts
+++ b/src/ui/src/services/env.ts
@@ -55,6 +55,17 @@ export function setEnvProviderEnabled(
 }
 
 /**
+ * Cheap DB-only read of the per-repo disabled env-provider plugin
+ * names. Used by the EnvPanel to hydrate placeholder rows before the
+ * initial `getEnvSources` resolve returns, so toggles for repos with
+ * already-disabled providers reflect the persisted state immediately
+ * rather than briefly showing as enabled.
+ */
+export function listEnvProviderDisabled(target: EnvTarget): Promise<string[]> {
+  return invoke("list_env_provider_disabled", { target });
+}
+
+/**
  * Run a plugin's trust command (`direnv allow`, `mise trust`) against
  * the target's worktree. Inherits `HOME`/`PATH` from Claudette so the
  * trust cache update lands in the user's normal location. Invalidates

--- a/src/ui/src/stores/slices/settingsSlice.ts
+++ b/src/ui/src/stores/slices/settingsSlice.ts
@@ -49,9 +49,11 @@ export interface SettingsSlice {
   extendedToolCallOutput: boolean;
   setExtendedToolCallOutput: (enabled: boolean) => void;
 
-  // Experimental
+  // Claudette Terminal (read-only mirror of agent shell + workspace provisioning output)
   claudetteTerminalEnabled: boolean;
   setClaudetteTerminalEnabled: (enabled: boolean) => void;
+
+  // Experimental
   usageInsightsEnabled: boolean;
   setUsageInsightsEnabled: (enabled: boolean) => void;
   pluginManagementEnabled: boolean;
@@ -141,7 +143,7 @@ export const createSettingsSlice: StateCreator<
   setExtendedToolCallOutput: (enabled) =>
     set({ extendedToolCallOutput: enabled }),
 
-  claudetteTerminalEnabled: false,
+  claudetteTerminalEnabled: true,
   setClaudetteTerminalEnabled: (enabled) =>
     set({ claudetteTerminalEnabled: enabled }),
   usageInsightsEnabled: false,

--- a/src/ui/src/stores/slices/terminalSlice.ts
+++ b/src/ui/src/stores/slices/terminalSlice.ts
@@ -51,6 +51,7 @@ export interface TerminalSlice {
   ) => void;
   setActiveTerminalTab: (wsId: string, id: number | null) => void;
   toggleTerminalPanel: () => void;
+  setTerminalPanelVisible: (visible: boolean) => void;
   setWorkspaceRunningCommand: (
     wsId: string,
     ptyId: number,
@@ -203,6 +204,7 @@ export const createTerminalSlice: StateCreator<
     })),
   toggleTerminalPanel: () =>
     set((s) => ({ terminalPanelVisible: !s.terminalPanelVisible })),
+  setTerminalPanelVisible: (visible) => set({ terminalPanelVisible: visible }),
   setWorkspaceRunningCommand: (wsId, ptyId, command) =>
     set((s) => {
       const wsMap = { ...(s.workspaceTerminalCommands[wsId] ?? {}) };

--- a/src/ui/src/stores/slices/workspacesSlice.test.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.test.ts
@@ -548,6 +548,30 @@ describe("findPendingPlaceholderForCreatedWorkspace", () => {
     expect(match).toBeNull();
   });
 
+  it("refuses suffixes the allocator never emits (-0, -1, -01)", () => {
+    // `workspace_alloc.rs` starts at attempt+1=2 — `-0` and `-1`
+    // can only come from manual renames or an unrelated workspace.
+    // Match them and we'd false-swap a real `<placeholder>-1` into
+    // the optimistic placeholder slot, hijacking the user's
+    // selection. Same for leading-zero variants — the allocator's
+    // `format!("...-{}", n)` never pads.
+    for (const badSuffix of ["main-fork-0", "main-fork-1", "main-fork-01"]) {
+      const match = findPendingPlaceholderForCreatedWorkspace({
+        workspaces: [
+          placeholder("pending-fork-1", "repo-1", "main-fork"),
+        ],
+        pendingCreates: {},
+        pendingForks: { "pending-fork-1": "ws-source" },
+        real: makeWorkspace({
+          id: "ws-real",
+          repository_id: "repo-1",
+          name: badSuffix,
+        }),
+      });
+      expect(match, `suffix ${badSuffix} must NOT match`).toBeNull();
+    }
+  });
+
   it("refuses the fallback when multiple placeholders are in flight", () => {
     // Two concurrent forks against the same repo: even an
     // allocator-suffix match is ambiguous because we can't tell which

--- a/src/ui/src/stores/slices/workspacesSlice.test.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useAppStore } from "../useAppStore";
+import { findPendingPlaceholderForCreatedWorkspace } from "./workspacesSlice";
 import type { Workspace } from "../../types/workspace";
 
 function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
@@ -349,5 +350,245 @@ describe("workspacesSlice pendingFork lifecycle", () => {
     expect(state.selectedWorkspaceId).toBe("ws-source");
     expect(state.pendingForks["pending-fork-abc"]).toBeUndefined();
     expect(state.workspaceEnvironment["pending-fork-abc"]).toBeUndefined();
+  });
+});
+
+describe("workspacesSlice pendingCreate lifecycle", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      workspaces: [],
+      selectedWorkspaceId: null,
+      workspaceEnvironment: {},
+      pendingCreates: {},
+      diffSelectionByWorkspace: {},
+      diffSelectedFile: null,
+      diffSelectedLayer: null,
+    });
+  });
+
+  function makePlaceholder(repoId: string): Workspace {
+    return makeWorkspace({
+      id: "pending-create-abc",
+      repository_id: repoId,
+      name: "lemur-snow",
+      branch_name: "",
+      worktree_path: null,
+      sort_order: Number.MAX_SAFE_INTEGER,
+    });
+  }
+
+  it("beginPendingCreate inserts the placeholder, selects it, and seeds env state to preparing", () => {
+    useAppStore.getState().beginPendingCreate(makePlaceholder("repo-1"));
+    const state = useAppStore.getState();
+    expect(state.workspaces.map((w) => w.id)).toEqual(["pending-create-abc"]);
+    expect(state.selectedWorkspaceId).toBe("pending-create-abc");
+    expect(state.pendingCreates["pending-create-abc"]).toBe("repo-1");
+    const env = state.workspaceEnvironment["pending-create-abc"];
+    expect(env?.status).toBe("preparing");
+    expect(env?.started_at).toBeTypeOf("number");
+  });
+
+  it("commitPendingCreate swaps placeholder for real, migrates env state, moves selection", () => {
+    useAppStore.getState().beginPendingCreate(makePlaceholder("repo-1"));
+    const real = makeWorkspace({
+      id: "ws-real",
+      repository_id: "repo-1",
+      name: "lemur-snow",
+    });
+    useAppStore.getState().commitPendingCreate("pending-create-abc", real);
+    const state = useAppStore.getState();
+    expect(state.workspaces.map((w) => w.id)).toEqual(["ws-real"]);
+    expect(state.selectedWorkspaceId).toBe("ws-real");
+    expect(state.pendingCreates["pending-create-abc"]).toBeUndefined();
+    expect(state.workspaceEnvironment["pending-create-abc"]).toBeUndefined();
+    // Placeholder's "preparing" state migrates to the real id so the
+    // chat composer / sidebar stay in their loading state until the
+    // env-prep hook transitions it to "ready".
+    expect(state.workspaceEnvironment["ws-real"]?.status).toBe("preparing");
+  });
+
+  it("commitPendingCreate dedupes when workspaces-changed already added the real row", () => {
+    // Race: backend emits `workspaces-changed` before the IPC
+    // response resolves, so App.tsx's listener inserts the real row
+    // first. Commit must not double-add.
+    useAppStore.getState().beginPendingCreate(makePlaceholder("repo-1"));
+    const real = makeWorkspace({ id: "ws-real", repository_id: "repo-1" });
+    useAppStore.getState().addWorkspace(real);
+    useAppStore.getState().commitPendingCreate("pending-create-abc", real);
+    const ids = useAppStore.getState().workspaces.map((w) => w.id);
+    expect(ids).toEqual(["ws-real"]);
+  });
+
+  it("commitPendingCreate leaves selection alone if user navigated away mid-create", () => {
+    useAppStore.getState().addWorkspace(
+      makeWorkspace({ id: "ws-other", repository_id: "repo-2" }),
+    );
+    useAppStore.getState().beginPendingCreate(makePlaceholder("repo-1"));
+    useAppStore.getState().selectWorkspace("ws-other");
+    useAppStore.getState().commitPendingCreate(
+      "pending-create-abc",
+      makeWorkspace({ id: "ws-real" }),
+    );
+    expect(useAppStore.getState().selectedWorkspaceId).toBe("ws-other");
+  });
+
+  it("cancelPendingCreate drops placeholder, env state, and restores selection", () => {
+    useAppStore.getState().beginPendingCreate(makePlaceholder("repo-1"));
+    useAppStore.getState().cancelPendingCreate("pending-create-abc", null);
+    const state = useAppStore.getState();
+    expect(state.workspaces).toEqual([]);
+    expect(state.selectedWorkspaceId).toBeNull();
+    expect(state.pendingCreates["pending-create-abc"]).toBeUndefined();
+    expect(state.workspaceEnvironment["pending-create-abc"]).toBeUndefined();
+  });
+});
+
+describe("findPendingPlaceholderForCreatedWorkspace", () => {
+  function placeholder(id: string, repoId: string, name: string): Workspace {
+    return makeWorkspace({
+      id,
+      repository_id: repoId,
+      name,
+      branch_name: "",
+      worktree_path: null,
+    });
+  }
+
+  it("returns null when no placeholder exists for the repo", () => {
+    const match = findPendingPlaceholderForCreatedWorkspace({
+      workspaces: [
+        placeholder("pending-create-1", "repo-1", "lemur-snow"),
+      ],
+      pendingCreates: { "pending-create-1": "repo-1" },
+      pendingForks: {},
+      real: makeWorkspace({ id: "ws-real", repository_id: "repo-2" }),
+    });
+    expect(match).toBeNull();
+  });
+
+  it("matches a pending create by repo + slug", () => {
+    const match = findPendingPlaceholderForCreatedWorkspace({
+      workspaces: [
+        placeholder("pending-create-1", "repo-1", "lemur-snow"),
+      ],
+      pendingCreates: { "pending-create-1": "repo-1" },
+      pendingForks: {},
+      real: makeWorkspace({
+        id: "ws-real",
+        repository_id: "repo-1",
+        name: "lemur-snow",
+      }),
+    });
+    expect(match).toEqual({
+      placeholderId: "pending-create-1",
+      from: "create",
+    });
+  });
+
+  it("matches a single in-flight fork when allocator added a -N suffix", () => {
+    // Fork-of-fork-of-fork: allocator may produce `<source>-fork-2`
+    // when `<source>-fork` already exists. The placeholder always uses
+    // `<source>-fork`. Allocator-suffix match keeps the swap working.
+    const match = findPendingPlaceholderForCreatedWorkspace({
+      workspaces: [
+        placeholder("pending-fork-1", "repo-1", "main-fork"),
+      ],
+      pendingCreates: {},
+      pendingForks: { "pending-fork-1": "ws-source" },
+      real: makeWorkspace({
+        id: "ws-real",
+        repository_id: "repo-1",
+        name: "main-fork-2",
+      }),
+    });
+    expect(match).toEqual({
+      placeholderId: "pending-fork-1",
+      from: "fork",
+    });
+  });
+
+  it("refuses the fallback when the real name isn't an allocator-suffix variant of the placeholder", () => {
+    // Concurrent CLI / IPC create lands while a placeholder is in
+    // flight, same repo, unrelated name. The pre-fix heuristic would
+    // swap the placeholder to the unrelated workspace and steal the
+    // user's selection. With the allocator-suffix constraint, the
+    // real name `c-fork` is not a suffix variant of `main-fork`, so
+    // we leave the placeholder alone and let the IPC return commit it.
+    const match = findPendingPlaceholderForCreatedWorkspace({
+      workspaces: [
+        placeholder("pending-fork-1", "repo-1", "main-fork"),
+      ],
+      pendingCreates: {},
+      pendingForks: { "pending-fork-1": "ws-source" },
+      real: makeWorkspace({
+        id: "ws-real",
+        repository_id: "repo-1",
+        name: "c-fork",
+      }),
+    });
+    expect(match).toBeNull();
+  });
+
+  it("refuses a suffix-shaped name that isn't a numeric allocator variant", () => {
+    // `main-fork-bug` shares the `<placeholder>-` prefix but the
+    // suffix isn't a positive integer — that's a human-chosen name,
+    // not an allocator-suffix collision. Must not match.
+    const match = findPendingPlaceholderForCreatedWorkspace({
+      workspaces: [
+        placeholder("pending-fork-1", "repo-1", "main-fork"),
+      ],
+      pendingCreates: {},
+      pendingForks: { "pending-fork-1": "ws-source" },
+      real: makeWorkspace({
+        id: "ws-real",
+        repository_id: "repo-1",
+        name: "main-fork-bug",
+      }),
+    });
+    expect(match).toBeNull();
+  });
+
+  it("refuses the fallback when multiple placeholders are in flight", () => {
+    // Two concurrent forks against the same repo: even an
+    // allocator-suffix match is ambiguous because we can't tell which
+    // placeholder the suffix-bearing name resolves to. Skip the eager
+    // swap; the IPC return handler will commit them in order.
+    const match = findPendingPlaceholderForCreatedWorkspace({
+      workspaces: [
+        placeholder("pending-fork-1", "repo-1", "a-fork"),
+        placeholder("pending-fork-2", "repo-1", "a-fork"),
+      ],
+      pendingCreates: {},
+      pendingForks: {
+        "pending-fork-1": "ws-a",
+        "pending-fork-2": "ws-a",
+      },
+      real: makeWorkspace({
+        id: "ws-real",
+        repository_id: "repo-1",
+        name: "a-fork-2",
+      }),
+    });
+    expect(match).toBeNull();
+  });
+
+  it("prefers an exact name match over the single-placeholder fallback", () => {
+    const match = findPendingPlaceholderForCreatedWorkspace({
+      workspaces: [
+        placeholder("pending-create-1", "repo-1", "lemur-snow"),
+        placeholder("pending-fork-1", "repo-1", "anything"),
+      ],
+      pendingCreates: { "pending-create-1": "repo-1" },
+      pendingForks: { "pending-fork-1": "ws-source" },
+      real: makeWorkspace({
+        id: "ws-real",
+        repository_id: "repo-1",
+        name: "lemur-snow",
+      }),
+    });
+    expect(match).toEqual({
+      placeholderId: "pending-create-1",
+      from: "create",
+    });
   });
 });

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -6,6 +6,77 @@ import type { AppState } from "../useAppStore";
 // Fire-and-forget wrapper around the typed service call. Errors are
 // swallowed because selection is a pure UI action — a failed notification
 // just means the backend keeps polling on its prior tier, which is fine.
+/** True when `real` could be the post-allocator name for a workspace
+ *  whose requested name was `placeholder`. The Rust allocator
+ *  (`src/workspace_alloc.rs`) takes the requested name on the first
+ *  attempt and appends `-2`, `-3`, … on collision until it finds a
+ *  free slot. So either exact match, or `placeholder-N` where N is a
+ *  positive integer. Used by the eager-swap fallback to associate an
+ *  optimistic placeholder with the real workspace even when the
+ *  allocator added a numeric suffix.
+ *
+ *  Deliberately strict: matching `<placeholder>-anything` (no digit
+ *  guard) would let an unrelated workspace named e.g. `main-fork-bug`
+ *  swap a `main-fork` placeholder out from under the user. */
+function realNameMatchesAllocatorSuffix(
+  placeholder: string,
+  real: string,
+): boolean {
+  if (real === placeholder) return true;
+  const prefix = `${placeholder}-`;
+  if (!real.startsWith(prefix)) return false;
+  const suffix = real.slice(prefix.length);
+  return suffix.length > 0 && /^\d+$/.test(suffix);
+}
+
+/** Match an incoming `workspaces-changed (created)` workspace against
+ *  any pending optimistic-create / optimistic-fork placeholder in the
+ *  store. Returns the placeholder id + the slice the match came from,
+ *  or null if no swap is needed. Extracted so App.tsx's listener can
+ *  call a pure function — keeps the matching heuristic testable
+ *  without mounting React.
+ *
+ *  Matching is exact on `repository_id`, and on name the real workspace
+ *  must either equal the placeholder name (the common case — create
+ *  passes the slug verbatim) or look like an allocator-suffix variant
+ *  (`<placeholder>-N`). The earlier "any single in-flight placeholder
+ *  in this repo" fallback was too lax: a concurrent CLI / IPC create
+ *  in the same repo would get cross-associated with the placeholder
+ *  and steal the user's selection.
+ */
+export function findPendingPlaceholderForCreatedWorkspace(args: {
+  workspaces: Workspace[];
+  pendingCreates: Record<string, string>;
+  pendingForks: Record<string, string>;
+  real: Workspace;
+}): { placeholderId: string; from: "create" | "fork" } | null {
+  const matchingRepo = args.workspaces.filter(
+    (w) =>
+      (w.id in args.pendingCreates || w.id in args.pendingForks) &&
+      w.repository_id === args.real.repository_id,
+  );
+  // Prefer exact match, then allocator-suffix match. Only consider the
+  // suffix candidate when exactly one placeholder is in flight; with
+  // multiple in-flight placeholders we can't safely guess which one
+  // the suffix-bearing name resolves to, and the IPC return path will
+  // commit the right one anyway.
+  const exact = matchingRepo.find((w) => w.name === args.real.name);
+  const suffixCandidate =
+    matchingRepo.length === 1 &&
+    realNameMatchesAllocatorSuffix(matchingRepo[0].name, args.real.name)
+      ? matchingRepo[0]
+      : undefined;
+  const match = exact ?? suffixCandidate;
+  if (!match) return null;
+  if (match.id in args.pendingCreates) {
+    return { placeholderId: match.id, from: "create" };
+  }
+  if (match.id in args.pendingForks) {
+    return { placeholderId: match.id, from: "fork" };
+  }
+  return null;
+}
+
 function notifyBackendSelection(workspaceId: string | null) {
   notifyWorkspaceSelected(workspaceId).catch(() => {});
 }
@@ -65,6 +136,35 @@ export interface WorkspacesSlice {
    *  workspace id (typically the source the user was viewing before
    *  they clicked Fork). */
   cancelPendingFork: (placeholderId: string, restoreSelectionTo: string | null) => void;
+  /** Temporary placeholder workspace ids that map to an in-flight
+   *  workspace creation. Sibling of [`pendingForks`]: the sidebar `+`
+   *  / welcome-card / Cmd+Shift+N orchestration inserts a placeholder
+   *  workspace, selects it, and writes an entry here so the chat
+   *  panel renders a "preparing workspace…" placard pointing at the
+   *  in-flight worktree. Resolved by `commitPendingCreate` once
+   *  `create_workspace` returns the real row, or torn down by
+   *  `cancelPendingCreate` on error.
+   *
+   *  Keyed by placeholder workspace id; the value is the repo id the
+   *  workspace was created against — used by the chat panel to
+   *  render "Preparing workspace in <repo>…" without re-walking the
+   *  repositories array. */
+  pendingCreates: Record<string, string>;
+  beginPendingCreate: (placeholder: Workspace) => void;
+  /** Resolve a pending create: drop the placeholder row, add the
+   *  real workspace, and move selection from the placeholder id to
+   *  the real workspace id (only if the placeholder is still
+   *  selected — if the user navigated away mid-create, leave their
+   *  selection alone). Any provisioning output already written into
+   *  the workspace's Claudette Terminal file stays on disk under the
+   *  placeholder path — the real workspace's tab starts a fresh tail
+   *  against its own file once env/setup writes there. */
+  commitPendingCreate: (placeholderId: string, real: Workspace) => void;
+  /** Tear down a pending create that failed. Drops the placeholder
+   *  row and restores selection to the supplied workspace id
+   *  (typically null since the user was on the placeholder when
+   *  it failed). */
+  cancelPendingCreate: (placeholderId: string, restoreSelectionTo: string | null) => void;
   workspaceEnvironment: Record<string, WorkspaceEnvironmentPreparation>;
   setWorkspaces: (workspaces: Workspace[]) => void;
   addWorkspace: (ws: Workspace) => void;
@@ -237,6 +337,127 @@ export const createWorkspacesSlice: StateCreator<
       return {
         workspaces: s.workspaces.filter((w) => w.id !== placeholderId),
         pendingForks: nextPendingForks,
+        selectedWorkspaceId: stillSelected
+          ? restoreSelectionTo
+          : s.selectedWorkspaceId,
+        workspaceEnvironment: nextWorkspaceEnv,
+      };
+    }),
+  pendingCreates: {},
+  beginPendingCreate: (placeholder) =>
+    set((s) => {
+      // Mirror `beginPendingFork` — insert the placeholder row, select
+      // it, and seed `workspaceEnvironment` to "preparing" with a
+      // `started_at` of now so the sidebar's icon cascade
+      // (status === "preparing" + started_at != null →
+      // WorkspaceEnvSpinner) immediately lights up. The backend's
+      // `workspace_env_progress` events flow against the REAL id once
+      // `commitPendingCreate` swaps that in, so the placeholder's
+      // progress is driven from here.
+      //
+      // We deliberately do NOT call `notifyBackendSelection(placeholder.id)`:
+      // the placeholder id has no DB row, so writing it into the
+      // backend's selection / activity maps would orphan an entry per
+      // attempted create. The real id gets notified on commit.
+      //
+      // Inline the diff/preview/right-sidebar resets that
+      // `selectWorkspace` would normally perform so the placeholder
+      // navigation doesn't leak the previously selected workspace's
+      // file/diff context.
+      const prev = s.selectedWorkspaceId;
+      let selectionMap = s.diffSelectionByWorkspace;
+      if (prev) {
+        if (s.diffSelectedFile) {
+          selectionMap = {
+            ...selectionMap,
+            [prev]: { path: s.diffSelectedFile, layer: s.diffSelectedLayer },
+          };
+        } else if (prev in selectionMap) {
+          const next = { ...selectionMap };
+          delete next[prev];
+          selectionMap = next;
+        }
+      }
+      return {
+        workspaces: [...s.workspaces, placeholder],
+        selectedWorkspaceId: placeholder.id,
+        selectedRepositoryId: null,
+        rightSidebarTab: "files",
+        diffSelectionByWorkspace: selectionMap,
+        diffSelectedFile: null,
+        diffSelectedLayer: null,
+        diffContent: null,
+        diffError: null,
+        diffPreviewMode: "diff",
+        diffPreviewContent: null,
+        diffPreviewLoading: false,
+        diffPreviewError: null,
+        diffMergeBase: null,
+        pendingCreates: {
+          ...s.pendingCreates,
+          [placeholder.id]: placeholder.repository_id,
+        },
+        workspaceEnvironment: {
+          ...s.workspaceEnvironment,
+          [placeholder.id]: {
+            status: "preparing",
+            started_at: Date.now(),
+          },
+        },
+      };
+    }),
+  commitPendingCreate: (placeholderId, real) =>
+    set((s) => {
+      const stillSelected = s.selectedWorkspaceId === placeholderId;
+      const nextPendingCreates = { ...s.pendingCreates };
+      delete nextPendingCreates[placeholderId];
+      // Dedupe (same pattern as commitPendingFork): the backend's
+      // `workspaces-changed` event may have already raced ahead of
+      // the IPC response and inserted the real workspace via App.tsx's
+      // listener. Filter both the placeholder AND any pre-existing
+      // real-id row, then concat the freshest copy so the sidebar
+      // never has two rows for the same workspace.
+      const filtered = s.workspaces.filter(
+        (w) => w.id !== placeholderId && w.id !== real.id,
+      );
+      const nextWorkspaces = filtered.concat(real);
+      const nextWorkspaceEnv = { ...s.workspaceEnvironment };
+      delete nextWorkspaceEnv[placeholderId];
+      // Migrate the placeholder's env-prep entry to the real id when
+      // the real id has no entry of its own yet — preserves the
+      // "preparing" status + started_at so the chat composer / sidebar
+      // stay in their loading state until the env-prep hook fires for
+      // the real workspace and transitions to "ready". If the real
+      // workspace already has its own env entry (a workspaces-changed
+      // event arrived first and the env-prep hook beat us), trust
+      // that one.
+      if (!nextWorkspaceEnv[real.id]) {
+        const ph = s.workspaceEnvironment[placeholderId];
+        if (ph) nextWorkspaceEnv[real.id] = ph;
+      }
+      if (stillSelected) {
+        notifyBackendSelection(real.id);
+      }
+      return {
+        workspaces: nextWorkspaces,
+        pendingCreates: nextPendingCreates,
+        selectedWorkspaceId: stillSelected ? real.id : s.selectedWorkspaceId,
+        workspaceEnvironment: nextWorkspaceEnv,
+      };
+    }),
+  cancelPendingCreate: (placeholderId, restoreSelectionTo) =>
+    set((s) => {
+      const stillSelected = s.selectedWorkspaceId === placeholderId;
+      const nextPendingCreates = { ...s.pendingCreates };
+      delete nextPendingCreates[placeholderId];
+      const nextWorkspaceEnv = { ...s.workspaceEnvironment };
+      delete nextWorkspaceEnv[placeholderId];
+      if (stillSelected) {
+        notifyBackendSelection(restoreSelectionTo);
+      }
+      return {
+        workspaces: s.workspaces.filter((w) => w.id !== placeholderId),
+        pendingCreates: nextPendingCreates,
         selectedWorkspaceId: stillSelected
           ? restoreSelectionTo
           : s.selectedWorkspaceId,

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -10,14 +10,18 @@ import type { AppState } from "../useAppStore";
  *  whose requested name was `placeholder`. The Rust allocator
  *  (`src/workspace_alloc.rs`) takes the requested name on the first
  *  attempt and appends `-2`, `-3`, … on collision until it finds a
- *  free slot. So either exact match, or `placeholder-N` where N is a
- *  positive integer. Used by the eager-swap fallback to associate an
- *  optimistic placeholder with the real workspace even when the
- *  allocator added a numeric suffix.
+ *  free slot. So either exact match, or `placeholder-N` where N is an
+ *  integer ≥ 2 with no leading zero. Used by the eager-swap fallback
+ *  to associate an optimistic placeholder with the real workspace
+ *  even when the allocator added a numeric suffix.
  *
- *  Deliberately strict: matching `<placeholder>-anything` (no digit
- *  guard) would let an unrelated workspace named e.g. `main-fork-bug`
- *  swap a `main-fork` placeholder out from under the user. */
+ *  Deliberately strict on both ends:
+ *  - matching `<placeholder>-anything` (no digit guard) would let an
+ *    unrelated workspace named e.g. `main-fork-bug` swap a
+ *    `main-fork` placeholder out from under the user.
+ *  - accepting `-0` / `-1` / `-01` would false-match a manually-named
+ *    workspace `<placeholder>-1` against an optimistic placeholder,
+ *    since the allocator itself never emits those suffixes. */
 function realNameMatchesAllocatorSuffix(
   placeholder: string,
   real: string,
@@ -26,7 +30,14 @@ function realNameMatchesAllocatorSuffix(
   const prefix = `${placeholder}-`;
   if (!real.startsWith(prefix)) return false;
   const suffix = real.slice(prefix.length);
-  return suffix.length > 0 && /^\d+$/.test(suffix);
+  // No-leading-zero digit run — `-02`, `-0`, etc. fail. Allocator's
+  // `format!("...-{}", n)` is base-10 with no padding, so any
+  // leading-zero suffix came from a user/manual rename.
+  if (!/^[1-9]\d*$/.test(suffix)) return false;
+  // Match allocator's first collision suffix (2) and up. Number()
+  // is safe because the regex already constrained the input to a
+  // bounded decimal run.
+  return Number(suffix) >= 2;
 }
 
 /** Match an incoming `workspaces-changed (created)` workspace against

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -107,21 +107,21 @@ describe("effortLevel (per-workspace)", () => {
   });
 });
 
-describe("experimental Claudette terminal setting", () => {
-  beforeEach(() => {
-    useAppStore.setState({ claudetteTerminalEnabled: false });
-  });
-
-  it("defaults to disabled so the read-only agent terminal is opt-in", () => {
-    expect(useAppStore.getState().claudetteTerminalEnabled).toBe(false);
-  });
-
-  it("can be enabled and disabled from settings state", () => {
-    useAppStore.getState().setClaudetteTerminalEnabled(true);
+describe("Claudette terminal setting", () => {
+  it("defaults to enabled so workspace provisioning + agent shell output are visible out of the box", () => {
+    // Read the default rather than resetting first — this asserts the
+    // initial-state contract callers (GeneralSettings, TerminalPanel) rely
+    // on. Flipping the default to `true` was the whole point of
+    // promoting this out of Experimental.
     expect(useAppStore.getState().claudetteTerminalEnabled).toBe(true);
+  });
 
+  it("can be toggled off and back on from settings state", () => {
     useAppStore.getState().setClaudetteTerminalEnabled(false);
     expect(useAppStore.getState().claudetteTerminalEnabled).toBe(false);
+
+    useAppStore.getState().setClaudetteTerminalEnabled(true);
+    expect(useAppStore.getState().claudetteTerminalEnabled).toBe(true);
   });
 });
 

--- a/src/ui/src/utils/workspaceEnvironment.ts
+++ b/src/ui/src/utils/workspaceEnvironment.ts
@@ -24,6 +24,40 @@ export function isPendingForkWorkspace(
 }
 
 /**
+ * Sibling of [`isPendingForkWorkspace`] for the optimistic-create
+ * placeholder. Returns `true` while the workspace id is an in-flight
+ * create that hasn't been committed yet. Same use case: short-circuit
+ * any workspace-keyed loader (FilesPanel, RightSidebar diff sync,
+ * task history, env-prep IPC) so the user doesn't see a "Workspace
+ * not found" toast against a placeholder id that has no backing DB
+ * row. The placeholder is removed by `commitPendingCreate` (success)
+ * or `cancelPendingCreate` (error), at which point the same loaders
+ * fire against the real id naturally.
+ */
+export function isPendingCreateWorkspace(
+  state: AppState,
+  workspaceId: string | null,
+): boolean {
+  if (!workspaceId) return false;
+  return !!state.pendingCreates[workspaceId];
+}
+
+/**
+ * Convenience union — true for either pending-fork or pending-create
+ * placeholders. Most workspace-keyed loaders want to skip both
+ * equally, so callers can use this instead of OR-ing the two checks.
+ */
+export function isPendingPlaceholderWorkspace(
+  state: AppState,
+  workspaceId: string | null,
+): boolean {
+  return (
+    isPendingForkWorkspace(state, workspaceId) ||
+    isPendingCreateWorkspace(state, workspaceId)
+  );
+}
+
+/**
  * Whether the workspace is in the middle of an env-provider resolve and
  * UI surfaces (terminal new-tab button, chat composer, etc.) should
  * block waiting for it. Shared by `TerminalPanel` and `ChatPanel` so


### PR DESCRIPTION
## Summary

- Promote **Claudette Terminal** out of Experimental into a first-class General feature, defaulting **ON**. The terminal mirrors workspace provisioning, the agent's Bash tool, and background task output for the selected workspace, all into a single workspace-scoped output file at `$TMPDIR/claudette-workspace-terminal/<workspace_id>/terminal.output`.
- Route `env-provider` stdout/stderr (`host.exec_streaming`) and the setup-script runner through a shared `WorkspaceTerminalFileSink`. xterm.js renders native ANSI from `nix -L`, `direnv`, `mise`, and `bun install` directly — no parallel React renderer, no Tauri event fan-out per line, no stripped escapes.
- Optimistic-create / optimistic-fork navigation with eager placeholder→real swap; bottom panel auto-opens and active tab switches to Claudette Terminal on env-prep transition (keyboard focus stays in chat composer).
- **Allow disabling an env provider mid-resolve** — the previous `!resolvedOnce` gate locked the toggle for 60-120s on cold direnv/Nix resolves, exactly when the user wants to cancel. Toggle is now actionable mid-resolve with optimistic UI, placeholder hydration from persisted state, and rollback on save failure.
- Closes #818.

## Detailed changes

### Output routing & unified transcript

`agent_bash_output_path(chat_session_id)` is gone. The agent shell Bash tool (foreground + background-task mirror), env-provider streaming, and setup script now all write to `workspace_terminal_output_path(workspace_id)`. One workspace, one transcript file, accumulated across every chat session in that workspace. `ensure_claudette_terminal_tab` and the IPC-side `get_or_create_agent_shell_terminal_tab` still stamp the chat-session id on the tab row (background-task lookups by session depend on it), but `output_path` stays workspace-scoped from create through every session's lifetime — no rebinds.

The chat-session-scoped truncate-on-fresh-bash-command path is gone too: with a unified transcript, wiping the file at the start of each Bash invocation would erase env-provider history and prior session output. `truncate_agent_bash_output` is removed.

### Security: env-provider stdout suppression

Env-provider plugins run JSON-producing commands like `direnv export json`, `mise env --json`, and `nix print-dev-env --json` whose stdout contains the FULL machine-readable environment payload — every variable including secrets (`AWS_SECRET_ACCESS_KEY`, `GH_TOKEN`, `ANTHROPIC_API_KEY`, …). The runtime drops stdout from the sink when `ctx.kind == PluginKind::EnvProvider`. Captured `result.stdout` returned to Lua is unaffected so `host.json_decode` still works. The progress info users actually want lives on stderr (direnv's `loading .envrc`, nix's `-L` per-derivation log, mise's tool-install chatter) and continues to flow. Regression tests pin the contract for both env-provider (suppressed) and SCM (forwarded) so a future over-eager change can't silence ALL streaming.

### Optimistic navigation + early visibility

Clicking `+` immediately selects a placeholder workspace with a "Preparing workspace in <repo>…" placard, swapped for the real row when the IPC resolves. The bottom panel auto-opens on transition into env-preparing state, and the active tab switches to the Claudette Terminal so streaming nix/direnv/setup output is visible without a click — but keyboard focus is intentionally left alone via `suppressNextTerminalFocusRef`: the user's typing context stays in the chat composer while provisioning runs.

`create_workspace_inner` emits an early `workspaces-changed (Created)` event so the terminal tab is visible the moment provisioning starts, not 30-90s later when resolve finishes. Immediately after it emits a synthetic `workspace_env_progress (started, plugin="provisioning")` event so the env-prep store sees `preparing` with a `started_at` even for IPC/CLI/remote-driven creates that don't run through the optimistic-nav frontend path. The env-sink's `Complete` event terminates the preparing state. Forks skip this signal (they don't warmup) so selecting one still runs the standard env-prep IPC.

App.tsx's `workspaces-changed (Created)` listener matches the incoming real workspace against any pending placeholder for the same repo and immediately commits the swap. The matching heuristic (`findPendingPlaceholderForCreatedWorkspace`) is unit-testable without React and constrains the fallback to allocator-suffix names only — exact match OR `<placeholder>-N` (positive integer suffix). A concurrent CLI/IPC create in the same repo can no longer steal the user's placeholder selection.

The optimistic-create commit stamps `remote_connection_id: null` on the result workspace before any store write (mirrors the existing fork-path stamp) so the env-prep hook's `=== null` strict-check doesn't trip on `undefined` from the Rust IPC payload and strand the workspace at `preparing`.

### Duplicate sidebar row fix

Sidebar's `+` button now uses the default `selectOnCreate: true`, and `useCreateWorkspace` clears `creatingWorkspaceRepoId` as soon as the slug is in hand — regardless of `selectOnCreate`. Previously the pre-slug indicator row stayed visible while the backend's early `workspaces-changed (Created)` emit added the real row, producing two visible rows for the full IPC round-trip.

### Mid-resolve toggle (env-provider Disable while resolving)

**Frontend** — `EnvPanel.tsx`:
- Drop `!resolvedOnce` from the toggle's `disabled` gate. Cold direnv/Nix resolves run 60-120s, and that's exactly when the user wants to cancel a slow provider.
- Hydrate placeholder rows from a new `list_env_provider_disabled` IPC (cheap DB-only read) so the toggle reflects persisted per-repo state even before the initial `getEnvSources` resolve returns.
- Optimistic flip on click — the row's `enabled` state flips immediately so the button visibly switches regardless of how long the post-toggle refresh takes.
- Optimistic spinner clear — when disabling the currently-resolving plugin (`envProgress.current_plugin === pluginName`), the per-plugin progress entry is cleared so the "Resolving env-X… Ns elapsed" hint disappears immediately.
- **Rollback on save failure** — snapshot the row's prior `enabled` value AND any cleared env-progress entry before the optimistic update; restore both if `setEnvProviderEnabled` rejects. Toggle errors are NOT routed through `setFetchError` (which would blank the whole panel for a single failed row write); the rollback is the user-visible signal, and the error logs to console for diagnostic.

**Backend** — `commands/env.rs`:
- New `list_env_provider_disabled` IPC for the placeholder hydration above.
- After every `resolve_with_registry_streaming` call in `prepare_workspace_environment` and `get_env_sources`, re-read `load_disabled_providers` and:
  - Invalidate the cache for any plugin newly disabled mid-resolve (defends against a still-running `export` repopulating the cache via `cache.put` after the user's `set_env_provider_enabled` invalidate).
  - Use the post-resolve disabled set for the `EnvSourceInfo.enabled` field, so a slow response that lands after the user disabled the provider can't overwrite the optimistic UI flip with a stale `enabled = true`.
- Pure `newly_disabled` helper unit-tested with synthetic HashSets.

### Scope (deliberately out)

The mid-resolve disable change does **not** kill the in-flight subprocess. A slow `nix print-dev-env` keeps running to completion in the background; the user just sees the UI respond to their disable instantly and the cache stays clean. Threading a CancellationToken through the resolver → backend → host_api.exec → tokio::process::Command stack is a larger refactor and would land separately.

### Removed

- `EnvProvisioningConsole` React component (chat pollution)
- `workspace_env_output` + `workspace_setup_output` Tauri events
- Experimental gate on the Claudette Terminal toggle
- `agent_bash_output_path` and `truncate_agent_bash_output`
- The chat-panel Provisioning console docs section

## Test plan

Backend (`cargo test -p claudette-tauri --bin claudette-app commands::env::`) — 29 tests pass:
- [x] `newly_disabled_returns_diff_only`
- [x] `newly_disabled_handles_no_changes`
- [x] `newly_disabled_ignores_re_enabled_plugins`
- [x] `newly_disabled_diff_drives_get_env_sources_enabled_field`
- [x] `set_env_provider_enabled_persists_and_invalidates_cache`

Frontend (`bun run test EnvPanel`) — 9 tests pass:
- [x] Existing 4 tests for per-repo settings drawer (Settings button gating, workspace-mode, lazy-load, disabled-plugin exclusion).
- [x] `keeps the toggle clickable while the initial resolve is still in flight`
- [x] `clears the current_plugin spinner when the user disables the actively-resolving plugin`
- [x] `does not touch unrelated workspaceEnvironment entries on disable`
- [x] `hydrates placeholder rows from listEnvProviderDisabled before the resolve returns`
- [x] `rolls back the optimistic flip when setEnvProviderEnabled rejects`

Full sweeps:
- [x] `bun run test` — 2240 tests pass across 191 files
- [x] `bunx tsc -b` — clean
- [x] `cargo check -p claudette-tauri` — clean
- [x] UAT: creating new workspaces, forks, env-prep visibility, optimistic nav, disable-mid-resolve from settings, all manually verified

Manual UAT focus areas:
- [x] Create a new workspace on a cold-flake repo and confirm the Claudette Terminal auto-opens with live `nix -L` build output
- [x] Disable an env-provider mid-resolve from the per-repo Environment panel — toggle responds instantly, spinner clears, cache stays clean on the next spawn
- [x] No keyboard focus theft into the terminal pane during env-prep
- [x] Sidebar shows exactly one placeholder row during workspace creation (not two)
- [x] Forks remain interactable immediately and clear `preparing` state correctly