### PR TITLE
docs(installation): document Homebrew cask + automate version bumps

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -395,6 +395,63 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "${{ needs.resolve-tag.outputs.tag }}" --draft=false --repo "${{ github.repository }}"
 
+  homebrew-cask-bump:
+    name: Bump Homebrew Cask
+    needs: [resolve-tag, publish]
+    if: always() && needs.publish.result == 'success'
+    # macos-latest comes with brew preinstalled and writable, so brew's
+    # developer commands (bump-cask-pr) work without extra setup.
+    runs-on: macos-latest
+    steps:
+      - name: Bail out if HOMEBREW_GITHUB_API_TOKEN is missing
+        id: gate-secret
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+        run: |
+          if [ -z "${HOMEBREW_GITHUB_API_TOKEN}" ]; then
+            echo "HOMEBREW_GITHUB_API_TOKEN secret is not set — skipping cask bump."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check the claudette cask exists upstream
+        if: steps.gate-secret.outputs.skip != 'true'
+        id: gate-cask
+        run: |
+          set -euo pipefail
+          # Resolves to the Casks/c/claudette.rb raw file on Homebrew/homebrew-cask
+          # main. 200 = merged and live; 404 = not yet merged (this PR is sitting
+          # in a draft state, or the upstream PR hasn't landed). Anything else
+          # we treat as transient and skip — don't fail the release on it.
+          status=$(curl -sS -o /dev/null -w '%{http_code}' \
+            "https://raw.githubusercontent.com/Homebrew/homebrew-cask/HEAD/Casks/c/claudette.rb" || echo "000")
+          if [ "$status" = "200" ]; then
+            echo "Cask exists upstream — proceeding with bump."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Cask not found upstream (HTTP $status) — skipping bump."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open bump-cask-pr against Homebrew/homebrew-cask
+        if: steps.gate-secret.outputs.skip != 'true' && steps.gate-cask.outputs.skip != 'true'
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          TAG: ${{ needs.resolve-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          # bump-cask-pr re-renders the URL with the new version, downloads each
+          # arch variant, recomputes sha256s, and opens the PR upstream from the
+          # token owner's fork. No manual checksum plumbing needed.
+          brew bump-cask-pr \
+            --version "$VERSION" \
+            --no-browse \
+            --message "Released by claudette release-please workflow." \
+            claudette
+
   notify-discord:
     name: Discord Release Notification
     needs: [resolve-tag, publish]

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -395,62 +395,72 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "${{ needs.resolve-tag.outputs.tag }}" --draft=false --repo "${{ github.repository }}"
 
-  homebrew-cask-bump:
-    name: Bump Homebrew Cask
+  homebrew-tap-bump:
+    name: Bump utensils/homebrew-tap
     needs: [resolve-tag, publish]
     if: always() && needs.publish.result == 'success'
-    # macos-latest comes with brew preinstalled and writable, so brew's
-    # developer commands (bump-cask-pr) work without extra setup.
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
-      - name: Bail out if HOMEBREW_GITHUB_API_TOKEN is missing
+      - name: Bail out if HOMEBREW_TAP_TOKEN is missing
         id: gate-secret
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
-          if [ -z "${HOMEBREW_GITHUB_API_TOKEN}" ]; then
-            echo "HOMEBREW_GITHUB_API_TOKEN secret is not set — skipping cask bump."
+          if [ -z "${HOMEBREW_TAP_TOKEN}" ]; then
+            echo "HOMEBREW_TAP_TOKEN secret is not set — skipping tap bump."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check the claudette cask exists upstream
+      - name: Compute sha256 for both arch DMGs
         if: steps.gate-secret.outputs.skip != 'true'
-        id: gate-cask
-        run: |
-          set -euo pipefail
-          # Resolves to the Casks/c/claudette.rb raw file on Homebrew/homebrew-cask
-          # main. 200 = merged and live; 404 = not yet merged (this PR is sitting
-          # in a draft state, or the upstream PR hasn't landed). Anything else
-          # we treat as transient and skip — don't fail the release on it.
-          status=$(curl -sS -o /dev/null -w '%{http_code}' \
-            "https://raw.githubusercontent.com/Homebrew/homebrew-cask/HEAD/Casks/c/claudette.rb" || echo "000")
-          if [ "$status" = "200" ]; then
-            echo "Cask exists upstream — proceeding with bump."
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Cask not found upstream (HTTP $status) — skipping bump."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Open bump-cask-pr against Homebrew/homebrew-cask
-        if: steps.gate-secret.outputs.skip != 'true' && steps.gate-cask.outputs.skip != 'true'
+        id: shasums
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-          HOMEBREW_NO_AUTO_UPDATE: "1"
           TAG: ${{ needs.resolve-tag.outputs.tag }}
         run: |
           set -euo pipefail
           VERSION="${TAG#v}"
-          # bump-cask-pr re-renders the URL with the new version, downloads each
-          # arch variant, recomputes sha256s, and opens the PR upstream from the
-          # token owner's fork. No manual checksum plumbing needed.
-          brew bump-cask-pr \
-            --version "$VERSION" \
-            --no-browse \
-            --message "Released by claudette release-please workflow." \
-            claudette
+          BASE="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+          # Stream-hash both arch DMGs without keeping them on disk.
+          ARM_SHA=$(curl -fsSL "${BASE}/Claudette_${VERSION}_aarch64.dmg" | sha256sum | cut -d' ' -f1)
+          INTEL_SHA=$(curl -fsSL "${BASE}/Claudette_${VERSION}_x64.dmg" | sha256sum | cut -d' ' -f1)
+          echo "version=${VERSION}"  >> "$GITHUB_OUTPUT"
+          echo "arm=${ARM_SHA}"      >> "$GITHUB_OUTPUT"
+          echo "intel=${INTEL_SHA}"  >> "$GITHUB_OUTPUT"
+
+      - name: Push updated cask to utensils/homebrew-tap
+        if: steps.gate-secret.outputs.skip != 'true'
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.shasums.outputs.version }}
+          ARM_SHA: ${{ steps.shasums.outputs.arm }}
+          INTEL_SHA: ${{ steps.shasums.outputs.intel }}
+        run: |
+          set -euo pipefail
+          git config --global user.name  "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/utensils/homebrew-tap.git" tap
+          cd tap
+
+          cask="Casks/claudette.rb"
+          # Replace exactly the three lines that change per release. Anchored
+          # patterns keep this surgical — accidental matches elsewhere are
+          # unlikely given the surrounding quotes.
+          sed -i -E "s|^(  version )\"[^\"]+\"|\\1\"${VERSION}\"|"            "${cask}"
+          sed -i -E "s|^(  sha256 arm:   )\"[0-9a-f]+\"|\\1\"${ARM_SHA}\"|"    "${cask}"
+          sed -i -E "s|^(         intel: )\"[0-9a-f]+\"|\\1\"${INTEL_SHA}\"|"  "${cask}"
+
+          # No-op when the cask is already at this version (e.g. on workflow re-run).
+          if git diff --quiet; then
+            echo "Cask already at ${VERSION} — nothing to do."
+            exit 0
+          fi
+
+          git add "${cask}"
+          git commit -m "claudette ${VERSION}"
+          git push
 
   notify-discord:
     name: Discord Release Notification

