### PR TITLE
feat(right-sidebar): remember Files/Changes/Tasks tab per workspace

### DIFF
--- a/site/src/content/docs/features/task-history.mdx
+++ b/site/src/content/docs/features/task-history.mdx
@@ -21,7 +21,7 @@ Subagent labels are derived from the agent's `description` field and capped at o
 
 TeamCreate teammates run as **sibling chat sessions** in the same workspace. While a teammate's agent is still running, that session's live tasks (and its own subagents) appear as a dedicated lane in the Tasks panel — distinguished from **Current** by the session name and a pulsing live dot. Only after the teammate goes idle do its leftover tasks graduate into **History** under the session's name.
 
-The right-sidebar tab auto-switches to **Tasks** once per workspace selection when tasks first appear, so you don't have to hunt for the tab on every new session. Manually picking a different tab on that workspace cancels future auto-switches for the rest of the session.
+The right sidebar remembers which tab (**Files**, **Changes**, or **Tasks**) you last selected for each workspace. Switching to a different workspace and back leaves your tab choice intact — every workspace returns to exactly where you left it. On a brand-new workspace, the tab defaults to **Files**; it auto-switches to **Tasks** the first time live tasks appear so you don't have to hunt for the tab. Once you've explicitly chosen a tab for that workspace (or the auto-switch has fired), the choice is locked in for the session and no further auto-switches occur. Restarting the app resets all workspaces to **Files**.
 
 ## Historical Runs
 

--- a/src/ui/src/components/chat/WorkspaceEmptyTabs.test.tsx
+++ b/src/ui/src/components/chat/WorkspaceEmptyTabs.test.tsx
@@ -115,7 +115,7 @@ function resetStore() {
     diffSelectedFile: null,
     diffSelectedLayer: null,
     rightSidebarVisible: false,
-    rightSidebarTab: "files",
+    rightSidebarTabByWorkspace: {},
     requestNewFileNonceByWorkspace: {},
   });
 }

