### PR TITLE
test(task-tracker): pin phase-progression + hook-reactivity regressions

### DIFF
--- a/src/ui/src/hooks/useTaskTracker.test.ts
+++ b/src/ui/src/hooks/useTaskTracker.test.ts
@@ -365,10 +365,10 @@ describe("deriveTaskState", () => {
 // "completed" as work progresses through each phase. The right-sidebar
 // Tasks panel should reflect the live count after every update.
 //
-// Regression target: a #573-era refactor moved TodoWrite handling into
-// `deriveTaskStateFromEntries` and split the registry off into
-// `parseTodoTasks`; the synthetic IDs assigned to id-less todos (modern
-// TodoWrite has no `id` field — only `content` / `status` / `activeForm`)
+// Regression target: the task-history refactor (PR 773) moved TodoWrite
+// handling into `deriveTaskStateFromEntries` and split the registry off
+// into `parseTodoTasks`. The synthetic IDs assigned to id-less todos
+// (modern TodoWrite has no id field — only content / status / activeForm)
 // must remain stable enough across passes that `todoMap.clear()` plus
 // re-set always reflects the LATEST call's statuses, not a stale snapshot.
 describe("deriveTaskState — phase progression regression", () => {

--- a/src/ui/src/hooks/useTaskTracker.test.ts
+++ b/src/ui/src/hooks/useTaskTracker.test.ts
@@ -356,3 +356,195 @@ describe("deriveTaskState", () => {
     expect(result.current.tasks).toEqual([]);
   });
 });
+
+// ── regression: phase-progression workflow ───────────────────
+//
+// Pins the most common real-world TodoWrite pattern: agent emits a list
+// of N tasks, then re-emits the same list multiple times during the
+// turn, flipping one task at a time from "pending" → "in_progress" →
+// "completed" as work progresses through each phase. The right-sidebar
+// Tasks panel should reflect the live count after every update.
+//
+// Regression target: a #573-era refactor moved TodoWrite handling into
+// `deriveTaskStateFromEntries` and split the registry off into
+// `parseTodoTasks`; the synthetic IDs assigned to id-less todos (modern
+// TodoWrite has no `id` field — only `content` / `status` / `activeForm`)
+// must remain stable enough across passes that `todoMap.clear()` plus
+// re-set always reflects the LATEST call's statuses, not a stale snapshot.
+describe("deriveTaskState — phase progression regression", () => {
+  // Build a TodoWrite activity using the modern Claude Code TodoWrite
+  // schema (no `id`, no `priority`, content+status+activeForm only).
+  const modernTodoWrite = (
+    items: Array<{ content: string; status: string; activeForm?: string }>,
+  ) =>
+    activity("TodoWrite", {
+      todos: items.map((it) => ({
+        content: it.content,
+        status: it.status,
+        activeForm: it.activeForm ?? it.content,
+      })),
+    });
+
+  const PHASES = [
+    "Phase 1: Move transport module",
+    "Phase 2: Implement RPC handler",
+    "Phase 3: Add Tauri command",
+    "Phase 4: Workspace member wiring",
+    "Phase 5: Plugin integration",
+    "Phase 6: Generic send_rpc helper",
+    "Phase 7: Load chat history",
+    "Phase 8: AskQuestionSheet bottom sheet",
+  ];
+
+  it("reflects each phase completion when TodoWrite is re-emitted within a single turn", () => {
+    // Three TodoWrite calls in the SAME turn (no finalizeTurn between
+    // them), each flipping one phase from pending → completed. This is
+    // the screenshot scenario — agent emits the plan once, then re-emits
+    // after each commit + push.
+    const initial = PHASES.map((p) => ({ content: p, status: "pending" }));
+    const afterPhase1 = PHASES.map((p, i) => ({
+      content: p,
+      status: i === 0 ? "completed" : i === 1 ? "in_progress" : "pending",
+    }));
+    const afterPhase2 = PHASES.map((p, i) => ({
+      content: p,
+      status: i < 2 ? "completed" : i === 2 ? "in_progress" : "pending",
+    }));
+
+    const current = [
+      modernTodoWrite(initial),
+      modernTodoWrite(afterPhase1),
+      modernTodoWrite(afterPhase2),
+    ];
+
+    const result = deriveTaskState([], current);
+
+    expect(result.history).toHaveLength(0);
+    expect(result.current.totalCount).toBe(8);
+    expect(result.current.completedCount).toBe(2);
+    // Order must mirror the latest TodoWrite payload, not the first.
+    expect(result.current.tasks.map((t) => t.description)).toEqual(PHASES);
+    expect(result.current.tasks.map((t) => t.status)).toEqual([
+      "completed",
+      "completed",
+      "in_progress",
+      "pending",
+      "pending",
+      "pending",
+      "pending",
+      "pending",
+    ]);
+  });
+
+  it("preserves phase completion across a turn boundary", () => {
+    // Turn 1: emit the plan with 1 phase completed and persist it as a
+    // completed turn. Turn 2 (current): emit another update completing
+    // phase 2. The active state should reflect the merged latest view.
+    const t1 = turn([
+      modernTodoWrite(
+        PHASES.map((p, i) => ({
+          content: p,
+          status: i === 0 ? "completed" : i === 1 ? "in_progress" : "pending",
+        })),
+      ),
+    ]);
+    const current = [
+      modernTodoWrite(
+        PHASES.map((p, i) => ({
+          content: p,
+          status: i < 2 ? "completed" : i === 2 ? "in_progress" : "pending",
+        })),
+      ),
+    ];
+
+    const result = deriveTaskState([t1], current);
+
+    expect(result.history).toHaveLength(0); // status-only update, not archived
+    expect(result.current.totalCount).toBe(8);
+    expect(result.current.completedCount).toBe(2);
+    expect(result.current.tasks[0].status).toBe("completed");
+    expect(result.current.tasks[1].status).toBe("completed");
+    expect(result.current.tasks[2].status).toBe("in_progress");
+  });
+
+  it("does not lose previously-completed phases after a non-TodoWrite tool call between updates", () => {
+    // Agent pattern: TodoWrite (mark phase 1 in_progress) → Bash (run
+    // commit) → TodoWrite (mark phase 1 completed, phase 2 in_progress).
+    // The Bash call must not reset todoMap.
+    const inProgress = PHASES.map((p, i) => ({
+      content: p,
+      status: i === 0 ? "in_progress" : "pending",
+    }));
+    const completed = PHASES.map((p, i) => ({
+      content: p,
+      status: i === 0 ? "completed" : i === 1 ? "in_progress" : "pending",
+    }));
+
+    const result = deriveTaskState(
+      [],
+      [
+        modernTodoWrite(inProgress),
+        activity("Bash", { command: "git commit -am phase-1" }),
+        modernTodoWrite(completed),
+      ],
+    );
+
+    expect(result.current.totalCount).toBe(8);
+    expect(result.current.completedCount).toBe(1);
+    expect(result.current.tasks[0].status).toBe("completed");
+    expect(result.current.tasks[1].status).toBe("in_progress");
+  });
+
+  it("treats normalized status strings ('Completed', 'IN_PROGRESS', 'done') as canonical", () => {
+    // Defensive: pin that case/punctuation variants from older harnesses
+    // (Codex, Pi) still normalize to the canonical TaskStatus values.
+    const result = deriveTaskState(
+      [],
+      [
+        modernTodoWrite([
+          { content: "A", status: "Completed" },
+          { content: "B", status: "IN_PROGRESS" },
+          { content: "C", status: "in-progress" },
+          { content: "D", status: "done" },
+          { content: "E", status: "Running" },
+          { content: "F", status: "pending" },
+        ]),
+      ],
+    );
+
+    expect(result.current.completedCount).toBe(2);
+    expect(result.current.tasks.map((t) => t.status)).toEqual([
+      "completed",
+      "in_progress",
+      "in_progress",
+      "completed",
+      "in_progress",
+      "pending",
+    ]);
+  });
+
+  it("counts completions correctly when the modern TodoWrite schema (no id field) is used", () => {
+    // Modern Claude Code TodoWrite has no `id` field — only content,
+    // status, activeForm. Earlier versions sent an `id`. The tracker
+    // must handle both without losing completion state when only the
+    // status field changes between calls.
+    const oldSchema = activity("TodoWrite", {
+      todos: [
+        { id: "a", content: "A", status: "pending" },
+        { id: "b", content: "B", status: "pending" },
+      ],
+    });
+    const newSchemaCompleted = modernTodoWrite([
+      { content: "A", status: "completed" },
+      { content: "B", status: "pending" },
+    ]);
+
+    const result = deriveTaskState([], [oldSchema, newSchemaCompleted]);
+
+    expect(result.current.totalCount).toBe(2);
+    expect(result.current.completedCount).toBe(1);
+    // Tasks reflect the LATEST call's order + statuses.
+    expect(result.current.tasks.map((t) => t.description)).toEqual(["A", "B"]);
+    expect(result.current.tasks[0].status).toBe("completed");
+  });
+});

--- a/src/ui/src/hooks/useTaskTrackerWithHistory.integration.test.tsx
+++ b/src/ui/src/hooks/useTaskTrackerWithHistory.integration.test.tsx
@@ -1,0 +1,285 @@
+// @vitest-environment happy-dom
+
+// Integration test for `useTaskTrackerWithHistory` — the hook the
+// right-sidebar Tasks panel actually consumes. Pinned because the unit
+// tests for `deriveTaskState` exercise the pure derivation only;
+// regressions in the store-subscription path (stale selector caches,
+// missing reactivity on append, wrong sessionId scoping) would slip past
+// them. Mounts a real React tree, mutates the Zustand store the way
+// `useAgentStream` does at runtime, and asserts the rendered counts
+// update live without a full re-mount.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useTaskTrackerWithHistory } from "./useTaskTracker";
+import {
+  useAppStore,
+  type CompletedTurn,
+  type ToolActivity,
+} from "../stores/useAppStore";
+
+const SESSION_ID = "session-under-test";
+const OTHER_SESSION_ID = "other-session";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+function todoActivity(
+  toolUseId: string,
+  todos: Array<{ content: string; status: string; activeForm?: string }>,
+): ToolActivity {
+  return {
+    toolUseId,
+    toolName: "TodoWrite",
+    inputJson: JSON.stringify({
+      todos: todos.map((t) => ({
+        content: t.content,
+        status: t.status,
+        activeForm: t.activeForm ?? t.content,
+      })),
+    }),
+    resultText: "",
+    collapsed: true,
+    summary: "",
+  };
+}
+
+function completedTurn(activities: ToolActivity[]): CompletedTurn {
+  return {
+    id: `turn-${Math.random()}`,
+    activities,
+    messageCount: 1,
+    collapsed: false,
+    afterMessageIndex: 0,
+  };
+}
+
+function Harness({ sessionId }: { sessionId: string | null }) {
+  const state = useTaskTrackerWithHistory(sessionId);
+  return (
+    <>
+      <span data-testid="completed">{state.current.completedCount}</span>
+      <span data-testid="total">{state.current.totalCount}</span>
+      <span data-testid="history">{state.history.length}</span>
+      <span data-testid="statuses">
+        {state.current.tasks.map((t) => t.status).join(",")}
+      </span>
+    </>
+  );
+}
+
+async function render(node: React.ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return container;
+}
+
+function readCounts(container: HTMLElement) {
+  return {
+    completed: container.querySelector("[data-testid=completed]")?.textContent,
+    total: container.querySelector("[data-testid=total]")?.textContent,
+    history: container.querySelector("[data-testid=history]")?.textContent,
+    statuses: container.querySelector("[data-testid=statuses]")?.textContent,
+  };
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    toolActivities: {},
+    completedTurns: {},
+  });
+});
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+  useAppStore.setState({
+    toolActivities: {},
+    completedTurns: {},
+  });
+});
+
+describe("useTaskTrackerWithHistory — store-driven reactivity", () => {
+  it("renders zero state when no activities or turns exist for the session", async () => {
+    const container = await render(<Harness sessionId={SESSION_ID} />);
+    expect(readCounts(container)).toEqual({
+      completed: "0",
+      total: "0",
+      history: "0",
+      statuses: "",
+    });
+  });
+
+  it("reflects an initial TodoWrite added to toolActivities", async () => {
+    useAppStore.setState({
+      toolActivities: {
+        [SESSION_ID]: [
+          todoActivity("tu-1", [
+            { content: "A", status: "pending" },
+            { content: "B", status: "pending" },
+            { content: "C", status: "pending" },
+          ]),
+        ],
+      },
+    });
+
+    const container = await render(<Harness sessionId={SESSION_ID} />);
+    expect(readCounts(container)).toMatchObject({
+      completed: "0",
+      total: "3",
+      statuses: "pending,pending,pending",
+    });
+  });
+
+  it("re-renders with updated completion count when a follow-up TodoWrite appends", async () => {
+    // Initial: 3 pending tasks.
+    useAppStore.setState({
+      toolActivities: {
+        [SESSION_ID]: [
+          todoActivity("tu-1", [
+            { content: "A", status: "pending" },
+            { content: "B", status: "pending" },
+            { content: "C", status: "pending" },
+          ]),
+        ],
+      },
+    });
+    const container = await render(<Harness sessionId={SESSION_ID} />);
+    expect(readCounts(container).completed).toBe("0");
+
+    // Simulate the agent emitting a second TodoWrite that marks A as
+    // completed. This is the exact pattern `useAgentStream` produces
+    // via `addToolActivity`: a NEW ToolActivity entry appended onto the
+    // existing array. The hook must re-derive and bump completedCount.
+    await act(async () => {
+      const cur = useAppStore.getState().toolActivities[SESSION_ID] ?? [];
+      useAppStore.setState({
+        toolActivities: {
+          ...useAppStore.getState().toolActivities,
+          [SESSION_ID]: [
+            ...cur,
+            todoActivity("tu-2", [
+              { content: "A", status: "completed" },
+              { content: "B", status: "in_progress" },
+              { content: "C", status: "pending" },
+            ]),
+          ],
+        },
+      });
+    });
+
+    expect(readCounts(container)).toMatchObject({
+      completed: "1",
+      total: "3",
+      statuses: "completed,in_progress,pending",
+    });
+  });
+
+  it("rolls completed-turn state forward into current activities", async () => {
+    // A persisted completed turn established the plan with phase 1 done.
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION_ID]: [
+          completedTurn([
+            todoActivity("tu-1", [
+              { content: "Phase 1", status: "completed" },
+              { content: "Phase 2", status: "in_progress" },
+              { content: "Phase 3", status: "pending" },
+            ]),
+          ]),
+        ],
+      },
+      toolActivities: {
+        [SESSION_ID]: [],
+      },
+    });
+
+    const container = await render(<Harness sessionId={SESSION_ID} />);
+    expect(readCounts(container)).toMatchObject({
+      completed: "1",
+      total: "3",
+      history: "0",
+      statuses: "completed,in_progress,pending",
+    });
+
+    // Agent starts a new turn: phase 2 finishes, phase 3 picks up.
+    await act(async () => {
+      useAppStore.setState({
+        toolActivities: {
+          ...useAppStore.getState().toolActivities,
+          [SESSION_ID]: [
+            todoActivity("tu-2", [
+              { content: "Phase 1", status: "completed" },
+              { content: "Phase 2", status: "completed" },
+              { content: "Phase 3", status: "in_progress" },
+            ]),
+          ],
+        },
+      });
+    });
+
+    expect(readCounts(container)).toMatchObject({
+      completed: "2",
+      total: "3",
+      history: "0",
+      statuses: "completed,completed,in_progress",
+    });
+  });
+
+  it("does not leak task state across sessions when sessionId is scoped", async () => {
+    useAppStore.setState({
+      toolActivities: {
+        [SESSION_ID]: [
+          todoActivity("tu-1", [
+            { content: "Visible task", status: "completed" },
+          ]),
+        ],
+        [OTHER_SESSION_ID]: [
+          todoActivity("tu-2", [
+            { content: "Hidden task A", status: "pending" },
+            { content: "Hidden task B", status: "pending" },
+          ]),
+        ],
+      },
+    });
+
+    const container = await render(<Harness sessionId={SESSION_ID} />);
+    expect(readCounts(container)).toMatchObject({
+      completed: "1",
+      total: "1",
+    });
+  });
+
+  it("renders the EMPTY_WITH_HISTORY shape when sessionId is null", async () => {
+    useAppStore.setState({
+      toolActivities: {
+        [SESSION_ID]: [
+          todoActivity("tu-1", [
+            { content: "Stale task", status: "pending" },
+          ]),
+        ],
+      },
+    });
+
+    const container = await render(<Harness sessionId={null} />);
+    expect(readCounts(container)).toMatchObject({
+      completed: "0",
+      total: "0",
+      history: "0",
+      statuses: "",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

User report: "agent is calling the tool correctly but its not updating in our tasks properly" — the right-sidebar **Tasks** panel was showing `0/8` while the agent was driving an 8-phase plan (visible in [the linked screenshot](#) — agent mid Phase 1, all 8 task items rendered with empty `○` pending icons, badge `TASKS 8`, header `CURRENT 0/8`).

I traced the full task-tracking pipeline end-to-end and **could not reproduce the regression in code or tests** — every derivation and hook-reactivity path I exercised correctly bumps `completedCount` when a TodoWrite status flips. The most plausible explanation for the screenshot is that the agent had just emitted the initial all-pending plan and hadn't yet re-emitted TodoWrite with Phase 1 marked completed (the bash commit was still in flight at the moment of the screenshot).

To keep this from rotting silently — and to give us a fast signal if a future refactor *does* break the live counter — this PR lands a substantial regression-test suite that pins the exact behaviors the Tasks panel relies on, plus integration tests that mount a real React tree against the Zustand store and verify the panel re-renders live as TodoWrite events stream in.

## What I investigated

- **Pure derivation** (`useTaskTracker.ts`): `processActivities`, `parseTodoTasks`, `deriveTaskState`, `deriveTaskStateFromEntries`, `isReplacedTodoRun`. All correct for the screenshot's pattern (single TodoWrite, multiple status updates).
- **Hook reactivity** (`useTaskTrackerWithHistory`): Zustand selectors create new array references on every mutation, `useMemo` dependency list is correct, no stale closures.
- **Store mutations** (`chatSlice.ts`): `addToolActivity`, `appendToolActivityInput`, `finalizeTurn`, `hydrateCompletedTurns` all produce new array refs that the selectors will see.
- **Streaming ingestion** (`useAgentStream.ts`): both `input_json_delta` and `tool_use_delta` paths append to the activity's `inputJson`; `content_block_start` correctly seeds an empty entry; `content_block_stop` only extracts the summary (doesn't clobber input).
- **Persistence round-trip** (`reconstructTurns.ts`, `loadCompletedTurns`): `input_json` is preserved byte-for-byte from DB.
- **Sub-agent / Codex / Pi paths**: TodoWrite is handled identically — the tool name is always `"TodoWrite"` and the input is always `{todos: [...]}` with the modern `{content, status, activeForm}` schema.

If the regression *is* real (i.e. not the snapshot-timing explanation above), it must live in a code path that's not reachable from the test surface — most likely a specific Claude CLI version emitting unusual stream shapes. If/when we get a concrete repro, the diagnostic next step is to dump the offending session's persisted `tool_activities.input_json` rows and walk them through `deriveTaskState` manually; the new integration tests have the harness scaffolding to make that quick.

## Tests added

### `useTaskTracker.test.ts` — 5 new cases (new `phase progression` describe)

- **Multi-call TodoWrite within a single turn**: 3 TodoWrites flipping Phase 1 then Phase 2 through pending → in_progress → completed. `completedCount` reflects the latest call, task order mirrors the latest payload, individual statuses are preserved.
- **Phase completion across a turn boundary**: status-only update spanning a `CompletedTurn` and current activities — current state merges correctly, no spurious history archive.
- **Non-TodoWrite tool between two TodoWrite updates**: a `Bash` call between two TodoWrite emissions does NOT reset the todoMap.
- **Status normalization**: case/punctuation variants (`"Completed"`, `"IN_PROGRESS"`, `"in-progress"`, `"Running"`, `"done"`) all normalize to canonical `TaskStatus` values.
- **Modern TodoWrite schema migration**: an old-schema TodoWrite (with `id`/`priority`) followed by a new-schema TodoWrite (just `content`/`status`/`activeForm`) still tracks completion correctly when only the status field changes.

### `useTaskTrackerWithHistory.integration.test.tsx` — 6 new cases (new file)

Real React + Zustand integration; mounts a `<Harness />` component that surfaces the hook's outputs as `data-testid` spans, then mutates the store and asserts the spans re-render.

- **Empty state** when no activities or turns exist.
- **Initial TodoWrite** is reflected on first render.
- **Live append** — a follow-up TodoWrite added the same way `useAgentStream`'s `addToolActivity` does it re-derives and bumps `completedCount` without a remount. *This is the critical screenshot scenario.*
- **Persisted CompletedTurn carries forward** into current activities when the agent starts a new turn.
- **Per-session scoping** — task state from a different session does NOT leak through.
- **`sessionId === null`** returns the `EMPTY_WITH_HISTORY` shape.

## Verification

- `bunx tsc -b` → clean
- `bun run test --run` → **2295 passed | 6 skipped** (was 2284 before; +11 new cases, all green)

## Test plan

- [x] Local: full vitest suite green
- [x] Local: TypeScript build clean
- [ ] Reviewer: if you can reproduce the `0/N` regression in a real workspace, please attach the session's `tool_activities` rows so I can replay them through `deriveTaskState` manually
- [ ] CI: clippy + cargo test + frontend lint/build/test/css