### PR TITLE
fix(ci): scope tauri-action to src-tauri and stamp src-mobile in nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -167,7 +167,18 @@ jobs:
           perl -i -pe 's/^version\s*=\s*"[^"]+"/version = "$ENV{NIGHTLY_VERSION}"/' src-tauri/Cargo.toml
           perl -i -pe 's/^version\s*=\s*"[^"]+"/version = "$ENV{NIGHTLY_VERSION}"/' src-server/Cargo.toml
           perl -i -pe 's/^version\s*=\s*"[^"]+"/version = "$ENV{NIGHTLY_VERSION}"/' src-cli/Cargo.toml
-          grep '^version' Cargo.toml src-tauri/Cargo.toml src-server/Cargo.toml src-cli/Cargo.toml
+          # `src-mobile` is part of the workspace but not built by this
+          # nightly. Stamp it anyway so the workspace stays version-consistent
+          # and so any tooling that scans every Cargo.toml / tauri.conf.json
+          # sees the same dev version. The hardcoded version in
+          # `src-mobile/tauri.conf.json` is also what tripped tauri-action
+          # into uploading artifacts under the stale `0.24.0` name (see #846
+          # area). Keep the JSON regex anchored on the `"version"` key so it
+          # only rewrites that line.
+          perl -i -pe 's/^version\s*=\s*"[^"]+"/version = "$ENV{NIGHTLY_VERSION}"/' src-mobile/Cargo.toml
+          perl -i -pe 's/("version"\s*:\s*)"[^"]+"/$1"$ENV{NIGHTLY_VERSION}"/' src-mobile/tauri.conf.json
+          grep '^version' Cargo.toml src-tauri/Cargo.toml src-server/Cargo.toml src-cli/Cargo.toml src-mobile/Cargo.toml
+          grep '"version"' src-mobile/tauri.conf.json
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -271,6 +282,19 @@ jobs:
           APPLE_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_PASSWORD || '' }}
           APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_TEAM_ID || '' }}
         with:
+          # Scope tauri-action to the desktop project explicitly. The
+          # default `projectPath: .` triggers a recursive walk that picks
+          # up *any* `tauri.conf.json` in the repo — alphabetical order
+          # lands on `src-mobile/tauri.conf.json` (added in #840) before
+          # `src-tauri/tauri.conf.json`, and the mobile file's hardcoded
+          # `"version"` is what got reported to the post-bundle upload
+          # step. The bundler still uses Cargo.toml's (stamped) version
+          # for the artifact filename, so the lookup name and the actual
+          # filename drifted apart and the Linux upload failed with
+          # "No artifacts were found." Pinning the path keeps the action
+          # on the desktop project regardless of any future tauri.conf.json
+          # files added to other workspace members.
+          projectPath: src-tauri
           tagName: nightly-staging
           releaseName: "Nightly ${{ needs.compute-version.outputs.version }}"
           releaseDraft: true
@@ -298,6 +322,19 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
+          # Scope tauri-action to the desktop project explicitly. The
+          # default `projectPath: .` triggers a recursive walk that picks
+          # up *any* `tauri.conf.json` in the repo — alphabetical order
+          # lands on `src-mobile/tauri.conf.json` (added in #840) before
+          # `src-tauri/tauri.conf.json`, and the mobile file's hardcoded
+          # `"version"` is what got reported to the post-bundle upload
+          # step. The bundler still uses Cargo.toml's (stamped) version
+          # for the artifact filename, so the lookup name and the actual
+          # filename drifted apart and the Linux upload failed with
+          # "No artifacts were found." Pinning the path keeps the action
+          # on the desktop project regardless of any future tauri.conf.json
+          # files added to other workspace members.
+          projectPath: src-tauri
           tagName: nightly-staging
           releaseName: "Nightly ${{ needs.compute-version.outputs.version }}"
           releaseDraft: true
