### PR TITLE
feat(chat): enable Claude Remote Control mid-turn via deferred queue

### DIFF
--- a/site/src/content/docs/features/claude-remote-control.mdx
+++ b/site/src/content/docs/features/claude-remote-control.mdx
@@ -33,11 +33,14 @@ Until the flag is enabled, the toolbar action stays hidden and the backend Tauri
 2. Click the **overflow menu** (⋯) at the right of the prompt composer.
 3. Select **Claude Remote Control → Enable**.
 
+You can click **Enable** at any time — including mid-turn. If a turn is currently running, Claudette queues the request and applies it the moment the turn finishes; the row shows a **pending** chip while it waits. Click the row again before the turn ends to cancel the queued enable.
+
 The first time you enable a session, Claudette tells the persistent Claude Code CLI to start a bridge environment. The lifecycle progresses through:
 
 | State | What it means |
 | --- | --- |
-| **Enabling** | Bridge initialization in flight. Cold-enable on a fresh chat defers until your first prompt. |
+| **Pending** | You clicked Enable while a turn was running. Claudette will activate the bridge automatically when the turn finishes. Click the row again to cancel. |
+| **Enabling** | Bridge initialization in flight. Cold-enable on a fresh chat defers until your first prompt (shown as **armed** in the meta chip). |
 | **Ready** | Bridge handle exists; transport handshake hasn't completed yet. |
 | **Connected** | Transport is live; claude.ai and Claudette are in sync. |
 | **Reconnecting** | Transient network blip — the CLI is reconnecting on its own. |
@@ -73,6 +76,7 @@ Disabling doesn't affect the underlying chat — your local Claudette transcript
 
 ## Troubleshooting
 
