### PR TITLE
fix(env): emit workspace_env_trust_needed from create/fork warmup

### DIFF
--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -712,7 +712,7 @@ fn clean_direnv(body: &str) -> CleanedTrustError {
 /// `None` when no source flagged a trust error. Pure — extracted so the
 /// command site stays small and the unit tests can assert payload
 /// shape without a Tauri AppHandle.
-fn build_trust_needed_payload(
+pub(crate) fn build_trust_needed_payload(
     workspace_id: &str,
     repo_id: &str,
     resolved: &claudette::env_provider::ResolvedEnv,
@@ -1702,6 +1702,34 @@ mod tests {
         assert!(message.starts_with("Environment provider failed:"));
         assert!(message.contains("env-direnv"));
         assert!(!message.contains("env-mise"));
+    }
+
+    #[test]
+    fn build_trust_needed_payload_is_pub_crate_for_warmup_path() {
+        // Regression: `resolve_env_for_workspace` in
+        // `src-tauri/src/commands/workspace.rs` (the create / fork /
+        // run-setup warmup) calls this function so the new-workspace
+        // path can emit `workspace_env_trust_needed` itself — without
+        // that emit, a blocked `.envrc` on a fresh worktree silently
+        // logs the error to the Claudette Terminal and the user is
+        // stuck staring at "Preparing…" forever, because the per-
+        // selection env-prep hook skips `prepare_workspace_environment`
+        // once the warmup's synthetic progress event has already
+        // seeded `started_at`. This call site forces the symbol to
+        // stay reachable from the workspace.rs module; demoting it
+        // back to `fn` (private) would break the crate build.
+        let mut s = src("env-direnv");
+        s.error = Some(
+            "direnv: error /repo/.envrc is blocked. Run `direnv allow` to approve its content"
+                .to_string(),
+        );
+        let resolved = ResolvedEnv {
+            sources: vec![s],
+            ..Default::default()
+        };
+        let payload = super::build_trust_needed_payload("ws-id", "repo-id", &resolved).unwrap();
+        assert_eq!(payload.workspace_id, "ws-id");
+        assert_eq!(payload.plugins[0].plugin_name, "env-direnv");
     }
 
     #[test]

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -391,6 +391,27 @@ async fn resolve_env_for_workspace(
         &resolved.sources,
     )
     .await;
+    // Surface trust-class failures via the modal-driving event. The
+    // create / fork / run-setup callers invoke this warmup as a
+    // fire-and-forget (`let _ = ...`), so its return value never
+    // reaches the frontend — and the per-selection env-prep hook
+    // skips `prepare_workspace_environment` when status is already
+    // "preparing" with a `started_at` (the warmup's own synthetic
+    // progress emit sets that), so the modal would otherwise never
+    // fire for a newly-created workspace whose .envrc is blocked.
+    // Emit here so the EnvTrustModal listener in
+    // `useWorkspaceEnvironmentPreparation` opens the modal once per
+    // workspace+signature for the app session. Skipped when `app` is
+    // None (archive teardown path — no UI to show a modal to).
+    if let Some(handle) = app
+        && let Some(payload) = crate::commands::env::build_trust_needed_payload(
+            &ws_info.id,
+            &ws_info.repo_id.clone().unwrap_or_default(),
+            &resolved,
+        )
+    {
+        let _ = handle.emit("workspace_env_trust_needed", payload);
+    }
     Some(resolved)
 }
 


### PR DESCRIPTION
## Summary

Regression introduced by the optimistic-create + env-prep dedup work in #820: when `create_workspace_inner` runs its env-provider warmup (`resolve_env_for_workspace` in `src-tauri/src/commands/workspace.rs`) on a fresh worktree whose `.envrc` is blocked, the resolve produced a trust error but **never emitted `workspace_env_trust_needed`** — only `prepare_workspace_environment` did. And the per-selection `useWorkspaceEnvironmentPreparation` hook skips that command when status is already \"preparing\" with a `started_at` (which the warmup's synthetic progress emit sets).

**Net result for the user**: the EnvTrustModal never fires on a newly-created workspace with a blocked `.envrc`. The Claudette Terminal shows the `direnv: error … is blocked` line and the user is stuck staring at the preparing spinner with no actionable next step. Reproduces every time on `claudex/gnarled-hyacinth` (any fresh worktree of a flake that uses direnv).

## Fix

Have the warmup emit `workspace_env_trust_needed` after the resolve completes, gated on the `app` parameter (the archive teardown path passes `None` and has no UI to show a modal to). The frontend listener + `openTrustModalOnce` already enforce \"once per workspace per app session until accepted or denied\" via a `Map<workspace_id, signature>` ref, so a duplicate emit from a later prepare path is a no-op.

Promoted `build_trust_needed_payload` to `pub(crate)` so `workspace.rs` can reuse it instead of duplicating the trust-error heuristic.

## Test plan

- [x] `cargo test -p claudette-tauri --bin claudette-app commands::env::` — 30 tests pass, including the new `build_trust_needed_payload_is_pub_crate_for_warmup_path` regression test that pins the symbol's visibility (demoting it back to `fn` would now break the crate build).
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` — clean (no new warnings)
- [ ] Manual UAT: create a workspace on a repo with a blocked `.envrc`, confirm EnvTrustModal opens once on first sighting, accept → modal doesn't re-fire on subsequent re-enters, deny → modal doesn't re-fire either.