@@ -323,6 +360,19 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
+          # Scope tauri-action to the desktop project explicitly. The
+          # default `projectPath: .` triggers a recursive walk that picks
+          # up *any* `tauri.conf.json` in the repo — alphabetical order
+          # lands on `src-mobile/tauri.conf.json` (added in #840) before
+          # `src-tauri/tauri.conf.json`, and the mobile file's hardcoded
+          # `"version"` is what got reported to the post-bundle upload
+          # step. The bundler still uses Cargo.toml's (stamped) version
+          # for the artifact filename, so the lookup name and the actual
+          # filename drifted apart and the Linux upload failed with
+          # "No artifacts were found." Pinning the path keeps the action
+          # on the desktop project regardless of any future tauri.conf.json
+          # files added to other workspace members.
+          projectPath: src-tauri
           tagName: nightly-staging
           releaseName: "Nightly ${{ needs.compute-version.outputs.version }}"
           releaseDraft: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -177,6 +177,14 @@ jobs:
           APPLE_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_PASSWORD || '' }}
           APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_TEAM_ID || '' }}
         with:
+          # Scope tauri-action to the desktop project. See the matching
+          # comment in nightly.yml for the full failure story — short
+          # version: the default `projectPath: .` walks the repo and
+          # finds `src-mobile/tauri.conf.json` (added in #840) before
+          # `src-tauri/tauri.conf.json`, so the upload step looks for
+          # artifacts under the mobile config's hardcoded version
+          # instead of the desktop bundler's actual filename.
+          projectPath: src-tauri
           tagName: ${{ needs.resolve-tag.outputs.tag }}
           releaseName: ${{ needs.resolve-tag.outputs.tag }}
           releaseDraft: true
@@ -203,6 +211,14 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
+          # Scope tauri-action to the desktop project. See the matching
+          # comment in nightly.yml for the full failure story — short
+          # version: the default `projectPath: .` walks the repo and
+          # finds `src-mobile/tauri.conf.json` (added in #840) before
+          # `src-tauri/tauri.conf.json`, so the upload step looks for
+          # artifacts under the mobile config's hardcoded version
+          # instead of the desktop bundler's actual filename.
+          projectPath: src-tauri
           tagName: ${{ needs.resolve-tag.outputs.tag }}
           releaseName: ${{ needs.resolve-tag.outputs.tag }}
           releaseDraft: true
@@ -227,6 +243,14 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
+          # Scope tauri-action to the desktop project. See the matching
+          # comment in nightly.yml for the full failure story — short
+          # version: the default `projectPath: .` walks the repo and
+          # finds `src-mobile/tauri.conf.json` (added in #840) before
+          # `src-tauri/tauri.conf.json`, so the upload step looks for
+          # artifacts under the mobile config's hardcoded version
+          # instead of the desktop bundler's actual filename.
+          projectPath: src-tauri
           tagName: ${{ needs.resolve-tag.outputs.tag }}
           releaseName: ${{ needs.resolve-tag.outputs.tag }}
           releaseDraft: true


### PR DESCRIPTION
## Summary

- PR #840 (iOS foundation) added `src-mobile/tauri.conf.json` with a hardcoded `"version": "0.24.0"`. `tauri-action@v0`'s default `projectPath: .` walks the repo for `tauri.conf.json`; `src-mobile/` sorts alphabetically before `src-tauri/`, so the upload step built expected filenames from the mobile config's stale version while the bundler used the correctly stamped `Cargo.toml` version. On Linux the names diverged and the upload failed with `No artifacts were found.`; on macOS the version-less `Claudette.app` / `.app.tar.gz` still matched so the job superficially succeeded while silently dropping the `.dmg` from the release.
- Set `projectPath: src-tauri` on every `tauri-action@v0` call in `nightly.yml` and `release-please.yml` so the action stays locked to the desktop project regardless of any other `tauri.conf.json` files later added to other workspace members.
- Extend the nightly **Stamp** step to also rewrite `src-mobile/Cargo.toml` and `src-mobile/tauri.conf.json` so the whole workspace stays version-consistent.

## Failing run for reference

[Run 26000376428](https://github.com/utensils/claudette/actions/runs/26000376428) — Linux x86_64 + aarch64 builds both errored with `No artifacts were found.` after the bundler produced `Claudette_0.25.0-dev.68.g1b2305c_amd64.deb` but tauri-action looked for `Claudette_0.24.0_amd64.deb`. macOS aarch64 in the same run shows `Looking for artifacts in: …Claudette_0.24.0_aarch64.dmg` immediately followed by `Found artifacts: …Claudette.app …Claudette.app.tar.gz` — i.e. the DMG was silently dropped.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, the next nightly produces a `.deb` per Linux leg and a `.dmg` per macOS leg under the dev version, and `Publish Nightly` runs (rather than `skipped`).
- [ ] No regression on Windows (Windows path doesn't go through tauri-action; should remain unaffected).