--- a/site/src/content/docs/getting-started/installation.mdx
+++ b/site/src/content/docs/getting-started/installation.mdx
@@ -5,13 +5,17 @@ description: Download and install Claudette on macOS, Linux, or Windows.
 
 ## Install on macOS (Homebrew)
 
-The recommended path on macOS is [Homebrew](https://brew.sh/):
+The recommended path on macOS is [Homebrew](https://brew.sh/), via the Utensils tap:
 
 ```bash
-brew install --cask claudette
+brew install --cask utensils/tap/claudette
 ```
 
-The cask downloads the Developer ID-signed, Apple-notarized `.dmg` for your architecture (Apple Silicon or Intel), drags `Claudette.app` into `/Applications`, and registers Claudette with Spotlight and Launchpad. Claudette ships its own signed updater, so `brew upgrade` will not touch it after install — the app keeps itself current via the built-in updater. To uninstall and remove all local data (workspaces, plugins, DB, caches), run `brew uninstall --zap --cask claudette`.
+This taps [`utensils/homebrew-tap`](https://github.com/utensils/homebrew-tap) on first run, downloads the Developer ID-signed, Apple-notarized `.dmg` for your architecture (Apple Silicon or Intel), drags `Claudette.app` into `/Applications`, and registers it with Spotlight and Launchpad. Claudette ships its own signed Tauri updater, so `brew upgrade` only refreshes the cask version pointer — in-place updates are handled by the app itself. To uninstall and remove all local data (workspaces, plugins, DB, caches), run `brew uninstall --zap --cask claudette`.
+
+:::note
+Claudette lives in a personal tap rather than the main `homebrew-cask` repository until the GitHub project crosses Homebrew's notability threshold (≥75 stars, ≥30 forks, or ≥30 watchers). The cask format and install behavior are identical; only the tap prefix differs. Star or watch [utensils/Claudette](https://github.com/utensils/Claudette) if you'd like to help move it upstream.
+:::
 
 ## Download
 

--- a/site/src/content/docs/getting-started/installation.mdx
+++ b/site/src/content/docs/getting-started/installation.mdx
@@ -3,9 +3,19 @@ title: Installation
 description: Download and install Claudette on macOS, Linux, or Windows.
 ---
 
+## Install on macOS (Homebrew)
+
+The recommended path on macOS is [Homebrew](https://brew.sh/):
+
+```bash
+brew install --cask claudette
+```
+
+The cask downloads the Developer ID-signed, Apple-notarized `.dmg` for your architecture (Apple Silicon or Intel), drags `Claudette.app` into `/Applications`, and registers Claudette with Spotlight and Launchpad. Claudette ships its own signed updater, so `brew upgrade` will not touch it after install — the app keeps itself current via the built-in updater. To uninstall and remove all local data (workspaces, plugins, DB, caches), run `brew uninstall --zap --cask claudette`.
+
 ## Download
 
-Claudette is available as a pre-built binary from [GitHub Releases](https://github.com/utensils/Claudette/releases).
+Claudette is also available as a pre-built binary from [GitHub Releases](https://github.com/utensils/Claudette/releases).
 
 | Platform | Architecture | Format |
 |----------|-------------|--------|
@@ -17,7 +27,7 @@ Claudette is available as a pre-built binary from [GitHub Releases](https://gith
 | Windows | ARM64 | `.zip` |
 
 1. Download the appropriate binary for your platform from the [latest release](https://github.com/utensils/Claudette/releases/latest)
-2. **macOS**: Open the `.dmg` and drag Claudette to your Applications folder
+2. **macOS**: Open the `.dmg` and drag Claudette to your Applications folder (or use the Homebrew cask above)
 3. **Linux**: Install the `.deb` package with `sudo apt install ./Claudette_*.deb`
 4. **Windows**: Extract the `.zip` archive and run `claudette.exe`
 


### PR DESCRIPTION
## Summary

Prepares Claudette for end-user install via Homebrew. We submitted to the main `homebrew-cask` repo first ([#264624](https://github.com/Homebrew/homebrew-cask/pull/264624)), but the audit blocked us on Homebrew's notability rule — `<75 stars OR <30 forks OR <30 watchers`. Claudette is at 43/7/0 today, so the PR was closed cleanly with a note. The cask now ships through a personal tap until we cross the threshold.

- **`site/src/content/docs/getting-started/installation.mdx`** — adds a new `## Install on macOS (Homebrew)` section recommending `brew install --cask utensils/tap/claudette`, calls out that the built-in Tauri updater (not brew) handles in-place upgrades after install, and points at `brew uninstall --zap --cask claudette` for clean removal. Notes the tap-vs-upstream situation so users know why it's not in the main repo yet.
- **`.github/workflows/release-please.yml`** — new `homebrew-tap-bump` job that runs after `publish` on each release. Stream-hashes both arch DMGs from the release URLs (`curl -fsSL | sha256sum`, no on-disk binaries), edits version + sha256 lines in `Casks/claudette.rb` on [`utensils/homebrew-tap`](https://github.com/utensils/homebrew-tap), and pushes directly. Idempotent (`git diff --quiet` short-circuits no-op commits), and gated to skip silently if the `HOMEBREW_TAP_TOKEN` secret is unset.

## Out of band changes

- **[`utensils/homebrew-tap`](https://github.com/utensils/homebrew-tap)** created and seeded with the v0.24.0 cask. `brew tap utensils/tap && brew info --cask claudette` already works.
- **[Homebrew/homebrew-cask#264624](https://github.com/Homebrew/homebrew-cask/pull/264624)** closed with an explanatory comment.
- **`HOMEBREW_TAP_TOKEN` repo secret** configured on `utensils/Claudette` (2026-05-16). Fine-grained PAT scoped to `utensils/homebrew-tap`, `Contents: Read and write` only, expires 2027-05-16.

## Test plan

- [x] Configure `HOMEBREW_TAP_TOKEN`.
- [ ] Merge this PR.
- [ ] On the next release, confirm `homebrew-tap-bump` runs, fetches the new DMGs, computes both sha256s, and pushes a `claudette <version>` commit to `utensils/homebrew-tap`.
- [ ] `brew update && brew upgrade --cask claudette` shows the new version pointer (in-place app update still handled by Tauri's updater).
- [ ] Eventually: when stars cross 75 (or forks cross 30, or watchers cross 30), resubmit to `homebrew-cask`. The same cask file works — just drop `verified:` (already done) and convert `depends_on macos:` to symbol form (already done). At that point the tap can either be retired or kept as a beta channel.