### PR TITLE
refactor(chat): extract slash picker state into useSlashPicker hook

### DIFF
--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -47,8 +47,8 @@ import { AttachMenu } from "./AttachMenu";
 import { FileMentionPicker, matchFiles } from "./FileMentionPicker";
 import { PinnedPromptsBar } from "./PinnedPromptsBar";
 import { extractMentionPaths } from "./queuedMessageEditing";
-import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
-import { describeSlashQuery } from "./nativeSlashCommands";
+import { SlashCommandPicker } from "./SlashCommandPicker";
+import { useSlashPicker } from "../../hooks/useSlashPicker";
 import { hasUltrathink, renderUltrathinkText } from "./ultrathink";
 import styles from "./ChatPanel.module.css";
 
@@ -214,8 +214,6 @@ export function ChatInputArea({
   const [chatInput, setChatInput] = useState(initialDraft.text);
   const [cursorPos, setCursorPos] = useState(0);
   const [inputScrollTop, setInputScrollTop] = useState(0);
-  const [slashPickerIndex, setSlashPickerIndex] = useState(0);
-  const [slashPickerDismissed, setSlashPickerDismissed] = useState(false);
   const [slashCommands, setSlashCommandsLocal] = useState<SlashCommand[]>([]);
   const setSlashCommandsStore = useAppStore((s) => s.setSlashCommands);
   const setSlashCommands = useCallback(
@@ -566,22 +564,37 @@ export function ChatInputArea({
     };
   }, [projectPath, selectedWorkspaceId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Filter by the command-name token (text before the first whitespace) so the
-  // picker stays open while the user types arguments. This keeps the argument
-  // hint visible for native commands like `/plugin install …`.
-  const slashQuery = composerMode === "prompt" ? describeSlashQuery(chatInput) : null;
-  const slashQueryToken = slashQuery?.token ?? null;
-  const slashHasArgs = slashQuery?.hasArgs ?? false;
-  const slashResults = useMemo(
-    () => (slashQueryToken === null ? [] : filterSlashCommands(slashCommands, slashQueryToken)),
-    [slashCommands, slashQueryToken],
+  // The picker filters by the command-name token (text before the first
+  // whitespace) so it stays open while the user types arguments — this
+  // keeps the argument hint visible for native commands like `/plugin install …`.
+  const handleSlashSelect = useCallback(
+    (cmd: SlashCommand, send: string) => {
+      onSend(send);
+      setChatInput("");
+      // Native commands record their canonical name from inside the
+      // handleSend dispatcher; record here only for file-based commands
+      // that go straight to the agent.
+      if (!cmd.kind) {
+        recordSlashCommandUsage(selectedWorkspaceId, cmd.name)
+          .then(refreshSlashCommands)
+          .catch((e) => console.error("Failed to record slash command usage:", e));
+      }
+    },
+    [onSend, selectedWorkspaceId, refreshSlashCommands],
   );
-  const showSlashPicker = slashQueryToken !== null && slashResults.length > 0 && !slashPickerDismissed;
 
-  useEffect(() => {
-    setSlashPickerIndex(0);
-    setSlashPickerDismissed(false);
-  }, [slashQueryToken]);
+  const handleSlashAutocomplete = useCallback(
+    (replacement: string) => setChatInput(replacement),
+    [],
+  );
+
+  const slashPicker = useSlashPicker({
+    chatInput,
+    composerMode,
+    slashCommands,
+    onSelectCommand: handleSlashSelect,
+    onAutocomplete: handleSlashAutocomplete,
+  });
 
   // --- File mention picker ---
 
@@ -1068,51 +1081,9 @@ export function ChatInputArea({
     }
 
     // Slash command picker navigation
-    if (showSlashPicker) {
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setSlashPickerIndex((i) => Math.min(i + 1, slashResults.length - 1));
-        return;
-      }
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setSlashPickerIndex((i) => Math.max(i - 1, 0));
-        return;
-      }
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        const cmd = slashResults[slashPickerIndex];
-        if (cmd) {
-          // If the user has already typed arguments after the command name,
-          // keep what they typed; otherwise substitute the canonical name.
-          const send = slashHasArgs ? chatInput : "/" + cmd.name;
-          onSend(send);
-          setChatInput("");
-          // Native commands record their canonical name from inside the
-          // handleSend dispatcher; record here only for file-based commands
-          // that go straight to the agent.
-          if (!cmd.kind) {
-            recordSlashCommandUsage(selectedWorkspaceId, cmd.name)
-              .then(refreshSlashCommands)
-              .catch((e) => console.error("Failed to record slash command usage:", e));
-          }
-        }
-        return;
-      }
-      if (e.key === "Tab" && !e.shiftKey) {
-        e.preventDefault();
-        const cmd = slashResults[slashPickerIndex];
-        if (cmd) {
-          setChatInput("/" + cmd.name + " ");
-          setSlashPickerDismissed(true);
-        }
-        return;
-      }
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setSlashPickerDismissed(true);
-        return;
-      }
+    if (slashPicker.handleKeyDown(e)) {
+      e.preventDefault();
+      return;
     }
 
     // Skip-queue / steer: when the configured "send now" hotkey fires
@@ -1189,21 +1160,12 @@ export function ChatInputArea({
           onHover={setFilePickerIndex}
         />
       )}
-      {showSlashPicker && (
+      {slashPicker.showSlashPicker && (
         <SlashCommandPicker
-          commands={slashResults}
-          selectedIndex={slashPickerIndex}
-          onSelect={(cmd) => {
-            const send = slashHasArgs ? chatInput : "/" + cmd.name;
-            onSend(send);
-            setChatInput("");
-            if (!cmd.kind) {
-              recordSlashCommandUsage(selectedWorkspaceId, cmd.name)
-                .then(refreshSlashCommands)
-                .catch((e) => console.error("Failed to record slash command usage:", e));
-            }
-          }}
-          onHover={setSlashPickerIndex}
+          commands={slashPicker.slashResults}
+          selectedIndex={slashPicker.selectedIndex}
+          onSelect={slashPicker.selectCommand}
+          onHover={slashPicker.setSelectedIndex}
         />
       )}
       {pendingAttachments.length > 0 && (

--- a/src/ui/src/hooks/useSlashPicker.test.tsx
+++ b/src/ui/src/hooks/useSlashPicker.test.tsx
@@ -1,0 +1,336 @@
+// @vitest-environment happy-dom
+
+import { act, useEffect, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { SlashCommand } from "../services/tauri";
+import { useSlashPicker } from "./useSlashPicker";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+type Api = ReturnType<typeof useSlashPicker>;
+
+interface HarnessProps {
+  chatInput: string;
+  composerMode: "prompt" | "shell";
+  slashCommands: SlashCommand[];
+  onSelectCommand: (cmd: SlashCommand, send: string) => void;
+  onAutocomplete: (replacement: string) => void;
+  onReady: (api: Api) => void;
+}
+
+function Harness({
+  chatInput,
+  composerMode,
+  slashCommands,
+  onSelectCommand,
+  onAutocomplete,
+  onReady,
+}: HarnessProps) {
+  const api = useSlashPicker({
+    chatInput,
+    composerMode,
+    slashCommands,
+    onSelectCommand,
+    onAutocomplete,
+  });
+  useEffect(() => {
+    onReady(api);
+  });
+  return null;
+}
+
+async function render(node: ReactNode): Promise<void> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+}
+
+async function rerender(node: ReactNode): Promise<void> {
+  const root = mountedRoots[mountedRoots.length - 1];
+  await act(async () => {
+    root.render(node);
+  });
+}
+
+afterEach(() => {
+  while (mountedRoots.length) {
+    const root = mountedRoots.pop()!;
+    act(() => root.unmount());
+  }
+  while (mountedContainers.length) {
+    const container = mountedContainers.pop()!;
+    container.remove();
+  }
+});
+
+function makeCmd(name: string, kind?: SlashCommand["kind"]): SlashCommand {
+  return { name, kind, description: "" } as SlashCommand;
+}
+
+function keyEvent(key: string, opts: { shiftKey?: boolean } = {}): React.KeyboardEvent {
+  return { key, shiftKey: opts.shiftKey ?? false } as React.KeyboardEvent;
+}
+
+const COMMANDS: SlashCommand[] = [
+  makeCmd("plugin"),
+  makeCmd("plan"),
+  makeCmd("model"),
+];
+
+describe("useSlashPicker", () => {
+  it("is closed when input does not start with /", async () => {
+    let api: Api | undefined;
+    await render(
+      <Harness
+        chatInput="hello"
+        composerMode="prompt"
+        slashCommands={COMMANDS}
+        onSelectCommand={() => undefined}
+        onAutocomplete={() => undefined}
+        onReady={(a) => (api = a)}
+      />,
+    );
+    expect(api!.showSlashPicker).toBe(false);
+    expect(api!.slashResults).toEqual([]);
+  });
+
+  it("is closed when composerMode is shell, even with a slash input", async () => {
+    let api: Api | undefined;
+    await render(
+      <Harness
+        chatInput="/plan"
+        composerMode="shell"
+        slashCommands={COMMANDS}
+        onSelectCommand={() => undefined}
+        onAutocomplete={() => undefined}
+        onReady={(a) => (api = a)}
+      />,
+    );
+    expect(api!.showSlashPicker).toBe(false);
+  });
+
+  it("opens with filtered results when input is /<prefix>", async () => {
+    let api: Api | undefined;
+    await render(
+      <Harness
+        chatInput="/pl"
+        composerMode="prompt"
+        slashCommands={COMMANDS}
+        onSelectCommand={() => undefined}
+        onAutocomplete={() => undefined}
+        onReady={(a) => (api = a)}
+      />,
+    );
+    expect(api!.showSlashPicker).toBe(true);
+    expect(api!.slashResults.map((c) => c.name)).toEqual(["plugin", "plan"]);
+    expect(api!.selectedIndex).toBe(0);
+  });
+
+  it("ArrowDown / ArrowUp navigate within bounds; out-of-bounds keys not consumed", async () => {
+    let api: Api | undefined;
+    await render(
+      <Harness
+        chatInput="/pl"
+        composerMode="prompt"
+        slashCommands={COMMANDS}
+        onSelectCommand={() => undefined}
+        onAutocomplete={() => undefined}
+        onReady={(a) => (api = a)}
+      />,
+    );
+    await act(async () => {
+      expect(api!.handleKeyDown(keyEvent("ArrowDown"))).toBe(true);
+    });
+    expect(api!.selectedIndex).toBe(1);
+
+    await act(async () => {
+      // Already at last index — clamps, no overflow.
+      expect(api!.handleKeyDown(keyEvent("ArrowDown"))).toBe(true);
+    });
+    expect(api!.selectedIndex).toBe(1);
+
+    await act(async () => {
+      expect(api!.handleKeyDown(keyEvent("ArrowUp"))).toBe(true);
+    });
+    expect(api!.selectedIndex).toBe(0);
+
+    await act(async () => {
+      // Already at 0 — clamps, no negative.
+      expect(api!.handleKeyDown(keyEvent("ArrowUp"))).toBe(true);
+    });
+    expect(api!.selectedIndex).toBe(0);
+
+    await act(async () => {
+      // Unrelated key not consumed.
+      expect(api!.handleKeyDown(keyEvent("a"))).toBe(false);
+    });
+  });
+
+  it("Enter sends canonical /<name> when no args typed", async () => {
+    const onSelect = vi.fn();
+    let api: Api | undefined;
+    await render(
+      <Harness
+        chatInput="/pl"
+        composerMode="prompt"
+        slashCommands={COMMANDS}
+        onSelectCommand={onSelect}
+        onAutocomplete={() => undefined}
+        onReady={(a) => (api = a)}
+      />,
+    );
+    await act(async () => {
+      expect(api!.handleKeyDown(keyEvent("Enter"))).toBe(true);
+    });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].name).toBe("plugin");
+    expect(onSelect.mock.calls[0][1]).toBe("/plugin");
+  });
+
+  it("Enter sends the user's typed string when args are present", async () => {
+    const onSelect = vi.fn();
+    let api: Api | undefined;
+    await render(
+      <Harness
+        chatInput="/plugin install foo"
+        composerMode="prompt"
+        slashCommands={COMMANDS}
+        onSelectCommand={onSelect}
+        onAutocomplete={() => undefined}
+        onReady={(a) => (api = a)}
+      />,
+    );
+    await act(async () => {
+      expect(api!.handleKeyDown(keyEvent("Enter"))).toBe(true);
+    });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][1]).toBe("/plugin install foo");
+  });
+
+  it("Shift+Enter is not consumed (preserves newline behavior)", async () => {
+    const onSelect = vi.fn();
+    let api: Api | undefined;
+    await render(
+      <Harness
+        chatInput="/pl"
+        composerMode="prompt"
+        slashCommands={COMMANDS}
+        onSelectCommand={onSelect}
+        onAutocomplete={() => undefined}
+        onReady={(a) => (api = a)}
+      />,
+    );
+    await act(async () => {
+      expect(api!.handleKeyDown(keyEvent("Enter", { shiftKey: true }))).toBe(false);
+    });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("Tab autocompletes to /<name>  and dismisses", async () => {
+    const onAutocomplete = vi.fn();
+    let api: Api | undefined;
+    await render(
+      <Harness
+        chatInput="/pl"
+        composerMode="prompt"
+        slashCommands={COMMANDS}
+        onSelectCommand={() => undefined}
+        onAutocomplete={onAutocomplete}
+        onReady={(a) => (api = a)}
+      />,
+    );
+    await act(async () => {
+      expect(api!.handleKeyDown(keyEvent("Tab"))).toBe(true);
+    });
+    expect(onAutocomplete).toHaveBeenCalledWith("/plugin ");
+    // Picker dismissed even though slashQueryToken still matches.
+    expect(api!.showSlashPicker).toBe(false);
+  });
+
+  it("Shift+Tab is not consumed", async () => {
+    const onAutocomplete = vi.fn();
+    let api: Api | undefined;
+    await render(
+      <Harness
+        chatInput="/pl"
+        composerMode="prompt"
+        slashCommands={COMMANDS}
+        onSelectCommand={() => undefined}
+        onAutocomplete={onAutocomplete}
+        onReady={(a) => (api = a)}
+      />,
+    );
+    await act(async () => {
+      expect(api!.handleKeyDown(keyEvent("Tab", { shiftKey: true }))).toBe(false);
+    });
+    expect(onAutocomplete).not.toHaveBeenCalled();
+  });
+
+  it("Escape dismisses without invoking any selection callback", async () => {
+    const onSelect = vi.fn();
+    const onAutocomplete = vi.fn();
+    let api: Api | undefined;
+    await render(
+      <Harness
+        chatInput="/pl"
+        composerMode="prompt"
+        slashCommands={COMMANDS}
+        onSelectCommand={onSelect}
+        onAutocomplete={onAutocomplete}
+        onReady={(a) => (api = a)}
+      />,
+    );
+    await act(async () => {
+      expect(api!.handleKeyDown(keyEvent("Escape"))).toBe(true);
+    });
+    expect(api!.showSlashPicker).toBe(false);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onAutocomplete).not.toHaveBeenCalled();
+  });
+
+  it("changing the slash token resets index and clears dismiss", async () => {
+    let api: Api | undefined;
+    const onReady = (a: Api) => (api = a);
+    await render(
+      <Harness
+        chatInput="/pl"
+        composerMode="prompt"
+        slashCommands={COMMANDS}
+        onSelectCommand={() => undefined}
+        onAutocomplete={() => undefined}
+        onReady={onReady}
+      />,
+    );
+    // Advance + dismiss.
+    await act(async () => {
+      api!.handleKeyDown(keyEvent("ArrowDown"));
+    });
+    await act(async () => {
+      api!.handleKeyDown(keyEvent("Escape"));
+    });
+    expect(api!.showSlashPicker).toBe(false);
+    expect(api!.selectedIndex).toBe(1);
+
+    // Rerender with a new token — should reset both pieces of state.
+    await rerender(
+      <Harness
+        chatInput="/mo"
+        composerMode="prompt"
+        slashCommands={COMMANDS}
+        onSelectCommand={() => undefined}
+        onAutocomplete={() => undefined}
+        onReady={onReady}
+      />,
+    );
+    expect(api!.showSlashPicker).toBe(true);
+    expect(api!.selectedIndex).toBe(0);
+  });
+});

--- a/src/ui/src/hooks/useSlashPicker.ts
+++ b/src/ui/src/hooks/useSlashPicker.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { SlashCommand } from "../services/tauri";
+import { describeSlashQuery } from "../components/chat/nativeSlashCommands";
+import { filterSlashCommands } from "../components/chat/SlashCommandPicker";
+
+type ComposerMode = "prompt" | "shell";
+
+interface UseSlashPickerOptions {
+  chatInput: string;
+  composerMode: ComposerMode;
+  slashCommands: SlashCommand[];
+  /**
+   * Called when the user selects a command — either via Enter or by clicking
+   * the picker. `send` is what should be dispatched: the full input if the
+   * user already typed arguments after the command name, otherwise the
+   * canonical `/<name>`. The caller decides what to do with it (typically
+   * onSend(send) + setChatInput("") + recordSlashCommandUsage).
+   */
+  onSelectCommand: (cmd: SlashCommand, send: string) => void;
+  /**
+   * Called when the user accepts a command via Tab (autocomplete-and-stay).
+   * Receives the canonical `"/<name> "` text the caller should write into
+   * the input. The hook dismisses itself afterwards.
+   */
+  onAutocomplete: (replacement: string) => void;
+}
+
+interface UseSlashPickerResult {
+  showSlashPicker: boolean;
+  slashResults: SlashCommand[];
+  selectedIndex: number;
+  setSelectedIndex: (i: number) => void;
+  /**
+   * Returns true if the event was consumed by the picker (Arrow/Enter/Tab/
+   * Escape while open). The caller should `return` immediately on true. The
+   * hook does NOT call `preventDefault` — the caller does, to keep all
+   * preventDefault calls in one place (the surrounding keyboard handler).
+   */
+  handleKeyDown: (e: React.KeyboardEvent) => boolean;
+  /** Imperatively select a command — used as the picker's onSelect prop. */
+  selectCommand: (cmd: SlashCommand) => void;
+}
+
+/**
+ * Slash-command picker state for the chat composer.
+ *
+ * Owns: open/closed (showSlashPicker), result list, selected index, dismiss
+ * state, keyboard navigation (Arrow/Enter/Tab/Escape), and the send-vs-
+ * autocomplete decision. Does NOT own slash-command loading — `slashCommands`
+ * is shared with PinnedPromptsManager and lives outside.
+ *
+ * Distinct from `useSlashAutocomplete` (used by the pinned-prompt editor),
+ * which treats `/x` as text to *insert*. The composer treats `/x` as a
+ * command to *run*, so Enter sends and Tab autocompletes.
+ */
+export function useSlashPicker({
+  chatInput,
+  composerMode,
+  slashCommands,
+  onSelectCommand,
+  onAutocomplete,
+}: UseSlashPickerOptions): UseSlashPickerResult {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [dismissed, setDismissed] = useState(false);
+
+  const slashQuery = composerMode === "prompt" ? describeSlashQuery(chatInput) : null;
+  const slashQueryToken = slashQuery?.token ?? null;
+  const slashHasArgs = slashQuery?.hasArgs ?? false;
+
+  const slashResults = useMemo(
+    () => (slashQueryToken === null ? [] : filterSlashCommands(slashCommands, slashQueryToken)),
+    [slashCommands, slashQueryToken],
+  );
+
+  const showSlashPicker =
+    slashQueryToken !== null && slashResults.length > 0 && !dismissed;
+
+  // Reset selection + dismiss whenever the slash token changes so a fresh
+  // query always starts from the top of the list. Preserves the exact
+  // behavior from ChatInputArea.tsx prior to extraction.
+  useEffect(() => {
+    setSelectedIndex(0);
+    setDismissed(false);
+  }, [slashQueryToken]);
+
+  const selectCommand = useCallback(
+    (cmd: SlashCommand) => {
+      // If the user has already typed arguments after the command name,
+      // keep what they typed; otherwise substitute the canonical name.
+      const send = slashHasArgs ? chatInput : "/" + cmd.name;
+      onSelectCommand(cmd, send);
+    },
+    [chatInput, slashHasArgs, onSelectCommand],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent): boolean => {
+      if (!showSlashPicker) return false;
+
+      if (e.key === "ArrowDown") {
+        setSelectedIndex((i) => Math.min(i + 1, slashResults.length - 1));
+        return true;
+      }
+      if (e.key === "ArrowUp") {
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+        return true;
+      }
+      if (e.key === "Enter" && !e.shiftKey) {
+        const cmd = slashResults[selectedIndex];
+        if (cmd) selectCommand(cmd);
+        return true;
+      }
+      if (e.key === "Tab" && !e.shiftKey) {
+        const cmd = slashResults[selectedIndex];
+        if (cmd) {
+          onAutocomplete("/" + cmd.name + " ");
+          setDismissed(true);
+        }
+        return true;
+      }
+      if (e.key === "Escape") {
+        setDismissed(true);
+        return true;
+      }
+      return false;
+    },
+    [showSlashPicker, slashResults, selectedIndex, selectCommand, onAutocomplete],
+  );
+
+  return {
+    showSlashPicker,
+    slashResults,
+    selectedIndex,
+    setSelectedIndex,
+    handleKeyDown,
+    selectCommand,
+  };
+}


### PR DESCRIPTION
## Summary

- `ChatInputArea` owned the slash-command picker's open flag, result list, selected index, dismiss state, keyboard navigation, and select-command path — duplicated between the keyboard `Enter` handler and the picker's `onSelect` prop. Lift the whole thing into `useSlashPicker` so the composer stops carrying state that isn't about composing.
- Behavior is byte-for-byte preserved: `Tab` autocompletes `/<name> `, `Enter` sends `chatInput` when args are present or `/<name>` when not, `Shift+Enter` and `Shift+Tab` pass through, `Escape` dismisses without clearing the input, and the dismiss-on-token-change reset is preserved exactly.
- Distinct from the existing `useSlashAutocomplete` used by `PinnedPromptsManager` — that one treats `/x` as text to *insert* into a template; the chat composer treats `/x` as a command to *run*. Different Enter/Tab semantics, so a separate hook rather than generalizing.
- `ChatInputArea` net: **-38 lines** (`useState` 12→10, `useEffect` 17→16, `useMemo` 2→1, `useCallback` 11→13). Hook + 11 tests are pure additions.

## Test plan

- [x] `bunx tsc -b` — clean
- [x] `bun run test --run` — **2290 / 2290** pass (+11 new tests in `useSlashPicker.test.tsx`)
- [x] `bun run lint` — 0 new errors / warnings (15 pre-existing warnings in unrelated files unchanged)
- [x] `bun run lint:css` — passed
- [x] **Live UAT** against running dev build (debug port 19432, branch `refactor/chat-input-slash-picker-hook`) via `/claudette-debug`:
  - [x] Type `/` → picker opens with 35 options
  - [x] `ArrowDown` ×2, `ArrowUp` ×1 → selectedIndex 0→1→2→1
  - [x] `Escape` → picker dismissed, input `/` retained
  - [x] `Tab` → autocompletes to `/agent-sdk-dev:new-sdk-app `, picker reopens via the token-change reset (matches pre-refactor behavior)
  - [x] `Shift+Enter` on open picker → hook returns false, picker stays open, default newline passes through

## Notes

- The `useSlashPicker.test.tsx` suite uses the same `createRoot` + `Harness` test pattern as `useStickyScroll.test.tsx` (the local convention — no `@testing-library/react`).
- A latent bug in the original code is intentionally **preserved**: when `slashCommands` reloads asynchronously and the matched-command set shrinks below `selectedIndex`, Enter does nothing. `useSlashAutocomplete` has a clamp for this; this hook deliberately does not, so behavior matches the prior `ChatInputArea` code. Worth a follow-up PR if we want to align both hooks.