### PR TITLE
ci(mobile): add macOS clippy + test job for claudette-mobile crate

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ Control god files. Do not make already-large files the default destination for n
 
 When touching a god file, keep the diff surgical or extract cohesive behavior first. New code should reduce or isolate complexity, not add another unrelated responsibility.
 
-Use the repo's tools. Rust CI expects `cargo fmt --all --check`, `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` with `RUSTFLAGS=-Dwarnings`, and `cargo test --all-features`. Frontend CI expects `cd src/ui && bun install --frozen-lockfile`, `bunx tsc --noEmit`, `bun run lint:css`, `bun run build`, and `bun run test`.
+Use the repo's tools. Rust CI expects `cargo fmt --all --check`, `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` with `RUSTFLAGS=-Dwarnings`, and `cargo test --all-features` on Linux. A separate macOS job also runs `cargo clippy -p claudette-mobile --target aarch64-apple-darwin --all-targets --locked` and `cargo test -p claudette-mobile --locked` (`claudette-tauri` remains excluded — it requires system libs not installed on the lint runner). Frontend CI expects `cd src/ui && bun install --frozen-lockfile`, `bunx tsc --noEmit`, `bun run lint:css`, `bun run build`, and `bun run test`.
 
 Always run `cd src/ui && bunx tsc -b` after TypeScript changes. Vitest uses esbuild and does not type-check the project.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features
 
+  mobile:
+    name: Mobile (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+          targets: aarch64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
+      - name: Clippy (claudette-mobile, desktop-fallback target)
+        run: cargo clippy -p claudette-mobile --target aarch64-apple-darwin --all-targets --locked
+      - name: Test (claudette-mobile)
+        run: cargo test -p claudette-mobile --locked
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ cargo test -p claudette -p claudette-server -p claudette-cli --all-features  # R
 cargo test -p claudette --test diff_tests        # Run a single test file
 cargo test -p claudette parse_unified -- --exact # Run a single test by name
 cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features  # Lint (CI command — must pass with zero warnings)
+cargo clippy -p claudette-mobile --target aarch64-apple-darwin --all-targets --locked  # Mobile lint (CI command — macOS only)
+cargo test -p claudette-mobile --locked          # Mobile tests (CI command — macOS only)
 cargo fmt --all --check                          # Check formatting
 
 # Frontend (React/TypeScript)
@@ -55,7 +57,7 @@ IMPORTANT: CI sets `RUSTFLAGS="-Dwarnings"` — all compiler warnings are errors
 
 IMPORTANT: Always run `cd src/ui && bunx tsc -b` after modifying TypeScript files (including tests). CI runs `tsc -b` via `bun run build` — `vitest` does **not** type-check (it uses esbuild), so tests can pass locally while types are broken. Run `tsc -b` as the final check before committing any frontend change.
 
-CI also enforces `bun install --frozen-lockfile` — do not modify `bun.lock` without intention. CI runs `cargo llvm-cov` for Rust test coverage (uploaded to Codecov, informational/non-blocking). CI clippy lints `claudette`, `claudette-server`, and `claudette-cli` (not `claudette-tauri`, which requires system libs that aren't installed on the lint runner). Frontend CI runs `bunx tsc --noEmit` as a dedicated type-check step before `bun run build`.
+CI also enforces `bun install --frozen-lockfile` — do not modify `bun.lock` without intention. CI runs `cargo llvm-cov` for Rust test coverage (uploaded to Codecov, informational/non-blocking). CI clippy lints `claudette`, `claudette-server`, and `claudette-cli` on Linux, plus `claudette-mobile` on macOS (host target `aarch64-apple-darwin`, desktop-fallback build — iOS target compilation is intentionally not in CI; it requires Xcode + Apple SDK + `cargo tauri ios init` scaffolding). `claudette-tauri` is still excluded because it requires system libs not installed on the lint runner. Frontend CI runs `bunx tsc --noEmit` as a dedicated type-check step before `bun run build`.
 
 ## Code style
 


### PR DESCRIPTION
## Summary

- Add a new `Mobile (macOS)` job to `.github/workflows/ci.yml` that runs `cargo clippy` and `cargo test` for the `claudette-mobile` crate on `macos-latest` against the `aarch64-apple-darwin` target. Runs in parallel with the existing matrix — not bolted onto the Linux clippy job — so PR turnaround stays fast.
- Both commands use `--locked` (defensive against silent `Cargo.lock` bumps from a mobile-side dep change) and inherit the workflow-level `RUSTFLAGS: -Dwarnings`.
- Update `CLAUDE.md` Build & test commands block and the CI-coverage paragraph to document the new commands and explain why `claudette-tauri` is still excluded.

### Why

PR #840 landed `claudette-mobile` but left it out of CI — the existing clippy job runs `-p claudette -p claudette-server -p claudette-cli` on Ubuntu, and Tauri Mobile won't build there. So a regression on the mobile crate's Rust side (Cargo.toml drift, dep version drift, broken `cfg(mobile)` gating, missing module declarations) wouldn't surface until someone ran the iOS build locally — which, on a small team, is rarely.

### Why not iOS-target compilation?

`aarch64-apple-ios` needs Xcode + the Apple SDK + `cargo tauri ios init` scaffolding — heavier, separate PR. The desktop-fallback build catches the regressions this job is meant to catch (the `cfg(not(mobile))` branch in `src-mobile/src/lib.rs:42-47` exercises all the same module wiring and dep resolution).

### Why not also a `fmt` step?

The existing workspace-wide `fmt` job (`cargo fmt --all --check`) on Ubuntu already covers `src-mobile/` — rustfmt output is platform-independent, so duplicating it on a slower macOS runner adds cost without catching anything new.

## Test plan

- [x] Local clippy: `nix develop -c cargo clippy -p claudette-mobile --target aarch64-apple-darwin --all-targets --locked` — green, zero warnings.
- [x] Local tests: `nix develop -c cargo test -p claudette-mobile --locked` — 8/8 passed.
- [ ] CI: new `Mobile (macOS)` job appears in the PR checks and goes green, runs in parallel with existing `Lint` / `Test` jobs.
- [ ] Existing jobs (`Lint`, `Test`, `Format`, `Frontend`, etc.) remain green and unaffected.