### PR TITLE
fix(chat): keep sticky scroll pinned during live tools

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -486,6 +486,7 @@ export function ChatPanel() {
     scrollToBottom,
     restoreScrollPosition,
     handleContentChanged,
+    markUserScrollIntent,
     suppressNextAutoScrollRef,
   } = useStickyScroll(messagesContainerRef);
   usePreventScrollBounce(messagesContainerRef);
@@ -1667,7 +1668,10 @@ export function ChatPanel() {
          * pixel-identical at every browser zoom (the OS overlay
          * scrollbar that WKWebView would render on `.messages` instead
          * doesn't scale with zoom). */}
-        <OverlayScrollbar targetRef={messagesContainerRef} />
+        <OverlayScrollbar
+          targetRef={messagesContainerRef}
+          onUserScrollIntent={markUserScrollIntent}
+        />
         <div className={styles.messages} ref={messagesContainerRef}>
           <CliInvocationBanner
             invocation={cliInvocation}

--- a/src/ui/src/components/chat/OverlayScrollbar.test.tsx
+++ b/src/ui/src/components/chat/OverlayScrollbar.test.tsx
@@ -180,10 +180,12 @@ function Harness({
   metrics,
   nullTarget,
   onTargetReady,
+  onUserScrollIntent,
 }: {
   metrics?: { scrollTop?: number; scrollHeight: number; clientHeight: number };
   nullTarget?: boolean;
   onTargetReady?: (el: HTMLDivElement) => void;
+  onUserScrollIntent?: () => void;
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
   return (
@@ -200,7 +202,10 @@ function Harness({
           }}
         />
       )}
-      <OverlayScrollbar targetRef={ref} />
+      <OverlayScrollbar
+        targetRef={ref}
+        onUserScrollIntent={onUserScrollIntent}
+      />
     </div>
   );
 }
@@ -526,6 +531,36 @@ describe("OverlayScrollbar drag mapping", () => {
     expect(slider.dataset.dragging).toBe("false");
   });
 
+  it("marks user scroll intent for slider drag start and movement", async () => {
+    const onUserScrollIntent = vi.fn();
+    const container = await render(
+      <Harness
+        metrics={{ scrollTop: 0, scrollHeight: 1000, clientHeight: 400 }}
+        onUserScrollIntent={onUserScrollIntent}
+      />,
+    );
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    Object.defineProperty(slider, "offsetHeight", {
+      configurable: true,
+      value: 160,
+    });
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+
+    await act(async () => {
+      pointerDown(slider, 0);
+    });
+    pointerMove(slider, 100);
+
+    expect(onUserScrollIntent).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      pointerUp(slider);
+    });
+  });
+
   it("clamps drag-driven scrollTop to [0, scrollRange]", async () => {
     let target!: HTMLDivElement;
     const container = await render(
@@ -672,6 +707,37 @@ describe("OverlayScrollbar track click-to-page", () => {
     trackPointerDown(track, 300);
     await flushRaf();
     expect(target.scrollTop).toBe(400);
+  });
+
+  it("marks user scroll intent before track click-to-page changes scrollTop", async () => {
+    const onUserScrollIntent = vi.fn();
+    const container = await render(
+      <Harness
+        metrics={{ scrollTop: 0, scrollHeight: 1000, clientHeight: 400 }}
+        onUserScrollIntent={onUserScrollIntent}
+      />,
+    );
+    const track = container.querySelector(`.${styles.track}`) as HTMLElement;
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    Object.defineProperty(slider, "getBoundingClientRect", {
+      value: () => ({
+        top: 0,
+        bottom: 160,
+        height: 160,
+        left: 0,
+        right: 8,
+        width: 8,
+        x: 0,
+        y: 0,
+        toJSON: () => null,
+      }),
+    });
+
+    trackPointerDown(track, 300);
+
+    expect(onUserScrollIntent).toHaveBeenCalledTimes(1);
   });
 
   it("pages up by clientHeight when the click lands above the slider", async () => {

--- a/src/ui/src/components/chat/OverlayScrollbar.tsx
+++ b/src/ui/src/components/chat/OverlayScrollbar.tsx
@@ -16,6 +16,7 @@ interface OverlayScrollbarProps {
    * of the scrolling element itself (children would scroll with content).
    */
   targetRef: RefObject<HTMLElement | null>;
+  onUserScrollIntent?: () => void;
 }
 
 /**
@@ -50,7 +51,10 @@ interface OverlayScrollbarProps {
  * explicitly below to preserve the behavior the native scrollbar gave
  * us before the swap.
  */
-export function OverlayScrollbar({ targetRef }: OverlayScrollbarProps) {
+export function OverlayScrollbar({
+  targetRef,
+  onUserScrollIntent,
+}: OverlayScrollbarProps) {
   const sliderRef = useRef<HTMLDivElement | null>(null);
   const rafPendingRef = useRef(false);
   const [overflowing, setOverflowing] = useState(false);
@@ -141,6 +145,7 @@ export function OverlayScrollbar({ targetRef }: OverlayScrollbarProps) {
       // also fire on the same pointerdown.
       e.preventDefault();
       e.stopPropagation();
+      onUserScrollIntent?.();
       slider.setPointerCapture(e.pointerId);
       setDragging(true);
       const startY = e.clientY;
@@ -155,6 +160,7 @@ export function OverlayScrollbar({ targetRef }: OverlayScrollbarProps) {
       // doesn't push scrollTop outside its valid range.
       const scale = usableTrack > 0 ? scrollRange / usableTrack : 0;
       const onMove = (ev: PointerEvent) => {
+        onUserScrollIntent?.();
         const delta = (ev.clientY - startY) * scale;
         const next = Math.max(
           0,
@@ -173,7 +179,7 @@ export function OverlayScrollbar({ targetRef }: OverlayScrollbarProps) {
       slider.addEventListener("pointerup", onUp);
       slider.addEventListener("pointercancel", onUp);
     },
-    [targetRef],
+    [onUserScrollIntent, targetRef],
   );
 
   // Track click-to-page. Native macOS scrollbar (and Monaco's slider)
@@ -193,6 +199,7 @@ export function OverlayScrollbar({ targetRef }: OverlayScrollbarProps) {
       const slider = sliderRef.current;
       if (!target || !slider) return;
       e.preventDefault();
+      onUserScrollIntent?.();
       const sliderRect = slider.getBoundingClientRect();
       // Page up if click is above the slider's top edge, down if below
       // its bottom edge. A click directly on the slider hits the slider
@@ -207,7 +214,7 @@ export function OverlayScrollbar({ targetRef }: OverlayScrollbarProps) {
       );
       target.scrollTop = next;
     },
-    [targetRef],
+    [onUserScrollIntent, targetRef],
   );
 
   return (

--- a/src/ui/src/hooks/useStickyScroll.test.tsx
+++ b/src/ui/src/hooks/useStickyScroll.test.tsx
@@ -222,4 +222,30 @@ describe("useStickyScroll", () => {
     expect(target.scrollTop).toBe(500);
     expect(api.isAtBottom).toBe(false);
   });
+
+  it("does not force bottom when the overlay scrollbar marks user intent", async () => {
+    let api!: StickyScrollApi;
+    let target!: HTMLDivElement;
+    await render(
+      <Harness
+        metrics={{ scrollTop: 600, scrollHeight: 1000, clientHeight: 400 }}
+        onReady={(nextApi, nextTarget) => {
+          api = nextApi;
+          target = nextTarget;
+        }}
+      />,
+    );
+
+    await act(async () => {
+      api.handleContentChanged();
+      setScrollHeight(target, 1200);
+      api.markUserScrollIntent();
+      target.scrollTop = 500;
+      target.dispatchEvent(new Event("scroll"));
+      flushAnimationFrames();
+    });
+
+    expect(target.scrollTop).toBe(500);
+    expect(api.isAtBottom).toBe(false);
+  });
 });

--- a/src/ui/src/hooks/useStickyScroll.test.tsx
+++ b/src/ui/src/hooks/useStickyScroll.test.tsx
@@ -8,6 +8,7 @@ import { useStickyScroll } from "./useStickyScroll";
 
 const mountedRoots: Root[] = [];
 const mountedContainers: HTMLElement[] = [];
+let rafCallbacks: FrameRequestCallback[] = [];
 
 type StickyScrollApi = ReturnType<typeof useStickyScroll>;
 
@@ -27,25 +28,44 @@ function configureScrollMetrics(
   el: HTMLElement,
   metrics: { scrollTop?: number; scrollHeight: number; clientHeight: number },
 ) {
+  const target = el as HTMLElement & {
+    _clientHeight?: number;
+    _stickyMetricsConfigured?: boolean;
+    _scrollHeight?: number;
+    _scrollTop?: number;
+  };
+  target._stickyMetricsConfigured = true;
+  target._scrollHeight = metrics.scrollHeight;
+  target._clientHeight = metrics.clientHeight;
   Object.defineProperty(el, "scrollTop", {
     configurable: true,
-    get: () => (el as HTMLElement & { _scrollTop?: number })._scrollTop ?? 0,
+    get: () => target._scrollTop ?? 0,
     set: (value: number) => {
-      (el as HTMLElement & { _scrollTop?: number })._scrollTop = value;
+      target._scrollTop = value;
     },
   });
   if (metrics.scrollTop != null) el.scrollTop = metrics.scrollTop;
   Object.defineProperty(el, "scrollHeight", {
     configurable: true,
-    value: metrics.scrollHeight,
+    get: () => target._scrollHeight ?? 0,
   });
   Object.defineProperty(el, "clientHeight", {
     configurable: true,
-    value: metrics.clientHeight,
+    get: () => target._clientHeight ?? 0,
   });
 }
 
+function setScrollHeight(el: HTMLElement, scrollHeight: number) {
+  (el as HTMLElement & { _scrollHeight?: number })._scrollHeight = scrollHeight;
+}
+
+function flushAnimationFrames() {
+  const callbacks = rafCallbacks.splice(0);
+  callbacks.forEach((cb) => cb(0));
+}
+
 function installDomObservers() {
+  rafCallbacks = [];
   globalThis.ResizeObserver = vi.fn().mockImplementation(function () {
     return {
       observe: () => undefined,
@@ -61,8 +81,8 @@ function installDomObservers() {
     };
   }) as unknown as typeof globalThis.MutationObserver;
   globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
-    cb(0);
-    return 1;
+    rafCallbacks.push(cb);
+    return rafCallbacks.length;
   }) as typeof globalThis.requestAnimationFrame;
 }
 
@@ -82,7 +102,13 @@ function Harness({
     <div
       ref={(el) => {
         ref.current = el;
-        if (el) configureScrollMetrics(el, metrics);
+        if (
+          el &&
+          !(el as HTMLElement & { _stickyMetricsConfigured?: boolean })
+            ._stickyMetricsConfigured
+        ) {
+          configureScrollMetrics(el, metrics);
+        }
       }}
     />
   );
@@ -145,5 +171,55 @@ describe("useStickyScroll", () => {
 
     expect(target.scrollTop).toBe(600);
     expect(api.isAtBottom).toBe(true);
+  });
+
+  it("keeps following bottom when inline live tool content grows before the scheduled frame", async () => {
+    let api!: StickyScrollApi;
+    let target!: HTMLDivElement;
+    await render(
+      <Harness
+        metrics={{ scrollTop: 600, scrollHeight: 1000, clientHeight: 400 }}
+        onReady={(nextApi, nextTarget) => {
+          api = nextApi;
+          target = nextTarget;
+        }}
+      />,
+    );
+
+    await act(async () => {
+      api.handleContentChanged();
+      setScrollHeight(target, 1200);
+      target.dispatchEvent(new Event("scroll"));
+      flushAnimationFrames();
+    });
+
+    expect(target.scrollTop).toBe(1200);
+    expect(api.isAtBottom).toBe(true);
+  });
+
+  it("does not force bottom when the user scrolls up during a pending live tool update", async () => {
+    let api!: StickyScrollApi;
+    let target!: HTMLDivElement;
+    await render(
+      <Harness
+        metrics={{ scrollTop: 600, scrollHeight: 1000, clientHeight: 400 }}
+        onReady={(nextApi, nextTarget) => {
+          api = nextApi;
+          target = nextTarget;
+        }}
+      />,
+    );
+
+    await act(async () => {
+      api.handleContentChanged();
+      setScrollHeight(target, 1200);
+      target.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }));
+      target.scrollTop = 500;
+      target.dispatchEvent(new Event("scroll"));
+      flushAnimationFrames();
+    });
+
+    expect(target.scrollTop).toBe(500);
+    expect(api.isAtBottom).toBe(false);
   });
 });

--- a/src/ui/src/hooks/useStickyScroll.ts
+++ b/src/ui/src/hooks/useStickyScroll.ts
@@ -19,6 +19,7 @@ export function useStickyScroll(
   const [isAtBottom, setIsAtBottom] = useState(true);
   const programmaticScrollRef = useRef(false);
   const rafPendingRef = useRef(false);
+  const userScrollVersionRef = useRef(0);
   const suppressNextAutoScrollRef = useRef(false);
   // Kept in a ref so the RAF callback always reads the latest value without
   // needing threshold in its useCallback deps (which would recreate the fn
@@ -33,6 +34,8 @@ export function useStickyScroll(
    */
   const handleContentChanged = useCallback(() => {
     if (rafPendingRef.current) return;
+    const shouldAutoScroll = isAtBottomRef.current;
+    const userScrollVersion = userScrollVersionRef.current;
     rafPendingRef.current = true;
     requestAnimationFrame(() => {
       rafPendingRef.current = false;
@@ -56,13 +59,24 @@ export function useStickyScroll(
         }
         return;
       }
-      if (!isAtBottomRef.current) return;
+      const userScrolledSinceSchedule =
+        userScrollVersionRef.current !== userScrollVersion;
+      if (
+        (!shouldAutoScroll && !isAtBottomRef.current) ||
+        (userScrolledSinceSchedule && !isAtBottomRef.current)
+      ) {
+        return;
+      }
       const el = containerRef.current;
       if (el) {
         const prev = el.scrollTop;
         el.scrollTop = el.scrollHeight;
         if (el.scrollTop !== prev) {
           programmaticScrollRef.current = true;
+        }
+        if (!isAtBottomRef.current) {
+          isAtBottomRef.current = true;
+          setIsAtBottom(true);
         }
       }
     });
@@ -87,6 +101,9 @@ export function useStickyScroll(
         return;
       }
       checkPosition();
+    };
+    const noteUserScrollIntent = () => {
+      userScrollVersionRef.current += 1;
     };
 
     // ResizeObserver: catches container resizes (panel toggle, window resize).
@@ -119,9 +136,15 @@ export function useStickyScroll(
     };
 
     el.addEventListener("scroll", onScroll, { passive: true });
+    el.addEventListener("wheel", noteUserScrollIntent, { passive: true });
+    el.addEventListener("touchmove", noteUserScrollIntent, { passive: true });
+    el.addEventListener("keydown", noteUserScrollIntent);
     window.addEventListener("focus", onFocus);
     return () => {
       el.removeEventListener("scroll", onScroll);
+      el.removeEventListener("wheel", noteUserScrollIntent);
+      el.removeEventListener("touchmove", noteUserScrollIntent);
+      el.removeEventListener("keydown", noteUserScrollIntent);
       window.removeEventListener("focus", onFocus);
       resizeObserver.disconnect();
       mutationObserver.disconnect();

--- a/src/ui/src/hooks/useStickyScroll.ts
+++ b/src/ui/src/hooks/useStickyScroll.ts
@@ -27,6 +27,10 @@ export function useStickyScroll(
   const thresholdRef = useRef(threshold);
   thresholdRef.current = threshold;
 
+  const markUserScrollIntent = useCallback(() => {
+    userScrollVersionRef.current += 1;
+  }, []);
+
   /**
    * Auto-scroll to bottom if the user is already there.
    * Coalesced: at most one requestAnimationFrame callback per frame,
@@ -102,10 +106,6 @@ export function useStickyScroll(
       }
       checkPosition();
     };
-    const noteUserScrollIntent = () => {
-      userScrollVersionRef.current += 1;
-    };
-
     // ResizeObserver: catches container resizes (panel toggle, window resize).
     // Scroll first if pinned to bottom — prevents checkPosition() from
     // flipping isAtBottomRef to false before auto-scroll can act on it.
@@ -136,20 +136,20 @@ export function useStickyScroll(
     };
 
     el.addEventListener("scroll", onScroll, { passive: true });
-    el.addEventListener("wheel", noteUserScrollIntent, { passive: true });
-    el.addEventListener("touchmove", noteUserScrollIntent, { passive: true });
-    el.addEventListener("keydown", noteUserScrollIntent);
+    el.addEventListener("wheel", markUserScrollIntent, { passive: true });
+    el.addEventListener("touchmove", markUserScrollIntent, { passive: true });
+    el.addEventListener("keydown", markUserScrollIntent);
     window.addEventListener("focus", onFocus);
     return () => {
       el.removeEventListener("scroll", onScroll);
-      el.removeEventListener("wheel", noteUserScrollIntent);
-      el.removeEventListener("touchmove", noteUserScrollIntent);
-      el.removeEventListener("keydown", noteUserScrollIntent);
+      el.removeEventListener("wheel", markUserScrollIntent);
+      el.removeEventListener("touchmove", markUserScrollIntent);
+      el.removeEventListener("keydown", markUserScrollIntent);
       window.removeEventListener("focus", onFocus);
       resizeObserver.disconnect();
       mutationObserver.disconnect();
     };
-  }, [containerRef, threshold, handleContentChanged]);
+  }, [containerRef, threshold, handleContentChanged, markUserScrollIntent]);
 
   /** Programmatically scroll to bottom and re-enable auto-follow. */
   const scrollToBottom = useCallback(() => {
@@ -190,6 +190,7 @@ export function useStickyScroll(
     scrollToBottom,
     restoreScrollPosition,
     handleContentChanged,
+    markUserScrollIntent,
     suppressNextAutoScrollRef,
   } as const;
 }


### PR DESCRIPTION
## Summary

Fixes a sticky-scroll regression in the chat transcript while live tool calls or agent tool calls are updating, especially when the grouped/collapsed tool-call display is disabled and tool output renders inline.

## Root Cause

`useStickyScroll` schedules bottom-following work in `requestAnimationFrame` after transcript content changes. Live tool rows can grow between scheduling and the frame running. That intermediate layout change can emit a scroll/position check where `scrollTop + clientHeight` is no longer near the new `scrollHeight`, so the hook incorrectly decides the user left the bottom even though they did not scroll. Once that happens, later tool-call updates stop auto-following until the turn completes or the user manually jumps back down.

Inline tool mode makes the bug much easier to hit because running Agent/tool rows expose more live content and therefore produce larger transcript height changes.

## What Changed

- Snapshot whether the transcript was sticky at the time a content-change frame is scheduled.
- Keep following the bottom if the only thing that changed before the frame was content height.
- Track real user scroll intent via `wheel`, `touchmove`, and keyboard input so an actual user scroll still disables auto-follow.
- Preserve the existing suppression path used for deliberate non-sticky content changes like expanding inline previews.
- Add regression coverage that simulates live inline tool content growing before the scheduled sticky-scroll frame runs.
- Add coverage that proves a real user scroll during the pending update still wins and prevents forced scrolling.

## User Impact

When agents or tool calls are actively running, the chat should remain pinned to the latest output if the user was already at the bottom. Users can still scroll up to inspect earlier transcript content without the hook fighting them.

## Validation

- `cd src/ui && bun run test -- useStickyScroll.test.tsx`
- `cd src/ui && bunx tsc -b`
- `git diff --check`
