### PR TITLE
perf(right-sidebar): cache workspace files and changes

### DIFF
--- a/src/ui/src/components/files/FilesPanel.cache.test.tsx
+++ b/src/ui/src/components/files/FilesPanel.cache.test.tsx
@@ -1,0 +1,230 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "../../stores/useAppStore";
+import type { FileEntry } from "../../services/tauri";
+import type { Workspace } from "../../types";
+import { FilesPanel } from "./FilesPanel";
+
+const serviceMocks = vi.hoisted(() => ({
+  listWorkspaceFiles: vi.fn(),
+  createWorkspaceFile: vi.fn(),
+  loadDiffFiles: vi.fn(),
+  renameWorkspacePath: vi.fn(),
+  restoreWorkspacePathFromTrash: vi.fn(),
+  trashWorkspacePath: vi.fn(),
+}));
+
+vi.mock("../../services/tauri", () => ({
+  listWorkspaceFiles: serviceMocks.listWorkspaceFiles,
+  createWorkspaceFile: serviceMocks.createWorkspaceFile,
+  loadDiffFiles: serviceMocks.loadDiffFiles,
+  renameWorkspacePath: serviceMocks.renameWorkspacePath,
+  restoreWorkspacePathFromTrash: serviceMocks.restoreWorkspacePathFromTrash,
+  trashWorkspacePath: serviceMocks.trashWorkspacePath,
+}));
+
+vi.mock("./FileTree", () => ({
+  FileTree: ({ entries }: { entries: FileEntry[] }) => (
+    <div>
+      {entries.map((entry) => (
+        <div key={entry.path}>{entry.path}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("./FilePathContextMenu", () => ({
+  FilePathContextMenu: () => null,
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function makeWorkspace(id: string): Workspace {
+  return {
+    id,
+    repository_id: "repo-1",
+    name: id,
+    branch_name: "main",
+    worktree_path: `/tmp/${id}`,
+    status: "Active",
+    agent_status: "Idle",
+    status_line: "",
+    created_at: "2026-05-17T00:00:00Z",
+    sort_order: 0,
+    remote_connection_id: null,
+  };
+}
+
+function entries(paths: string[]): FileEntry[] {
+  return paths.map((path) => ({ path, is_directory: false }));
+}
+
+const roots: Root[] = [];
+const containers: HTMLElement[] = [];
+
+async function renderPanel(): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  containers.push(container);
+  await act(async () => {
+    root.render(<FilesPanel />);
+  });
+  return container;
+}
+
+async function flushTimers(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+beforeEach(() => {
+  serviceMocks.listWorkspaceFiles.mockReset();
+  useAppStore.setState({
+    selectedWorkspaceId: "files-cache-ws-a",
+    workspaces: [
+      makeWorkspace("files-cache-ws-a"),
+      makeWorkspace("files-cache-ws-b"),
+    ],
+    fileTreeRefreshNonceByWorkspace: {},
+  });
+});
+
+afterEach(async () => {
+  for (const root of roots.splice(0).reverse()) {
+    await act(async () => root.unmount());
+  }
+  for (const container of containers.splice(0)) container.remove();
+});
+
+describe("FilesPanel workspace cache", () => {
+  it("renders cached entries immediately when switching back to a workspace", async () => {
+    const firstA = deferred<FileEntry[]>();
+    const firstB = deferred<FileEntry[]>();
+    const secondA = deferred<FileEntry[]>();
+    const loads = new Map<string, Deferred<FileEntry[]>[]>([
+      ["files-cache-ws-a", [firstA, secondA]],
+      ["files-cache-ws-b", [firstB]],
+    ]);
+    serviceMocks.listWorkspaceFiles.mockImplementation((workspaceId: string) => {
+      const next = loads.get(workspaceId)?.shift();
+      if (!next) throw new Error(`unexpected load for ${workspaceId}`);
+      return next.promise;
+    });
+
+    const container = await renderPanel();
+    expect(container.textContent).toContain("Loading");
+
+    await flushTimers();
+    await act(async () => {
+      firstA.resolve(entries(["src/a.ts"]));
+      await firstA.promise;
+    });
+    expect(container.textContent).toContain("src/a.ts");
+
+    await act(async () => {
+      useAppStore.setState({ selectedWorkspaceId: "files-cache-ws-b" });
+    });
+    expect(container.textContent).toContain("Loading");
+
+    await flushTimers();
+    await act(async () => {
+      firstB.resolve(entries(["src/b.ts"]));
+      await firstB.promise;
+    });
+    expect(container.textContent).toContain("src/b.ts");
+
+    await act(async () => {
+      useAppStore.setState({ selectedWorkspaceId: "files-cache-ws-a" });
+    });
+    expect(container.textContent).toContain("src/a.ts");
+    expect(container.textContent).not.toContain("Loading");
+
+    await flushTimers();
+    await act(async () => {
+      secondA.resolve(entries(["src/a.ts", "src/a-new.ts"]));
+      await secondA.promise;
+    });
+    expect(container.textContent).toContain("src/a-new.ts");
+  });
+
+  it("invalidates cached entries when the workspace refresh nonce changes", async () => {
+    const first = deferred<FileEntry[]>();
+    const refreshed = deferred<FileEntry[]>();
+    serviceMocks.listWorkspaceFiles
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(refreshed.promise);
+
+    const container = await renderPanel();
+    await flushTimers();
+    await act(async () => {
+      first.resolve(entries(["src/original.ts"]));
+      await first.promise;
+    });
+
+    await act(async () => {
+      useAppStore.setState({
+        fileTreeRefreshNonceByWorkspace: { "files-cache-ws-a": 1 },
+      });
+    });
+    expect(container.textContent).toContain("Loading");
+    expect(container.textContent).not.toContain("src/original.ts");
+
+    await flushTimers();
+    await act(async () => {
+      refreshed.resolve(entries(["src/refreshed.ts"]));
+      await refreshed.promise;
+    });
+    expect(container.textContent).toContain("src/refreshed.ts");
+  });
+
+  it("surfaces background refresh failures while keeping cached entries visible", async () => {
+    useAppStore.setState({
+      selectedWorkspaceId: "files-cache-error-ws-a",
+      workspaces: [makeWorkspace("files-cache-error-ws-a")],
+      fileTreeRefreshNonceByWorkspace: {},
+    });
+    const first = deferred<FileEntry[]>();
+    serviceMocks.listWorkspaceFiles
+      .mockReturnValueOnce(first.promise)
+      .mockRejectedValueOnce(new Error("git status failed"));
+
+    const container = await renderPanel();
+    await flushTimers();
+    await act(async () => {
+      first.resolve(entries(["src/cached.ts"]));
+      await first.promise;
+    });
+
+    await act(async () => {
+      useAppStore.setState({ selectedWorkspaceId: null });
+    });
+    await act(async () => {
+      useAppStore.setState({ selectedWorkspaceId: "files-cache-error-ws-a" });
+    });
+    await flushTimers();
+
+    expect(container.textContent).toContain("src/cached.ts");
+    expect(container.textContent).toContain("Refresh failed");
+    expect(container.textContent).toContain("git status failed");
+  });
+});

--- a/src/ui/src/components/files/FilesPanel.module.css
+++ b/src/ui/src/components/files/FilesPanel.module.css
@@ -11,3 +11,12 @@
   color: var(--text-dim);
   font-size: var(--body-size);
 }
+
+.refreshError {
+  margin: 8px;
+  padding: 6px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  color: var(--diff-removed-text);
+  font-size: var(--caption-size);
+}

--- a/src/ui/src/components/files/FilesPanel.tsx
+++ b/src/ui/src/components/files/FilesPanel.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -20,6 +21,47 @@ import type { FileContextTarget } from "./fileContextMenu";
 import { FileTree } from "./FileTree";
 import { useFilePathActions } from "./useFilePathActions";
 import styles from "./FilesPanel.module.css";
+
+interface CachedFileEntries {
+  refreshNonce: number;
+  entries: FileEntry[];
+}
+
+const MAX_CACHED_WORKSPACES = 20;
+const fileEntriesCache = new Map<string, CachedFileEntries>();
+
+function getCachedFileEntries(
+  workspaceId: string,
+  refreshNonce: number,
+): FileEntry[] | null {
+  const cached = fileEntriesCache.get(workspaceId);
+  if (cached?.refreshNonce !== refreshNonce) return null;
+  // Refresh LRU position.
+  fileEntriesCache.delete(workspaceId);
+  fileEntriesCache.set(workspaceId, cached);
+  return cached.entries;
+}
+
+function setCachedFileEntries(
+  workspaceId: string,
+  refreshNonce: number,
+  entries: FileEntry[],
+): void {
+  fileEntriesCache.set(workspaceId, { refreshNonce, entries });
+  while (fileEntriesCache.size > MAX_CACHED_WORKSPACES) {
+    const oldestKey = fileEntriesCache.keys().next().value;
+    if (!oldestKey) return;
+    fileEntriesCache.delete(oldestKey);
+  }
+}
+
+function pruneFileEntriesCache(activeWorkspaceIds: Set<string>): void {
+  for (const workspaceId of fileEntriesCache.keys()) {
+    if (!activeWorkspaceIds.has(workspaceId)) {
+      fileEntriesCache.delete(workspaceId);
+    }
+  }
+}
 
 export function FilesPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
@@ -102,23 +144,27 @@ export function FilesPanel() {
   }, []);
 
   const loadFiles = useCallback(
-    async (workspaceId: string, showLoading: boolean) => {
+    async (workspaceId: string, expectedRefreshNonce: number, showLoading: boolean) => {
       const version = ++loadVersionRef.current;
       if (showLoading) {
         setLoading(true);
       }
-      setError(null);
       loadFilesInFlightCount.current += 1;
       try {
         const result = await listWorkspaceFiles(workspaceId);
         if (version !== loadVersionRef.current) return;
         if (useAppStore.getState().selectedWorkspaceId !== workspaceId) return;
+        setCachedFileEntries(workspaceId, expectedRefreshNonce, result);
         setEntries(result);
+        setError(null);
         setLoading(false);
       } catch (e) {
         if (version !== loadVersionRef.current) return;
         if (useAppStore.getState().selectedWorkspaceId !== workspaceId) return;
         setError(String(e));
+        if (!showLoading) {
+          console.error("Failed to refresh workspace files:", e);
+        }
         setLoading(false);
       } finally {
         loadFilesInFlightCount.current -= 1;
@@ -128,6 +174,10 @@ export function FilesPanel() {
   );
 
   useEffect(() => {
+    pruneFileEntriesCache(new Set(workspaces.map((workspace) => workspace.id)));
+  }, [workspaces]);
+
+  useLayoutEffect(() => {
     if (!selectedWorkspaceId || isPendingPlaceholder) {
       // Bumping the version invalidates any in-flight load from the
       // previously-selected workspace so its `.then` can't land here
@@ -140,8 +190,22 @@ export function FilesPanel() {
       setLoading(false);
       return;
     }
+    const cachedEntries = getCachedFileEntries(selectedWorkspaceId, refreshNonce);
+    setError(null);
+    if (cachedEntries) {
+      setEntries(cachedEntries);
+      setLoading(false);
+    } else {
+      setEntries([]);
+      setLoading(true);
+    }
+  }, [selectedWorkspaceId, refreshNonce, isPendingPlaceholder]);
+
+  useEffect(() => {
+    if (!selectedWorkspaceId || isPendingPlaceholder) return;
+    const cachedEntries = getCachedFileEntries(selectedWorkspaceId, refreshNonce);
     const timer = window.setTimeout(() => {
-      void loadFiles(selectedWorkspaceId, true);
+      void loadFiles(selectedWorkspaceId, refreshNonce, cachedEntries === null);
     }, 0);
     return () => window.clearTimeout(timer);
   }, [selectedWorkspaceId, refreshNonce, loadFiles, isPendingPlaceholder]);
@@ -152,10 +216,10 @@ export function FilesPanel() {
       // Skip when a previous load is still in flight — see
       // `loadFilesInFlightCount` declaration above for the pileup rationale.
       if (loadFilesInFlightCount.current > 0) return;
-      void loadFiles(selectedWorkspaceId, false);
+      void loadFiles(selectedWorkspaceId, refreshNonce, false);
     }, FILES_AGENT_RUNNING_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [isRunning, selectedWorkspaceId, loadFiles, isPendingPlaceholder]);
+  }, [isRunning, selectedWorkspaceId, refreshNonce, loadFiles, isPendingPlaceholder]);
 
   useEffect(() => {
     const wasRunning = prevIsRunning.current;
@@ -163,10 +227,10 @@ export function FilesPanel() {
     if (!selectedWorkspaceId || isPendingPlaceholder || wasRunning !== true || isRunning) return;
 
     const timer = setTimeout(() => {
-      void loadFiles(selectedWorkspaceId, false);
+      void loadFiles(selectedWorkspaceId, refreshNonce, false);
     }, 500);
     return () => clearTimeout(timer);
-  }, [isRunning, selectedWorkspaceId, loadFiles, isPendingPlaceholder]);
+  }, [isRunning, selectedWorkspaceId, refreshNonce, loadFiles, isPendingPlaceholder]);
 
   // Idle polling: refresh file tree while agent is not running so
   // manually-edited files surface without navigating away. The cadence
@@ -179,10 +243,10 @@ export function FilesPanel() {
       // Skip when a previous load is still in flight — see
       // `loadFilesInFlightCount` declaration above for the pileup rationale.
       if (loadFilesInFlightCount.current > 0) return;
-      void loadFiles(selectedWorkspaceId, false);
+      void loadFiles(selectedWorkspaceId, refreshNonce, false);
     }, IDLE_REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [isRunning, selectedWorkspaceId, loadFiles, isPendingPlaceholder]);
+  }, [isRunning, selectedWorkspaceId, refreshNonce, loadFiles, isPendingPlaceholder]);
 
   // React to the `requestNewFileAtRoot` nonce: open the inline create
   // editor at the workspace root.
@@ -259,51 +323,56 @@ export function FilesPanel() {
     <div className={styles.panel} onKeyDownCapture={handlePanelKeyDownCapture}>
       {loading ? (
         <div className={styles.empty}>Loading…</div>
-      ) : error ? (
+      ) : error && entries.length === 0 ? (
         <div className={styles.empty}>Failed to load: {error}</div>
       ) : (
-        <FileTree
-          workspaceId={selectedWorkspaceId}
-          entries={entries}
-          onActivateFile={handleActivateFile}
-          onActivateDiff={handleActivateDiff}
-          onContextMenu={(target, x, y) => setContextMenu({ target, x, y })}
-          creatingParentPath={creatingParentPath}
-          focusRequest={focusRequest}
-          onCreateCommit={async (parentPath, name) => {
-            try {
-              await filePathActions.createFile(parentPath, name);
+        <>
+          {error && (
+            <div className={styles.refreshError}>Refresh failed: {error}</div>
+          )}
+          <FileTree
+            workspaceId={selectedWorkspaceId}
+            entries={entries}
+            onActivateFile={handleActivateFile}
+            onActivateDiff={handleActivateDiff}
+            onContextMenu={(target, x, y) => setContextMenu({ target, x, y })}
+            creatingParentPath={creatingParentPath}
+            focusRequest={focusRequest}
+            onCreateCommit={async (parentPath, name) => {
+              try {
+                await filePathActions.createFile(parentPath, name);
+                setCreatingParentPath(null);
+                refocusExplorer();
+                return true;
+              } catch (err) {
+                console.error("Failed to create file:", err);
+                useAppStore.getState().addToast(`Create file failed: ${String(err)}`);
+                return false;
+              }
+            }}
+            onCreateCancel={() => {
               setCreatingParentPath(null);
               refocusExplorer();
-              return true;
-            } catch (err) {
-              console.error("Failed to create file:", err);
-              useAppStore.getState().addToast(`Create file failed: ${String(err)}`);
-              return false;
-            }
-          }}
-          onCreateCancel={() => {
-            setCreatingParentPath(null);
-            refocusExplorer();
-          }}
-          renamingPath={renamingTarget?.path ?? null}
-          onRenameCommit={async (target, newName) => {
-            try {
-              await filePathActions.renamePath(target, newName);
+            }}
+            renamingPath={renamingTarget?.path ?? null}
+            onRenameCommit={async (target, newName) => {
+              try {
+                await filePathActions.renamePath(target, newName);
+                setRenamingTarget(null);
+                refocusExplorer();
+                return true;
+              } catch (err) {
+                console.error("Failed to rename file:", err);
+                useAppStore.getState().addToast(`Rename failed: ${String(err)}`);
+                return false;
+              }
+            }}
+            onRenameCancel={() => {
               setRenamingTarget(null);
               refocusExplorer();
-              return true;
-            } catch (err) {
-              console.error("Failed to rename file:", err);
-              useAppStore.getState().addToast(`Rename failed: ${String(err)}`);
-              return false;
-            }
-          }}
-          onRenameCancel={() => {
-            setRenamingTarget(null);
-            refocusExplorer();
-          }}
-        />
+            }}
+          />
+        </>
       )}
       {contextMenu && (
         <FilePathContextMenu

--- a/src/ui/src/components/right-sidebar/RightSidebar.cache.test.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.cache.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "../../stores/useAppStore";
+import type { DiffFilesResult } from "../../services/tauri";
+import type { DiffFile, StagedDiffFiles } from "../../types/diff";
+import type { Workspace } from "../../types";
+import { RightSidebar } from "./RightSidebar";
+
+const serviceMocks = vi.hoisted(() => ({
+  discardFile: vi.fn(),
+  discardFiles: vi.fn(),
+  loadDiffFiles: vi.fn(),
+  sendRemoteCommand: vi.fn(),
+  stageFile: vi.fn(),
+  stageFiles: vi.fn(),
+  unstageFile: vi.fn(),
+  unstageFiles: vi.fn(),
+}));
+
+vi.mock("../../services/tauri", () => ({
+  discardFile: serviceMocks.discardFile,
+  discardFiles: serviceMocks.discardFiles,
+  loadDiffFiles: serviceMocks.loadDiffFiles,
+  sendRemoteCommand: serviceMocks.sendRemoteCommand,
+  stageFile: serviceMocks.stageFile,
+  stageFiles: serviceMocks.stageFiles,
+  unstageFile: serviceMocks.unstageFile,
+  unstageFiles: serviceMocks.unstageFiles,
+}));
+
+vi.mock("../../hooks/useWorkspaceTaskHistory", () => ({
+  useWorkspaceTaskHistory: () => ({
+    totalBadgeCount: 0,
+    current: { tasks: [] },
+    subagents: [],
+  }),
+}));
+
+vi.mock("../files/FilesPanel", () => ({
+  FilesPanel: () => null,
+}));
+
+vi.mock("./PrStatusBanner", () => ({
+  PrStatusBanner: () => null,
+}));
+
+vi.mock("./TaskList", () => ({
+  TaskList: () => null,
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function makeWorkspace(id: string): Workspace {
+  return {
+    id,
+    repository_id: "repo-1",
+    name: id,
+    branch_name: "main",
+    worktree_path: `/tmp/${id}`,
+    status: "Active",
+    agent_status: "Idle",
+    status_line: "",
+    created_at: "2026-05-17T00:00:00Z",
+    sort_order: 0,
+    remote_connection_id: null,
+  };
+}
+
+function diffResult(path: string): DiffFilesResult {
+  const file: DiffFile = { path, status: "Modified" };
+  const staged_files: StagedDiffFiles = {
+    committed: [],
+    staged: [],
+    unstaged: [file],
+    untracked: [],
+  };
+  return {
+    files: [file],
+    merge_base: "abc123",
+    staged_files,
+    commits: [],
+  };
+}
+
+const roots: Root[] = [];
+const containers: HTMLElement[] = [];
+
+async function renderSidebar(): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  containers.push(container);
+  await act(async () => {
+    root.render(<RightSidebar />);
+  });
+  return container;
+}
+
+beforeEach(() => {
+  serviceMocks.loadDiffFiles.mockReset();
+  useAppStore.setState({
+    selectedWorkspaceId: "changes-cache-ws-a",
+    workspaces: [
+      makeWorkspace("changes-cache-ws-a"),
+      makeWorkspace("changes-cache-ws-b"),
+    ],
+    rightSidebarTabByWorkspace: {
+      "changes-cache-ws-a": "changes",
+      "changes-cache-ws-b": "changes",
+    },
+    fileTreeRefreshNonceByWorkspace: {},
+    diffFiles: [],
+    diffMergeBase: null,
+    diffStagedFiles: null,
+    diffLoading: false,
+    commitHistory: null,
+  });
+});
+
+afterEach(async () => {
+  for (const root of roots.splice(0).reverse()) {
+    await act(async () => root.unmount());
+  }
+  for (const container of containers.splice(0)) container.remove();
+});
+
+describe("RightSidebar changes cache", () => {
+  it("renders cached changes immediately when switching back to a workspace", async () => {
+    const firstA = deferred<DiffFilesResult>();
+    const firstB = deferred<DiffFilesResult>();
+    const secondA = deferred<DiffFilesResult>();
+    const loads = new Map<string, Deferred<DiffFilesResult>[]>([
+      ["changes-cache-ws-a", [firstA, secondA]],
+      ["changes-cache-ws-b", [firstB]],
+    ]);
+    serviceMocks.loadDiffFiles.mockImplementation((workspaceId: string) => {
+      const next = loads.get(workspaceId)?.shift();
+      if (!next) throw new Error(`unexpected load for ${workspaceId}`);
+      return next.promise;
+    });
+
+    const container = await renderSidebar();
+    expect(container.textContent).toContain("Loading");
+
+    await act(async () => {
+      firstA.resolve(diffResult("src/a.ts"));
+      await firstA.promise;
+    });
+    expect(container.textContent).toContain("src/a.ts");
+
+    await act(async () => {
+      useAppStore.setState({ selectedWorkspaceId: "changes-cache-ws-b" });
+    });
+    expect(container.textContent).toContain("Loading");
+
+    await act(async () => {
+      firstB.resolve(diffResult("src/b.ts"));
+      await firstB.promise;
+    });
+    expect(container.textContent).toContain("src/b.ts");
+
+    await act(async () => {
+      useAppStore.setState({ selectedWorkspaceId: "changes-cache-ws-a" });
+    });
+    expect(container.textContent).toContain("src/a.ts");
+    expect(container.textContent).not.toContain("Loading");
+
+    await act(async () => {
+      secondA.resolve(diffResult("src/a-new.ts"));
+      await secondA.promise;
+    });
+    expect(container.textContent).toContain("src/a-new.ts");
+  });
+
+  it("invalidates cached changes when the workspace refresh nonce changes", async () => {
+    const first = deferred<DiffFilesResult>();
+    const refreshed = deferred<DiffFilesResult>();
+    serviceMocks.loadDiffFiles
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(refreshed.promise);
+
+    const container = await renderSidebar();
+    await act(async () => {
+      first.resolve(diffResult("src/original.ts"));
+      await first.promise;
+    });
+
+    await act(async () => {
+      useAppStore.setState({
+        fileTreeRefreshNonceByWorkspace: { "changes-cache-ws-a": 1 },
+      });
+    });
+    expect(container.textContent).toContain("Loading");
+    expect(container.textContent).not.toContain("src/original.ts");
+
+    await act(async () => {
+      refreshed.resolve(diffResult("src/refreshed.ts"));
+      await refreshed.promise;
+    });
+    expect(container.textContent).toContain("src/refreshed.ts");
+  });
+});

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -1,4 +1,12 @@
-import { Fragment, memo, useCallback, useEffect, useRef, useState } from "react";
+import {
+  Fragment,
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { isAgentBusy } from "../../utils/agentStatus";
 import {
   DIFF_AGENT_RUNNING_INTERVAL_MS,
@@ -33,6 +41,47 @@ import {
 } from "./DiscardChangesConfirm";
 import styles from "./RightSidebar.module.css";
 
+interface CachedDiffResult {
+  refreshNonce: number;
+  result: DiffFilesResult;
+}
+
+const MAX_CACHED_WORKSPACES = 20;
+const diffResultCache = new Map<string, CachedDiffResult>();
+
+function getCachedDiffResult(
+  workspaceId: string,
+  refreshNonce: number,
+): DiffFilesResult | null {
+  const cached = diffResultCache.get(workspaceId);
+  if (cached?.refreshNonce !== refreshNonce) return null;
+  // Refresh LRU position.
+  diffResultCache.delete(workspaceId);
+  diffResultCache.set(workspaceId, cached);
+  return cached.result;
+}
+
+function setCachedDiffResult(
+  workspaceId: string,
+  refreshNonce: number,
+  result: DiffFilesResult,
+): void {
+  diffResultCache.set(workspaceId, { refreshNonce, result });
+  while (diffResultCache.size > MAX_CACHED_WORKSPACES) {
+    const oldestKey = diffResultCache.keys().next().value;
+    if (!oldestKey) return;
+    diffResultCache.delete(oldestKey);
+  }
+}
+
+function pruneDiffResultCache(activeWorkspaceIds: Set<string>): void {
+  for (const workspaceId of diffResultCache.keys()) {
+    if (!activeWorkspaceIds.has(workspaceId)) {
+      diffResultCache.delete(workspaceId);
+    }
+  }
+}
+
 function isDiscardableLayer(layer: DiffLayer | undefined): layer is DiscardableLayer {
   return layer === "unstaged" || layer === "untracked";
 }
@@ -46,11 +95,16 @@ export const RightSidebar = memo(function RightSidebar() {
   const diffSelectedLayer = useAppStore((s) => s.diffSelectedLayer);
   const diffLoading = useAppStore((s) => s.diffLoading);
   const setDiffFiles = useAppStore((s) => s.setDiffFiles);
-  const clearDiff = useAppStore((s) => s.clearDiff);
+  const clearDiffFiles = useAppStore((s) => s.clearDiffFiles);
   const openDiffTab = useAppStore((s) => s.openDiffTab);
   const openFileTab = useAppStore((s) => s.openFileTab);
   const setDiffLoading = useAppStore((s) => s.setDiffLoading);
   const requestFileTreeRefresh = useAppStore((s) => s.requestFileTreeRefresh);
+  const refreshNonce = useAppStore((s) =>
+    selectedWorkspaceId
+      ? (s.fileTreeRefreshNonceByWorkspace[selectedWorkspaceId] ?? 0)
+      : 0,
+  );
   const commitHistory = useAppStore((s) => s.commitHistory);
   const diffSelectedCommitHash = useAppStore((s) => s.diffSelectedCommitHash);
   const setDiffSelectedCommitHash = useAppStore((s) => s.setDiffSelectedCommitHash);
@@ -225,26 +279,48 @@ export const RightSidebar = memo(function RightSidebar() {
   );
 
   useEffect(() => {
+    pruneDiffResultCache(new Set(workspaces.map((workspace) => workspace.id)));
+  }, [workspaces]);
+
+  useLayoutEffect(() => {
     if (!selectedWorkspaceId) return;
-    // Clear before fetching so the file list, badge, and selection from the
-    // previous workspace don't leak into the new one while the fetch is in
-    // flight. The empty-list fallback `diffFiles.length === 0 && diffLoading`
-    // then renders "Loading..." instead of stale rows.
-    clearDiff();
     if (isPendingPlaceholder) {
       // Placeholder workspace — the backend doesn't have this id yet.
       // Skip the fetch entirely; the effect re-runs when commit swaps
       // selection to the real workspace.
+      diffLoadVersion.current += 1;
+      clearDiffFiles();
       setDiffLoading(false);
       return;
     }
-    setDiffLoading(true);
+    const cached = getCachedDiffResult(selectedWorkspaceId, refreshNonce);
+    if (cached) {
+      applyDiffResult(cached);
+      setDiffLoading(false);
+    } else {
+      clearDiffFiles();
+      setDiffLoading(true);
+    }
+  }, [
+    selectedWorkspaceId,
+    refreshNonce,
+    applyDiffResult,
+    clearDiffFiles,
+    setDiffLoading,
+    isPendingPlaceholder,
+  ]);
+
+  useEffect(() => {
+    if (!selectedWorkspaceId || isPendingPlaceholder) return;
+    const cached = getCachedDiffResult(selectedWorkspaceId, refreshNonce);
+    setDiffLoading(cached === null);
     const version = ++diffLoadVersion.current;
     const workspaceId = selectedWorkspaceId;
     loadDiffInFlightCount.current += 1;
     loadDiff(workspaceId)
       .then((result) => {
         if (!isDiffResultStillValid(workspaceId, version)) return;
+        if (result) setCachedDiffResult(workspaceId, refreshNonce, result);
         applyDiffResult(result);
         setDiffLoading(false);
       })
@@ -255,7 +331,15 @@ export const RightSidebar = memo(function RightSidebar() {
       .finally(() => {
         loadDiffInFlightCount.current -= 1;
       });
-  }, [selectedWorkspaceId, loadDiff, applyDiffResult, setDiffLoading, clearDiff, isDiffResultStillValid, isPendingPlaceholder]);
+  }, [
+    selectedWorkspaceId,
+    refreshNonce,
+    loadDiff,
+    applyDiffResult,
+    setDiffLoading,
+    isDiffResultStillValid,
+    isPendingPlaceholder,
+  ]);
 
   // Live-refresh diff files while agent is running.
   useEffect(() => {
@@ -272,6 +356,7 @@ export const RightSidebar = memo(function RightSidebar() {
       loadDiff(workspaceId)
         .then((result) => {
           if (!isDiffResultStillValid(workspaceId, version)) return;
+          if (result) setCachedDiffResult(workspaceId, refreshNonce, result);
           applyDiffResult(result);
         })
         .catch(() => {})
@@ -281,7 +366,15 @@ export const RightSidebar = memo(function RightSidebar() {
     }, DIFF_AGENT_RUNNING_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, isDiffResultStillValid, isPendingPlaceholder]);
+  }, [
+    isRunning,
+    selectedWorkspaceId,
+    refreshNonce,
+    loadDiff,
+    applyDiffResult,
+    isDiffResultStillValid,
+    isPendingPlaceholder,
+  ]);
 
   // Final refresh when agent stops running (after making changes).
   useEffect(() => {
@@ -292,12 +385,13 @@ export const RightSidebar = memo(function RightSidebar() {
     const workspaceId = selectedWorkspaceId;
 
     const timer = setTimeout(() => {
-      setDiffLoading(true);
+      setDiffLoading(getCachedDiffResult(workspaceId, refreshNonce) === null);
       const version = ++diffLoadVersion.current;
       loadDiffInFlightCount.current += 1;
       loadDiff(workspaceId)
         .then((result) => {
           if (!isDiffResultStillValid(workspaceId, version)) return;
+          if (result) setCachedDiffResult(workspaceId, refreshNonce, result);
           applyDiffResult(result);
           setDiffLoading(false);
         })
@@ -312,7 +406,16 @@ export const RightSidebar = memo(function RightSidebar() {
     }, 500);
 
     return () => clearTimeout(timer);
-  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, setDiffLoading, isDiffResultStillValid, isPendingPlaceholder]);
+  }, [
+    isRunning,
+    selectedWorkspaceId,
+    refreshNonce,
+    loadDiff,
+    applyDiffResult,
+    setDiffLoading,
+    isDiffResultStillValid,
+    isPendingPlaceholder,
+  ]);
 
   // Idle polling: refresh diff while agent is not running so manually-edited
   // files and external git ops surface without navigating away. The cadence
@@ -332,6 +435,7 @@ export const RightSidebar = memo(function RightSidebar() {
       loadDiff(workspaceId)
         .then((result) => {
           if (!isDiffResultStillValid(workspaceId, version)) return;
+          if (result) setCachedDiffResult(workspaceId, refreshNonce, result);
           applyDiffResult(result);
         })
         .catch(() => {})
@@ -341,7 +445,15 @@ export const RightSidebar = memo(function RightSidebar() {
     }, IDLE_REFRESH_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [isRunning, selectedWorkspaceId, loadDiff, applyDiffResult, isDiffResultStillValid, isPendingPlaceholder]);
+  }, [
+    isRunning,
+    selectedWorkspaceId,
+    refreshNonce,
+    loadDiff,
+    applyDiffResult,
+    isDiffResultStillValid,
+    isPendingPlaceholder,
+  ]);
 
   const statusLabel = (status: string | { Renamed: { from: string } }) => {
     if (typeof status === "string") {
@@ -510,6 +622,13 @@ export const RightSidebar = memo(function RightSidebar() {
         await op();
         const result = await loadDiff(selectedWorkspaceId);
         if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
+          const nextRefreshNonce =
+            (useAppStore.getState().fileTreeRefreshNonceByWorkspace[
+              selectedWorkspaceId
+            ] ?? 0) + 1;
+          if (result) {
+            setCachedDiffResult(selectedWorkspaceId, nextRefreshNonce, result);
+          }
           applyDiffResult(result);
           requestFileTreeRefresh(selectedWorkspaceId);
         }

--- a/src/ui/src/stores/slices/diffSlice.ts
+++ b/src/ui/src/stores/slices/diffSlice.ts
@@ -61,6 +61,7 @@ export interface DiffSlice {
   setDiffPreviewContent: (content: FileContent | null) => void;
   setDiffPreviewLoading: (loading: boolean) => void;
   setDiffPreviewError: (error: string | null) => void;
+  clearDiffFiles: () => void;
   clearDiff: () => void;
   // Replace the entire ordered list of diff tabs for a workspace. Used by
   // drag-reorder (volatile — not persisted across restarts; see SessionTabs
@@ -125,6 +126,14 @@ export const createDiffSlice: StateCreator<AppState, [], [], DiffSlice> = (
   setDiffPreviewContent: (content) => set({ diffPreviewContent: content }),
   setDiffPreviewLoading: (loading) => set({ diffPreviewLoading: loading }),
   setDiffPreviewError: (error) => set({ diffPreviewError: error }),
+  clearDiffFiles: () =>
+    set({
+      diffFiles: [],
+      diffMergeBase: null,
+      diffStagedFiles: null,
+      commitHistory: null,
+      diffSelectedCommitHash: null,
+    }),
   clearDiff: () =>
     set({
       diffFiles: [],


### PR DESCRIPTION
## Summary

- cache right-sidebar Files entries per workspace with stale-while-revalidate behavior
- cache right-sidebar Changes/diff results per workspace with the same refresh nonce invalidation
- keep first-visit and explicit refresh behavior honest by showing Loading only when there is no valid cache
- surface Files background refresh failures while keeping cached rows visible, so stale data is not silent
- add regression coverage for workspace A -> B -> A switching, nonce invalidation, and cached refresh failures

## Root Cause

The Files panel and Changes tab fully invalidated their current rows on every selectedWorkspaceId change. That forced the UI to wait for fresh git-backed file and diff loads even when the user had already visited that workspace and the previous rows were still the best available state.

## User Impact

Switching between recently visited workspaces now paints the cached Files tree and Changes rows immediately, then refreshes in the background. The Changes badge also keeps its cached count instead of briefly falling back to zero. First visits and manual refreshes still show Loading because there is no valid cache for that workspace/nonce.

If a Files background refresh fails after cached rows are visible, the sidebar keeps those cached rows on screen and shows a refresh-failed banner above them instead of silently leaving the user with stale data.

## Implementation Notes

- FilesPanel now keeps a bounded in-memory LRU cache keyed by workspace id and fileTreeRefreshNonceByWorkspace.
- RightSidebar now keeps a bounded in-memory LRU cache for DiffFilesResult keyed by workspace id and the same refresh nonce.
- The diff slice has a narrow clearDiffFiles action so cache misses can clear list data without destroying per-workspace diff tabs or selection maps.
- Removed workspaces are pruned from both caches while the sidebar is mounted.
- Copilot follow-up: background Files refresh errors now set panel error state and render non-blocking feedback when cached rows exist.

## Validation

- bunx vitest run src/components/files/FilesPanel.cache.test.tsx src/components/right-sidebar/RightSidebar.cache.test.tsx
- bunx tsc -b
- bun run lint:css
- git diff --check
- bun run lint (passes with pre-existing warnings only)

Closes #846
