### PR TITLE
fix(chat): open cross-worktree file links in Monaco instead of the OS

### DIFF
--- a/src/ui/src/components/chat/chatFileLinks.test.ts
+++ b/src/ui/src/components/chat/chatFileLinks.test.ts
@@ -39,4 +39,51 @@ describe("monacoFileLinkPath", () => {
     expect(monacoFileLinkPath("../README.md", "/repo")).toBeNull();
     expect(monacoFileLinkPath("..\\README.md", "/repo")).toBeNull();
   });
+
+  it("resolves cross-worktree Claudette paths to the equivalent file in the current worktree", () => {
+    // Plan / chat authored under one workspace mentions an absolute path
+    // that points into a sibling worktree of the same repo. The current
+    // worktree prefix doesn't match, so relativizePath alone leaves the
+    // path absolute — we'd previously bail and let the OS opener take
+    // over. Same project ⇒ identical file layout ⇒ the workspace-relative
+    // tail opens the same logical file in this worktree's Monaco.
+    expect(
+      monacoFileLinkPath(
+        "/Users/me/.claudette/workspaces/Claudette/cosmic-birch/src/main.rs",
+        "/Users/me/.claudette/workspaces/Claudette/jolly-ranunculus",
+      ),
+    ).toBe("src/main.rs");
+    expect(
+      monacoFileLinkTarget(
+        "/Users/me/.claudette/workspaces/Claudette/cosmic-birch/src/ui/src/components/chat/composer/OverflowMenu.tsx:42:5",
+        "/Users/me/.claudette/workspaces/Claudette/jolly-ranunculus",
+      ),
+    ).toEqual({
+      path: "src/ui/src/components/chat/composer/OverflowMenu.tsx",
+      revealTarget: {
+        startLine: 42,
+        startColumn: 5,
+        endLine: 42,
+        endColumn: undefined,
+      },
+    });
+  });
+
+  it("does not match absolute paths outside any Claudette worktree", () => {
+    // Genuine out-of-project absolute paths still bail so the OS opener
+    // handles them. The Claudette-pattern shortcut must not turn random
+    // absolute paths into in-workspace links.
+    expect(
+      monacoFileLinkPath(
+        "/Users/me/Documents/notes.md",
+        "/Users/me/.claudette/workspaces/Claudette/jolly-ranunculus",
+      ),
+    ).toBeNull();
+    expect(
+      monacoFileLinkPath(
+        "/var/log/system.log",
+        "/Users/me/.claudette/workspaces/Claudette/jolly-ranunculus",
+      ),
+    ).toBeNull();
+  });
 });

--- a/src/ui/src/components/chat/chatFileLinks.test.ts
+++ b/src/ui/src/components/chat/chatFileLinks.test.ts
@@ -86,4 +86,16 @@ describe("monacoFileLinkPath", () => {
       ),
     ).toBeNull();
   });
+
+  it("rejects cross-worktree paths whose tail contains parent traversal", () => {
+    // A traversal-shaped path under the Claudette workspaces dir would
+    // otherwise extract to `../other.rs` and bypass the existing
+    // `..`/`../` guard on the non-cross-worktree branch.
+    expect(
+      monacoFileLinkPath(
+        "/Users/me/.claudette/workspaces/Claudette/cosmic-birch/../etc/passwd",
+        "/Users/me/.claudette/workspaces/Claudette/jolly-ranunculus",
+      ),
+    ).toBeNull();
+  });
 });

--- a/src/ui/src/components/chat/chatFileLinks.ts
+++ b/src/ui/src/components/chat/chatFileLinks.ts
@@ -1,5 +1,8 @@
 import { relativizePath } from "../../hooks/toolSummary";