--- a/src/ui/src/components/file-viewer/editor-menubar/EditorMenubar.test.tsx
+++ b/src/ui/src/components/file-viewer/editor-menubar/EditorMenubar.test.tsx
@@ -24,7 +24,7 @@ interface MenubarStoreShape {
   setAllFilesSelectedPath: ReturnType<typeof vi.fn>;
   setAllFilesDirExpanded: ReturnType<typeof vi.fn>;
   toggleRightSidebar: ReturnType<typeof vi.fn>;
-  setRightSidebarTab: ReturnType<typeof vi.fn>;
+  setRightSidebarTabForWorkspace: ReturnType<typeof vi.fn>;
   openCommandPaletteFileMode: ReturnType<typeof vi.fn>;
   setEditorWordWrap: ReturnType<typeof vi.fn>;
   setEditorMinimapEnabled: ReturnType<typeof vi.fn>;
@@ -47,7 +47,7 @@ const store = vi.hoisted(
     setAllFilesSelectedPath: vi.fn(),
     setAllFilesDirExpanded: vi.fn(),
     toggleRightSidebar: vi.fn(),
-    setRightSidebarTab: vi.fn(),
+    setRightSidebarTabForWorkspace: vi.fn(),
     openCommandPaletteFileMode: vi.fn(),
     setEditorWordWrap: vi.fn(),
     setEditorMinimapEnabled: vi.fn(),

--- a/src/ui/src/components/file-viewer/editor-menubar/useEditorActions.test.ts
+++ b/src/ui/src/components/file-viewer/editor-menubar/useEditorActions.test.ts
@@ -44,7 +44,7 @@ function makeDeps(overrides: Partial<EditorActionsDeps> = {}): EditorActionsDeps
     setAllFilesDirExpanded: vi.fn(),
     rightSidebarVisible: false,
     showRightSidebar: vi.fn(),
-    setRightSidebarTab: vi.fn(),
+    setRightSidebarTabForWorkspace: vi.fn(),
     openCommandPaletteFileMode: vi.fn(),
     wordWrap: true,
     setWordWrap: vi.fn(),
@@ -145,7 +145,7 @@ describe("buildEditorActions — file menu", () => {
     const deps = makeDeps({ rightSidebarVisible: false });
     buildEditorActions(deps).onRevealInFiles();
     expect(deps.showRightSidebar).toHaveBeenCalledTimes(1);
-    expect(deps.setRightSidebarTab).toHaveBeenCalledWith("files");
+    expect(deps.setRightSidebarTabForWorkspace).toHaveBeenCalledWith("ws-1", "files");
     expect(deps.setAllFilesDirExpanded).toHaveBeenCalledWith(
       "ws-1",
       "src/",
@@ -166,7 +166,7 @@ describe("buildEditorActions — file menu", () => {
     const deps = makeDeps({ rightSidebarVisible: true });
     buildEditorActions(deps).onRevealInFiles();
     expect(deps.showRightSidebar).not.toHaveBeenCalled();
-    expect(deps.setRightSidebarTab).toHaveBeenCalledWith("files");
+    expect(deps.setRightSidebarTabForWorkspace).toHaveBeenCalledWith("ws-1", "files");
   });
 });
 

--- a/src/ui/src/components/file-viewer/editor-menubar/useEditorActions.ts
+++ b/src/ui/src/components/file-viewer/editor-menubar/useEditorActions.ts
@@ -53,7 +53,7 @@ export interface EditorActionsDeps {
   ) => void;
   rightSidebarVisible: boolean;
   showRightSidebar: () => void;
-  setRightSidebarTab: (tab: "files" | "changes" | "tasks") => void;
+  setRightSidebarTabForWorkspace: (workspaceId: string, tab: "files" | "changes" | "tasks") => void;
 
   openCommandPaletteFileMode: () => void;
 
@@ -165,7 +165,7 @@ export function buildEditorActions(deps: EditorActionsDeps): EditorActions {
 
   const onRevealInFiles = () => {
     if (!deps.rightSidebarVisible) deps.showRightSidebar();
-    deps.setRightSidebarTab("files");
+    deps.setRightSidebarTabForWorkspace(deps.workspaceId, "files");
     for (const dir of ancestorDirs(deps.path)) {
       deps.setAllFilesDirExpanded(deps.workspaceId, dir, true);
     }
@@ -290,7 +290,7 @@ export function useEditorActions(params: UseEditorActionsParams): EditorActions 
   const setAllFilesDirExpanded = useAppStore((s) => s.setAllFilesDirExpanded);
   const rightSidebarVisible = useAppStore((s) => s.rightSidebarVisible);
   const toggleRightSidebar = useAppStore((s) => s.toggleRightSidebar);
-  const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab);
+  const setRightSidebarTabForWorkspace = useAppStore((s) => s.setRightSidebarTabForWorkspace);
   const openCommandPaletteFileMode = useAppStore(
     (s) => s.openCommandPaletteFileMode,
   );
@@ -334,7 +334,7 @@ export function useEditorActions(params: UseEditorActionsParams): EditorActions 
         showRightSidebar: () => {
           if (!useAppStore.getState().rightSidebarVisible) toggleRightSidebar();
         },
-        setRightSidebarTab,
+        setRightSidebarTabForWorkspace,
         openCommandPaletteFileMode,
         wordWrap,
         setWordWrap,
@@ -365,7 +365,7 @@ export function useEditorActions(params: UseEditorActionsParams): EditorActions 
       setAllFilesDirExpanded,
       rightSidebarVisible,
       toggleRightSidebar,
-      setRightSidebarTab,
+      setRightSidebarTabForWorkspace,
       openCommandPaletteFileMode,
       wordWrap,
       setWordWrap,

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -54,8 +54,16 @@ export const RightSidebar = memo(function RightSidebar() {
   const commitHistory = useAppStore((s) => s.commitHistory);
   const diffSelectedCommitHash = useAppStore((s) => s.diffSelectedCommitHash);
   const setDiffSelectedCommitHash = useAppStore((s) => s.setDiffSelectedCommitHash);
-  const activeTab = useAppStore((s) => s.rightSidebarTab);
-  const setActiveTab = useAppStore((s) => s.setRightSidebarTab);
+  const activeTab = useAppStore(
+    (s) => s.rightSidebarTabByWorkspace[s.selectedWorkspaceId ?? ""] ?? "files",
+  );
+  const setRightSidebarTabForWorkspace = useAppStore((s) => s.setRightSidebarTabForWorkspace);
+  const setActiveTab = useCallback(
+    (tab: "files" | "changes" | "tasks") => {
+      if (selectedWorkspaceId) setRightSidebarTabForWorkspace(selectedWorkspaceId, tab);
+    },
+    [selectedWorkspaceId, setRightSidebarTabForWorkspace],
+  );
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const isRunning = isAgentBusy(ws?.agent_status);
@@ -119,21 +127,16 @@ export const RightSidebar = memo(function RightSidebar() {
   const hasLiveTasks =
     taskHistory.current.tasks.length > 0 ||
     taskHistory.subagents.length > 0;
-  // One auto-switch per workspace selection. Tracks the workspace ids
-  // we've already auto-switched for and reset on workspace change so
-  // each workspace gets at most one nudge before it learns the user's
-  // tab preference for the remainder of the session.
-  const autoSwitchedForWorkspaceRef = useRef<Set<string>>(new Set());
+  // Auto-switch to Tasks the first time a workspace has live tasks, but
+  // only when the user hasn't yet made an explicit tab choice for it.
+  // Writing to the per-workspace map via setActiveTab also records the
+  // choice, so subsequent visits to the same workspace skip the nudge.
   useEffect(() => {
     if (!selectedWorkspaceId || !hasLiveTasks) return;
-    if (autoSwitchedForWorkspaceRef.current.has(selectedWorkspaceId)) return;
-    if (activeTab === "tasks") {
-      autoSwitchedForWorkspaceRef.current.add(selectedWorkspaceId);
-      return;
-    }
-    autoSwitchedForWorkspaceRef.current.add(selectedWorkspaceId);
+    const { rightSidebarTabByWorkspace } = useAppStore.getState();
+    if (rightSidebarTabByWorkspace[selectedWorkspaceId] !== undefined) return;
     setActiveTab("tasks");
-  }, [selectedWorkspaceId, hasLiveTasks, activeTab, setActiveTab]);
+  }, [selectedWorkspaceId, hasLiveTasks, setActiveTab]);
 
   // Local-only stage/unstage/discard UI state. None of these git index
   // operations are bridged through the remote server (matches revert_file),

--- a/src/ui/src/hooks/useViewTogglePersistence.test.ts
+++ b/src/ui/src/hooks/useViewTogglePersistence.test.ts
@@ -72,7 +72,7 @@ function resetStore() {
     sidebarWidth: 260,
     rightSidebarWidth: 250,
     terminalHeight: 300,
-    rightSidebarTab: "files",
+    rightSidebarTabByWorkspace: {},
     sidebarGroupBy: "repo",
     sidebarRepoFilter: "all",
     sidebarShowArchived: false,

--- a/src/ui/src/hooks/useViewTogglePersistence.ts
+++ b/src/ui/src/hooks/useViewTogglePersistence.ts
@@ -448,7 +448,7 @@ export function buildPersistedViewState(state: AppState): PersistedViewStateV1 {
     sidebarWidth: state.sidebarWidth,
     rightSidebarWidth: state.rightSidebarWidth,
     terminalHeight: state.terminalHeight,
-    rightSidebarTab: state.rightSidebarTab,
+    rightSidebarTab: "files",
     sidebarGroupBy: state.sidebarGroupBy,
     sidebarRepoFilter: state.sidebarRepoFilter,
     sidebarShowArchived: state.sidebarShowArchived,
@@ -477,7 +477,6 @@ async function loadLegacyPanelState(): Promise<Partial<AppState>> {
     sbW,
     rsbW,
     termH,
-    rsbTab,
     sbGroup,
     sbArch,
   ] = await Promise.all([
@@ -487,7 +486,6 @@ async function loadLegacyPanelState(): Promise<Partial<AppState>> {
     getAppSetting(LEGACY_KEYS.sidebarWidth),
     getAppSetting(LEGACY_KEYS.rightSidebarWidth),
     getAppSetting(LEGACY_KEYS.terminalHeight),
-    getAppSetting(LEGACY_KEYS.rightSidebarTab),
     getAppSetting(LEGACY_KEYS.sidebarGroupBy),
     getAppSetting(LEGACY_KEYS.sidebarShowArchived),
   ]);
@@ -505,9 +503,6 @@ async function loadLegacyPanelState(): Promise<Partial<AppState>> {
   if (rsbWN !== null) updates.rightSidebarWidth = rsbWN;
   const termHN = parseClampedInt(termH, 100, 800);
   if (termHN !== null) updates.terminalHeight = termHN;
-  if (rsbTab && (RIGHT_SIDEBAR_TABS as readonly string[]).includes(rsbTab)) {
-    updates.rightSidebarTab = rsbTab as RightSidebarTab;
-  }
   if (sbGroup && (SIDEBAR_GROUP_BYS as readonly string[]).includes(sbGroup)) {
     updates.sidebarGroupBy = sbGroup as SidebarGroupBy;
   }
@@ -598,7 +593,6 @@ export function applyPersistedViewState(
     sidebarWidth: persisted.sidebarWidth,
     rightSidebarWidth: persisted.rightSidebarWidth,
     terminalHeight: persisted.terminalHeight,
-    rightSidebarTab: persisted.rightSidebarTab,
     sidebarGroupBy: persisted.sidebarGroupBy,
     sidebarRepoFilter:
       persisted.sidebarRepoFilter === "all" || activeRepositoryIds.has(persisted.sidebarRepoFilter)

--- a/src/ui/src/hotkeys/contextActions.test.ts
+++ b/src/ui/src/hotkeys/contextActions.test.ts
@@ -49,7 +49,7 @@ function resetStore() {
     diffSelectedFile: null,
     diffSelectedLayer: null,
     rightSidebarVisible: false,
-    rightSidebarTab: "files",
+    rightSidebarTabByWorkspace: {},
     requestNewFileNonceByWorkspace: {},
     requestCloseFileTabNonceByWorkspace: {},
   });
@@ -204,7 +204,7 @@ describe("executeNewTab", () => {
     useAppStore.setState({
       activeFileTabByWorkspace: { [WS]: "src/main.rs" },
       rightSidebarVisible: false,
-      rightSidebarTab: "tasks",
+      rightSidebarTabByWorkspace: { [WS]: "tasks" as const },
     });
     const createChatSession = vi.fn();
 
@@ -213,7 +213,7 @@ describe("executeNewTab", () => {
     const post = useAppStore.getState();
     expect(post.requestNewFileNonceByWorkspace[WS]).toBe(1);
     expect(post.rightSidebarVisible).toBe(true);
-    expect(post.rightSidebarTab).toBe("files");
+    expect(post.rightSidebarTabByWorkspace[WS]).toBe("files");
     expect(createChatSession).not.toHaveBeenCalled();
   });
 
@@ -221,15 +221,18 @@ describe("executeNewTab", () => {
     useAppStore.setState({
       activeFileTabByWorkspace: { [WS]: "README.md" },
       rightSidebarVisible: true,
-      rightSidebarTab: "files",
+      rightSidebarTabByWorkspace: {},
     });
     const toggleRightSidebar = vi.spyOn(useAppStore.getState(), "toggleRightSidebar");
-    const setRightSidebarTab = vi.spyOn(useAppStore.getState(), "setRightSidebarTab");
+    const setRightSidebarTabForWorkspace = vi.spyOn(
+      useAppStore.getState(),
+      "setRightSidebarTabForWorkspace",
+    );
 
     executeNewTab();
 
     expect(toggleRightSidebar).not.toHaveBeenCalled();
-    expect(setRightSidebarTab).not.toHaveBeenCalled();
+    expect(setRightSidebarTabForWorkspace).not.toHaveBeenCalled();
     expect(useAppStore.getState().requestNewFileNonceByWorkspace[WS]).toBe(1);
   });
 

--- a/src/ui/src/hotkeys/contextActions.ts
+++ b/src/ui/src/hotkeys/contextActions.ts
@@ -174,7 +174,7 @@ export function executeNewTab(overrides?: Partial<ContextActionDeps>): void {
   const activeFile = store.activeFileTabByWorkspace[wsId] ?? null;
   if (activeFile) {
     if (!store.rightSidebarVisible) store.toggleRightSidebar();
-    if (store.rightSidebarTab !== "files") store.setRightSidebarTab("files");
+    if ((store.rightSidebarTabByWorkspace[wsId] ?? "files") !== "files") store.setRightSidebarTabForWorkspace(wsId, "files");
     store.requestNewFileAtRoot(wsId);
     return;
   }

--- a/src/ui/src/stores/slices/uiSlice.ts
+++ b/src/ui/src/stores/slices/uiSlice.ts
@@ -29,7 +29,7 @@ export interface UiSlice {
   sidebarWidth: number;
   rightSidebarWidth: number;
   terminalHeight: number;
-  rightSidebarTab: "files" | "changes" | "tasks";
+  rightSidebarTabByWorkspace: Record<string, "files" | "changes" | "tasks">;
   sidebarGroupBy: "status" | "repo";
   sidebarRepoFilter: string; // repo ID or "all"
   sidebarShowArchived: boolean;
@@ -41,7 +41,7 @@ export interface UiSlice {
   commandPaletteInitialMode: "file" | null;
   toggleSidebar: () => void;
   toggleRightSidebar: () => void;
-  setRightSidebarTab: (tab: "files" | "changes" | "tasks") => void;
+  setRightSidebarTabForWorkspace: (workspaceId: string, tab: "files" | "changes" | "tasks") => void;
   setSidebarWidth: (w: number) => void;
   setRightSidebarWidth: (w: number) => void;
   setTerminalHeight: (h: number) => void;
@@ -165,7 +165,7 @@ export const createUiSlice: StateCreator<AppState, [], [], UiSlice> = (
   sidebarWidth: 260,
   rightSidebarWidth: 250,
   terminalHeight: 300,
-  rightSidebarTab: "files",
+  rightSidebarTabByWorkspace: {},
   sidebarGroupBy: "repo",
   sidebarRepoFilter: "all",
   sidebarShowArchived: false,
@@ -176,7 +176,10 @@ export const createUiSlice: StateCreator<AppState, [], [], UiSlice> = (
   toggleSidebar: () => set((s) => ({ sidebarVisible: !s.sidebarVisible })),
   toggleRightSidebar: () =>
     set((s) => ({ rightSidebarVisible: !s.rightSidebarVisible })),
-  setRightSidebarTab: (tab) => set({ rightSidebarTab: tab }),
+  setRightSidebarTabForWorkspace: (workspaceId, tab) =>
+    set((s) => ({
+      rightSidebarTabByWorkspace: { ...s.rightSidebarTabByWorkspace, [workspaceId]: tab },
+    })),
   setSidebarWidth: (w) => set({ sidebarWidth: w }),
   setRightSidebarWidth: (w) => set({ rightSidebarWidth: w }),
   setTerminalHeight: (h) => set({ terminalHeight: h }),

--- a/src/ui/src/stores/slices/workspacesSlice.test.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.test.ts
@@ -172,6 +172,45 @@ describe("workspacesSlice.addWorkspace", () => {
   });
 });
 
+describe("workspacesSlice rightSidebarTabByWorkspace", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      workspaces: [],
+      selectedWorkspaceId: null,
+      rightSidebarTabByWorkspace: {},
+    });
+  });
+
+  it("preserves per-workspace tab choice on workspace switch and return", () => {
+    useAppStore.getState().addWorkspace(makeWorkspace({ id: "ws-a" }));
+    useAppStore.getState().addWorkspace(makeWorkspace({ id: "ws-b" }));
+    useAppStore.getState().selectWorkspace("ws-a");
+    useAppStore.getState().setRightSidebarTabForWorkspace("ws-a", "changes");
+
+    useAppStore.getState().selectWorkspace("ws-b");
+    // Workspace B has no explicit choice — map entry absent (resolves to "files").
+    expect(useAppStore.getState().rightSidebarTabByWorkspace["ws-b"]).toBeUndefined();
+
+    useAppStore.getState().selectWorkspace("ws-a");
+    expect(useAppStore.getState().rightSidebarTabByWorkspace["ws-a"]).toBe("changes");
+  });
+
+  it("new workspace has no map entry (resolves to files default)", () => {
+    useAppStore.getState().addWorkspace(makeWorkspace({ id: "ws-new" }));
+    useAppStore.getState().selectWorkspace("ws-new");
+    expect(useAppStore.getState().rightSidebarTabByWorkspace["ws-new"]).toBeUndefined();
+  });
+
+  it("removeWorkspace drops the tab entry from the map", () => {
+    useAppStore.getState().addWorkspace(makeWorkspace({ id: "ws-1" }));
+    useAppStore.getState().setRightSidebarTabForWorkspace("ws-1", "tasks");
+    expect(useAppStore.getState().rightSidebarTabByWorkspace["ws-1"]).toBe("tasks");
+
+    useAppStore.getState().removeWorkspace("ws-1");
+    expect(useAppStore.getState().rightSidebarTabByWorkspace["ws-1"]).toBeUndefined();
+  });
+});
+
 describe("workspacesSlice pendingFork lifecycle", () => {
   beforeEach(() => {
     useAppStore.setState({
@@ -304,7 +343,7 @@ describe("workspacesSlice pendingFork lifecycle", () => {
       diffSelectedLayer: "unstaged",
       diffMergeBase: "abc123",
       diffPreviewLoading: true,
-      rightSidebarTab: "changes",
+      rightSidebarTabByWorkspace: { "ws-source": "changes" as const },
     } as Partial<typeof useAppStore extends { getState: () => infer T } ? T : never>);
 
     useAppStore.getState().beginPendingFork(
@@ -320,7 +359,10 @@ describe("workspacesSlice pendingFork lifecycle", () => {
     expect(state.diffPreviewContent).toBeNull();
     expect(state.diffPreviewLoading).toBe(false);
     expect(state.diffPreviewMode).toBe("diff");
-    expect(state.rightSidebarTab).toBe("files");
+    // Placeholder has no tab entry — resolves to the "files" default.
+    expect(state.rightSidebarTabByWorkspace["pending-fork-abc"]).toBeUndefined();
+    // Source's tab choice is preserved across the fork.
+    expect(state.rightSidebarTabByWorkspace["ws-source"]).toBe("changes");
     // The source's diff selection is preserved in the per-workspace
     // map so returning to it (via cancel, or the user navigating back)
     // restores what they were viewing.

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -275,7 +275,6 @@ export const createWorkspacesSlice: StateCreator<
         workspaces: [...s.workspaces, placeholder],
         selectedWorkspaceId: placeholder.id,
         selectedRepositoryId: null,
-        rightSidebarTab: "files",
         diffSelectionByWorkspace: selectionMap,
         diffSelectedFile: null,
         diffSelectedLayer: null,
@@ -393,7 +392,6 @@ export const createWorkspacesSlice: StateCreator<
         workspaces: [...s.workspaces, placeholder],
         selectedWorkspaceId: placeholder.id,
         selectedRepositoryId: null,
-        rightSidebarTab: "files",
         diffSelectionByWorkspace: selectionMap,
         diffSelectedFile: null,
         diffSelectedLayer: null,
@@ -568,6 +566,8 @@ export const createWorkspacesSlice: StateCreator<
       delete newScmSummary[id];
       const newScmDetails = { ...s.scmDetails };
       delete newScmDetails[id];
+      const newRightSidebarTabByWorkspace = { ...s.rightSidebarTabByWorkspace };
+      delete newRightSidebarTabByWorkspace[id];
       return {
         workspaces: s.workspaces.filter((w) => w.id !== id),
         selectedWorkspaceId:
@@ -586,6 +586,7 @@ export const createWorkspacesSlice: StateCreator<
         workspaceEnvironment: newWorkspaceEnvironment,
         scmSummary: newScmSummary,
         scmDetails: newScmDetails,
+        rightSidebarTabByWorkspace: newRightSidebarTabByWorkspace,
       };
     }),
   selectWorkspace: (id) =>
@@ -629,7 +630,6 @@ export const createWorkspacesSlice: StateCreator<
         // `selectWorkspace(null)` (Back-to-Dashboard) preserves any
         // selectedRepositoryId the user already navigated to.
         selectedRepositoryId: id ? null : s.selectedRepositoryId,
-        rightSidebarTab: "files",
         diffSelectionByWorkspace: selectionMap,
         diffSelectedFile: tabExists ? restored!.path : null,
         diffSelectedLayer: tabExists ? restored!.layer : null,


### PR DESCRIPTION
## Summary

Closes #848.

Replaces the single global `rightSidebarTab` with `rightSidebarTabByWorkspace: Record<string, "files" | "changes" | "tasks">` so the user's last-selected tab is remembered per workspace across switches. Absence in the map resolves to `"files"` via `?? "files"` at every read site — brand-new workspaces still open on Files, no migration needed.

**What changed:**
- `uiSlice.ts`: `rightSidebarTab` → `rightSidebarTabByWorkspace` map; `setRightSidebarTab` → `setRightSidebarTabForWorkspace(workspaceId, tab)`
- `workspacesSlice.ts`: removed the three `rightSidebarTab: "files"` force-resets in `selectWorkspace`, `beginPendingFork`, and `beginPendingCreate`; added map-entry cleanup in `removeWorkspace`
- `RightSidebar.tsx`: selector reads `rightSidebarTabByWorkspace[selectedWorkspaceId] ?? "files"`; auto-switch-to-Tasks nudge checks map presence instead of a per-session ref — any workspace with an entry (from user click or prior auto-switch) skips the nudge
- `useViewTogglePersistence.ts`: global tab is no longer serialized or re-applied on load (in-memory only; app restart puts everyone back on Files)
- All consumers updated: `contextActions.ts`, `useEditorActions.ts`, and their test files

## Test plan

- [ ] Pick **Changes** on workspace A → switch to B → switch back to A → still on Changes
- [ ] Brand-new workspace opens on **Files** (no map entry → default)
- [ ] Workspace with live tasks auto-switches to **Tasks** once on first visit; subsequent visits respect the remembered tab
- [ ] Delete/archive a workspace → `rightSidebarTabByWorkspace` entry is dropped
- [ ] Cmd+T "new file at workspace root" still switches to Files (writes the per-workspace entry)
- [ ] All 2491 existing vitest tests pass; 3 new tests added
- [ ] `tsc -b` clean, ESLint no new errors