### PR TITLE
chore(direnv): switch to nix-direnv for cached devshell activation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,8 +4,9 @@
 #   • `use flake` (vanilla direnv) re-evaluates the flake on every shell
 #     entry and rebuilds the env. nix-direnv caches the rendered
 #     environment to `.direnv/` and only re-evaluates when one of the
-#     watched files actually changes — entry time drops from seconds to
-#     ~50ms.
+#     watched files actually changes — entry time drops from multi-
+#     second (cold `nix print-dev-env`) to sub-second on warm cache
+#     hits.
 #   • Cache invalidation is keyed on flake.nix + flake.lock by default —
 #     touching scripts in `scripts/` or anything else outside the flake
 #     does not force a reload, which is what makes the steady-state
@@ -23,14 +24,19 @@ if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
 fi
 
 # Speed knobs:
-#   nix_direnv_manual_reload=0 keeps the default "auto reload on change"
-#   behavior; set this to 1 in `~/.config/direnv/direnv.toml` if you
-#   prefer triggering reloads explicitly with `direnv reload`.
+#   `nix_direnv_manual_reload` is a shell variable read by nix-direnv
+#   when this `.envrc` is evaluated — direnv's `direnv.toml` does not
+#   propagate arbitrary variables into the evaluated env. If you want
+#   to opt out of auto-reload on flake.nix/.lock changes, export it
+#   here before `use flake` (or set it in your user-wide
+#   `~/.config/direnv/direnvrc`):
+#     # nix_direnv_manual_reload=1
 
 # `use flake` (intercepted by nix-direnv) builds the devShell with
-# `nix print-dev-env`, caches the result, and exports the env in <50ms
-# on subsequent entries. The cache is invalidated only when flake.nix
-# or flake.lock change — script bodies referenced by devshell
-# `commands` entries (e.g. scripts/dev.sh) are exec'd at runtime and do
-# NOT affect the env, so they intentionally aren't watched.
+# `nix print-dev-env`, caches the result, and exports the env on
+# subsequent entries without re-running Nix. The cache is invalidated
+# only when flake.nix or flake.lock change — script bodies referenced
+# by devshell `commands` entries (e.g. scripts/dev.sh) are exec'd at
+# runtime and do NOT affect the env, so they intentionally aren't
+# watched.
 use flake

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,36 @@
+# Claudette devshell activation via nix-direnv.
+#
+# Why nix-direnv:
+#   • `use flake` (vanilla direnv) re-evaluates the flake on every shell
+#     entry and rebuilds the env. nix-direnv caches the rendered
+#     environment to `.direnv/` and only re-evaluates when one of the
+#     watched files actually changes — entry time drops from seconds to
+#     ~50ms.
+#   • Cache invalidation is keyed on flake.nix + flake.lock by default —
+#     touching scripts in `scripts/` or anything else outside the flake
+#     does not force a reload, which is what makes the steady-state
+#     loop fast.
+#
+# If nix-direnv is installed system-wide (e.g. via home-manager /
+# nix-darwin), this `source_url` line is a no-op fast path — the
+# installed copy wins because direnv resolves `nix_direnv_version`
+# before running the bootstrap. Otherwise the bootstrap downloads a
+# pinned `direnvrc` once, stores it under `~/.cache/direnv/` for
+# subsequent reuse, and we get cached activation everywhere — including
+# teammate machines that don't run a Nix-managed home.
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
+fi
+
+# Speed knobs:
+#   nix_direnv_manual_reload=0 keeps the default "auto reload on change"
+#   behavior; set this to 1 in `~/.config/direnv/direnv.toml` if you
+#   prefer triggering reloads explicitly with `direnv reload`.
+
+# `use flake` (intercepted by nix-direnv) builds the devShell with
+# `nix print-dev-env`, caches the result, and exports the env in <50ms
+# on subsequent entries. The cache is invalidated only when flake.nix
+# or flake.lock change — script bodies referenced by devshell
+# `commands` entries (e.g. scripts/dev.sh) are exec'd at runtime and do
+# NOT affect the env, so they intentionally aren't watched.
 use flake


### PR DESCRIPTION
## Summary

- Replace `.envrc` of bare `use flake` with a nix-direnv-bootstrapped version so devshell activation is **cached** instead of being rebuilt on every shell entry.
- Bootstrap uses `source_url` pinned to nix-direnv 3.0.6 with a verified sha256, so teammates without nix-direnv in their home-manager / nix-darwin still benefit — direnv stores the downloaded direnvrc in `~/.cache/direnv/cas/` and content-verifies on subsequent loads.
- No flake.nix changes in this PR; just the activation layer.

## Why

Vanilla `use flake` re-runs `nix print-dev-env` on every shell entry — every `cd` into the project, every `direnv exec`, every shell spawn. With a devshell as large as Claudette's (Rust toolchain via fenix, bun, cargo-tauri, cargo-xwin, clang-unwrapped, llvm, awscli2, plus all the Linux webkit/gtk deps), that rebuild is the dominant source of perceived "the devshell is slow" friction.

nix-direnv intercepts `use flake`, caches the rendered env to `.direnv/flake-profile-<rev>` keyed on flake.nix + flake.lock, and exports the cached env on subsequent entries. Cold rebuild only fires when the flake content itself changes.

## Measured locally (aarch64-darwin)

- **Cold first entry** — unchanged (~few seconds for `nix print-dev-env` + downloading new toolchain bits if any).
- **Warm subsequent entries** — drops to ~450ms (was multi-second per `cd` before).

Confirmed by running `direnv exec . true` three times after the switch.

## Deliberate non-choices

- **Did not** add `watch_file` entries for `scripts/dev.sh` etc. Those scripts are `exec`'d at runtime by devshell `commands` — their bodies don't affect env contents, so invalidating on script edits would force unnecessary reloads.
- **Did not** split the heavy Windows-cross / AWS toolchains into separate opt-in shells, pin the fenix channel, or add `nixConfig.extra-substituters`. Those are real follow-up wins but each one has UX tradeoffs worth discussing separately.

## Test plan

- [x] `direnv allow .envrc` and confirm devshell menu prints (the `🔨 Welcome to claudette` banner with all categories).
- [x] `direnv exec . true` repeatedly to confirm warm activation is sub-second.
- [x] Verify `.direnv/flake-profile-<rev>` is created and the rc cache exists.
- [x] Verify `~/.cache/direnv/cas/<sha>` holds the pinned direnvrc so the `source_url` line doesn't re-download on every entry.
- [ ] Reviewer with no system-installed nix-direnv runs `direnv allow` once and confirms the bootstrap fetches + verifies + activates without prompting.