### PR TITLE
fix(terminal): stop panel re-opening on every workspace switch

### DIFF
--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -707,9 +707,9 @@ export const TerminalPanel = memo(function TerminalPanel() {
   // Follow-up: once the workspace's tab list lands in the store,
   // promote the Claudette Terminal (the AgentTask-kind tab) to active
   // so the user lands on the streaming provisioning output even if
-  // their previous active tab in this workspace was a PTY. Fires
-  // exactly once per workspace's transition into preparing — if they
-  // click away to Terminal 1 mid-resolve we honor that, no reflux.
+  // their previous active tab in this workspace was a PTY. Fires at
+  // most once per workspace for the lifetime of this mounted component —
+  // if they click away to Terminal 1 mid-resolve we honor that, no reflux.
   useEffect(() => {
     if (
       !selectedWorkspaceId ||

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -88,6 +88,7 @@ import {
 import { viewportToFixed } from "../../utils/zoom";
 import { adjustTerminalFontSize } from "../../utils/fontSettings";
 import { reclaimScrollLines } from "./terminalReclaim";
+import { useTerminalEnvAutoOpen } from "./useTerminalEnvAutoOpen";
 import "@xterm/xterm/css/xterm.css";
 import styles from "./TerminalPanel.module.css";
 
@@ -681,8 +682,18 @@ export const TerminalPanel = memo(function TerminalPanel() {
   // load-tabs effect below populates `terminalTabs[wsId]` only after
   // the panel becomes visible, so we apply focus in a follow-up effect
   // that watches the populated tab list rather than racing it here.
-  const lastAutoOpenedForRef = useRef<string | null>(null);
-  const lastAutoFocusedForRef = useRef<string | null>(null);
+  useTerminalEnvAutoOpen(
+    selectedWorkspaceId,
+    workspaceEnvironmentPreparing,
+    claudetteTerminalEnabled,
+    terminalPanelVisible,
+    setTerminalPanelVisible,
+  );
+
+  // Per-workspace set tracking which workspaces we've already auto-focused
+  // the Claudette Terminal for during env preparation. A Set (vs the previous
+  // string | null) ensures that switching away and back doesn't re-focus.
+  const autoFocusedWorkspacesRef = useRef<Set<string>>(new Set());
   // Set true when our auto-focus effect is about to switch the active
   // terminal tab to the Claudette Terminal during env preparation.
   // The focus-management useLayoutEffect below consumes this on its
@@ -692,28 +703,6 @@ export const TerminalPanel = memo(function TerminalPanel() {
   // provisioning output land in view, but keyboard focus stays where
   // they had it — typically the chat composer.
   const suppressNextTerminalFocusRef = useRef(false);
-  useEffect(() => {
-    if (
-      !selectedWorkspaceId ||
-      !workspaceEnvironmentPreparing ||
-      !claudetteTerminalEnabled
-    ) {
-      lastAutoOpenedForRef.current = null;
-      lastAutoFocusedForRef.current = null;
-      return;
-    }
-    if (lastAutoOpenedForRef.current === selectedWorkspaceId) return;
-    lastAutoOpenedForRef.current = selectedWorkspaceId;
-    if (!terminalPanelVisible) {
-      setTerminalPanelVisible(true);
-    }
-  }, [
-    selectedWorkspaceId,
-    workspaceEnvironmentPreparing,
-    claudetteTerminalEnabled,
-    terminalPanelVisible,
-    setTerminalPanelVisible,
-  ]);
 
   // Follow-up: once the workspace's tab list lands in the store,
   // promote the Claudette Terminal (the AgentTask-kind tab) to active
@@ -728,7 +717,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
       !claudetteTerminalEnabled
     )
       return;
-    if (lastAutoFocusedForRef.current === selectedWorkspaceId) return;
+    if (autoFocusedWorkspacesRef.current.has(selectedWorkspaceId)) return;
     const tabs = terminalTabs[selectedWorkspaceId];
     if (!tabs || tabs.length === 0) return;
     const claudette = tabs.find((tab) => tab.kind === "agent_task");
@@ -736,10 +725,10 @@ export const TerminalPanel = memo(function TerminalPanel() {
     if (useAppStore.getState().activeTerminalTabId[selectedWorkspaceId] === claudette.id) {
       // Already the active tab — no need to switch, and triggering a
       // no-op set would still re-fire the focus useLayoutEffect.
-      lastAutoFocusedForRef.current = selectedWorkspaceId;
+      autoFocusedWorkspacesRef.current.add(selectedWorkspaceId);
       return;
     }
-    lastAutoFocusedForRef.current = selectedWorkspaceId;
+    autoFocusedWorkspacesRef.current.add(selectedWorkspaceId);
     // Tell the focus layout effect to skip keyboard-focus stealing
     // for the activation we're about to dispatch. The user's
     // attention belongs in the chat composer while provisioning runs.

--- a/src/ui/src/components/terminal/useTerminalEnvAutoOpen.test.tsx
+++ b/src/ui/src/components/terminal/useTerminalEnvAutoOpen.test.tsx
@@ -1,0 +1,213 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTerminalEnvAutoOpen } from "./useTerminalEnvAutoOpen";
+
+interface HarnessProps {
+  selectedWorkspaceId: string | null;
+  workspaceEnvironmentPreparing: boolean;
+  claudetteTerminalEnabled: boolean;
+  terminalPanelVisible: boolean;
+  setTerminalPanelVisible: (visible: boolean) => void;
+}
+
+function Harness(props: HarnessProps) {
+  useTerminalEnvAutoOpen(
+    props.selectedWorkspaceId,
+    props.workspaceEnvironmentPreparing,
+    props.claudetteTerminalEnabled,
+    props.terminalPanelVisible,
+    props.setTerminalPanelVisible,
+  );
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function render(props: HarnessProps) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Harness {...props} />);
+  });
+}
+
+async function rerender(props: HarnessProps) {
+  await act(async () => {
+    root!.render(<Harness {...props} />);
+  });
+}
+
+describe("useTerminalEnvAutoOpen", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root!.unmount();
+      });
+    }
+    root = null;
+    container?.remove();
+    container = null;
+  });
+
+  it("auto-opens terminal when env begins preparing and panel is hidden", async () => {
+    const setVisible = vi.fn();
+    await render({
+      selectedWorkspaceId: "ws-1",
+      workspaceEnvironmentPreparing: true,
+      claudetteTerminalEnabled: true,
+      terminalPanelVisible: false,
+      setTerminalPanelVisible: setVisible,
+    });
+    expect(setVisible).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it("does not open terminal when already visible", async () => {
+    const setVisible = vi.fn();
+    await render({
+      selectedWorkspaceId: "ws-1",
+      workspaceEnvironmentPreparing: true,
+      claudetteTerminalEnabled: true,
+      terminalPanelVisible: true,
+      setTerminalPanelVisible: setVisible,
+    });
+    expect(setVisible).not.toHaveBeenCalled();
+  });
+
+  it("does not open terminal when claudetteTerminalEnabled is false", async () => {
+    const setVisible = vi.fn();
+    await render({
+      selectedWorkspaceId: "ws-1",
+      workspaceEnvironmentPreparing: true,
+      claudetteTerminalEnabled: false,
+      terminalPanelVisible: false,
+      setTerminalPanelVisible: setVisible,
+    });
+    expect(setVisible).not.toHaveBeenCalled();
+  });
+
+  it("does not open terminal when no workspace is selected", async () => {
+    const setVisible = vi.fn();
+    await render({
+      selectedWorkspaceId: null,
+      workspaceEnvironmentPreparing: true,
+      claudetteTerminalEnabled: true,
+      terminalPanelVisible: false,
+      setTerminalPanelVisible: setVisible,
+    });
+    expect(setVisible).not.toHaveBeenCalled();
+  });
+
+  // Regression: terminal re-opened on every workspace switch because
+  // selectWorkspace briefly resets env status to "preparing", and the old
+  // string | null guard was cleared when env previously resolved to "ready".
+  it("does not re-open terminal when switching back to a workspace already auto-opened", async () => {
+    const setVisible = vi.fn();
+    // First visit to ws-1: env preparing, panel hidden → auto-open fires.
+    await render({
+      selectedWorkspaceId: "ws-1",
+      workspaceEnvironmentPreparing: true,
+      claudetteTerminalEnabled: true,
+      terminalPanelVisible: false,
+      setTerminalPanelVisible: setVisible,
+    });
+    expect(setVisible).toHaveBeenCalledExactlyOnceWith(true);
+    setVisible.mockClear();
+
+    // Env resolves to ready; user hides the terminal.
+    await rerender({
+      selectedWorkspaceId: "ws-1",
+      workspaceEnvironmentPreparing: false,
+      claudetteTerminalEnabled: true,
+      terminalPanelVisible: false,
+      setTerminalPanelVisible: setVisible,
+    });
+    expect(setVisible).not.toHaveBeenCalled();
+
+    // Switch to ws-2 (not preparing).
+    await rerender({
+      selectedWorkspaceId: "ws-2",
+      workspaceEnvironmentPreparing: false,
+      claudetteTerminalEnabled: true,
+      terminalPanelVisible: false,
+      setTerminalPanelVisible: setVisible,
+    });
+    expect(setVisible).not.toHaveBeenCalled();
+
+    // Switch back to ws-1: selectWorkspace sets env back to "preparing".
+    // The panel must NOT re-open — user already closed it deliberately.
+    await rerender({
+      selectedWorkspaceId: "ws-1",
+      workspaceEnvironmentPreparing: true,
+      claudetteTerminalEnabled: true,
+      terminalPanelVisible: false,
+      setTerminalPanelVisible: setVisible,
+    });
+    expect(setVisible).not.toHaveBeenCalled();
+  });
+
+  it("auto-opens for a new workspace that was never seen before", async () => {
+    const setVisible = vi.fn();
+    // ws-1 already resolved, user hid terminal.
+    await render({
+      selectedWorkspaceId: "ws-1",
+      workspaceEnvironmentPreparing: true,
+      claudetteTerminalEnabled: true,
+      terminalPanelVisible: false,
+      setTerminalPanelVisible: setVisible,
+    });
+    setVisible.mockClear();
+
+    // Switch to brand-new ws-2 that starts preparing → should auto-open.
+    await rerender({
+      selectedWorkspaceId: "ws-2",
+      workspaceEnvironmentPreparing: true,
+      claudetteTerminalEnabled: true,
+      terminalPanelVisible: false,
+      setTerminalPanelVisible: setVisible,
+    });
+    expect(setVisible).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it("auto-opens independently for multiple workspaces encountered in sequence", async () => {
+    const setVisible = vi.fn();
+    // ws-a preparing.
+    await render({
+      selectedWorkspaceId: "ws-a",
+      workspaceEnvironmentPreparing: true,
+      claudetteTerminalEnabled: true,
+      terminalPanelVisible: false,
+      setTerminalPanelVisible: setVisible,
+    });
+    expect(setVisible).toHaveBeenCalledTimes(1);
+
+    // Switch to ws-b (also preparing).
+    await rerender({
+      selectedWorkspaceId: "ws-b",
+      workspaceEnvironmentPreparing: true,
+      claudetteTerminalEnabled: true,
+      terminalPanelVisible: false,
+      setTerminalPanelVisible: setVisible,
+    });
+    expect(setVisible).toHaveBeenCalledTimes(2);
+
+    // Re-visit ws-a while it's still "preparing" (selectWorkspace reset it).
+    await rerender({
+      selectedWorkspaceId: "ws-a",
+      workspaceEnvironmentPreparing: true,
+      claudetteTerminalEnabled: true,
+      terminalPanelVisible: false,
+      setTerminalPanelVisible: setVisible,
+    });
+    // Must NOT fire a third time.
+    expect(setVisible).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/ui/src/components/terminal/useTerminalEnvAutoOpen.ts
+++ b/src/ui/src/components/terminal/useTerminalEnvAutoOpen.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Auto-opens the terminal panel when a workspace's environment begins
+ * preparing (env-provider resolve, nix devshell, direnv, etc.).
+ *
+ * Uses a Set so we remember every workspace we've already opened for —
+ * not just the last one. selectWorkspace briefly resets env status to
+ * "preparing" on every workspace switch, so a string | null guard would
+ * clear on navigation away and re-open the panel when the user switches
+ * back, ignoring any explicit close they made in between.
+ */
+export function useTerminalEnvAutoOpen(
+  selectedWorkspaceId: string | null,
+  workspaceEnvironmentPreparing: boolean,
+  claudetteTerminalEnabled: boolean,
+  terminalPanelVisible: boolean,
+  setTerminalPanelVisible: (visible: boolean) => void,
+): void {
+  const autoOpenedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!selectedWorkspaceId || !workspaceEnvironmentPreparing || !claudetteTerminalEnabled)
+      return;
+    if (autoOpenedRef.current.has(selectedWorkspaceId)) return;
+    autoOpenedRef.current.add(selectedWorkspaceId);
+    if (!terminalPanelVisible) {
+      setTerminalPanelVisible(true);
+    }
+  }, [
+    selectedWorkspaceId,
+    workspaceEnvironmentPreparing,
+    claudetteTerminalEnabled,
+    terminalPanelVisible,
+    setTerminalPanelVisible,
+  ]);
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `TerminalPanel`'s env-preparation auto-open effect used a `string | null` ref (`lastAutoOpenedForRef`) tracking only the *last* workspace opened. When env resolved, the ref was cleared to `null`. On every subsequent workspace switch, `selectWorkspace` resets `workspaceEnvironment[id].status` to `"preparing"` and `useWorkspaceEnvironmentPreparation` re-calls `prepareWorkspaceEnvironment` — both make `workspaceEnvironmentPreparing` briefly `true`. With the ref cleared, the guard failed and the panel was force-opened even though the user had hidden it.
- **Fix**: Replace `lastAutoOpenedForRef: string | null` and `lastAutoFocusedForRef: string | null` with `Set<string>` refs that accumulate every workspace seen — never clear them on workspace switch. Auto-open now fires at most once per workspace, regardless of how many times the user navigates away and back.
- The auto-open logic is extracted to `useTerminalEnvAutoOpen` (12 lines) so it can be tested independently without mounting the full `TerminalPanel`.

## Test plan

- [ ] Toggle the terminal panel off in workspace A
- [ ] Switch to workspace B — panel must remain hidden
- [ ] Switch back to workspace A — panel must remain hidden
- [ ] Create a brand-new workspace — panel should auto-open while env provisions
- [ ] `bun run test -- --run` passes (195 files, 2291 tests, 0 failures)
- [ ] `bun run build` produces a clean TypeScript build with no type errors