-import { parseFilePathTarget } from "../../utils/filePathLinks";
+import {
+  extractClaudetteWorktreeRelativePath,
+  parseFilePathTarget,
+} from "../../utils/filePathLinks";
 
 export interface MonacoFileRevealTarget {
   startLine: number;
@@ -25,12 +28,22 @@ export function monacoFileLinkTarget(
   worktreePath: string | null | undefined,
 ): MonacoFileLinkTarget | null {
   const parsed = parseFilePathTarget(filePath);
-  const rel = relativizePath(parsed.path, worktreePath);
+  let rel = relativizePath(parsed.path, worktreePath);
   if (
     /^([a-zA-Z]:[\\/]|[\\/])/.test(rel) ||
     rel === "~" ||
     rel.startsWith("~/") ||
-    rel.startsWith("~\\") ||
+    rel.startsWith("~\\")
+  ) {
+    // Absolute or home-relative after stripping the current worktree —
+    // the path points outside `worktreePath`. If it's still inside *some*
+    // Claudette-managed worktree of the same project, fall through to the
+    // workspace-relative form so the equivalent file opens in the current
+    // worktree's Monaco. Otherwise let the caller defer to the OS opener.
+    const fromOtherWorktree = extractClaudetteWorktreeRelativePath(rel);
+    if (!fromOtherWorktree) return null;
+    rel = fromOtherWorktree;
+  } else if (
     rel === "." ||
     rel === ".." ||
     rel.startsWith("../") ||

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
@@ -103,6 +103,43 @@ describe("useWorkspaceFileIndex", () => {
     expect(serviceMocks.listWorkspaceFiles).toHaveBeenCalledTimes(2);
   });
 
+  it("resolves absolute paths that point into a Claudette worktree to the matching workspace file", async () => {
+    await render("ws-claudette");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Same project, different worktree — the index for the currently
+    // viewed workspace already contains the equivalent file, so the
+    // resolver should return the workspace-relative path so the
+    // MarkdownLink renders a button that opens Monaco rather than
+    // falling through to the OS opener.
+    expect(
+      latestResolve?.(
+        "/Users/me/.claudette/workspaces/Claudette/cosmic-birch/src/main.rs",
+      ),
+    ).toBe("src/main.rs");
+    expect(
+      latestResolve?.(
+        "/Users/me/.claudette/workspaces/Claudette/cosmic-birch/Cargo.toml:7:2-9:4",
+      ),
+    ).toBe("Cargo.toml:7:2-9:4");
+
+    // File doesn't exist in this workspace — resolver still returns null
+    // so the link stays in its OS-opener fallback path.
+    expect(
+      latestResolve?.(
+        "/Users/me/.claudette/workspaces/Claudette/cosmic-birch/src/missing.rs",
+      ),
+    ).toBeNull();
+
+    // Out-of-project absolute paths must NOT collapse to a basename
+    // match — otherwise `/etc/Cargo.toml`-style references could falsely
+    // resolve to a same-named in-workspace file.
+    expect(latestResolve?.("/etc/Cargo.toml")).toBeNull();
+    expect(latestResolve?.("/Users/me/Documents/README.md")).toBeNull();
+  });
+
   it("does not cache rejected workspace file loads", async () => {
     serviceMocks.listWorkspaceFiles
       .mockRejectedValueOnce(new Error("temporary failure"))

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.ts
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.ts
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { listWorkspaceFiles } from "../../services/tauri";
 import { useAppStore } from "../../stores/useAppStore";
-import { parseFilePathTarget } from "../../utils/filePathLinks";
+import {
+  extractClaudetteWorktreeRelativePath,
+  parseFilePathTarget,
+} from "../../utils/filePathLinks";
 
 export interface WorkspaceFileIndex {
   resolve: (path: string) => string | null;
@@ -71,6 +74,19 @@ export function useWorkspaceFileIndex(
         if (!normalized || normalized.startsWith("../")) return null;
         const lineSuffix = formatLineSuffix(parsed);
         if (data.paths.has(normalized)) return `${normalized}${lineSuffix}`;
+        // Absolute paths under a Claudette-managed worktree (this one or a
+        // sibling worktree of the same repo) collapse to their workspace-
+        // relative form. If the collapsed path is tracked in the index, the
+        // file lives in this worktree too and can open in Monaco.
+        const isAbsolute =
+          normalized.startsWith("/") || /^[A-Za-z]:\//.test(normalized);
+        if (isAbsolute) {
+          const fromWorktree = extractClaudetteWorktreeRelativePath(normalized);
+          if (fromWorktree && data.paths.has(fromWorktree)) {
+            return `${fromWorktree}${lineSuffix}`;
+          }
+          return null;
+        }
         if (normalized.includes("/")) return null;
         const basenamePath = data.uniqueBasenames.get(normalized.toLowerCase());
         return basenamePath ? `${basenamePath}${lineSuffix}` : null;

--- a/src/ui/src/utils/filePathLinks.test.ts
+++ b/src/ui/src/utils/filePathLinks.test.ts
@@ -7,6 +7,7 @@ import {
   detectFileReferences,
   detectFilePaths,
   encodeFilePathHref,
+  extractClaudetteWorktreeRelativePath,
   FILE_PATH_SCHEME,
   formatFilePathDisplayLabel,
   isExplicitFilePathTarget,
@@ -258,6 +259,41 @@ describe("localhost file URL decoding", () => {
     expect(formatFilePathDisplayLabel("/tmp/report.md:2:4-5:8")).toBe(
       "report.md:2:4-5:8",
     );
+  });
+});
+
+describe("extractClaudetteWorktreeRelativePath", () => {
+  it("returns the workspace-relative tail of a Claudette worktree path", () => {
+    expect(
+      extractClaudetteWorktreeRelativePath(
+        "/Users/me/.claudette/workspaces/Claudette/cosmic-birch/src/main.rs",
+      ),
+    ).toBe("src/main.rs");
+    expect(
+      extractClaudetteWorktreeRelativePath(
+        "/Users/me/.claudette/workspaces/Claudette/cosmic-birch/src/ui/src/components/chat/composer/OverflowMenu.tsx",
+      ),
+    ).toBe("src/ui/src/components/chat/composer/OverflowMenu.tsx");
+  });
+
+  it("normalizes Windows-style separators before matching", () => {
+    expect(
+      extractClaudetteWorktreeRelativePath(
+        "C:\\Users\\me\\.claudette\\workspaces\\Claudette\\cosmic-birch\\src\\main.rs",
+      ),
+    ).toBe("src/main.rs");
+  });
+
+  it("returns null for paths outside any Claudette worktree", () => {
+    expect(
+      extractClaudetteWorktreeRelativePath("/Users/me/Documents/notes.md"),
+    ).toBeNull();
+    expect(
+      extractClaudetteWorktreeRelativePath(
+        "/Users/me/.claudette/workspaces/Claudette",
+      ),
+    ).toBeNull();
+    expect(extractClaudetteWorktreeRelativePath("src/main.rs")).toBeNull();
   });
 });
 

--- a/src/ui/src/utils/filePathLinks.test.ts
+++ b/src/ui/src/utils/filePathLinks.test.ts
@@ -295,6 +295,28 @@ describe("extractClaudetteWorktreeRelativePath", () => {
     ).toBeNull();
     expect(extractClaudetteWorktreeRelativePath("src/main.rs")).toBeNull();
   });
+
+  it("rejects captures containing parent-traversal segments", () => {
+    // The captured tail is fed back into the Monaco-opener pipeline, which
+    // would otherwise treat `../other.rs` as a valid workspace-relative
+    // path and escape the worktree. Reject traversal at the helper level
+    // so every consumer is protected by default.
+    expect(
+      extractClaudetteWorktreeRelativePath(
+        "/Users/me/.claudette/workspaces/Claudette/cosmic-birch/../other.rs",
+      ),
+    ).toBeNull();
+    expect(
+      extractClaudetteWorktreeRelativePath(
+        "/Users/me/.claudette/workspaces/Claudette/cosmic-birch/src/../../etc/passwd",
+      ),
+    ).toBeNull();
+    expect(
+      extractClaudetteWorktreeRelativePath(
+        "/Users/me/.claudette/workspaces/Claudette/cosmic-birch/src/..",
+      ),
+    ).toBeNull();
+  });
 });
 
 describe("encode/decode round trip", () => {

--- a/src/ui/src/utils/filePathLinks.ts
+++ b/src/ui/src/utils/filePathLinks.ts
@@ -275,14 +275,36 @@ export function stripFileLineSuffix(path: string): string {
   return parseFilePathTarget(path).path;
 }
 
+/**
+ * Match an absolute path that sits under a Claudette-managed git worktree
+ * directory (`~/.claudette/workspaces/<project>/<workspace>/<rest>`) and
+ * capture the `<rest>` portion — the file's path relative to its worktree
+ * root. Used to recognize cross-worktree references: a plan or chat message
+ * authored in one workspace that mentions paths under a sibling workspace
+ * of the same repository.
+ */
+const CLAUDETTE_WORKTREE_RELATIVE_REGEX =
+  /\/\.claudette\/workspaces\/[^/]+\/[^/]+\/(.+)$/;
+
+/**
+ * If `path` points inside a Claudette-managed worktree directory, return
+ * the workspace-relative file path; otherwise return `null`. Because every
+ * worktree of a given repo shares the same file structure, the returned
+ * relative path is also the equivalent file in any other worktree of that
+ * repo — including the one the user is currently viewing.
+ */
+export function extractClaudetteWorktreeRelativePath(
+  path: string,
+): string | null {
+  const normalized = path.replace(/\\/g, "/");
+  return normalized.match(CLAUDETTE_WORKTREE_RELATIVE_REGEX)?.[1] ?? null;
+}
+
 export function formatFilePathDisplayLabel(path: string): string {
   const target = parseFilePathTarget(path);
   const normalizedPath = target.path.replace(/\\/g, "/");
-  const workspaceRelativeMatch = normalizedPath.match(
-    /\/\.claudette\/workspaces\/[^/]+\/[^/]+\/(.+)$/,
-  );
   const displayPath =
-    workspaceRelativeMatch?.[1] ??
+    extractClaudetteWorktreeRelativePath(normalizedPath) ??
     normalizedPath.split("/").filter(Boolean).pop() ??
     normalizedPath;
   const rangeSuffix = formatFilePathRangeSuffix(target);

--- a/src/ui/src/utils/filePathLinks.ts
+++ b/src/ui/src/utils/filePathLinks.ts
@@ -292,12 +292,26 @@ const CLAUDETTE_WORKTREE_RELATIVE_REGEX =
  * worktree of a given repo shares the same file structure, the returned
  * relative path is also the equivalent file in any other worktree of that
  * repo — including the one the user is currently viewing.
+ *
+ * Captures containing `..` traversal segments are rejected so a path like
+ * `~/.claudette/workspaces/proj/ws/../other` doesn't slip past callers'
+ * parent-traversal guards as a bare `../other` workspace-relative path.
  */
 export function extractClaudetteWorktreeRelativePath(
   path: string,
 ): string | null {
   const normalized = path.replace(/\\/g, "/");
-  return normalized.match(CLAUDETTE_WORKTREE_RELATIVE_REGEX)?.[1] ?? null;
+  const captured = normalized.match(CLAUDETTE_WORKTREE_RELATIVE_REGEX)?.[1];
+  if (!captured) return null;
+  if (
+    captured === ".." ||
+    captured.startsWith("../") ||
+    captured.endsWith("/..") ||
+    captured.includes("/../")
+  ) {
+    return null;
+  }
+  return captured;
 }
 
 export function formatFilePathDisplayLabel(path: string): string {


### PR DESCRIPTION
## Summary

- Absolute paths under a *sibling* Claudette worktree of the same repo (e.g. a plan authored in `cosmic-birch` that names `/Users/me/.claudette/workspaces/Claudette/cosmic-birch/src/main.rs`, viewed from `jolly-ranunculus`) were falling through to the OS default app even though the equivalent file exists in the currently viewed worktree.
- The current worktree prefix didn't match in `relativizePath`, so `monacoFileLinkTarget` returned `null`. `MarkdownLink`'s fallback then called `openInEditor` (OS opener) instead of routing to Monaco.
- Fix: extract a shared `extractClaudetteWorktreeRelativePath` helper (re-using the regex already in `formatFilePathDisplayLabel`) and use it as a fallback in both `monacoFileLinkTarget` and `useWorkspaceFileIndex.resolve`. Cross-worktree references collapse to their workspace-relative tail and open in Monaco; genuinely out-of-project absolute paths still bail so the OS opener handles them.

## Test plan

- [x] `bun run test chatFileLinks useWorkspaceFileIndex filePathLinks` — adds cross-worktree resolution cases + negative cases for out-of-project paths and missing-in-this-worktree files; all 64 affected tests pass.
- [x] `bun run test` — full frontend suite green (2459 passed, 6 skipped).
- [x] `bunx tsc -b` — clean.
- [x] `bun run lint` — 0 errors (16 pre-existing warnings, none in changed files).
- [ ] Manual: in workspace A, view a plan/chat that references an absolute path inside workspace B (sibling worktree of the same repo) — click should open in Monaco; reference to `/tmp/foo.csv` should still open in the OS default app.