### PR TITLE
fix(command-palette): keep arrow navigation locked to the visible row

### DIFF
--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -30,19 +30,11 @@ import {
   buildModelCommands,
   buildEffortCommands,
   buildFileCommands,
-  CATEGORY_ORDER,
-  CATEGORY_LABELS,
-  type Command,
-  type CommandCategory,
+  groupCommandsByCategory,
   type FileEntry,
+  type GroupedCommands,
 } from "./commands";
 import styles from "./CommandPalette.module.css";
-
-interface GroupedCommands {
-  category: CommandCategory;
-  label: string;
-  commands: Command[];
-}
 
 export function CommandPalette() {
   const { t } = useTranslation("chat");
@@ -128,6 +120,16 @@ export function CommandPalette() {
   useEffect(() => {
     loadAllThemes().then(setThemes).catch(console.error);
   }, []);
+
+  // `autoFocus` is best-effort: in the Tauri webview the palette can mount
+  // while the OS still has focus elsewhere, so the search input never picks
+  // it up and Arrow keys fall through to the document. Schedule an explicit
+  // focus on mount and after each sub-mode transition so the keyboard
+  // handler on the input is the one that fires.
+  useEffect(() => {
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [mode]);
 
   const close = toggleCommandPalette;
 
@@ -437,28 +439,39 @@ export function CommandPalette() {
         ? [{ category: "general", label: "Results", commands: filteredCommands }]
         : [];
     }
-    const map = new Map<CommandCategory, Command[]>();
-    for (const cmd of filteredCommands) {
-      const arr = map.get(cmd.category) ?? [];
-      arr.push(cmd);
-      map.set(cmd.category, arr);
-    }
-    return CATEGORY_ORDER.filter((cat) => map.has(cat)).map((cat) => ({
-      category: cat,
-      label: CATEGORY_LABELS[cat],
-      commands: map.get(cat)!,
-    }));
+    return groupCommandsByCategory(filteredCommands);
   }, [filteredCommands, mode]);
+
+  // Rendered (visual) order — what arrow keys must index into so the
+  // highlighted row and the command executed on Enter always agree.
+  // Without this, browsing the main mode (no query) would highlight the
+  // category-sorted row N but Enter would fire activeCommands[N].
+  const flatCommands = useMemo(
+    () => grouped.flatMap((g) => g.commands),
+    [grouped],
+  );
+
+  // Keep the highlight within bounds when filtering shrinks the list
+  // (e.g. typing extra characters that remove matches under the cursor).
+  useEffect(() => {
+    if (flatCommands.length === 0) {
+      if (selectedIndex !== 0) setSelectedIndex(0);
+      return;
+    }
+    if (selectedIndex > flatCommands.length - 1) {
+      setSelectedIndex(flatCommands.length - 1);
+    }
+  }, [flatCommands.length, selectedIndex]);
 
   // Theme live preview on arrow navigation (only in theme mode)
   useEffect(() => {
     if (mode !== "theme" || themes.length === 0) return;
-    const cmd = filteredCommands[selectedIndex];
+    const cmd = flatCommands[selectedIndex];
     if (cmd?.id.startsWith("theme:")) {
       const themeId = cmd.id.slice("theme:".length);
       applyThemeWithFonts(themeId);
     }
-  }, [selectedIndex, filteredCommands, themes, mode]);
+  }, [selectedIndex, flatCommands, themes, mode]);
 
   // Revert theme on unmount (safety net)
   useEffect(() => {
@@ -483,13 +496,15 @@ export function CommandPalette() {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setSelectedIndex((i) => Math.min(i + 1, filteredCommands.length - 1));
+      setSelectedIndex((i) =>
+        flatCommands.length === 0 ? 0 : Math.min(i + 1, flatCommands.length - 1),
+      );
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setSelectedIndex((i) => Math.max(i - 1, 0));
-    } else if (e.key === "Enter" && filteredCommands[selectedIndex]) {
+    } else if (e.key === "Enter" && flatCommands[selectedIndex]) {
       e.preventDefault();
-      filteredCommands[selectedIndex].execute();
+      flatCommands[selectedIndex].execute();
     } else if (e.key === "Escape") {
       e.preventDefault();
       // Stop propagation so the global keyboard shortcut handler doesn't
@@ -516,11 +531,36 @@ export function CommandPalette() {
     close();
   };
 
+  // Fallback keydown for the whole card: if a click on a result row stole
+  // focus from the search input, arrow keys would otherwise do nothing.
+  // Re-dispatch them through the same handler, and for any printable key
+  // bounce focus back to the input so typing continues to filter.
+  const handleCardKeyDown = (e: React.KeyboardEvent) => {
+    if (e.target === inputRef.current) return;
+    if (
+      e.key === "ArrowDown" ||
+      e.key === "ArrowUp" ||
+      e.key === "Enter" ||
+      e.key === "Escape" ||
+      e.key === "Backspace"
+    ) {
+      handleKeyDown(e);
+      return;
+    }
+    if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      inputRef.current?.focus();
+    }
+  };
+
   let flatIndex = 0;
 
   return (
     <div className={styles.backdrop} onClick={handleBackdropClick}>
-      <div className={styles.card} onClick={(e) => e.stopPropagation()}>
+      <div
+        className={styles.card}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleCardKeyDown}
+      >
         <div className={styles.inputRow}>
           {mode !== "main" ? (
             <button
@@ -551,6 +591,10 @@ export function CommandPalette() {
               : "Type a command..."
             }
             autoFocus
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
           />
           {mode !== "main" && (
             <span className={styles.modeBadge}>

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -531,10 +531,12 @@ export function CommandPalette() {
     close();
   };
 
-  // Fallback keydown for the whole card: if a click on a result row stole
-  // focus from the search input, arrow keys would otherwise do nothing.
-  // Re-dispatch them through the same handler, and for any printable key
-  // bounce focus back to the input so typing continues to filter.
+  // Fallback keydown for the whole card: result rows preventDefault on
+  // mousedown so the input keeps focus, but any other focus drift (browser
+  // weirdness, an injected button taking focus) would leave arrow keys
+  // dead. Re-dispatch them through the same handler, and for any printable
+  // key bounce focus back to the input AND apply the character so the
+  // triggering keystroke isn't dropped.
   const handleCardKeyDown = (e: React.KeyboardEvent) => {
     if (e.target === inputRef.current) return;
     if (
@@ -548,7 +550,10 @@ export function CommandPalette() {
       return;
     }
     if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
       inputRef.current?.focus();
+      setQuery((q) => q + e.key);
+      setSelectedIndex(0);
     }
   };
 
@@ -634,6 +639,7 @@ export function CommandPalette() {
                     data-index={idx}
                     className={`${styles.result} ${idx === selectedIndex ? styles.resultSelected : ""}`}
                     onClick={() => cmd.execute()}
+                    onMouseDown={(e) => e.preventDefault()}
                     onMouseEnter={() => setSelectedIndex(idx)}
                   >
                     {themeColor ? (

--- a/src/ui/src/components/command-palette/commands.test.ts
+++ b/src/ui/src/components/command-palette/commands.test.ts
@@ -14,7 +14,9 @@ import { afterAll } from "vitest";
 vi.stubGlobal("navigator", { platform: "MacIntel", userAgentData: undefined });
 afterAll(() => { vi.unstubAllGlobals(); });
 
-const { buildCommands, buildModelCommands, buildEffortCommands, buildFileCommands } = await import("./commands");
+const { buildCommands, buildModelCommands, buildEffortCommands, buildFileCommands, groupCommandsByCategory, CATEGORY_ORDER } = await import("./commands");
+const { Search: stubIcon } = await import("lucide-react");
+type Command = ReturnType<typeof buildCommands>[number];
 
 /** Minimal CommandContext stub — only the fields buildCommands needs. */
 function makeContext(overrides: Partial<CommandContext> = {}): CommandContext {
@@ -325,5 +327,82 @@ describe("zoom command discoverability via searchScore", () => {
   it("'reset' query matches reset-zoom", () => {
     const score = scoreCommand("Reset Zoom", "Reset UI font size to default (13px)", ["zoom", "reset", "actual", "default", "font", "size"], "reset");
     expect(score).toBeGreaterThan(0);
+  });
+});
+
+describe("groupCommandsByCategory — keyboard navigation invariant", () => {
+  // Build a small set spanning multiple categories with the **input order**
+  // deliberately different from `CATEGORY_ORDER`. The bug fixed in
+  // CommandPalette.tsx was: `selectedIndex` indexed the input-order array
+  // while the highlight indexed the rendered (grouped) order. Pressing
+  // Enter on row N executed input[N], not rendered[N]. This test pins the
+  // invariant that the flattened group order is what callers must index.
+  const makeCmd = (id: string, category: Command["category"]): Command => ({
+    id,
+    name: id,
+    category,
+    icon: stubIcon,
+    execute: () => {},
+  });
+
+  const filtered: Command[] = [
+    // Input order intentionally mixes categories so grouping must shuffle.
+    makeCmd("ws-1", "workspace"),
+    makeCmd("nav-1", "navigation"),
+    makeCmd("gen-1", "general"),
+    makeCmd("ws-2", "workspace"),
+    makeCmd("ui-1", "ui"),
+    makeCmd("gen-2", "general"),
+  ];
+
+  it("orders buckets by CATEGORY_ORDER", () => {
+    const groups = groupCommandsByCategory(filtered);
+    expect(groups.map((g) => g.category)).toEqual([
+      "general",
+      "ui",
+      "workspace",
+      "navigation",
+    ]);
+  });
+
+  it("preserves input order within each bucket", () => {
+    const groups = groupCommandsByCategory(filtered);
+    const general = groups.find((g) => g.category === "general")!;
+    expect(general.commands.map((c) => c.id)).toEqual(["gen-1", "gen-2"]);
+    const workspace = groups.find((g) => g.category === "workspace")!;
+    expect(workspace.commands.map((c) => c.id)).toEqual(["ws-1", "ws-2"]);
+  });
+
+  it("flattened group order is what arrow keys must index — not the input order", () => {
+    const groups = groupCommandsByCategory(filtered);
+    const flat = groups.flatMap((g) => g.commands);
+
+    // The visible/rendered order:
+    expect(flat.map((c) => c.id)).toEqual([
+      "gen-1", "gen-2",   // general bucket first per CATEGORY_ORDER
+      "ui-1",             // then ui
+      "ws-1", "ws-2",     // then workspace
+      "nav-1",            // then navigation
+    ]);
+
+    // Sanity check that the input order differs — i.e. without the helper
+    // (or with the old `filteredCommands[selectedIndex]` lookup) row 0
+    // would execute "ws-1" while the user sees "gen-1" highlighted.
+    expect(filtered.map((c) => c.id)[0]).toBe("ws-1");
+    expect(flat.map((c) => c.id)[0]).toBe("gen-1");
+  });
+
+  it("handles empty filtered list", () => {
+    expect(groupCommandsByCategory([])).toEqual([]);
+  });
+
+  it("CATEGORY_ORDER includes every category referenced in commands", () => {
+    // Smoke check: if a future commit adds a new CommandCategory but
+    // forgets to register it in CATEGORY_ORDER, that bucket would be
+    // silently dropped from the rendered list.
+    const seen = new Set(filtered.map((c) => c.category));
+    for (const cat of seen) {
+      expect(CATEGORY_ORDER).toContain(cat);
+    }
   });
 });

--- a/src/ui/src/components/command-palette/commands.test.ts
+++ b/src/ui/src/components/command-palette/commands.test.ts
@@ -14,7 +14,7 @@ import { afterAll } from "vitest";
 vi.stubGlobal("navigator", { platform: "MacIntel", userAgentData: undefined });
 afterAll(() => { vi.unstubAllGlobals(); });
 
-const { buildCommands, buildModelCommands, buildEffortCommands, buildFileCommands, groupCommandsByCategory, CATEGORY_ORDER } = await import("./commands");
+const { buildCommands, buildModelCommands, buildEffortCommands, buildFileCommands, groupCommandsByCategory, CATEGORY_ORDER, CATEGORY_LABELS } = await import("./commands");
 const { Search: stubIcon } = await import("lucide-react");
 type Command = ReturnType<typeof buildCommands>[number];
 
@@ -396,13 +396,19 @@ describe("groupCommandsByCategory — keyboard navigation invariant", () => {
     expect(groupCommandsByCategory([])).toEqual([]);
   });
 
-  it("CATEGORY_ORDER includes every category referenced in commands", () => {
-    // Smoke check: if a future commit adds a new CommandCategory but
-    // forgets to register it in CATEGORY_ORDER, that bucket would be
-    // silently dropped from the rendered list.
-    const seen = new Set(filtered.map((c) => c.category));
-    for (const cat of seen) {
+  it("CATEGORY_ORDER includes every declared CommandCategory", () => {
+    // Source of truth: CATEGORY_LABELS is keyed by every CommandCategory
+    // (TypeScript enforces it via Record<CommandCategory, string>). If a
+    // future commit adds a category to the type but forgets to register
+    // it in CATEGORY_ORDER, that bucket would be silently dropped from
+    // the rendered list — catch that here instead of in the wild.
+    const declared = Object.keys(CATEGORY_LABELS);
+    for (const cat of declared) {
       expect(CATEGORY_ORDER).toContain(cat);
+    }
+    // And vice versa — no stale entries in CATEGORY_ORDER.
+    for (const cat of CATEGORY_ORDER) {
+      expect(declared).toContain(cat);
     }
   });
 });

--- a/src/ui/src/components/command-palette/commands.ts
+++ b/src/ui/src/components/command-palette/commands.ts
@@ -77,6 +77,37 @@ export const CATEGORY_ORDER: CommandCategory[] = [
   "settings",
 ];
 
+export interface GroupedCommands {
+  category: CommandCategory;
+  label: string;
+  commands: Command[];
+}
+
+/**
+ * Bucket commands by category and order the buckets by CATEGORY_ORDER.
+ * The visual rendering order is determined by this function — callers must
+ * flatten the result (e.g. `groups.flatMap(g => g.commands)`) and use that
+ * flat array for keyboard navigation so the highlighted row and the row
+ * Enter executes always agree. Indexing into the input `filteredCommands`
+ * order would diverge from the rendering whenever bucket reordering moves
+ * a command.
+ */
+export function groupCommandsByCategory(
+  filteredCommands: Command[],
+): GroupedCommands[] {
+  const map = new Map<CommandCategory, Command[]>();
+  for (const cmd of filteredCommands) {
+    const arr = map.get(cmd.category) ?? [];
+    arr.push(cmd);
+    map.set(cmd.category, arr);
+  }
+  return CATEGORY_ORDER.filter((cat) => map.has(cat)).map((cat) => ({
+    category: cat,
+    label: CATEGORY_LABELS[cat],
+    commands: map.get(cat)!,
+  }));
+}
+
 export interface CommandContext {
   // Store actions
   toggleSidebar: () => void;


### PR DESCRIPTION
## Summary

- Arrow navigation in the Cmd+P / Cmd+Shift+P palette was indexing the wrong array. The highlight tracked `flatIndex` (the grouped/rendered order produced by `CATEGORY_ORDER` bucketing) but `handleKeyDown` read `filteredCommands[selectedIndex]` from the input/scored order. Pressing ↓ moved the highlight relative to one array; Enter executed an entry from a different array. It read as "arrow keys don't navigate properly" the moment the user typed to search.
- Extracted the bucketing into `groupCommandsByCategory`, flattened the result into `flatCommands`, and routed arrow bounds + Enter through it so the highlighted row is the row that runs.
- Plus the smaller focus fixes: explicit `requestAnimationFrame` focus on mount and on every mode change (autoFocus is unreliable in the Tauri webview when the OS still holds focus elsewhere); card-level keydown that re-dispatches arrows from outside the input and bounces a printable key back to the input so a click on a row doesn't strand subsequent typing; clamp `selectedIndex` when filtering shrinks the list; `autoComplete="off" / autoCorrect="off" / spellCheck={false}` on the search input.
- Pinned the navigation invariant with a unit test on `groupCommandsByCategory`.

## Test plan

- [x] `bun run test` — 2453 passed (including 5 new `groupCommandsByCategory` cases)
- [x] `bunx tsc -b` — clean
- [x] `bun run lint` / `bun run lint:css` — no new warnings; pre-existing ones unchanged
- [ ] Manual: open Cmd+Shift+P, type a query, press ↑/↓ — highlighted row matches the row Enter executes
- [ ] Manual: open Cmd+Shift+P with no query — highlighted row matches the row Enter executes (this is where the bug was most visible)
- [ ] Manual: click a result row, press ↓ — focus returns to input and highlight advances; typing a letter continues to filter