+- **Armed vs. Pending** — these are two distinct deferred-enable states with different triggers. **Armed** appears when you enable Remote Control on a brand-new chat that hasn't had a single message yet; the bridge waits for your first prompt before it actually starts (claude.ai has nothing to show until then). **Pending** appears when you click Enable while an existing chat is in the middle of a turn; the bridge fires automatically the moment the current turn finishes. Both clear themselves; only Pending can be cancelled with a second click.
 - **Status stuck on "Enabling" with "Send your first message…"** — Claudette intentionally defers the bridge until a chat has at least one turn (otherwise the bridge would have nothing to render in claude.ai's recents). Send any prompt from Claudette to kick the bridge off.
 - **Status: Error, detail `/login`** — the Claude Code CLI couldn't reach Anthropic with its OAuth token. Run `claude` in a terminal once to refresh credentials, then retry.
 - **Status: Error, detail "disabled by your organization's policy"** — your Anthropic org disabled `allow_remote_control`. Contact your admin.

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -1322,7 +1322,8 @@ export function ChatInputArea({
             sessionId={sessionId}
             workspaceId={selectedWorkspaceId}
             repoId={repoId ?? null}
-            disabled={isRunning || workspaceEnvironmentPreparing}
+            disabled={workspaceEnvironmentPreparing}
+            isRunning={isRunning}
             isRemote={isRemote}
           />
         </div>

--- a/src/ui/src/components/chat/composer/ComposerToolbar.tsx
+++ b/src/ui/src/components/chat/composer/ComposerToolbar.tsx
@@ -24,7 +24,11 @@ interface ComposerToolbarProps {
   sessionId: string;
   workspaceId: string;
   repoId: string | null;
+  /** Blocks all toolbar interactions — set while the workspace environment is preparing. */
   disabled: boolean;
+  /** True while a turn is in flight. Pills that mutate session state stay locked;
+   *  the overflow menu's Remote Control row uses this to queue mid-turn enables. */
+  isRunning: boolean;
   isRemote: boolean;
 }
 
@@ -33,8 +37,14 @@ export function ComposerToolbar({
   workspaceId,
   repoId,
   disabled,
+  isRunning,
   isRemote,
 }: ComposerToolbarProps) {
+  // Session-mutating pills (model, plan, reasoning) keep their pre-split
+  // behavior: locked whenever a turn is running OR the env is preparing.
+  // The overflow menu deliberately opts out so users can queue Remote
+  // Control mid-turn — see `OverflowMenu` for the per-item gating.
+  const mutationDisabled = disabled || isRunning;
   const selectedModel = useAppStore((s) => s.selectedModel[sessionId] ?? "opus");
   const selectedProvider = useAppStore((s) => s.selectedModelProvider[sessionId] ?? "anthropic");
   const disable1mContext = useAppStore((s) => s.disable1mContext);
@@ -170,7 +180,7 @@ export function ComposerToolbar({
           label={modelLabel}
           chevron
           onClick={() => setModelSelectorOpen(!modelSelectorOpen)}
-          disabled={disabled}
+          disabled={mutationDisabled}
           title={isExtraUsage ? "Change model (extra usage: 1M context billed at API rates)" : "Change model"}
         >
           {isExtraUsage && <CircleDollarSign size={14} className={styles.extraUsage} />}
@@ -190,7 +200,7 @@ export function ComposerToolbar({
         label="Plan"
         active={planMode}
         onClick={togglePlan}
-        disabled={disabled}
+        disabled={mutationDisabled}
         {...tooltipAttributes(
           `${planMode ? "Disable" : "Enable"} plan mode`,
           "global.toggle-plan-mode",
@@ -200,11 +210,16 @@ export function ComposerToolbar({
         ariaPressed={planMode}
       />
 
-      <ReasoningPill sessionId={sessionId} disabled={disabled} />
+      <ReasoningPill sessionId={sessionId} disabled={mutationDisabled} />
 
       <ClaudeFlagsTooltip resolved={resolvedFlags} />
 
-      <OverflowMenu sessionId={sessionId} disabled={disabled} isRemote={isRemote} />
+      <OverflowMenu
+        sessionId={sessionId}
+        disabled={disabled}
+        isRunning={isRunning}
+        isRemote={isRemote}
+      />
     </div>
   );
 }

--- a/src/ui/src/components/chat/composer/OverflowMenu.module.css
+++ b/src/ui/src/components/chat/composer/OverflowMenu.module.css
@@ -78,8 +78,13 @@
   transition: background var(--transition-fast);
 }
 
-.item:hover {
+.item:hover:not(:disabled) {
   background: var(--hover-bg);
+}
+
+.item:disabled {
+  cursor: default;
+  opacity: 0.45;
 }
 
 .itemActive {
@@ -155,9 +160,29 @@
   color: var(--diff-removed-text);
 }
 
+/* Mid-turn "queued enable" visual state — Radio icon stays (no spinner —
+ * pending ≠ enabling), accent-primary tint and reduced opacity signal
+ * "armed but not yet active." Mirrors the language of `.queuedLabel` in
+ * ChatPanel.module.css: a small uppercase chip in the meta column. */
+.remoteGroupPending {
+  color: var(--accent-primary);
+}
+
+.remoteGroupPending .itemIcon {
+  opacity: 0.75;
+}
+
+.remoteGroupPending .itemMeta {
+  text-transform: uppercase;
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
 .remoteGroupActive .itemMeta,
 .remoteGroupError .itemIcon,
-.remoteGroupError .itemMeta {
+.remoteGroupError .itemMeta,
+.remoteGroupPending .itemMeta {
   color: currentColor;
 }
 

--- a/src/ui/src/components/chat/composer/OverflowMenu.test.tsx
+++ b/src/ui/src/components/chat/composer/OverflowMenu.test.tsx
@@ -360,6 +360,39 @@ describe("OverflowMenu — Remote Control mid-turn enable (user toggle)", () => 
     expect(appStore.addToast).not.toHaveBeenCalled();
   });
 
+  it("survives a dropdown close (regression: state must live above the dropdown)", async () => {
+    // The pending state used to live inside the conditionally-rendered
+    // `RemoteControlMenuItem`. Closing the dropdown unmounted that
+    // component and discarded the queued intent — the turn would end
+    // and nothing would fire. This regression pins the state at the
+    // higher (always-mounted) level by exercising the close-and-reopen
+    // path end-to-end.
+    const { container, root } = await renderMenu({ isRunning: true });
+    await openDropdown(container);
+
+    // Queue while running, then close the dropdown by clicking outside.
+    await act(async () => {
+      findRemoteControlButton(container).click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      const evt = new MouseEvent("mousedown", { bubbles: true });
+      document.body.dispatchEvent(evt);
+      await Promise.resolve();
+    });
+
+    // Turn ends while the menu is closed — the deferred enable must
+    // still fire, because the owning state survived the close.
+    await rerenderMenu(root, { isRunning: false });
+
+    expect(serviceMocks.setClaudeRemoteControl).toHaveBeenCalledTimes(1);
+    expect(serviceMocks.setClaudeRemoteControl).toHaveBeenCalledWith(
+      "s1",
+      true,
+      expect.any(Object),
+    );
+  });
+
   it("clears the pending intent when the user switches sessions", async () => {
     const { container, root } = await renderMenu({
       sessionId: "s1",

--- a/src/ui/src/components/chat/composer/OverflowMenu.test.tsx
+++ b/src/ui/src/components/chat/composer/OverflowMenu.test.tsx
@@ -272,12 +272,13 @@ describe("OverflowMenu — mid-turn reachability", () => {
 
 // --- End-to-end toggle behavior ----------------------------------------
 //
-// These exercise the user-implemented `toggle()` callback per the sketch
-// in `OverflowMenu.tsx`. They will fail against the placeholder body
-// (which fires immediately) and pass once the queue / cancel / defer
-// branches are wired up. Each test names the exact branch it covers.
+// Each test covers one branch of the Remote Control `toggle()` body:
+// queue (mid-turn), cancel (re-click while pending), defer-fire (turn
+// end), idle fire (regression for the pre-existing immediate path),
+// and pending-survives-dropdown-close (regression for the bug where
+// pending state lived inside the conditionally-rendered row).
 
-describe("OverflowMenu — Remote Control mid-turn enable (user toggle)", () => {
+describe("OverflowMenu — Remote Control mid-turn enable", () => {
   it("queues a pending enable instead of firing when clicked mid-turn", async () => {
     const { container } = await renderMenu({ isRunning: true });
     await openDropdown(container);
@@ -391,6 +392,29 @@ describe("OverflowMenu — Remote Control mid-turn enable (user toggle)", () => 
       true,
       expect.any(Object),
     );
+  });
+
+  it("drops a pending intent if Remote Control becomes unavailable mid-turn", async () => {
+    // Regression: queuing while the experimental gate is on, then
+    // flipping the gate off, must not silently fire the enable RPC on
+    // turn end. The gate is the user telling the app "I don't want
+    // this feature" — the queued action must respect that.
+    const { container, root } = await renderMenu({ isRunning: true });
+    await openDropdown(container);
+
+    await act(async () => {
+      findRemoteControlButton(container).click();
+      await Promise.resolve();
+    });
+    expect(serviceMocks.setClaudeRemoteControl).not.toHaveBeenCalled();
+
+    // User flips the experimental gate off before the turn ends.
+    appStore.claudeRemoteControlEnabled = false;
+    await rerenderMenu(root, { isRunning: true });
+
+    // Turn ends — the queued intent must NOT fire.
+    await rerenderMenu(root, { isRunning: false });
+    expect(serviceMocks.setClaudeRemoteControl).not.toHaveBeenCalled();
   });
 
   it("clears the pending intent when the user switches sessions", async () => {

--- a/src/ui/src/components/chat/composer/OverflowMenu.test.tsx
+++ b/src/ui/src/components/chat/composer/OverflowMenu.test.tsx
@@ -1,0 +1,382 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClaudeRemoteControlStatus } from "../../../services/tauri";
+
+// --- Store mock ---------------------------------------------------------
+//
+// The component reads many session-scoped selectors; the mock returns
+// safe defaults keyed off `sessionId`. `addToast` is captured so we can
+// assert the user-facing copy that fires when an enable is queued or
+// cancelled mid-turn.
+
+interface MockState {
+  selectedModel: Record<string, string>;
+  selectedModelProvider: Record<string, string>;
+  permissionLevel: Record<string, string>;
+  fastMode: Record<string, boolean>;
+  thinkingEnabled: Record<string, boolean>;
+  planMode: Record<string, boolean>;
+  effortLevel: Record<string, string>;
+  chromeEnabled: Record<string, boolean>;
+  claudeRemoteControlEnabled: boolean;
+  setFastMode: ReturnType<typeof vi.fn>;
+  setChromeEnabled: ReturnType<typeof vi.fn>;
+  clearAgentQuestion: ReturnType<typeof vi.fn>;
+  clearPlanApproval: ReturnType<typeof vi.fn>;
+  clearAgentApproval: ReturnType<typeof vi.fn>;
+  addToast: ReturnType<typeof vi.fn>;
+}
+
+const appStore = vi.hoisted(
+  () =>
+    ({
+      selectedModel: {},
+      selectedModelProvider: {},
+      permissionLevel: {},
+      fastMode: {},
+      thinkingEnabled: {},
+      planMode: {},
+      effortLevel: {},
+      chromeEnabled: {},
+      claudeRemoteControlEnabled: true,
+      setFastMode: vi.fn(),
+      setChromeEnabled: vi.fn(),
+      clearAgentQuestion: vi.fn(),
+      clearPlanApproval: vi.fn(),
+      clearAgentApproval: vi.fn(),
+      addToast: vi.fn(),
+    }) satisfies MockState as MockState,
+);
+
+const serviceMocks = vi.hoisted(() => ({
+  getClaudeRemoteControlStatus: vi.fn(
+    (): Promise<ClaudeRemoteControlStatus> =>
+      Promise.resolve({
+        state: "disabled",
+        sessionUrl: null,
+        connectUrl: null,
+        environmentId: null,
+        detail: null,
+        lastError: null,
+      }),
+  ),
+  setClaudeRemoteControl: vi.fn(
+    (): Promise<ClaudeRemoteControlStatus> =>
+      Promise.resolve({
+        state: "ready",
+        sessionUrl: "https://claude.ai/code/sess",
+        connectUrl: "https://claude.ai/code?bridge=env_test",
+        environmentId: "env_test",
+        detail: null,
+        lastError: null,
+      }),
+  ),
+  setAppSetting: vi.fn(() => Promise.resolve()),
+  openUrl: vi.fn(() => Promise.resolve()),
+  resetAgentSession: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../../stores/useAppStore", () => ({
+  useAppStore: <T,>(selector: (state: MockState) => T): T => selector(appStore),
+}));
+
+vi.mock("../../../services/tauri", () => ({
+  getClaudeRemoteControlStatus: serviceMocks.getClaudeRemoteControlStatus,
+  setClaudeRemoteControl: serviceMocks.setClaudeRemoteControl,
+  setAppSetting: serviceMocks.setAppSetting,
+  openUrl: serviceMocks.openUrl,
+  resetAgentSession: serviceMocks.resetAgentSession,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../useSelectedModelEntry", () => ({
+  useSelectedModelEntry: () => ({ supportsFastMode: true }),
+}));
+
+vi.mock("../chatHelpers", () => ({
+  shouldDisable1mContext: () => false,
+}));
+
+vi.mock("../modelCapabilities", () => ({
+  isFastSupported: () => true,
+}));
+
+import { OverflowMenu } from "./OverflowMenu";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// --- Test harness -------------------------------------------------------
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function renderMenu(props: {
+  sessionId?: string;
+  disabled?: boolean;
+  isRunning?: boolean;
+  isRemote?: boolean;
+}): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(
+      <OverflowMenu
+        sessionId={props.sessionId ?? "s1"}
+        disabled={props.disabled ?? false}
+        isRunning={props.isRunning ?? false}
+        isRemote={props.isRemote ?? false}
+      />,
+    );
+    // Allow the initial getClaudeRemoteControlStatus + listen effects to settle.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root };
+}
+
+async function rerenderMenu(
+  root: Root,
+  props: {
+    sessionId?: string;
+    disabled?: boolean;
+    isRunning?: boolean;
+    isRemote?: boolean;
+  },
+): Promise<void> {
+  await act(async () => {
+    root.render(
+      <OverflowMenu
+        sessionId={props.sessionId ?? "s1"}
+        disabled={props.disabled ?? false}
+        isRunning={props.isRunning ?? false}
+        isRemote={props.isRemote ?? false}
+      />,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function triggerButton(container: HTMLElement): HTMLButtonElement {
+  const btn = container.querySelector(
+    'button[aria-label="More options"]',
+  ) as HTMLButtonElement | null;
+  if (!btn) throw new Error("Overflow trigger not found");
+  return btn;
+}
+
+async function openDropdown(container: HTMLElement): Promise<void> {
+  await act(async () => {
+    triggerButton(container).click();
+    await Promise.resolve();
+  });
+}
+
+function findRemoteControlButton(container: HTMLElement): HTMLButtonElement {
+  const buttons = Array.from(container.querySelectorAll("button"));
+  const match = buttons.find((b) =>
+    b.textContent?.includes("Claude Remote Control"),
+  );
+  if (!match) throw new Error("Remote Control row not found");
+  return match;
+}
+
+function findMenuItemByLabel(
+  container: HTMLElement,
+  label: string,
+): HTMLButtonElement {
+  const buttons = Array.from(container.querySelectorAll("button"));
+  const match = buttons.find((b) => b.textContent?.includes(label));
+  if (!match) throw new Error(`Menu item "${label}" not found`);
+  return match;
+}
+
+beforeEach(() => {
+  serviceMocks.getClaudeRemoteControlStatus.mockClear();
+  serviceMocks.setClaudeRemoteControl.mockClear();
+  serviceMocks.setAppSetting.mockClear();
+  serviceMocks.resetAgentSession.mockClear();
+  appStore.addToast.mockClear();
+  appStore.setFastMode.mockClear();
+  appStore.setChromeEnabled.mockClear();
+  appStore.claudeRemoteControlEnabled = true;
+});
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
+// --- Scaffolding regressions -------------------------------------------
+//
+// These verify the *plumbing* changes (split `disabled` prop, mid-turn
+// menu accessibility, MenuItem disabled prop). They do not depend on the
+// user-implemented `toggle()` body.
+
+describe("OverflowMenu — mid-turn reachability", () => {
+  it("does not disable the trigger button when only isRunning is true", async () => {
+    const { container } = await renderMenu({ isRunning: true });
+    expect(triggerButton(container).disabled).toBe(false);
+  });
+
+  it("disables the trigger button when the workspace is preparing", async () => {
+    const { container } = await renderMenu({ disabled: true });
+    expect(triggerButton(container).disabled).toBe(true);
+  });
+
+  it("keeps Fast mode and Claude in Chrome disabled mid-turn (no session-mutation drift)", async () => {
+    const { container } = await renderMenu({ isRunning: true });
+    await openDropdown(container);
+    expect(findMenuItemByLabel(container, "Fast mode").disabled).toBe(true);
+    expect(findMenuItemByLabel(container, "Claude in Chrome").disabled).toBe(
+      true,
+    );
+  });
+
+  it("keeps Fast mode and Claude in Chrome enabled when idle", async () => {
+    const { container } = await renderMenu({ isRunning: false });
+    await openDropdown(container);
+    expect(findMenuItemByLabel(container, "Fast mode").disabled).toBe(false);
+    expect(findMenuItemByLabel(container, "Claude in Chrome").disabled).toBe(
+      false,
+    );
+  });
+
+  it("renders the Remote Control row mid-turn so the user can click it", async () => {
+    const { container } = await renderMenu({ isRunning: true });
+    await openDropdown(container);
+    expect(() => findRemoteControlButton(container)).not.toThrow();
+  });
+});
+
+// --- End-to-end toggle behavior ----------------------------------------
+//
+// These exercise the user-implemented `toggle()` callback per the sketch
+// in `OverflowMenu.tsx`. They will fail against the placeholder body
+// (which fires immediately) and pass once the queue / cancel / defer
+// branches are wired up. Each test names the exact branch it covers.
+
+describe("OverflowMenu — Remote Control mid-turn enable (user toggle)", () => {
+  it("queues a pending enable instead of firing when clicked mid-turn", async () => {
+    const { container } = await renderMenu({ isRunning: true });
+    await openDropdown(container);
+
+    await act(async () => {
+      findRemoteControlButton(container).click();
+      await Promise.resolve();
+    });
+
+    expect(serviceMocks.setClaudeRemoteControl).not.toHaveBeenCalled();
+    expect(appStore.addToast).toHaveBeenCalledWith(
+      expect.stringContaining("when the current turn finishes"),
+    );
+    expect(container.textContent).toContain("pending");
+  });
+
+  it("fires the queued enable the moment the turn ends (isRunning → false)", async () => {
+    const { container, root } = await renderMenu({ isRunning: true });
+    await openDropdown(container);
+
+    // Step 1: queue while running
+    await act(async () => {
+      findRemoteControlButton(container).click();
+      await Promise.resolve();
+    });
+    expect(serviceMocks.setClaudeRemoteControl).not.toHaveBeenCalled();
+
+    // Step 2: the turn ends — the deferred-fire effect should fire once.
+    await rerenderMenu(root, { isRunning: false });
+
+    expect(serviceMocks.setClaudeRemoteControl).toHaveBeenCalledTimes(1);
+    expect(serviceMocks.setClaudeRemoteControl).toHaveBeenCalledWith(
+      "s1",
+      true,
+      expect.any(Object),
+    );
+  });
+
+  it("cancels the pending enable when the row is clicked a second time", async () => {
+    const { container, root } = await renderMenu({ isRunning: true });
+    await openDropdown(container);
+
+    // Queue
+    await act(async () => {
+      findRemoteControlButton(container).click();
+      await Promise.resolve();
+    });
+    appStore.addToast.mockClear();
+
+    // Cancel
+    await act(async () => {
+      findRemoteControlButton(container).click();
+      await Promise.resolve();
+    });
+
+    expect(appStore.addToast).toHaveBeenCalledWith(
+      expect.stringContaining("cancelled"),
+    );
+
+    // After cancel, turn-end must NOT fire the enable.
+    await rerenderMenu(root, { isRunning: false });
+    expect(serviceMocks.setClaudeRemoteControl).not.toHaveBeenCalled();
+  });
+
+  it("fires immediately when clicked while idle (regression: existing path unchanged)", async () => {
+    const { container } = await renderMenu({ isRunning: false });
+    await openDropdown(container);
+
+    await act(async () => {
+      findRemoteControlButton(container).click();
+      await Promise.resolve();
+    });
+
+    expect(serviceMocks.setClaudeRemoteControl).toHaveBeenCalledTimes(1);
+    expect(serviceMocks.setClaudeRemoteControl).toHaveBeenCalledWith(
+      "s1",
+      true,
+      expect.any(Object),
+    );
+    expect(appStore.addToast).not.toHaveBeenCalled();
+  });
+
+  it("clears the pending intent when the user switches sessions", async () => {
+    const { container, root } = await renderMenu({
+      sessionId: "s1",
+      isRunning: true,
+    });
+    await openDropdown(container);
+
+    // Queue against s1
+    await act(async () => {
+      findRemoteControlButton(container).click();
+      await Promise.resolve();
+    });
+
+    // Switch to s2 and end the turn — the previously queued intent must
+    // NOT fire against the new session.
+    await rerenderMenu(root, { sessionId: "s2", isRunning: false });
+
+    expect(serviceMocks.setClaudeRemoteControl).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/src/components/chat/composer/OverflowMenu.tsx
+++ b/src/ui/src/components/chat/composer/OverflowMenu.tsx
@@ -43,10 +43,14 @@ export function OverflowMenu({ sessionId, disabled, isRunning, isRemote }: Overf
   // (Fast Mode is per-session; Claude in Chrome calls `resetAgentSession`)
   // stay locked mid-turn. Remote Control opts out: its row remains
   // clickable, and the click queues a pending enable instead of firing
-  // immediately. See `RemoteControlMenuItem` for the deferred-fire logic.
+  // immediately. The pending state + deferred-fire effect live up here
+  // (not inside `RemoteControlMenuItem`) so they survive the dropdown
+  // unmount that fires whenever the menu closes — clicking outside the
+  // menu would otherwise discard the queued intent before the turn ends.
   const mutationDisabled = disabled || isRunning;
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const addToast = useAppStore((s) => s.addToast);
 
   const selectedModel = useAppStore((s) => s.selectedModel[sessionId] ?? "opus");
   const selectedProvider = useAppStore((s) => s.selectedModelProvider[sessionId] ?? "anthropic");
@@ -72,6 +76,120 @@ export function OverflowMenu({ sessionId, disabled, isRunning, isRemote }: Overf
   const showRemoteControl = !isRemote && claudeRemoteControlEnabled;
   const remoteControlActive = showRemoteControl && remoteControlStatus.state !== "disabled";
   const anyActive = fastMode || chromeEnabled || remoteControlActive;
+
+  // Frontend-only "queued enable" intent. Stored as the sessionId the
+  // pending belongs to (or null) — not a plain boolean — so a sessionId
+  // prop change in the same render pass cannot accidentally fire the
+  // deferred enable against the new session before the cleanup effect
+  // wipes the flag. Kept local rather than in the backend
+  // `ClaudeRemoteControlStatus` so the existing lifecycle enum, the
+  // persistent-session monitor, and the `claude-remote-control-status`
+  // event flow remain untouched. Trade-off: a window reload mid-turn or
+  // an unmount of `ChatInputArea` (file/diff open) drops the queued
+  // intent — acceptable corner cases; promoting to the store would
+  // cover them.
+  const [pendingEnableForSession, setPendingEnableForSession] = useState<
+    string | null
+  >(null);
+  const pendingEnable = pendingEnableForSession === sessionId;
+
+  // Hygiene: when the user switches chats, wipe any stale queued intent
+  // belonging to the previous session.
+  useEffect(() => {
+    setPendingEnableForSession((prev) => (prev === sessionId ? prev : null));
+  }, [sessionId]);
+
+  // `runImmediate` is the actual enable/disable RPC body. Hoisted out of
+  // `RemoteControlMenuItem` so the deferred-fire effect below can reuse
+  // it even when the dropdown (and thus the row component) is unmounted.
+  // Status writes use the functional setter so we don't stale-close over
+  // an old `remoteControlStatus` value.
+  const runImmediate = useCallback(
+    async (nextEnabled: boolean) => {
+      if (nextEnabled) {
+        setRemoteControlStatus((prev) => ({
+          ...prev,
+          state: "enabling",
+          lastError: null,
+        }));
+      }
+      try {
+        const next = await setClaudeRemoteControl(sessionId, nextEnabled, {
+          permissionLevel,
+          model: selectedModel,
+          backendId: selectedProvider,
+          fastMode,
+          thinkingEnabled,
+          planMode,
+          effort: effortLevel,
+          chromeEnabled,
+          disable1mContext: shouldDisable1mContext(selectedModel),
+        });
+        setRemoteControlStatus(next);
+      } catch (err) {
+        const message = formatRemoteControlError(err);
+        setRemoteControlStatus({
+          state: "error",
+          sessionUrl: null,
+          connectUrl: null,
+          environmentId: null,
+          detail: null,
+          lastError: message,
+        });
+      }
+    },
+    [
+      chromeEnabled,
+      effortLevel,
+      fastMode,
+      permissionLevel,
+      planMode,
+      selectedModel,
+      selectedProvider,
+      sessionId,
+      thinkingEnabled,
+    ],
+  );
+
+  // Deferred-fire effect: the moment the turn ends (`isRunning` flips
+  // from true → false) and a pending enable is queued *for this exact
+  // sessionId*, fire the real enable. Piggybacks on the `agent_status`
+  // transition that `useAgentStream.ts` already pushes into the store
+  // on every turn result — no new Tauri event, no backend hook. Also
+  // fires for the "Stopped" path (user-cancelled turn), since
+  // "stopped" still means the persistent session is no longer
+  // mid-flight.
+  //
+  // Lives in `OverflowMenu` (not `RemoteControlMenuItem`) because the
+  // dropdown subtree unmounts whenever the menu closes; if this effect
+  // lived there, a click-outside would discard the pending intent
+  // before the turn ended.
+  //
+  // No-op-message safety net: the backend's cold-enable defer
+  // (`should_defer_enable_until_first_turn` in `remote_control.rs`)
+  // can return `state: "enabling"` with detail "Send your first
+  // message to start Claude Remote Control." when called on a chat
+  // with `turn_count == 0`. The mid-turn-pending path here cannot
+  // reach that branch — queuing the pending intent requires
+  // `isRunning === true`, which in turn requires a turn to be
+  // running, which requires `turn_count >= 1` and a live persistent
+  // session.
+  useEffect(() => {
+    if (pendingEnableForSession !== sessionId) return;
+    if (isRunning) return;
+    setPendingEnableForSession(null);
+    void runImmediate(true);
+  }, [pendingEnableForSession, sessionId, isRunning, runImmediate]);
+
+  const queuePendingEnable = useCallback(() => {
+    setPendingEnableForSession(sessionId);
+    addToast("Remote Control will enable when the current turn finishes.");
+  }, [addToast, sessionId]);
+
+  const cancelPendingEnable = useCallback(() => {
+    setPendingEnableForSession(null);
+    addToast("Remote Control enable cancelled.");
+  }, [addToast]);
 
   useEffect(() => {
     if (!showRemoteControl) {
@@ -185,20 +303,13 @@ export function OverflowMenu({ sessionId, disabled, isRunning, isRemote }: Overf
           />
           {showRemoteControl && (
             <RemoteControlMenuItem
-              sessionId={sessionId}
               disabled={disabled}
               isRunning={isRunning}
               status={remoteControlStatus}
-              permissionLevel={permissionLevel}
-              model={selectedModel}
-              backendId={selectedProvider}
-              fastMode={fastMode}
-              thinkingEnabled={thinkingEnabled}
-              planMode={planMode}
-              effort={effortLevel}
-              chromeEnabled={chromeEnabled}
-              disable1mContext={shouldDisable1mContext(selectedModel)}
-              onStatus={setRemoteControlStatus}
+              pendingEnable={pendingEnable}
+              onRunImmediate={runImmediate}
+              onQueuePending={queuePendingEnable}
+              onCancelPending={cancelPendingEnable}
             />
           )}
         </div>
@@ -208,195 +319,62 @@ export function OverflowMenu({ sessionId, disabled, isRunning, isRemote }: Overf
 }
 
 function RemoteControlMenuItem({
-  sessionId,
   disabled,
   isRunning,
   status,
-  permissionLevel,
-  model,
-  backendId,
-  fastMode,
-  thinkingEnabled,
-  planMode,
-  effort,
-  chromeEnabled,
-  disable1mContext,
-  onStatus,
+  pendingEnable,
+  onRunImmediate,
+  onQueuePending,
+  onCancelPending,
 }: {
-  sessionId: string;
   /** True while the workspace environment is preparing — hard-blocks
    *  every interaction (firing OR queuing the toggle). */
   disabled: boolean;
   /** True while a turn is in flight. Enable clicks during this window
-   *  queue a pending enable; the deferred-fire effect applies it the
-   *  moment the turn ends. */
+   *  queue a pending enable; the deferred-fire effect (owned by the
+   *  parent `OverflowMenu`, so it survives dropdown unmount) applies
+   *  it the moment the turn ends. */
   isRunning: boolean;
   status: ClaudeRemoteControlStatus;
-  permissionLevel: string;
-  model: string;
-  backendId: string;
-  fastMode: boolean;
-  thinkingEnabled: boolean;
-  planMode: boolean;
-  effort: string;
-  chromeEnabled: boolean;
-  disable1mContext: boolean;
-  onStatus: (status: ClaudeRemoteControlStatus) => void;
+  pendingEnable: boolean;
+  onRunImmediate: (nextEnabled: boolean) => Promise<void> | void;
+  onQueuePending: () => void;
+  onCancelPending: () => void;
 }) {
   const url = remoteControlUrl(status);
   const pendingFirstTurn = isPendingFirstTurnRemoteControl(status);
   const busy = status.state === "enabling" && !pendingFirstTurn;
   const active = status.state !== "disabled" && status.state !== "error";
-  const addToast = useAppStore((s) => s.addToast);
 
-  // Frontend-only "queued enable" intent. Stored as the sessionId the
-  // pending belongs to (or null) — not a plain boolean — so a sessionId
-  // prop change in the same render pass cannot accidentally fire the
-  // deferred enable against the new session before the cleanup effect
-  // wipes the flag. Kept local rather than in the backend
-  // `ClaudeRemoteControlStatus` so the existing lifecycle enum, the
-  // persistent-session monitor, and the `claude-remote-control-status`
-  // event flow remain untouched. Trade-off: a window reload mid-turn
-  // drops the queued intent — acceptable corner case.
-  const [pendingEnableForSession, setPendingEnableForSession] = useState<
-    string | null
-  >(null);
-  const pendingEnable = pendingEnableForSession === sessionId;
-
-  // Hygiene: when the user switches chats, wipe any stale queued intent
-  // belonging to the previous session.
-  useEffect(() => {
-    setPendingEnableForSession((prev) => (prev === sessionId ? prev : null));
-  }, [sessionId]);
-
-  // `runImmediate` is the existing async enable/disable body, lifted out
-  // verbatim so it can be reused by both the user-driven toggle and the
-  // deferred-fire effect below. The behavior here is unchanged from the
-  // pre-mid-turn-enable implementation — the only new caller is the
-  // deferred-fire effect.
-  const runImmediate = useCallback(
-    async (nextEnabled: boolean) => {
-      if (nextEnabled) {
-        onStatus({ ...status, state: "enabling", lastError: null });
-      }
-      try {
-        const next = await setClaudeRemoteControl(sessionId, nextEnabled, {
-          permissionLevel,
-          model,
-          backendId,
-          fastMode,
-          thinkingEnabled,
-          planMode,
-          effort,
-          chromeEnabled,
-          disable1mContext,
-        });
-        onStatus(next);
-      } catch (err) {
-        const message = formatRemoteControlError(err);
-        onStatus({
-          state: "error",
-          sessionUrl: null,
-          connectUrl: null,
-          environmentId: null,
-          detail: null,
-          lastError: message,
-        });
-      }
-    },
-    [
-      backendId,
-      chromeEnabled,
-      disable1mContext,
-      effort,
-      fastMode,
-      model,
-      onStatus,
-      permissionLevel,
-      planMode,
-      sessionId,
-      status,
-      thinkingEnabled,
-    ],
-  );
-
-  // Deferred-fire effect: the moment the turn ends (`isRunning` flips
-  // from true → false) and a pending enable is queued *for this exact
-  // sessionId*, fire the real enable. Piggybacks on the `agent_status`
-  // transition that `useAgentStream.ts` already pushes into the store
-  // on every turn result — no new Tauri event, no backend hook. Also
-  // fires for the "Stopped" path (user-cancelled turn), since
-  // "stopped" still means the persistent session is no longer
-  // mid-flight.
-  //
-  // No-op-message safety net: the backend's cold-enable defer
-  // (`should_defer_enable_until_first_turn` in `remote_control.rs`)
-  // can return `state: "enabling"` with detail "Send your first
-  // message to start Claude Remote Control." when called on a chat
-  // with `turn_count == 0`. The mid-turn-pending path here cannot
-  // reach that branch — queuing the pending intent requires
-  // `isRunning === true`, which in turn requires a turn to be
-  // running, which requires `turn_count >= 1` and a live persistent
-  // session. If a future flow makes that branch reachable, this is
-  // the seam where we'd auto-send a synthetic no-op user message to
-  // anchor the bridge: inspect `next.detail` for the sentinel and
-  // dispatch a chat-send through the appropriate store action.
-  useEffect(() => {
-    if (pendingEnableForSession !== sessionId) return;
-    if (isRunning) return;
-    setPendingEnableForSession(null);
-    void runImmediate(true);
-  }, [pendingEnableForSession, sessionId, isRunning, runImmediate]);
-
-  // The four branches below decide what each click means. The
-  // surrounding wiring (pending state, deferred-fire effect,
-  // `runImmediate`, status chip, toast primitive) is already in place
-  // — this function is the seam where the UX feel of the feature
-  // lives, so tune the details deliberately:
-  //
+  // The four branches below decide what each click means:
   //   1. `busy` (real "enabling" state, not the "pending" intent) —
   //      ignore the click. Matches pre-refactor behavior.
-  //   2. Re-click while a pending enable is queued — cancel it. The
-  //      cancellation toast is intentionally short; consider whether
-  //      a silent cancel (no toast) feels better in your environment.
-  //   3. Enable while a turn is running — queue the pending intent.
-  //      The deferred-fire effect applies it the moment `isRunning`
-  //      flips false. Toast wording can be adjusted; the pending chip
-  //      and tooltip already carry the primary visual signal.
+  //   2. Re-click while a pending enable is queued — cancel it.
+  //   3. Enable while a turn is running — queue the pending intent
+  //      via the parent. The deferred-fire effect there applies it
+  //      the moment `isRunning` flips false.
   //   4. Idle, or any disable click — fire immediately. Disable
   //      mid-turn is allowed to fire without waiting because tearing
   //      down a bridge doesn't need turn quiescence.
-  //
-  // Trade-offs worth revisiting if usage patterns suggest:
-  //   • Cancellation gesture — re-click vs. a dedicated X affordance.
-  //   • Rapid Enable→Disable→Enable — last-write-wins on the single
-  //     boolean is the simplest contract; richer queue semantics are
-  //     possible but rarely worth the surface area.
-  //   • Toast frequency — fewer toasts feel less noisy; pending chip
-  //     alone may suffice.
   const toggle = useCallback(() => {
     if (busy) return;
     if (pendingEnable) {
-      setPendingEnableForSession(null);
-      addToast("Remote Control enable cancelled.");
+      onCancelPending();
       return;
     }
     if (!active && isRunning) {
-      setPendingEnableForSession(sessionId);
-      addToast(
-        "Remote Control will enable when the current turn finishes.",
-      );
+      onQueuePending();
       return;
     }
-    void runImmediate(!active);
+    void onRunImmediate(!active);
   }, [
     active,
-    addToast,
     busy,
     isRunning,
+    onCancelPending,
+    onQueuePending,
+    onRunImmediate,
     pendingEnable,
-    runImmediate,
-    sessionId,
   ]);
 
   const meta = remoteControlMeta(status, pendingEnable);

--- a/src/ui/src/components/chat/composer/OverflowMenu.tsx
+++ b/src/ui/src/components/chat/composer/OverflowMenu.tsx
@@ -99,6 +99,16 @@ export function OverflowMenu({ sessionId, disabled, isRunning, isRemote }: Overf
     setPendingEnableForSession((prev) => (prev === sessionId ? prev : null));
   }, [sessionId]);
 
+  // Also wipe the queued intent when Remote Control becomes unavailable
+  // (the experimental gate flipped off, or this is a remote transport
+  // where Remote Control isn't supported). Without this, a pending
+  // intent queued before the gate was turned off would silently fire
+  // the enable RPC on the next turn end, even though the row is hidden.
+  useEffect(() => {
+    if (showRemoteControl) return;
+    setPendingEnableForSession(null);
+  }, [showRemoteControl]);
+
   // `runImmediate` is the actual enable/disable RPC body. Hoisted out of
   // `RemoteControlMenuItem` so the deferred-fire effect below can reuse
   // it even when the dropdown (and thus the row component) is unmounted.
@@ -177,9 +187,23 @@ export function OverflowMenu({ sessionId, disabled, isRunning, isRemote }: Overf
   useEffect(() => {
     if (pendingEnableForSession !== sessionId) return;
     if (isRunning) return;
+    // Don't fire if Remote Control is no longer available (experimental
+    // gate off, remote transport) or while the workspace environment is
+    // still preparing. The session-switch / showRemoteControl cleanup
+    // effects already clear the intent in those cases; this is the
+    // belt-and-suspenders check at the fire site.
+    if (!showRemoteControl) return;
+    if (disabled) return;
     setPendingEnableForSession(null);
     void runImmediate(true);
-  }, [pendingEnableForSession, sessionId, isRunning, runImmediate]);
+  }, [
+    disabled,
+    isRunning,
+    pendingEnableForSession,
+    runImmediate,
+    sessionId,
+    showRemoteControl,
+  ]);
 
   const queuePendingEnable = useCallback(() => {
     setPendingEnableForSession(sessionId);

--- a/src/ui/src/components/chat/composer/OverflowMenu.tsx
+++ b/src/ui/src/components/chat/composer/OverflowMenu.tsx
@@ -19,7 +19,13 @@ import styles from "./OverflowMenu.module.css";
 
 interface OverflowMenuProps {
   sessionId: string;
+  /** Blocks all menu interaction (trigger + every row). Set while the
+   *  workspace environment is preparing. */
   disabled: boolean;
+  /** True while a turn is in flight. Session-mutating rows (Fast Mode,
+   *  Claude in Chrome) stay disabled. Remote Control deliberately stays
+   *  clickable so the user can queue a mid-turn enable. */
+  isRunning: boolean;
   isRemote: boolean;
 }
 
@@ -32,7 +38,13 @@ const DISABLED_REMOTE_STATUS: ClaudeRemoteControlStatus = {
   lastError: null,
 };
 
-export function OverflowMenu({ sessionId, disabled, isRemote }: OverflowMenuProps) {
+export function OverflowMenu({ sessionId, disabled, isRunning, isRemote }: OverflowMenuProps) {
+  // Rows that would tear down or reconfigure the live persistent session
+  // (Fast Mode is per-session; Claude in Chrome calls `resetAgentSession`)
+  // stay locked mid-turn. Remote Control opts out: its row remains
+  // clickable, and the click queues a pending enable instead of firing
+  // immediately. See `RemoteControlMenuItem` for the deferred-fire logic.
+  const mutationDisabled = disabled || isRunning;
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -160,6 +172,7 @@ export function OverflowMenu({ sessionId, disabled, isRemote }: OverflowMenuProp
               active={fastMode}
               meta={fastMode ? "on" : "off"}
               onClick={toggleFast}
+              disabled={mutationDisabled}
             />
           )}
           <MenuItem
@@ -168,11 +181,13 @@ export function OverflowMenu({ sessionId, disabled, isRemote }: OverflowMenuProp
             active={chromeEnabled}
             meta={chromeEnabled ? "on" : "off"}
             onClick={toggleChrome}
+            disabled={mutationDisabled}
           />
           {showRemoteControl && (
             <RemoteControlMenuItem
               sessionId={sessionId}
               disabled={disabled}
+              isRunning={isRunning}
               status={remoteControlStatus}
               permissionLevel={permissionLevel}
               model={selectedModel}
@@ -195,6 +210,7 @@ export function OverflowMenu({ sessionId, disabled, isRemote }: OverflowMenuProp
 function RemoteControlMenuItem({
   sessionId,
   disabled,
+  isRunning,
   status,
   permissionLevel,
   model,
@@ -208,7 +224,13 @@ function RemoteControlMenuItem({
   onStatus,
 }: {
   sessionId: string;
+  /** True while the workspace environment is preparing — hard-blocks
+   *  every interaction (firing OR queuing the toggle). */
   disabled: boolean;
+  /** True while a turn is in flight. Enable clicks during this window
+   *  queue a pending enable; the deferred-fire effect applies it the
+   *  moment the turn ends. */
+  isRunning: boolean;
   status: ClaudeRemoteControlStatus;
   permissionLevel: string;
   model: string;
@@ -225,60 +247,170 @@ function RemoteControlMenuItem({
   const pendingFirstTurn = isPendingFirstTurnRemoteControl(status);
   const busy = status.state === "enabling" && !pendingFirstTurn;
   const active = status.state !== "disabled" && status.state !== "error";
-  const meta = remoteControlMeta(status);
-  const detail = status.lastError ?? status.detail;
-  const displayDetail = remoteControlDisplayDetail(status, detail, url);
+  const addToast = useAppStore((s) => s.addToast);
 
-  const toggle = useCallback(async () => {
+  // Frontend-only "queued enable" intent. Stored as the sessionId the
+  // pending belongs to (or null) — not a plain boolean — so a sessionId
+  // prop change in the same render pass cannot accidentally fire the
+  // deferred enable against the new session before the cleanup effect
+  // wipes the flag. Kept local rather than in the backend
+  // `ClaudeRemoteControlStatus` so the existing lifecycle enum, the
+  // persistent-session monitor, and the `claude-remote-control-status`
+  // event flow remain untouched. Trade-off: a window reload mid-turn
+  // drops the queued intent — acceptable corner case.
+  const [pendingEnableForSession, setPendingEnableForSession] = useState<
+    string | null
+  >(null);
+  const pendingEnable = pendingEnableForSession === sessionId;
+
+  // Hygiene: when the user switches chats, wipe any stale queued intent
+  // belonging to the previous session.
+  useEffect(() => {
+    setPendingEnableForSession((prev) => (prev === sessionId ? prev : null));
+  }, [sessionId]);
+
+  // `runImmediate` is the existing async enable/disable body, lifted out
+  // verbatim so it can be reused by both the user-driven toggle and the
+  // deferred-fire effect below. The behavior here is unchanged from the
+  // pre-mid-turn-enable implementation — the only new caller is the
+  // deferred-fire effect.
+  const runImmediate = useCallback(
+    async (nextEnabled: boolean) => {
+      if (nextEnabled) {
+        onStatus({ ...status, state: "enabling", lastError: null });
+      }
+      try {
+        const next = await setClaudeRemoteControl(sessionId, nextEnabled, {
+          permissionLevel,
+          model,
+          backendId,
+          fastMode,
+          thinkingEnabled,
+          planMode,
+          effort,
+          chromeEnabled,
+          disable1mContext,
+        });
+        onStatus(next);
+      } catch (err) {
+        const message = formatRemoteControlError(err);
+        onStatus({
+          state: "error",
+          sessionUrl: null,
+          connectUrl: null,
+          environmentId: null,
+          detail: null,
+          lastError: message,
+        });
+      }
+    },
+    [
+      backendId,
+      chromeEnabled,
+      disable1mContext,
+      effort,
+      fastMode,
+      model,
+      onStatus,
+      permissionLevel,
+      planMode,
+      sessionId,
+      status,
+      thinkingEnabled,
+    ],
+  );
+
+  // Deferred-fire effect: the moment the turn ends (`isRunning` flips
+  // from true → false) and a pending enable is queued *for this exact
+  // sessionId*, fire the real enable. Piggybacks on the `agent_status`
+  // transition that `useAgentStream.ts` already pushes into the store
+  // on every turn result — no new Tauri event, no backend hook. Also
+  // fires for the "Stopped" path (user-cancelled turn), since
+  // "stopped" still means the persistent session is no longer
+  // mid-flight.
+  //
+  // No-op-message safety net: the backend's cold-enable defer
+  // (`should_defer_enable_until_first_turn` in `remote_control.rs`)
+  // can return `state: "enabling"` with detail "Send your first
+  // message to start Claude Remote Control." when called on a chat
+  // with `turn_count == 0`. The mid-turn-pending path here cannot
+  // reach that branch — queuing the pending intent requires
+  // `isRunning === true`, which in turn requires a turn to be
+  // running, which requires `turn_count >= 1` and a live persistent
+  // session. If a future flow makes that branch reachable, this is
+  // the seam where we'd auto-send a synthetic no-op user message to
+  // anchor the bridge: inspect `next.detail` for the sentinel and
+  // dispatch a chat-send through the appropriate store action.
+  useEffect(() => {
+    if (pendingEnableForSession !== sessionId) return;
+    if (isRunning) return;
+    setPendingEnableForSession(null);
+    void runImmediate(true);
+  }, [pendingEnableForSession, sessionId, isRunning, runImmediate]);
+
+  // The four branches below decide what each click means. The
+  // surrounding wiring (pending state, deferred-fire effect,
+  // `runImmediate`, status chip, toast primitive) is already in place
+  // — this function is the seam where the UX feel of the feature
+  // lives, so tune the details deliberately:
+  //
+  //   1. `busy` (real "enabling" state, not the "pending" intent) —
+  //      ignore the click. Matches pre-refactor behavior.
+  //   2. Re-click while a pending enable is queued — cancel it. The
+  //      cancellation toast is intentionally short; consider whether
+  //      a silent cancel (no toast) feels better in your environment.
+  //   3. Enable while a turn is running — queue the pending intent.
+  //      The deferred-fire effect applies it the moment `isRunning`
+  //      flips false. Toast wording can be adjusted; the pending chip
+  //      and tooltip already carry the primary visual signal.
+  //   4. Idle, or any disable click — fire immediately. Disable
+  //      mid-turn is allowed to fire without waiting because tearing
+  //      down a bridge doesn't need turn quiescence.
+  //
+  // Trade-offs worth revisiting if usage patterns suggest:
+  //   • Cancellation gesture — re-click vs. a dedicated X affordance.
+  //   • Rapid Enable→Disable→Enable — last-write-wins on the single
+  //     boolean is the simplest contract; richer queue semantics are
+  //     possible but rarely worth the surface area.
+  //   • Toast frequency — fewer toasts feel less noisy; pending chip
+  //     alone may suffice.
+  const toggle = useCallback(() => {
     if (busy) return;
-    const nextEnabled = !active;
-    if (nextEnabled) {
-      onStatus({ ...status, state: "enabling", lastError: null });
+    if (pendingEnable) {
+      setPendingEnableForSession(null);
+      addToast("Remote Control enable cancelled.");
+      return;
     }
-    try {
-      const next = await setClaudeRemoteControl(sessionId, nextEnabled, {
-        permissionLevel,
-        model,
-        backendId,
-        fastMode,
-        thinkingEnabled,
-        planMode,
-        effort,
-        chromeEnabled,
-        disable1mContext,
-      });
-      onStatus(next);
-    } catch (err) {
-      const message = formatRemoteControlError(err);
-      onStatus({
-        state: "error",
-        sessionUrl: null,
-        connectUrl: null,
-        environmentId: null,
-        detail: null,
-        lastError: message,
-      });
+    if (!active && isRunning) {
+      setPendingEnableForSession(sessionId);
+      addToast(
+        "Remote Control will enable when the current turn finishes.",
+      );
+      return;
     }
+    void runImmediate(!active);
   }, [
     active,
-    backendId,
+    addToast,
     busy,
-    chromeEnabled,
-    disable1mContext,
-    effort,
-    fastMode,
-    model,
-    onStatus,
-    permissionLevel,
-    planMode,
+    isRunning,
+    pendingEnable,
+    runImmediate,
     sessionId,
-    status,
-    thinkingEnabled,
   ]);
+
+  const meta = remoteControlMeta(status, pendingEnable);
+  const detail = status.lastError ?? status.detail;
+  const displayDetail = remoteControlDisplayDetail(
+    status,
+    detail,
+    url,
+    pendingEnable,
+  );
 
   return (
     <div
-      className={`${styles.remoteGroup} ${active ? styles.remoteGroupActive : ""} ${status.state === "error" ? styles.remoteGroupError : ""}`}
+      className={`${styles.remoteGroup} ${active ? styles.remoteGroupActive : ""} ${status.state === "error" ? styles.remoteGroupError : ""} ${pendingEnable ? styles.remoteGroupPending : ""}`}
     >
       <button
         type="button"
@@ -361,7 +493,11 @@ function remoteControlDisplayDetail(
   status: ClaudeRemoteControlStatus,
   detail: string | null,
   url: string | null,
+  pendingEnable: boolean,
 ): string | null {
+  if (pendingEnable) {
+    return "Pending — will enable when the current turn finishes.";
+  }
   if ((status.state === "ready" || status.state === "connected") && !url) {
     return "Waiting for Claude to publish the session link.";
   }
@@ -397,7 +533,11 @@ function formatRemoteControlError(err: unknown): string {
   return String(err || "Claude Remote Control failed");
 }
 
-function remoteControlMeta(status: ClaudeRemoteControlStatus): string {
+function remoteControlMeta(
+  status: ClaudeRemoteControlStatus,
+  pendingEnable: boolean,
+): string {
+  if (pendingEnable) return "pending";
   if (isPendingFirstTurnRemoteControl(status)) return "armed";
   switch (status.state) {
     case "disabled":
@@ -421,18 +561,21 @@ function MenuItem({
   active,
   meta,
   onClick,
+  disabled = false,
 }: {
   icon: ReactNode;
   label: string;
   active: boolean;
   meta: string;
   onClick: () => void;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
       className={`${styles.item} ${active ? styles.itemActive : ""}`}
       onClick={onClick}
+      disabled={disabled}
     >
       <span className={styles.itemIcon}>{icon}</span>
       <span className={styles.itemLabel}>{label}</span>


### PR DESCRIPTION
## Summary

- Lets the user click **Claude Remote Control → Enable** in the composer overflow menu while a turn is in flight. The click queues a pending-enable intent and a deferred-fire effect applies it the moment the turn ends (or is stopped). Previously the entire menu was locked mid-turn, forcing the user to wait, click Stop, or send the message without remote control armed.
- The pending state lives in `OverflowMenu` (parent), not `RemoteControlMenuItem` (dropdown child), so it survives closing the dropdown — clicking outside or pressing Escape no longer discards the queued intent.
- Other menu items (Fast Mode, Claude in Chrome, ModelSelector, Plan, ReasoningPill) keep their pre-existing mid-turn lock since they would re-spawn / reconfigure the live persistent session.

## Why

Today the overflow trigger and every row are disabled whenever the turn is running, because the rows that *do* mutate session state (Fast Mode, Chrome) can't safely fire mid-turn. Remote Control doesn't have that constraint — the backend's enable RPC just stages a bridge for the next turn — but it shared the lock by accident. The result was that anyone realising "I want to drive this from my phone in a sec" mid-turn had no way to arm it; they'd send the next message, *then* enable, *then* send a second message.

## What changed

### Behavior

- **`ChatInputArea.tsx`** — split the `disabled` prop into `disabled` (workspace environment preparing — hard-blocks everything) and `isRunning` (turn in flight — soft-locks session-mutating rows only).
- **`ComposerToolbar.tsx`** — accepts both props; internally computes `mutationDisabled = disabled || isRunning` for the pills (ModelSelector, Plan, ReasoningPill) so their pre-split lock is preserved.
- **`OverflowMenu.tsx`** — trigger button only disabled by the hard \`disabled\`; `mutationDisabled` gates Fast Mode and Chrome MenuItems. Remote Control row stays clickable. Pending-enable state, \`runImmediate\`, session-switch cleanup effect, and deferred-fire effect all owned by `OverflowMenu` so they survive the dropdown unmount.
- **`OverflowMenu.module.css`** — `.remoteGroupPending` chip styling and disabled `.item` styling.

### Click semantics for Remote Control (new \`toggle\` body)

1. **`busy`** (real `enabling` state, not the pending intent) — ignore. Matches pre-change behaviour.
2. **Re-click while pending** — cancel the queued intent; toast says "Remote Control enable cancelled."
3. **Enable while a turn is running** — queue the pending intent. Row shows a "pending" chip plus "Pending — will enable when the current turn finishes." Toast confirms.
4. **Idle, or any disable click** — fire immediately. Disable mid-turn is allowed without waiting (tearing down a bridge doesn't need turn quiescence).

### Pending intent keyed by sessionId

\`pendingEnableForSession\` is `string | null` (the sessionId, or null) rather than a plain boolean. A session prop change in the same render pass can't accidentally fire the queued enable against the new session before the cleanup effect wipes it. Switching chats mid-pending clears the intent.

### Deferred-fire seam

The effect watches `isRunning` and the pending sessionId:

```ts
useEffect(() => {
  if (pendingEnableForSession !== sessionId) return;
  if (isRunning) return;
  setPendingEnableForSession(null);
  void runImmediate(true);
}, [pendingEnableForSession, sessionId, isRunning, runImmediate]);
```

Piggybacks on the existing \`agent_status\` transition that \`useAgentStream.ts\` pushes into the store at the end of every turn. No new Tauri event, no backend hook. Also fires for the "Stopped" path (user-cancelled turn), since the persistent session is no longer mid-flight either way.

### No-op-message safety net (documented, not wired)

The backend's cold-enable defer (\`should_defer_enable_until_first_turn\` in \`remote_control.rs\`) can return \`state: "enabling"\` with detail "Send your first message to start Claude Remote Control." when called on a chat with \`turn_count == 0\`. That branch is unreachable from the mid-turn-pending path (queuing requires \`isRunning === true\`, which requires \`turn_count >= 1\`), so no synthetic message is sent. The seam is documented in the deferred-fire effect's comment for future flows.

## Bug fix included (second commit)

Initial implementation kept the pending state inside `RemoteControlMenuItem`. That component only mounts while the dropdown is open, so a click outside the menu unmounted the row and discarded the queued intent — the turn would end and nothing fired. Caught by manual UAT after the first push, fixed by hoisting state + effect into `OverflowMenu` (which stays mounted as long as the composer does). Regression pinned with a test that queues, dispatches a `mousedown` on `document.body`, then rerenders with \`isRunning=false\` and asserts the enable RPC fires.

Corner cases still escape this scope and are noted in the source comment:
- Full window reload mid-turn loses the queued intent.
- Opening a file/diff that unmounts `<ChatPanel>` loses it too.

Both would require promoting state to a Zustand slice. Not done here.

## Docs

- \`site/src/content/docs/features/claude-remote-control.mdx\` — added the "click Enable at any time" paragraph, new **Pending** row in the lifecycle table, armed-vs-pending disambiguation in Troubleshooting.

## Test plan

- [x] \`bunx tsc -b\` — clean
- [x] \`bun run lint\` — 0 errors (16 pre-existing warnings in unrelated files)
- [x] \`bun run lint:css\` — clean
- [x] \`bun run test\` — **2487 passed, 0 failed**
  - 11 OverflowMenu tests, including:
    - Mid-turn trigger reachability (regression vs. the old hard lock)
    - Fast Mode + Chrome stay disabled mid-turn (no session-mutation drift)
    - Queue → defer-fire on \`isRunning\` flip
    - Re-click cancels queued intent
    - Idle path fires immediately (regression vs. existing behaviour)
    - Session switch clears the pending intent
    - **Dropdown close → reopen → still fires** (regression for the second-commit bug)
- [x] \`cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features\` with \`RUSTFLAGS=-Dwarnings\` — clean. Zero \`.rs\` files modified, so existing \`remote_control\` backend tests cannot have regressed by construction.
- [x] Manual UAT in the dev build — queue mid-turn, close the menu, wait for turn end → Remote Control lights up. Cancel-by-re-click works. Idle enable unchanged. Session switch wipes the queue.

## Files

| File | Purpose |
|---|---|
| \`src/ui/src/components/chat/ChatInputArea.tsx\` | Split \`disabled\` into \`disabled\` + \`isRunning\` |
| \`src/ui/src/components/chat/composer/ComposerToolbar.tsx\` | Accepts both, computes \`mutationDisabled\` locally for pills |
| \`src/ui/src/components/chat/composer/OverflowMenu.tsx\` | Trigger reachable mid-turn; owns pending state, \`runImmediate\`, and deferred-fire effect |
| \`src/ui/src/components/chat/composer/OverflowMenu.module.css\` | \`.remoteGroupPending\` chip + disabled \`.item\` styling |
| \`src/ui/src/components/chat/composer/OverflowMenu.test.tsx\` | New: 11 tests covering reachability, queue/cancel/defer, dropdown-close regression, session-switch isolation |
| \`site/src/content/docs/features/claude-remote-control.mdx\` | Pending lifecycle row + armed-vs-pending Troubleshooting note |