### PR TITLE
feat(storage): cleanup-all button and live progress for bulk archive cleanup

### DIFF
--- a/site/src/content/docs/features/git-worktrees.mdx
+++ b/site/src/content/docs/features/git-worktrees.mdx
@@ -37,15 +37,20 @@ When archiving a workspace, Claudette can optionally delete the local branch. Th
 
 Archived workspaces still occupy disk space in the database (chat history, terminal tab state, SCM cache). To purge them in batches:
 
-- **Project dashboard** → the **ARCHIVED** section header has a `Clean up…` button. Opens a modal scoped to the current repository.
-- **Settings → Storage** → lists every repository with its archived count and a per-row `Clean up…` button.
+- **Project dashboard** → the **ARCHIVED** section header has a `Clean up…` button. Opens the modal scoped to the current repository.
+- **Settings → Storage** → lists every local repository with its archived count and a per-row `Clean up…` button, plus a top-level **Clean up all (N)** button next to the section header that runs cleanup across **every** local repository in a single pass.
 - **Per-repo Settings** → the **Workspace cleanup** field at the bottom of the per-repo settings page opens the same modal.
 
 The cleanup modal lets you:
 
-- Filter to workspaces older than **30 / 60 / 90 days**, **6 months**, or **1 year** (measured from creation), or leave it on **All** to see every archived workspace in the repository.
+- Filter to workspaces older than **30 / 60 / 90 days**, **6 months**, or **1 year** (measured from creation), or leave it on **All** to see every archived workspace.
+- In cleanup-all mode, browse all eligible workspaces grouped by repository header (single-repo mode renders a flat list).
 - Select rows individually or use **Select all** to grab every eligible row in one click.
 - Permanently delete the selected workspaces — their worktrees, branches, chat history, and terminal state. **Lifetime metrics survive** in the `deleted_workspace_summaries` table so cost/turn dashboards stay accurate.
+
+While the run is in flight the modal shows **live per-row progress**: a spinner next to pending rows, a green check as each row completes its full DB + worktree + branch + env cleanup, an X for failures, and a circled dash for rows the user cancelled. A running counter at the top reports `X of N deleted, Y failed`. The `bulk-cleanup-progress` Tauri event drives the UI; a unique request id is generated per run so concurrent cleanups (e.g. from two Settings windows) stay isolated.
+
+**Cancel** stays enabled throughout the run. Clicking it (or closing the modal) flips the button to "Cancelling…" and signals cooperative cancellation: the in-flight row finishes its own DB + worktree teardown, then every remaining row is reported as `cancelled`. Cancelled rows are untouched in the DB and on disk, so re-running cleanup picks them up cleanly. Cleanup is atomic per row — each row either finishes its full DB + worktree + branch cleanup before its `deleted` event fires, or stays entirely intact, so a cancellation never leaves orphan worktrees behind a deleted database row.
 
 From the CLI:
 

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -147,8 +147,11 @@ See [Diagnostics & Logging](/claudette/features/diagnostics/) for the full pipel
 
 | Setting | Description | Default |
 |---------|-------------|---------|
+| Clean up all (N) | Top-level action that opens the bulk cleanup modal in **cleanup-all mode** — every archived workspace across every local repository, grouped by repo. Disabled when nothing is archived. | — |
 | Archived workspaces per repository | Per-repository count of archived workspaces. Each row's `Clean up…` button opens the bulk cleanup modal scoped to that repo. | — |
 | Clean up… (per row) | Permanently deletes selected archived workspaces — worktree, branch, chat history. Lifetime metrics are preserved in `deleted_workspace_summaries`. | — |
+
+The cleanup modal shows live per-row progress while a run is in flight: a spinner next to pending rows, a green check as each row deletes, an X for failures, and a circled dash for rows the user cancelled. The Cancel button stays active during a run — clicking it (or closing the modal) signals cooperative cancellation, the in-flight row finishes, and every remaining row is skipped. Cancelled rows are untouched in the DB, so re-running cleanup picks them up.
 
 The same modal is reachable from the project dashboard's **ARCHIVED** section header and from each per-repo settings page's **Workspace cleanup** field. See [Bulk Cleanup of Archived Workspaces](/claudette/features/git-worktrees/#bulk-cleanup-of-archived-workspaces) for the full UI walkthrough and the matching CLI subcommand.
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1102,10 +1102,11 @@ pub(crate) async fn delete_workspaces_bulk_inner(
         });
     }
 
-    // Register the cancel flag before the first DB call. The flag is
-    // unregistered in `finish_bulk_cleanup` at the end of this function,
-    // and the body is wrapped in an inner async block so a `?` early
-    // return below still hits the unregister step.
+    // Register the cancel flag before the first DB call. The body is
+    // pulled into `delete_workspaces_bulk_body` so we can unregister
+    // the flag (the `state.bulk_cleanup_cancels.write().await.remove(...)`
+    // below) unconditionally after it returns, including the `?`
+    // early-return paths inside the body.
     let cancel_flag: Option<Arc<AtomicBool>> = if let Some(req_id) = request_id {
         let flag = Arc::new(AtomicBool::new(false));
         state
@@ -1203,93 +1204,109 @@ async fn delete_workspaces_bulk_body(
         .map(|w| (w.id.clone(), w.name.clone()))
         .collect();
 
-    // DB deletes + summary materialization + Deleted hooks per row. Each
-    // row is its own transaction, so per-row failures (e.g. SQLITE_BUSY)
-    // are isolated and reported as `failed` rather than rolling back the
-    // whole batch.
+    // Per-row interleaved DB + agent-stop + worktree + branch + env
+    // cleanup. One loop, one cancel-check site, one terminal status
+    // per row. This shape was chosen over the prior two-batch design
+    // (DB pass → worktree pass) because:
     //
-    // Important: git/env cleanup runs ONLY after the DB delete succeeds
-    // (see below). Reversing that order made a "failed" outcome
-    // destructive — the row would survive but its worktree and branch
-    // were already gone, leaving the user with an archived workspace
-    // pointing at nothing they could restore.
+    // 1. Cancel between rows must skip both phases for the remaining
+    //    rows. With separate batches, a cancel after the fast DB pass
+    //    would still let the user wait through the slow worktree pass,
+    //    or — if we broke out of the worktree pass — would orphan
+    //    worktrees and branches for rows whose DB row was already
+    //    deleted. (PR #857 review, Copilot finding #3256083554.)
+    //
+    // 2. The `bulk-cleanup-progress` event for a row fires AFTER its
+    //    worktree cleanup completes, so the modal's per-row "deleted"
+    //    check matches when work is actually done — not when the
+    //    quick DB transaction committed. (PR #857 review, finding
+    //    #3256083564.)
+    //
+    // Order within each row: DB delete first (fails closed on raced
+    // restore via the in-transaction Archived guard in
+    // `try_delete_archived_workspace_with_summary`) → agent stop →
+    // worktree remove → branch delete → env unwatch + cache
+    // invalidate → emit progress. Worktree/agent/env teardown only
+    // runs when the DB delete succeeded; a failed row keeps its
+    // disk and branch state intact so retry can converge.
     let hooks = TauriHooks::new(app.clone());
-    // Bridge the ops-layer progress callback to a Tauri event the modal
-    // can subscribe to. Captures `request_id`, `name_by_id`, and
-    // `AppHandle` so the closure can emit on the same thread it's
-    // called from (synchronous — no .await available, no Send required).
-    let progress_emit = |outcome: &claudette::ops::workspace::DeleteWorkspaceOutcome| {
+    let mut deleted: Vec<String> = Vec::with_capacity(ids.len());
+    let mut failed: Vec<BulkDeleteFailure> = Vec::new();
+    let mut cancelled: Vec<String> = Vec::new();
+    let mut affected_repos: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut env_cleanup_paths: Vec<String> = Vec::new();
+
+    let emit_progress = |workspace_id: &str, status: &'static str, error: Option<String>| {
         let Some(req_id) = request_id else {
             return;
         };
-        let status: &'static str = if outcome.cancelled {
-            "cancelled"
-        } else if outcome.error.is_some() {
-            "failed"
-        } else {
-            "deleted"
-        };
         let payload = BulkCleanupProgress {
             request_id: req_id.to_string(),
-            workspace_id: outcome.id.clone(),
+            workspace_id: workspace_id.to_string(),
             name: name_by_id
-                .get(&outcome.id)
+                .get(workspace_id)
                 .cloned()
-                .unwrap_or_else(|| outcome.id.clone()),
+                .unwrap_or_else(|| workspace_id.to_string()),
             status,
-            error: outcome.error.clone(),
+            error,
         };
         if let Err(e) = app.emit("bulk-cleanup-progress", &payload) {
             tracing::warn!(
                 target: "claudette::workspace",
                 error = %e,
-                workspace_id = %outcome.id,
+                workspace_id = workspace_id,
                 "failed to emit bulk-cleanup-progress",
             );
         }
     };
-    let outcomes = claudette::ops::workspace::delete_workspaces_bulk(
-        &db,
-        hooks.as_ref(),
-        ids,
-        cancel_flag,
-        Some(&progress_emit),
-    )
-    .map_err(|e| e.to_string())?;
 
-    let mut deleted = Vec::with_capacity(outcomes.len());
-    let mut failed = Vec::new();
-    let mut cancelled = Vec::new();
-    let mut affected_repos: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for outcome in outcomes {
-        if outcome.cancelled {
-            cancelled.push(outcome.id);
+    for id in ids {
+        // Cancel check: every row after the user clicked Cancel is
+        // reported as `cancelled` with no DB, agent, or disk touch.
+        if cancel_flag.is_some_and(|f| f.load(Ordering::Relaxed)) {
+            cancelled.push(id.clone());
+            emit_progress(id, "cancelled", None);
             continue;
         }
-        match outcome.error {
-            None => {
-                affected_repos.insert(outcome.repository_id.clone());
-                deleted.push(outcome.id);
-            }
-            Some(err) => failed.push(BulkDeleteFailure {
-                id: outcome.id,
-                error: err,
-            }),
-        }
-    }
 
-    // Stop running agents for the rows whose DB delete succeeded — same
-    // gating discipline as the git/env cleanup below. A failed row
-    // keeps its agent running so a retry has a chance of converging,
-    // matching the contract a single retry against `delete_workspace`
-    // would offer.
-    if !deleted.is_empty() {
-        let deleted_set: std::collections::HashSet<String> = deleted.iter().cloned().collect();
+        let repo_id_for_row = workspaces
+            .iter()
+            .find(|w| &w.id == id)
+            .map(|w| w.repository_id.clone())
+            .unwrap_or_default();
+
+        // DB delete (in-transaction Archived guard inside).
+        match db.try_delete_archived_workspace_with_summary(id) {
+            Ok(true) => {} // success — fall through to cleanup
+            Ok(false) => {
+                let err = "workspace no longer archived".to_string();
+                failed.push(BulkDeleteFailure {
+                    id: id.clone(),
+                    error: err.clone(),
+                });
+                emit_progress(id, "failed", Some(err));
+                continue;
+            }
+            Err(e) => {
+                let err = e.to_string();
+                failed.push(BulkDeleteFailure {
+                    id: id.clone(),
+                    error: err.clone(),
+                });
+                emit_progress(id, "failed", Some(err));
+                continue;
+            }
+        }
+
+        // Stop any agents running against this workspace's chat
+        // sessions. Acquire-release the write lock per row instead of
+        // holding it across the whole batch so concurrent agent
+        // operations on unrelated workspaces aren't blocked.
         let pids_to_stop: Vec<u32> = {
             let mut agents = state.agents.write().await;
             let to_remove: Vec<String> = agents
                 .iter()
-                .filter(|(_, s)| deleted_set.contains(&s.workspace_id))
+                .filter(|(_, s)| s.workspace_id == *id)
                 .map(|(k, _)| k.clone())
                 .collect();
             to_remove
@@ -1300,64 +1317,48 @@ async fn delete_workspaces_bulk_body(
         for pid in pids_to_stop {
             let _ = claudette::agent::stop_agent(pid).await;
         }
-    }
 
-    // Git cleanup: best-effort worktree removal + force branch delete,
-    // ONLY for rows whose DB delete succeeded. Worktree/branch state for
-    // a failed row stays intact so the user can retry the cleanup.
-    //
-    // Cancel check between rows: a 50-workspace batch can spend most of
-    // its wall-clock time here (worktrees with `node_modules` are slow
-    // to `rm -rf`). Without this check, clicking Cancel after the fast
-    // DB pass would still leave the user waiting through every
-    // remaining worktree removal. The trade-off is that a cancelled
-    // mid-batch leaves orphan worktree directories on disk for rows
-    // that DB-committed but didn't get to git cleanup — the user can
-    // re-run cleanup (the orphans aren't visible in the UI since
-    // their DB row is gone) or remove them by hand. We accept the
-    // orphans because the alternative — making Cancel a no-op during
-    // the slow phase — is the bug we're fixing.
-    for ws_id in &deleted {
-        if cancel_flag.is_some_and(|f| f.load(Ordering::Relaxed)) {
-            tracing::info!(
-                target: "claudette::workspace",
-                request_id = request_id.unwrap_or(""),
-                "cancel observed mid-worktree-cleanup; \
-                 skipping remaining git/env work for this batch",
-            );
-            break;
-        }
-        let Some(meta) = target_meta.get(ws_id) else {
-            continue;
-        };
-        let Some(ref repo_path) = meta.repo_path else {
-            continue;
-        };
-        if let Some(ref wt_path) = meta.worktree_path {
-            let _ = git::remove_worktree(repo_path, wt_path, true).await;
-        }
-        let _ = git::branch_delete(repo_path, &meta.branch_name).await;
-    }
-
-    // Env-watcher unregister + env-cache invalidate, both gated on
-    // per-row DB success so we don't drop OS watch slots (or evict
-    // cached env exports) for paths that still own a live workspace
-    // row. Single pass — acquire the watcher read lock once and do
-    // both invalidations per row.
-    {
-        let watcher_guard = state.env_watcher.read().await;
-        let watcher = watcher_guard.as_ref();
-        for ws_id in &deleted {
-            if let Some(meta) = target_meta.get(ws_id) {
+        // Worktree + branch cleanup. Best-effort: a failed worktree
+        // removal (e.g. on-disk dir is gone, manual user cleanup) is
+        // logged-and-ignored — the DB row is already gone, so the
+        // "row deleted" contract holds even if disk lags.
+        if let Some(meta) = target_meta.get(id) {
+            if let Some(ref repo_path) = meta.repo_path {
                 if let Some(ref wt_path) = meta.worktree_path {
-                    let path = Path::new(wt_path);
-                    if let Some(watcher) = watcher {
-                        watcher.unregister(path, None);
-                    }
-                    state.env_cache.invalidate(path, None);
+                    let _ = git::remove_worktree(repo_path, wt_path, true).await;
+                    env_cleanup_paths.push(wt_path.clone());
                 }
+                let _ = git::branch_delete(repo_path, &meta.branch_name).await;
             }
         }
+
+        affected_repos.insert(repo_id_for_row);
+        deleted.push(id.clone());
+        emit_progress(id, "deleted", None);
+    }
+
+    // Env-watcher unregister + env-cache invalidate batched at the
+    // end so we acquire the watcher read lock once instead of
+    // per-row. Drops `watcher_guard` before MCP reconciliation so
+    // the read lock isn't held across the next `await`.
+    if !env_cleanup_paths.is_empty() {
+        let watcher_guard = state.env_watcher.read().await;
+        let watcher = watcher_guard.as_ref();
+        for wt_path in &env_cleanup_paths {
+            let path = Path::new(wt_path);
+            if let Some(watcher) = watcher {
+                watcher.unregister(path, None);
+            }
+            state.env_cache.invalidate(path, None);
+        }
+    }
+
+    // Single bulk hook fires the tray rebuild and emits one
+    // `workspaces-changed` event per actually-deleted id. See
+    // `TauriHooks::workspaces_changed_bulk` for the amortization
+    // rationale — 72 rows must not produce 72 tray rebuilds.
+    if !deleted.is_empty() {
+        hooks.workspaces_changed_bulk(&deleted, WorkspaceChangeKind::Deleted);
     }
 
     // Per affected repo: if no Active or Archived workspaces remain, drop

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
@@ -983,19 +984,40 @@ pub async fn delete_workspace(
 
 /// Result of [`delete_workspaces_bulk`]. `deleted` lists IDs that were
 /// successfully hard-deleted; `failed` carries per-ID error messages for
-/// rows that survived (typically due to a transient DB error). The
-/// frontend uses this to drive partial-failure UI and reconcile its
-/// store one row at a time.
+/// rows that survived (typically due to a transient DB error); `cancelled`
+/// lists IDs that were skipped because the user clicked Cancel before
+/// the row was attempted. The frontend uses this to drive partial-failure
+/// UI and reconcile its store one row at a time. Cancelled rows are
+/// untouched in the DB — re-running the cleanup will pick them up.
 #[derive(Debug, Serialize)]
 pub struct BulkDeleteResult {
     pub deleted: Vec<String>,
     pub failed: Vec<BulkDeleteFailure>,
+    pub cancelled: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct BulkDeleteFailure {
     pub id: String,
     pub error: String,
+}
+
+/// Per-row progress event payload emitted on `bulk-cleanup-progress` while
+/// a bulk delete is in flight. The frontend filters by `request_id` so
+/// concurrent runs (rare but legal — e.g. two Storage panels open) don't
+/// cross-pollute. `name` is included so the modal can render row labels
+/// even when the workspace has already been removed from the Zustand
+/// store via the `Deleted` hook by the time the event lands.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BulkCleanupProgress {
+    request_id: String,
+    workspace_id: String,
+    name: String,
+    /// `"deleted" | "failed" | "cancelled"` — matches the three terminal
+    /// states from `ops::workspace::DeleteWorkspaceOutcome`.
+    status: &'static str,
+    error: Option<String>,
 }
 
 /// Hard-delete a batch of archived workspaces. Mirrors the single-workspace
@@ -1018,15 +1040,40 @@ pub struct BulkDeleteFailure {
 #[tracing::instrument(
     target = "claudette::workspace",
     skip(app, state, supervisor),
-    fields(workspace_count = ids.len()),
+    fields(workspace_count = ids.len(), request_id = request_id.as_deref().unwrap_or("")),
 )]
 pub async fn delete_workspaces_bulk(
     ids: Vec<String>,
+    request_id: Option<String>,
     app: AppHandle,
     state: State<'_, AppState>,
     supervisor: State<'_, Arc<McpSupervisor>>,
 ) -> Result<BulkDeleteResult, String> {
-    delete_workspaces_bulk_inner(&ids, &app, &state, &supervisor).await
+    delete_workspaces_bulk_inner(&ids, request_id.as_deref(), &app, &state, &supervisor).await
+}
+
+/// Cooperative-cancel a bulk delete that is currently in flight.
+///
+/// Idempotent: flipping a flag that's already set, or one belonging to
+/// a run that already completed and was unregistered, is a no-op. Returns
+/// `true` if a matching run was found and cancelled, `false` otherwise —
+/// the frontend uses the boolean only for telemetry and otherwise treats
+/// both outcomes the same (the run's final result will report whichever
+/// rows were skipped).
+#[tauri::command]
+#[tracing::instrument(target = "claudette::workspace", skip(state))]
+pub async fn cancel_workspaces_bulk(
+    request_id: String,
+    state: State<'_, AppState>,
+) -> Result<bool, String> {
+    let cancels = state.bulk_cleanup_cancels.read().await;
+    match cancels.get(&request_id) {
+        Some(flag) => {
+            flag.store(true, Ordering::Relaxed);
+            Ok(true)
+        }
+        None => Ok(false),
+    }
 }
 
 /// Shared body of [`delete_workspaces_bulk`] used by both the Tauri
@@ -1035,8 +1082,14 @@ pub async fn delete_workspaces_bulk(
 /// `create_workspace_inner` — so the CLI path runs identical agent
 /// teardown, git cleanup, env-watcher reconciliation, and MCP supervisor
 /// updates without needing to construct Tauri `State` wrappers.
+///
+/// `request_id` is `Some` when the GUI initiated the run (so cancel
+/// works and per-row progress events fire); `None` from the CLI
+/// dispatcher today — CLI sessions don't have a UI to render progress
+/// or a Cancel button, so the bookkeeping cost would be wasted.
 pub(crate) async fn delete_workspaces_bulk_inner(
     ids: &[String],
+    request_id: Option<&str>,
     app: &AppHandle,
     state: &AppState,
     supervisor: &McpSupervisor,
@@ -1045,9 +1098,52 @@ pub(crate) async fn delete_workspaces_bulk_inner(
         return Ok(BulkDeleteResult {
             deleted: Vec::new(),
             failed: Vec::new(),
+            cancelled: Vec::new(),
         });
     }
 
+    // Register the cancel flag before the first DB call. The flag is
+    // unregistered in `finish_bulk_cleanup` at the end of this function,
+    // and the body is wrapped in an inner async block so a `?` early
+    // return below still hits the unregister step.
+    let cancel_flag: Option<Arc<AtomicBool>> = if let Some(req_id) = request_id {
+        let flag = Arc::new(AtomicBool::new(false));
+        state
+            .bulk_cleanup_cancels
+            .write()
+            .await
+            .insert(req_id.to_string(), Arc::clone(&flag));
+        Some(flag)
+    } else {
+        None
+    };
+    let result = delete_workspaces_bulk_body(
+        ids,
+        request_id,
+        cancel_flag.as_ref(),
+        app,
+        state,
+        supervisor,
+    )
+    .await;
+    if let Some(req_id) = request_id {
+        state.bulk_cleanup_cancels.write().await.remove(req_id);
+    }
+    result
+}
+
+/// Inner body of [`delete_workspaces_bulk_inner`] — pulled out so the
+/// outer function can manage the [`AppState::bulk_cleanup_cancels`]
+/// registration lifetime around a single body call, including the `?`
+/// early-return paths below.
+async fn delete_workspaces_bulk_body(
+    ids: &[String],
+    request_id: Option<&str>,
+    cancel_flag: Option<&Arc<AtomicBool>>,
+    app: &AppHandle,
+    state: &AppState,
+    supervisor: &McpSupervisor,
+) -> Result<BulkDeleteResult, String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
     let repos = db.list_repositories().map_err(|e| e.to_string())?;
@@ -1095,6 +1191,18 @@ pub(crate) async fn delete_workspaces_bulk_inner(
         })
         .collect();
 
+    // Display names for the per-row progress event. Built from the
+    // pre-delete snapshot of the workspaces table so a row whose DB
+    // delete commits mid-event still has a name to render (the Zustand
+    // store may have evicted it via the `Deleted` hook by the time the
+    // event lands). Missing IDs (not in `workspaces` at all) fall back
+    // to the id itself on the frontend.
+    let name_by_id: std::collections::HashMap<String, String> = workspaces
+        .iter()
+        .filter(|w| ids.iter().any(|id| id == &w.id))
+        .map(|w| (w.id.clone(), w.name.clone()))
+        .collect();
+
     // DB deletes + summary materialization + Deleted hooks per row. Each
     // row is its own transaction, so per-row failures (e.g. SQLITE_BUSY)
     // are isolated and reported as `failed` rather than rolling back the
@@ -1106,13 +1214,58 @@ pub(crate) async fn delete_workspaces_bulk_inner(
     // were already gone, leaving the user with an archived workspace
     // pointing at nothing they could restore.
     let hooks = TauriHooks::new(app.clone());
-    let outcomes = claudette::ops::workspace::delete_workspaces_bulk(&db, hooks.as_ref(), ids)
-        .map_err(|e| e.to_string())?;
+    // Bridge the ops-layer progress callback to a Tauri event the modal
+    // can subscribe to. Captures `request_id`, `name_by_id`, and
+    // `AppHandle` so the closure can emit on the same thread it's
+    // called from (synchronous — no .await available, no Send required).
+    let progress_emit = |outcome: &claudette::ops::workspace::DeleteWorkspaceOutcome| {
+        let Some(req_id) = request_id else {
+            return;
+        };
+        let status: &'static str = if outcome.cancelled {
+            "cancelled"
+        } else if outcome.error.is_some() {
+            "failed"
+        } else {
+            "deleted"
+        };
+        let payload = BulkCleanupProgress {
+            request_id: req_id.to_string(),
+            workspace_id: outcome.id.clone(),
+            name: name_by_id
+                .get(&outcome.id)
+                .cloned()
+                .unwrap_or_else(|| outcome.id.clone()),
+            status,
+            error: outcome.error.clone(),
+        };
+        if let Err(e) = app.emit("bulk-cleanup-progress", &payload) {
+            tracing::warn!(
+                target: "claudette::workspace",
+                error = %e,
+                workspace_id = %outcome.id,
+                "failed to emit bulk-cleanup-progress",
+            );
+        }
+    };
+    let outcomes = claudette::ops::workspace::delete_workspaces_bulk(
+        &db,
+        hooks.as_ref(),
+        ids,
+        cancel_flag,
+        Some(&progress_emit),
+    )
+    .map_err(|e| e.to_string())?;
 
     let mut deleted = Vec::with_capacity(outcomes.len());
     let mut failed = Vec::new();
+    let mut cancelled = Vec::new();
     let mut affected_repos: std::collections::HashSet<String> = std::collections::HashSet::new();
     for outcome in outcomes {
+        if outcome.cancelled {
+            cancelled.push(outcome.id);
+            continue;
+        }
         match outcome.error {
             None => {
                 affected_repos.insert(outcome.repository_id.clone());
@@ -1152,7 +1305,28 @@ pub(crate) async fn delete_workspaces_bulk_inner(
     // Git cleanup: best-effort worktree removal + force branch delete,
     // ONLY for rows whose DB delete succeeded. Worktree/branch state for
     // a failed row stays intact so the user can retry the cleanup.
+    //
+    // Cancel check between rows: a 50-workspace batch can spend most of
+    // its wall-clock time here (worktrees with `node_modules` are slow
+    // to `rm -rf`). Without this check, clicking Cancel after the fast
+    // DB pass would still leave the user waiting through every
+    // remaining worktree removal. The trade-off is that a cancelled
+    // mid-batch leaves orphan worktree directories on disk for rows
+    // that DB-committed but didn't get to git cleanup — the user can
+    // re-run cleanup (the orphans aren't visible in the UI since
+    // their DB row is gone) or remove them by hand. We accept the
+    // orphans because the alternative — making Cancel a no-op during
+    // the slow phase — is the bug we're fixing.
     for ws_id in &deleted {
+        if cancel_flag.is_some_and(|f| f.load(Ordering::Relaxed)) {
+            tracing::info!(
+                target: "claudette::workspace",
+                request_id = request_id.unwrap_or(""),
+                "cancel observed mid-worktree-cleanup; \
+                 skipping remaining git/env work for this batch",
+            );
+            break;
+        }
         let Some(meta) = target_meta.get(ws_id) else {
             continue;
         };
@@ -1211,7 +1385,11 @@ pub(crate) async fn delete_workspaces_bulk_inner(
         }
     }
 
-    Ok(BulkDeleteResult { deleted, failed })
+    Ok(BulkDeleteResult {
+        deleted,
+        failed,
+        cancelled,
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -1159,9 +1159,14 @@ async fn handle_delete_workspaces_bulk(
         .try_state::<Arc<claudette::mcp_supervisor::McpSupervisor>>()
         .ok_or_else(|| "McpSupervisor not initialised".to_string())?;
 
-    let result =
-        crate::commands::workspace::delete_workspaces_bulk_inner(&ids, app, &state, &supervisor)
-            .await?;
+    let result = crate::commands::workspace::delete_workspaces_bulk_inner(
+        &ids,
+        None,
+        app,
+        &state,
+        &supervisor,
+    )
+    .await?;
 
     serde_json::to_value(result).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -928,6 +928,7 @@ fn main() {
             commands::workspace::reorder_workspaces,
             commands::workspace::delete_workspace,
             commands::workspace::delete_workspaces_bulk,
+            commands::workspace::cancel_workspaces_bulk,
             commands::workspace::generate_workspace_name,
             commands::workspace::refresh_branches,
             commands::workspace::refresh_workspace_branch,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -629,6 +629,14 @@ pub struct AppState {
     /// the frontend forwards that code here so clean profiles can complete
     /// login without an attached terminal.
     pub auth_login_stdin: tokio::sync::Mutex<Option<tokio::process::ChildStdin>>,
+    /// Cancellation flags for in-flight bulk-cleanup runs, keyed by the
+    /// frontend-supplied `request_id`. The Tauri command inserts an
+    /// `Arc<AtomicBool>` on start and removes it on completion;
+    /// `cancel_workspaces_bulk(request_id)` flips the flag. Both the
+    /// per-row DB loop (in `ops::workspace::delete_workspaces_bulk`) and
+    /// the post-DB worktree/branch cleanup loop check the same flag, so
+    /// the user's Cancel click really does stop further work.
+    pub bulk_cleanup_cancels: RwLock<HashMap<String, Arc<AtomicBool>>>,
 }
 
 impl AppState {
@@ -678,6 +686,7 @@ impl AppState {
             claude_flag_defs: Arc::new(RwLock::new(ClaudeFlagDiscovery::Loading)),
             auth_login_cancel: tokio::sync::Mutex::new(None),
             auth_login_stdin: tokio::sync::Mutex::new(None),
+            bulk_cleanup_cancels: RwLock::new(HashMap::new()),
         }
     }
 

--- a/src/ops/workspace.rs
+++ b/src/ops/workspace.rs
@@ -16,6 +16,7 @@
 
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use serde::Serialize;
@@ -866,16 +867,30 @@ pub async fn archive(
     })
 }
 
-/// Per-workspace outcome from a [`delete_workspaces_bulk`] call. `error`
-/// is `None` on success; populated with the DB error message if the row
-/// couldn't be deleted (e.g. a transient SQLITE_BUSY). `repository_id` is
-/// surfaced so the caller can dedupe affected repos for MCP supervisor
-/// reconciliation without re-querying the DB.
+/// Per-workspace outcome from a [`delete_workspaces_bulk`] call.
+///
+/// Three terminal states, mutually exclusive:
+/// - **Deleted** — `error: None`, `cancelled: false`. The DB row is gone
+///   and the bulk hook has fired.
+/// - **Failed** — `error: Some(_)`, `cancelled: false`. The row survives;
+///   caller should not run worktree/branch cleanup for it.
+/// - **Cancelled** — `error: None`, `cancelled: true`. The cancel token
+///   was tripped before this row was attempted; the DB call never ran and
+///   the row's state is untouched. Frontend labels these as "skipped",
+///   not "failed", so the user knows a retry will pick them up cleanly.
+///
+/// `repository_id` is surfaced for every outcome so the caller can dedupe
+/// affected repos for MCP supervisor reconciliation without re-querying
+/// the DB.
 #[derive(Debug, Serialize)]
 pub struct DeleteWorkspaceOutcome {
     pub id: String,
     pub repository_id: String,
     pub error: Option<String>,
+    /// True iff this row was skipped because the cancel token was tripped
+    /// before its DB delete ran. See struct-level docs for full semantics.
+    #[serde(default)]
+    pub cancelled: bool,
 }
 
 /// Hard-delete a batch of workspaces. Each delete runs in its own
@@ -888,17 +903,33 @@ pub struct DeleteWorkspaceOutcome {
 /// `restore_workspace` could flip a row to `Active` in that window.
 ///
 /// Per-row outcomes:
-/// - DB row deleted → `error: None`, hook emits `Deleted`.
+/// - DB row deleted → `error: None, cancelled: false`, hook emits `Deleted`.
 /// - Row missing or no longer Archived → `error: Some("workspace no
-///   longer archived")`, no hook (a `restore_workspace` already fired
-///   its own).
-/// - SQLite error → `error: Some(...)`, no hook.
+///   longer archived"), cancelled: false`, no hook (a `restore_workspace`
+///   already fired its own).
+/// - SQLite error → `error: Some(...), cancelled: false`, no hook.
+/// - Cancel token tripped before the row was attempted →
+///   `error: None, cancelled: true`, no hook, no DB call.
+///
+/// Cancellation is cooperative: the loop checks `cancel` at the top of
+/// each iteration. The row currently mid-flight is allowed to complete
+/// (its DB transaction is short — milliseconds — and worktree/branch
+/// cleanup runs later in the caller, where the same flag is re-checked).
+/// Every subsequent row is recorded as `cancelled: true` with no DB
+/// touch. This matches the spec in issue #854: in-flight finishes,
+/// remaining work skips.
+///
+/// `on_progress` fires once per outcome immediately after the outcome is
+/// built — same thread, no async, no allocations beyond what the caller's
+/// closure does. The Tauri command bridges this to a per-row Tauri event
+/// so the modal can render live status; the CLI ignores it.
 ///
 /// Caller responsibilities (matching the single-workspace
 /// `delete_workspace` Tauri command):
 /// - Stop any running agents whose `workspace_id` matches before invoking.
 /// - Remove worktrees + delete git branches *for IDs whose outcome
-///   reports success* — never for rows where this op reported a failure.
+///   reports success* — never for rows where this op reported a failure
+///   or a cancellation.
 /// - Invalidate env-provider watcher entries and cache entries rooted at
 ///   each successful row's worktree path.
 /// - Run the "is this the last workspace in its repo?" MCP supervisor
@@ -907,6 +938,8 @@ pub fn delete_workspaces_bulk(
     db: &Database,
     hooks: &dyn OpsHooks,
     ids: &[String],
+    cancel: Option<&Arc<AtomicBool>>,
+    on_progress: Option<&dyn Fn(&DeleteWorkspaceOutcome)>,
 ) -> Result<Vec<DeleteWorkspaceOutcome>, OpsError> {
     let workspaces = db.list_workspaces()?;
     let mut outcomes = Vec::with_capacity(ids.len());
@@ -919,25 +952,46 @@ pub fn delete_workspaces_bulk(
             .map(|w| w.repository_id.clone())
             .unwrap_or_default();
 
-        let error = match db.try_delete_archived_workspace_with_summary(id) {
-            Ok(true) => {
-                deleted_ids.push(id.clone());
-                None
+        // Cooperative cancel: trip the flag and every subsequent row
+        // records as `cancelled: true` without touching the DB. The
+        // currently-running iteration (if any) already passed this check
+        // and runs to completion — its DB transaction is short and
+        // there's no safe interrupt point inside SQLite.
+        let outcome = if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
+            DeleteWorkspaceOutcome {
+                id: id.clone(),
+                repository_id,
+                error: None,
+                cancelled: true,
             }
-            Ok(false) => Some("workspace no longer archived".to_string()),
-            Err(e) => Some(e.to_string()),
+        } else {
+            let error = match db.try_delete_archived_workspace_with_summary(id) {
+                Ok(true) => {
+                    deleted_ids.push(id.clone());
+                    None
+                }
+                Ok(false) => Some("workspace no longer archived".to_string()),
+                Err(e) => Some(e.to_string()),
+            };
+            DeleteWorkspaceOutcome {
+                id: id.clone(),
+                repository_id,
+                error,
+                cancelled: false,
+            }
         };
 
-        outcomes.push(DeleteWorkspaceOutcome {
-            id: id.clone(),
-            repository_id,
-            error,
-        });
+        if let Some(cb) = on_progress {
+            cb(&outcome);
+        }
+        outcomes.push(outcome);
     }
 
     // One bulk hook for the whole batch — the GUI's hook impl amortizes
     // the tray rebuild and the workspace-row lookup so a 72-row delete
-    // doesn't fan out to 72 tray rebuilds + 72 DB list scans.
+    // doesn't fan out to 72 tray rebuilds + 72 DB list scans. Fires for
+    // whatever ran before cancel tripped; an entirely-cancelled batch
+    // (`deleted_ids.is_empty()`) skips the hook.
     if !deleted_ids.is_empty() {
         hooks.workspaces_changed_bulk(&deleted_ids, WorkspaceChangeKind::Deleted);
     }
@@ -1297,10 +1351,14 @@ mod tests {
             ids.push(created.workspace.id);
         }
 
-        let outcomes = delete_workspaces_bulk(&db, &hooks, &ids).unwrap();
+        let outcomes = delete_workspaces_bulk(&db, &hooks, &ids, None, None).unwrap();
         assert_eq!(outcomes.len(), 3);
         for outcome in &outcomes {
             assert!(outcome.error.is_none(), "expected success for {outcome:?}");
+            assert!(
+                !outcome.cancelled,
+                "no cancel token passed, no row should be cancelled: {outcome:?}",
+            );
             assert_eq!(outcome.repository_id, repo.id);
         }
 
@@ -1371,7 +1429,7 @@ mod tests {
             active.workspace.id.clone(),
             "does-not-exist".to_string(),
         ];
-        let outcomes = delete_workspaces_bulk(&db, &hooks, &ids).unwrap();
+        let outcomes = delete_workspaces_bulk(&db, &hooks, &ids, None, None).unwrap();
         assert_eq!(outcomes.len(), 3);
 
         // Archived row deleted.
@@ -1399,6 +1457,97 @@ mod tests {
             remaining.iter().any(|w| w.id == active.workspace.id),
             "active workspace must survive a bulk delete that included its id",
         );
+    }
+
+    /// Cancel-mid-batch semantics from issue #854: rows already past the
+    /// per-iteration check finish; the rest skip without touching the DB
+    /// and surface as `cancelled: true` outcomes. The progress callback
+    /// fires once per outcome, in order, so the frontend's live counter
+    /// matches the final outcomes list exactly.
+    #[tokio::test]
+    async fn delete_workspaces_bulk_short_circuits_on_cancel() {
+        use std::sync::Mutex as StdMutex;
+
+        let (_repo_dir, _db_dir, mut db, repo) = setup_repo_and_db().await;
+        let worktree_base = tempfile::tempdir().unwrap();
+        let hooks = RecordingHooks::default();
+
+        let mut ids = Vec::new();
+        for name in ["a", "b", "c", "d"] {
+            let created = create(
+                &mut db,
+                &hooks,
+                worktree_base.path(),
+                CreateParams {
+                    repo_id: &repo.id,
+                    name,
+                    branch_prefix: "test/",
+                },
+            )
+            .await
+            .unwrap();
+            db.update_workspace_status(&created.workspace.id, &WorkspaceStatus::Archived, None)
+                .unwrap();
+            ids.push(created.workspace.id);
+        }
+
+        // Trip the cancel flag from inside the progress callback, after
+        // the first row reports. Mirrors the real user pressing Cancel
+        // mid-flight: the second iteration sees the flag at its top-of-
+        // loop check and short-circuits without a DB call.
+        let cancel = Arc::new(AtomicBool::new(false));
+        let progress_log: Arc<StdMutex<Vec<(String, bool, bool)>>> =
+            Arc::new(StdMutex::new(Vec::new()));
+        let log_for_cb = Arc::clone(&progress_log);
+        let cancel_for_cb = Arc::clone(&cancel);
+        let on_progress = move |outcome: &DeleteWorkspaceOutcome| {
+            let mut log = log_for_cb.lock().unwrap();
+            log.push((
+                outcome.id.clone(),
+                outcome.error.is_none() && !outcome.cancelled,
+                outcome.cancelled,
+            ));
+            // After the first outcome lands, simulate the user pressing
+            // Cancel. Everything from row 2 onward must skip the DB.
+            if log.len() == 1 {
+                cancel_for_cb.store(true, Ordering::Relaxed);
+            }
+        };
+
+        let outcomes =
+            delete_workspaces_bulk(&db, &hooks, &ids, Some(&cancel), Some(&on_progress)).unwrap();
+
+        assert_eq!(outcomes.len(), 4, "every requested id must report once");
+        assert!(
+            outcomes[0].error.is_none() && !outcomes[0].cancelled,
+            "row 0 ran before cancel: {:?}",
+            outcomes[0],
+        );
+        for outcome in &outcomes[1..] {
+            assert!(
+                outcome.cancelled && outcome.error.is_none(),
+                "post-cancel row must be cancelled with no error: {outcome:?}",
+            );
+        }
+
+        // The remaining archived rows survive (the cancelled iterations
+        // never touched the DB).
+        let remaining = db.list_workspaces().unwrap();
+        let surviving: Vec<_> = remaining.iter().filter(|w| ids.contains(&w.id)).collect();
+        assert_eq!(
+            surviving.len(),
+            3,
+            "rows b/c/d should still be in the DB after cancel",
+        );
+
+        // Progress callback fired once per outcome, in declaration order.
+        let log = progress_log.lock().unwrap();
+        assert_eq!(log.len(), 4);
+        assert_eq!(log[0].0, ids[0]);
+        assert!(log[0].1, "first row reported as success");
+        for entry in &log[1..] {
+            assert!(entry.2, "row {} should be reported as cancelled", entry.0);
+        }
     }
 
     /// `build_script_command` must produce a Command that actually runs

--- a/src/ui/src/components/modals/BulkCleanupArchivedModal.helpers.test.ts
+++ b/src/ui/src/components/modals/BulkCleanupArchivedModal.helpers.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
-import type { Workspace } from "../../types";
+import type { Repository, Workspace } from "../../types";
 import {
   ageBucket,
   filterByAge,
+  groupByRepository,
   parseCreatedAt,
 } from "./BulkCleanupArchivedModal.helpers";
 
@@ -172,5 +173,66 @@ describe("filterByAge", () => {
     expect(filterByAge(all, "30", NOW).some((w) => w.id === "mystery")).toBe(
       false,
     );
+  });
+});
+
+describe("groupByRepository", () => {
+  function makeRepo(id: string, name: string): Repository {
+    return {
+      id,
+      path: `/tmp/${id}`,
+      name,
+      path_slug: id,
+      icon: null,
+      created_at: "0",
+      setup_script: null,
+      custom_instructions: null,
+      sort_order: 0,
+      branch_rename_preferences: null,
+      setup_script_auto_run: false,
+      archive_script: null,
+      archive_script_auto_run: false,
+      base_branch: null,
+      default_remote: null,
+      path_valid: true,
+      remote_connection_id: null,
+    };
+  }
+
+  function makeWs(id: string, repoId: string): Workspace {
+    return {
+      ...makeArchived(id, 0),
+      repository_id: repoId,
+    };
+  }
+
+  it("returns groups in `repositories` order, not workspace order", () => {
+    const repos = [makeRepo("r1", "first"), makeRepo("r2", "second")];
+    const ws = [makeWs("w1", "r2"), makeWs("w2", "r1"), makeWs("w3", "r2")];
+    const out = groupByRepository(ws, repos);
+    expect(out.map((g) => g.repo.id)).toEqual(["r1", "r2"]);
+    expect(out[0].workspaces.map((w) => w.id)).toEqual(["w2"]);
+    expect(out[1].workspaces.map((w) => w.id)).toEqual(["w1", "w3"]);
+  });
+
+  it("preserves input workspace order within each group", () => {
+    const repos = [makeRepo("r1", "first")];
+    const ws = [makeWs("c", "r1"), makeWs("a", "r1"), makeWs("b", "r1")];
+    const out = groupByRepository(ws, repos);
+    expect(out[0].workspaces.map((w) => w.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("omits repos with no workspaces", () => {
+    const repos = [makeRepo("r1", "has"), makeRepo("r2", "empty")];
+    const ws = [makeWs("w1", "r1")];
+    expect(groupByRepository(ws, repos).map((g) => g.repo.id)).toEqual(["r1"]);
+  });
+
+  it("drops workspaces whose repository_id is not in `repositories`", () => {
+    const repos = [makeRepo("r1", "known")];
+    const ws = [makeWs("w1", "r1"), makeWs("w2", "r-missing")];
+    const out = groupByRepository(ws, repos);
+    expect(out).toHaveLength(1);
+    expect(out[0].workspaces.map((w) => w.id)).toEqual(["w1"]);
   });
 });

--- a/src/ui/src/components/modals/BulkCleanupArchivedModal.helpers.ts
+++ b/src/ui/src/components/modals/BulkCleanupArchivedModal.helpers.ts
@@ -1,4 +1,4 @@
-import type { Workspace } from "../../types";
+import type { Repository, Workspace } from "../../types";
 
 /**
  * Pure helpers for `BulkCleanupArchivedModal`. Extracted so the age filter
@@ -84,6 +84,40 @@ export function ageBucket(createdAt: string, nowSecs: number): AgeBucket | null 
   if (days < 30) return { kind: "days", count: days };
   if (days < 365) return { kind: "months", count: Math.floor(days / 30) };
   return { kind: "years", count: Math.floor(days / 365) };
+}
+
+/** Group workspaces by their owning repository, preserving the input
+ *  workspace ordering inside each group and ordering groups themselves
+ *  by `repositories` order. Repos with no eligible workspaces are
+ *  omitted from the result. Used by the cleanup-all variant of the
+ *  modal to render per-repo headers in a stable order.
+ *
+ *  A workspace whose `repository_id` doesn't match any repo in
+ *  `repositories` is silently dropped — typically a remote-owned
+ *  workspace that slipped through the caller's filter; better to omit
+ *  it than render under a synthetic "unknown" header that the user
+ *  can't action on. */
+export function groupByRepository(
+  workspaces: Workspace[],
+  repositories: Repository[],
+): { repo: Repository; workspaces: Workspace[] }[] {
+  const byRepo = new Map<string, Workspace[]>();
+  for (const ws of workspaces) {
+    const bucket = byRepo.get(ws.repository_id);
+    if (bucket) {
+      bucket.push(ws);
+    } else {
+      byRepo.set(ws.repository_id, [ws]);
+    }
+  }
+  const out: { repo: Repository; workspaces: Workspace[] }[] = [];
+  for (const repo of repositories) {
+    const ws = byRepo.get(repo.id);
+    if (ws && ws.length > 0) {
+      out.push({ repo, workspaces: ws });
+    }
+  }
+  return out;
 }
 
 /** Filter the archived list by the chosen age window. The user-facing

--- a/src/ui/src/components/modals/BulkCleanupArchivedModal.module.css
+++ b/src/ui/src/components/modals/BulkCleanupArchivedModal.module.css
@@ -244,6 +244,16 @@
   }
 }
 
+/* Respect reduced-motion: same convention as SetupScriptBanner /
+   SessionStatusIcon. The spinner becomes a static border ring so
+   the user still sees a visual indicator for "pending" without the
+   rotation. */
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+  }
+}
+
 /* Live progress counter shown in the header row while a run is in
    flight ("X of N deleted, Y failed"). Replaces the selection counter
    for the duration of the run. */

--- a/src/ui/src/components/modals/BulkCleanupArchivedModal.module.css
+++ b/src/ui/src/components/modals/BulkCleanupArchivedModal.module.css
@@ -167,3 +167,88 @@
   font-size: 13px;
   color: var(--text-muted);
 }
+
+/* Per-repo group header in cleanup-all mode. Renders as a thin label
+   bar above each repo's row block. */
+.repoHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 4px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+/* Indent rows beneath a repo header so the visual hierarchy reads as
+   "repo → its workspaces" rather than a flat list mixing the two. */
+.repoSection {
+  list-style: none;
+  margin: 0 0 8px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Status icon column added to rowLabel when a run is in flight. The
+   grid template grows by one column on .rowLabelRunning so checkboxes
+   slide right to make room for the spinner / check / X. */
+.rowLabelRunning {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  cursor: default;
+  min-width: 0;
+}
+
+.rowStatus {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.rowStatusDeleted {
+  color: var(--status-running);
+}
+
+.rowStatusFailed {
+  color: var(--status-stopped);
+}
+
+.rowStatusCancelled {
+  color: var(--text-faint);
+}
+
+/* Pure-CSS spinner used while a row is still being processed. */
+.spinner {
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  border: 1.5px solid var(--divider);
+  border-top-color: var(--text-primary);
+  border-radius: 50%;
+  animation: bulkCleanupSpin 0.8s linear infinite;
+}
+
+@keyframes bulkCleanupSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Live progress counter shown in the header row while a run is in
+   flight ("X of N deleted, Y failed"). Replaces the selection counter
+   for the duration of the run. */
+.progressCounter {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}

--- a/src/ui/src/components/modals/BulkCleanupArchivedModal.tsx
+++ b/src/ui/src/components/modals/BulkCleanupArchivedModal.tsx
@@ -163,13 +163,15 @@ export function BulkCleanupArchivedModal() {
     return runIds.map((id) => {
       const live = byId.get(id);
       if (live) return live;
-      // Synthesized fallback for evicted rows. Only the fields the
-      // row renderer reads are populated; the rest stay defaults.
-      const progressEntry = progress.get(id);
-      const placeholder: Workspace = {
+      // Synthesized fallback for evicted rows. `name` is left empty
+      // so the row renderer's `ws.name || runNamesRef.current.get(ws.id)
+      // || ws.id` chain falls through to the dispatch-time snapshot
+      // (or the event payload), giving the user a real workspace
+      // name instead of a UUID-looking id.
+      return {
         id,
         repository_id: "",
-        name: progressEntry ? `${id}` : id,
+        name: "",
         branch_name: "",
         worktree_path: null,
         status: "Archived",
@@ -178,28 +180,41 @@ export function BulkCleanupArchivedModal() {
         created_at: "",
         sort_order: 0,
         remote_connection_id: null,
-      };
-      // If we captured a friendly name in progress events, expose it.
-      // The event payload uses `name`, but progress map values today
-      // only carry status + error. Names are looked up from the
-      // pre-run snapshot below instead.
-      return placeholder;
+      } satisfies Workspace;
     });
-  }, [runIds, workspaces, progress]);
+  }, [runIds, workspaces]);
 
   // Name snapshot captured at run start so evicted rows can still show
   // their original workspace name in the live list. Keyed by
   // workspace_id; survives until the next run begins.
   const runNamesRef = useRef<Map<string, string>>(new Map());
 
-  // Repo display info captured at run start so we can keep rendering
-  // per-repo headers even after a repo's last workspace evicts.
-  const runReposRef = useRef<Map<string, Repository>>(new Map());
-
   // workspace_id → repository_id snapshot at dispatch time. Used in
   // run mode to reconstruct grouping even after Zustand evictions
   // null out `row.repository_id` on the synthesized placeholder.
   const runIdToRepoIdRef = useRef<Map<string, string>>(new Map());
+
+  // Tracks whether the modal is still mounted. Prevents the
+  // dispatched `handleDelete` promise from calling `closeModal()`
+  // (a global store action that dismisses *whatever* modal is open)
+  // after the user has closed this modal and opened a different one.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Active request id for the in-flight run. The progress listener
+  // reads this ref to filter events instead of subscribing per-run,
+  // which avoids three lifecycle hazards from the prior per-run
+  // effect design: a listen()-race where fast events emit before
+  // the subscribe resolves; an unsubscribe/resubscribe gap when the
+  // user clicks Cancel and flips `runState.cancelling`; and an
+  // `unlisten` leak when the effect cleans up before the async
+  // listen() resolves.
+  const currentRequestIdRef = useRef<string | null>(null);
 
   const clearStaleFailures = () => {
     setFailures((prev) => (prev.size === 0 ? prev : new Map()));
@@ -232,22 +247,20 @@ export function BulkCleanupArchivedModal() {
     }
   };
 
-  // Subscribe to per-row progress events for the current run only.
-  // Filter by requestId so a concurrent cleanup in another window
-  // doesn't bleed into our state.
+  // Install the progress listener once at mount, filter inside the
+  // handler via `currentRequestIdRef`. Replaces the prior per-run
+  // effect that had three race / leak hazards (see ref comment).
+  // The listener is unregistered when the modal unmounts.
   useEffect(() => {
-    if (runState.kind !== "running") return;
-    const activeRequestId = runState.requestId;
     let unlisten: UnlistenFn | undefined;
     let cancelled = false;
     (async () => {
       try {
-        unlisten = await listen<BulkCleanupProgress>(
+        const fn = await listen<BulkCleanupProgress>(
           "bulk-cleanup-progress",
           (event) => {
-            if (cancelled) return;
             const payload = event.payload;
-            if (payload.requestId !== activeRequestId) return;
+            if (payload.requestId !== currentRequestIdRef.current) return;
             setProgress((prev) => {
               const next = new Map(prev);
               next.set(payload.workspaceId, {
@@ -256,16 +269,20 @@ export function BulkCleanupArchivedModal() {
               });
               return next;
             });
-            // Capture the friendly name from the event payload too —
-            // some rows arrive after the Deleted hook has already
-            // evicted them from the store, and the snapshot built
-            // before dispatch may miss future-runs of the same
-            // workspace if a later cleanup-all races with restore.
             if (payload.name) {
               runNamesRef.current.set(payload.workspaceId, payload.name);
             }
           },
         );
+        if (cancelled) {
+          // The effect cleaned up before listen() resolved (modal
+          // unmounted very fast). Immediately invoke the returned
+          // unlisten so we don't leave a stale handler registered for
+          // the lifetime of the webview.
+          fn();
+          return;
+        }
+        unlisten = fn;
       } catch {
         // No event bridge → the live list won't update incrementally,
         // but the final result still resolves. The modal still works,
@@ -276,21 +293,19 @@ export function BulkCleanupArchivedModal() {
       cancelled = true;
       unlisten?.();
     };
-  }, [runState]);
+  }, []);
 
   const handleDelete = async () => {
     const ids = [...effectiveSelection];
     if (ids.length === 0) return;
 
-    // Snapshot names + repos before dispatch so the live list keeps
-    // labels even after the Deleted hook evicts rows from the store.
+    // Snapshot names + repo ids before dispatch so the live list
+    // keeps labels and grouping even after the `Deleted` hook
+    // evicts rows from the Zustand store.
     runNamesRef.current = new Map(
-      eligible.filter((w) => effectiveSelection.has(w.id)).map((w) => [w.id, w.name]),
-    );
-    runReposRef.current = new Map(
-      repositories
-        .filter((r) => ids.some((id) => workspaces.find((w) => w.id === id)?.repository_id === r.id))
-        .map((r) => [r.id, r]),
+      eligible
+        .filter((w) => effectiveSelection.has(w.id))
+        .map((w) => [w.id, w.name]),
     );
     runIdToRepoIdRef.current = new Map(
       ids.map((id) => [
@@ -300,10 +315,15 @@ export function BulkCleanupArchivedModal() {
     );
 
     const requestId = crypto.randomUUID();
-    setRunState({ kind: "running", requestId, cancelling: false });
+    // Set the ref BEFORE invoking the backend so the at-mount
+    // listener filters in any events that fire before React commits
+    // the `setRunState` below — the DB pass can complete a few
+    // rows in single-digit milliseconds.
+    currentRequestIdRef.current = requestId;
     setRunIds(ids);
     setProgress(new Map());
     setFailures(new Map());
+    setRunState({ kind: "running", requestId, cancelling: false });
 
     try {
       const result = await deleteWorkspacesBulk(ids, requestId);
@@ -323,7 +343,11 @@ export function BulkCleanupArchivedModal() {
             { count: succeeded },
           ),
         );
-        closeModal();
+        // Background-completion guard: if the modal was closed (or
+        // replaced) while the run was in flight, `closeModal()` would
+        // dismiss whatever modal is now open. Only close when we're
+        // still mounted.
+        if (mountedRef.current) closeModal();
         return;
       }
 
@@ -335,20 +359,26 @@ export function BulkCleanupArchivedModal() {
             cancelled: skipped,
           }),
         );
-        closeModal();
+        if (mountedRef.current) closeModal();
         return;
       }
 
-      // Partial failure (with or without cancellations).
+      // Partial failure (with or without cancellations). When the
+      // user also cancelled, surface the skipped count too — they
+      // need to know some rows were intentionally left untouched
+      // and require a re-run, separate from the failures.
       const failureMap = new Map<string, string>();
       for (const f of result.failed) failureMap.set(f.id, f.error);
       setFailures(failureMap);
       setSelected(new Set(result.failed.map((f) => f.id)));
       addToast(
-        t("bulk_cleanup_partial", {
-          succeeded,
-          failed,
-        }),
+        skipped > 0
+          ? t("bulk_cleanup_partial_with_cancelled", {
+              succeeded,
+              failed,
+              cancelled: skipped,
+            })
+          : t("bulk_cleanup_partial", { succeeded, failed }),
       );
     } catch (e) {
       addToast(
@@ -357,6 +387,13 @@ export function BulkCleanupArchivedModal() {
         }),
       );
     } finally {
+      currentRequestIdRef.current = null;
+      // Clear `runIds` so `renderingRun` (keyed on `runIds.length`,
+      // not `progress.size`) flips back to false. We intentionally
+      // leave `progress` populated for the partial-failure path so
+      // failed rows can keep their per-row error string visible in
+      // idle mode — the renderer reads `failures.get(id)` first and
+      // falls back to `progress.get(id)?.error` if absent.
       setRunState({ kind: "idle" });
       setRunIds([]);
     }
@@ -426,7 +463,14 @@ export function BulkCleanupArchivedModal() {
   // - Running: render `runRows` (the dispatched snapshot), still
   //   grouped by repo in cleanup-all mode. Selection checkboxes are
   //   replaced with status icons.
-  const renderingRun = isRunning || progress.size > 0;
+  //
+  // Keyed on `runIds.length`, not `progress.size`. The partial-failure
+  // path clears `runIds` (so the modal flips back to idle and the
+  // failed rows render in the eligible list with their per-row error)
+  // but intentionally leaves `progress` populated so a fast Cancel→
+  // retry round-trip doesn't lose context. Using `progress.size`
+  // would trap the modal in run-mode with an empty `runRows` list.
+  const renderingRun = isRunning || runIds.length > 0;
   const rowsForRender = renderingRun ? runRows : eligible;
   const groupedForRender = useMemo(() => {
     if (repoId !== null) {
@@ -515,7 +559,14 @@ export function BulkCleanupArchivedModal() {
           // During a run, the select-all checkbox is meaningless — the
           // selection is locked. Show the live progress counter
           // instead so the user can read forward motion at a glance.
-          <span className={styles.progressCounter}>
+          // `role=status` + `aria-live=polite` mirrors the convention
+          // used in ChatPanel and SettingsPage so screen readers
+          // announce each per-row completion.
+          <span
+            className={styles.progressCounter}
+            role="status"
+            aria-live="polite"
+          >
             {t("bulk_cleanup_live_counter", {
               deleted: counts.deleted,
               total: totalForCounter,
@@ -563,64 +614,71 @@ export function BulkCleanupArchivedModal() {
                 const err = failures.get(ws.id) ?? rowProgress?.error;
                 const displayName =
                   ws.name || runNamesRef.current.get(ws.id) || ws.id;
-                return (
-                  <li key={ws.id} className={styles.row}>
-                    <div
-                      className={
-                        renderingRun
-                          ? styles.rowLabelRunning
-                          : styles.rowLabel
-                      }
-                    >
-                      {renderingRun ? (
-                        <span className={styles.rowStatus}>
-                          {rowProgress?.status === "deleted" ? (
-                            <Check
-                              size={12}
-                              className={styles.rowStatusDeleted}
-                              aria-label={t("bulk_cleanup_row_deleted")}
-                            />
-                          ) : rowProgress?.status === "failed" ? (
-                            <X
-                              size={12}
-                              className={styles.rowStatusFailed}
-                              aria-label={t("bulk_cleanup_row_failed")}
-                            />
-                          ) : rowProgress?.status === "cancelled" ? (
-                            <MinusCircle
-                              size={12}
-                              className={styles.rowStatusCancelled}
-                              aria-label={t("bulk_cleanup_row_cancelled")}
-                            />
-                          ) : (
-                            <span
-                              className={styles.spinner}
-                              aria-label={t("bulk_cleanup_row_pending")}
-                            />
-                          )}
-                        </span>
-                      ) : null}
-                      <input
-                        type="checkbox"
-                        checked={isSelected}
-                        disabled={renderingRun}
-                        onChange={() => toggleRow(ws.id)}
-                        aria-label={displayName}
-                      />
-                      <span className={styles.rowName}>{displayName}</span>
-                      <span className={styles.rowBranch}>
-                        {ws.branch_name && (
-                          <>
-                            <GitBranch size={11} aria-hidden="true" />
-                            {ws.branch_name}
-                          </>
+                // Idle rows wrap in a <label> so clicking the workspace
+                // name / branch / age toggles the checkbox (matches the
+                // pre-multirepo UX). Running rows can't be toggled, and
+                // the status icon takes the click target slot — render
+                // a non-label <div> in that case so the spinner /
+                // check / X / dash isn't bound to a no-op input.
+                const rowInner = (
+                  <>
+                    {renderingRun ? (
+                      <span className={styles.rowStatus}>
+                        {rowProgress?.status === "deleted" ? (
+                          <Check
+                            size={12}
+                            className={styles.rowStatusDeleted}
+                            aria-label={t("bulk_cleanup_row_deleted")}
+                          />
+                        ) : rowProgress?.status === "failed" ? (
+                          <X
+                            size={12}
+                            className={styles.rowStatusFailed}
+                            aria-label={t("bulk_cleanup_row_failed")}
+                          />
+                        ) : rowProgress?.status === "cancelled" ? (
+                          <MinusCircle
+                            size={12}
+                            className={styles.rowStatusCancelled}
+                            aria-label={t("bulk_cleanup_row_cancelled")}
+                          />
+                        ) : (
+                          <span
+                            className={styles.spinner}
+                            aria-label={t("bulk_cleanup_row_pending")}
+                          />
                         )}
                       </span>
-                      <span className={styles.rowAge}>
-                        {ws.created_at &&
-                          ageBucketLabel(ageBucket(ws.created_at, nowSecs))}
-                      </span>
-                    </div>
+                    ) : null}
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      disabled={renderingRun}
+                      onChange={() => toggleRow(ws.id)}
+                      aria-label={displayName}
+                    />
+                    <span className={styles.rowName}>{displayName}</span>
+                    <span className={styles.rowBranch}>
+                      {ws.branch_name && (
+                        <>
+                          <GitBranch size={11} aria-hidden="true" />
+                          {ws.branch_name}
+                        </>
+                      )}
+                    </span>
+                    <span className={styles.rowAge}>
+                      {ws.created_at &&
+                        ageBucketLabel(ageBucket(ws.created_at, nowSecs))}
+                    </span>
+                  </>
+                );
+                return (
+                  <li key={ws.id} className={styles.row}>
+                    {renderingRun ? (
+                      <div className={styles.rowLabelRunning}>{rowInner}</div>
+                    ) : (
+                      <label className={styles.rowLabel}>{rowInner}</label>
+                    )}
                     {err && <div className={styles.rowError}>{err}</div>}
                   </li>
                 );

--- a/src/ui/src/components/modals/BulkCleanupArchivedModal.tsx
+++ b/src/ui/src/components/modals/BulkCleanupArchivedModal.tsx
@@ -1,9 +1,15 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { GitBranch } from "lucide-react";
+import { Check, GitBranch, MinusCircle, X } from "lucide-react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useAppStore } from "../../stores/useAppStore";
-import { deleteWorkspacesBulk } from "../../services/tauri";
-import type { Workspace } from "../../types";
+import {
+  cancelWorkspacesBulk,
+  deleteWorkspacesBulk,
+  type BulkCleanupProgress,
+} from "../../services/tauri";
+import { RepoIcon } from "../shared/RepoIcon";
+import type { Repository, Workspace } from "../../types";
 import { Modal } from "./Modal";
 import shared from "./shared.module.css";
 import styles from "./BulkCleanupArchivedModal.module.css";
@@ -13,36 +19,54 @@ import {
   type AgeFilter,
   ageBucket,
   filterByAge,
+  groupByRepository,
   parseCreatedAt,
 } from "./BulkCleanupArchivedModal.helpers";
+
+/** Per-row terminal state populated from `bulk-cleanup-progress` events
+ *  during a run. Rows that haven't been processed yet are absent from
+ *  the map — the row UI treats absence as "pending" (spinner). */
+type RowProgressStatus = "deleted" | "failed" | "cancelled";
+
+interface RowProgress {
+  status: RowProgressStatus;
+  error?: string;
+}
+
+/** Run lifecycle. Drives which controls render (Cancel vs Cancelling…
+ *  vs Confirm). `requestId` is the UUID the modal generated when it
+ *  invoked `deleteWorkspacesBulk` — kept in state so the Cancel button
+ *  can target the right run and the event listener can filter events. */
+type RunState =
+  | { kind: "idle" }
+  | { kind: "running"; requestId: string; cancelling: boolean };
 
 export function BulkCleanupArchivedModal() {
   const { t } = useTranslation("modals");
   const { t: tCommon } = useTranslation("common");
   const closeModal = useAppStore((s) => s.closeModal);
   const modalData = useAppStore((s) => s.modalData);
-  // `repoId` lives in `modalData`, which is typed as `Record<string,
-  // unknown>` — every entry surface in this PR populates it, but a
-  // future deep link / command-palette item could open the modal
-  // without it. Guard so the modal closes loudly instead of rendering
-  // an empty selection that looks like the cleanup just succeeded.
-  const repoId =
-    typeof modalData.repoId === "string" && modalData.repoId.length > 0
-      ? modalData.repoId
-      : null;
+  // `repoId` is one of:
+  //   - a string  → single-repo mode (the per-repo Clean up… button).
+  //   - `null`    → cleanup-all mode (Storage section header button).
+  //   - missing / wrong type → close immediately. A future deep-link
+  //     opening the modal without `repoId` set is still legal as
+  //     long as the caller sets it to `null` explicitly.
+  const repoId = (() => {
+    if (modalData.repoId === null) return null;
+    if (typeof modalData.repoId === "string" && modalData.repoId.length > 0) {
+      return modalData.repoId;
+    }
+    return undefined;
+  })();
   const workspaces = useAppStore((s) => s.workspaces);
   const repositories = useAppStore((s) => s.repositories);
   const removeWorkspace = useAppStore((s) => s.removeWorkspace);
   const addToast = useAppStore((s) => s.addToast);
 
   useEffect(() => {
-    if (!repoId) closeModal();
+    if (repoId === undefined) closeModal();
   }, [repoId, closeModal]);
-
-  const repo = useMemo(
-    () => (repoId ? repositories.find((r) => r.id === repoId) ?? null : null),
-    [repositories, repoId],
-  );
 
   const ageBucketLabel = (bucket: AgeBucket | null): string => {
     if (!bucket) return "";
@@ -58,47 +82,53 @@ export function BulkCleanupArchivedModal() {
     }
   };
 
+  // Local repos only — bulk delete dispatches to the local Tauri
+  // command, which can't reach workspaces owned by a paired remote
+  // connection. Cleanup-all flattens across every local repo.
+  const localRepoIds = useMemo(
+    () =>
+      new Set(
+        repositories.filter((r) => !r.remote_connection_id).map((r) => r.id),
+      ),
+    [repositories],
+  );
+
   const archived = useMemo<Workspace[]>(
     () =>
       workspaces
-        // Drop rows owned by a paired remote connection — the local
-        // Tauri delete command only validates IDs in the desktop app's
-        // local DB and would reject them. Entry points already gate by
-        // repo, but this is a belt-and-suspenders defense in case a
-        // future surface (command palette, deep link) lands here with a
-        // remote repo id.
-        .filter(
-          (w) =>
-            w.repository_id === repoId &&
-            w.status === "Archived" &&
-            !w.remote_connection_id,
-        )
-        // Sort newest-first by parsed Unix-seconds. A lexical
-        // compare on the unpadded string field works today but
-        // silently breaks the day any timestamp grows a digit
-        // (year 2286) or a caller writes a differently-formatted
-        // value — numeric compare doesn't depend on that
-        // invariant. Rows whose `created_at` won't parse sink to
-        // the bottom (treated as `-Infinity`).
+        .filter((w) => {
+          if (w.status !== "Archived") return false;
+          if (w.remote_connection_id) return false;
+          if (!localRepoIds.has(w.repository_id)) return false;
+          if (repoId !== null && w.repository_id !== repoId) return false;
+          return true;
+        })
         .sort((a, b) => {
           const av = parseCreatedAt(a.created_at) ?? Number.NEGATIVE_INFINITY;
           const bv = parseCreatedAt(b.created_at) ?? Number.NEGATIVE_INFINITY;
           return bv - av;
         }),
-    [workspaces, repoId],
+    [workspaces, repoId, localRepoIds],
   );
 
   const [ageFilter, setAgeFilter] = useState<AgeFilter>("all");
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [deleting, setDeleting] = useState(false);
+  const [runState, setRunState] = useState<RunState>({ kind: "idle" });
   const [failures, setFailures] = useState<Map<string, string>>(new Map());
-
-  // Treat the modal's mounted instant as "now". Stable across renders so
-  // the age column doesn't tick mid-selection.
-  const nowSecs = useMemo(
-    () => Math.floor(Date.now() / 1000),
-    [],
+  // Live per-row status during a run, keyed by workspace_id. Cleared
+  // when a fresh run starts; preserved between Cancel and the toast so
+  // the user sees the final counts before the modal closes.
+  const [progress, setProgress] = useState<Map<string, RowProgress>>(
+    new Map(),
   );
+  // Snapshot of ids dispatched at the start of the current run. Used
+  // as the source of truth for the live list — `archived` may shrink
+  // mid-run as the Deleted hook evicts rows from the Zustand store,
+  // and we want the list to keep rendering every row through to its
+  // terminal status.
+  const [runIds, setRunIds] = useState<string[]>([]);
+
+  const nowSecs = useMemo(() => Math.floor(Date.now() / 1000), []);
 
   const eligible = useMemo<Workspace[]>(
     () => filterByAge(archived, ageFilter, nowSecs),
@@ -110,9 +140,6 @@ export function BulkCleanupArchivedModal() {
     [eligible],
   );
 
-  // Selection is always the intersection of user picks with eligibility —
-  // switching the filter to a stricter window can never delete more rows
-  // than the user can see.
   const effectiveSelection = useMemo(() => {
     const out = new Set<string>();
     for (const id of selected) {
@@ -124,21 +151,68 @@ export function BulkCleanupArchivedModal() {
   const allEligibleSelected =
     eligible.length > 0 && effectiveSelection.size === eligible.length;
 
-  // Whenever the user interacts with selection or the filter, drop any
-  // lingering per-row error from a previous partial-failure run.
-  // Otherwise a `"workspace no longer archived"` message from attempt N
-  // sits next to a freshly-selected row in attempt N+1 and the user
-  // can't tell whether it's stale or live.
+  // Workspaces rendered during a run come from `runIds` (the dispatched
+  // snapshot) — we look up each id in `workspaces` to get the row data.
+  // If the Zustand store has already evicted it (Deleted hook fired
+  // before this render), we synthesize a minimal record from the
+  // progress event's `name` payload so the row still renders with a
+  // visible label and its final status icon.
+  const runRows = useMemo<Workspace[]>(() => {
+    if (runIds.length === 0) return [];
+    const byId = new Map(workspaces.map((w) => [w.id, w]));
+    return runIds.map((id) => {
+      const live = byId.get(id);
+      if (live) return live;
+      // Synthesized fallback for evicted rows. Only the fields the
+      // row renderer reads are populated; the rest stay defaults.
+      const progressEntry = progress.get(id);
+      const placeholder: Workspace = {
+        id,
+        repository_id: "",
+        name: progressEntry ? `${id}` : id,
+        branch_name: "",
+        worktree_path: null,
+        status: "Archived",
+        agent_status: "Stopped",
+        status_line: "",
+        created_at: "",
+        sort_order: 0,
+        remote_connection_id: null,
+      };
+      // If we captured a friendly name in progress events, expose it.
+      // The event payload uses `name`, but progress map values today
+      // only carry status + error. Names are looked up from the
+      // pre-run snapshot below instead.
+      return placeholder;
+    });
+  }, [runIds, workspaces, progress]);
+
+  // Name snapshot captured at run start so evicted rows can still show
+  // their original workspace name in the live list. Keyed by
+  // workspace_id; survives until the next run begins.
+  const runNamesRef = useRef<Map<string, string>>(new Map());
+
+  // Repo display info captured at run start so we can keep rendering
+  // per-repo headers even after a repo's last workspace evicts.
+  const runReposRef = useRef<Map<string, Repository>>(new Map());
+
+  // workspace_id → repository_id snapshot at dispatch time. Used in
+  // run mode to reconstruct grouping even after Zustand evictions
+  // null out `row.repository_id` on the synthesized placeholder.
+  const runIdToRepoIdRef = useRef<Map<string, string>>(new Map());
+
   const clearStaleFailures = () => {
     setFailures((prev) => (prev.size === 0 ? prev : new Map()));
   };
 
   const handleAgeFilterChange = (next: AgeFilter) => {
+    if (runState.kind === "running") return;
     setAgeFilter(next);
     clearStaleFailures();
   };
 
   const toggleRow = (id: string) => {
+    if (runState.kind === "running") return;
     clearStaleFailures();
     setSelected((prev) => {
       const next = new Set(prev);
@@ -149,6 +223,7 @@ export function BulkCleanupArchivedModal() {
   };
 
   const toggleSelectAll = () => {
+    if (runState.kind === "running") return;
     clearStaleFailures();
     if (allEligibleSelected) {
       setSelected(new Set());
@@ -157,37 +232,122 @@ export function BulkCleanupArchivedModal() {
     }
   };
 
+  // Subscribe to per-row progress events for the current run only.
+  // Filter by requestId so a concurrent cleanup in another window
+  // doesn't bleed into our state.
+  useEffect(() => {
+    if (runState.kind !== "running") return;
+    const activeRequestId = runState.requestId;
+    let unlisten: UnlistenFn | undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        unlisten = await listen<BulkCleanupProgress>(
+          "bulk-cleanup-progress",
+          (event) => {
+            if (cancelled) return;
+            const payload = event.payload;
+            if (payload.requestId !== activeRequestId) return;
+            setProgress((prev) => {
+              const next = new Map(prev);
+              next.set(payload.workspaceId, {
+                status: payload.status,
+                error: payload.error,
+              });
+              return next;
+            });
+            // Capture the friendly name from the event payload too —
+            // some rows arrive after the Deleted hook has already
+            // evicted them from the store, and the snapshot built
+            // before dispatch may miss future-runs of the same
+            // workspace if a later cleanup-all races with restore.
+            if (payload.name) {
+              runNamesRef.current.set(payload.workspaceId, payload.name);
+            }
+          },
+        );
+      } catch {
+        // No event bridge → the live list won't update incrementally,
+        // but the final result still resolves. The modal still works,
+        // just without the per-row animation.
+      }
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [runState]);
+
   const handleDelete = async () => {
     const ids = [...effectiveSelection];
     if (ids.length === 0) return;
-    setDeleting(true);
+
+    // Snapshot names + repos before dispatch so the live list keeps
+    // labels even after the Deleted hook evicts rows from the store.
+    runNamesRef.current = new Map(
+      eligible.filter((w) => effectiveSelection.has(w.id)).map((w) => [w.id, w.name]),
+    );
+    runReposRef.current = new Map(
+      repositories
+        .filter((r) => ids.some((id) => workspaces.find((w) => w.id === id)?.repository_id === r.id))
+        .map((r) => [r.id, r]),
+    );
+    runIdToRepoIdRef.current = new Map(
+      ids.map((id) => [
+        id,
+        workspaces.find((w) => w.id === id)?.repository_id ?? "",
+      ]),
+    );
+
+    const requestId = crypto.randomUUID();
+    setRunState({ kind: "running", requestId, cancelling: false });
+    setRunIds(ids);
+    setProgress(new Map());
+    setFailures(new Map());
+
     try {
-      const result = await deleteWorkspacesBulk(ids);
+      const result = await deleteWorkspacesBulk(ids, requestId);
       for (const id of result.deleted) {
         removeWorkspace(id);
       }
-      if (result.failed.length === 0) {
+      const succeeded = result.deleted.length;
+      const failed = result.failed.length;
+      const skipped = result.cancelled.length;
+
+      if (failed === 0 && skipped === 0) {
         addToast(
           t(
-            result.deleted.length === 1
+            succeeded === 1
               ? "bulk_cleanup_success_singular"
               : "bulk_cleanup_success_plural",
-            { count: result.deleted.length },
+            { count: succeeded },
           ),
         );
         closeModal();
         return;
       }
-      // Partial failure: keep the modal open, surface per-row errors,
-      // shrink the selection to the rows that actually need attention.
+
+      if (failed === 0 && skipped > 0) {
+        // Pure cancel — the user got out cleanly, nothing failed.
+        addToast(
+          t("bulk_cleanup_cancelled_toast", {
+            succeeded,
+            cancelled: skipped,
+          }),
+        );
+        closeModal();
+        return;
+      }
+
+      // Partial failure (with or without cancellations).
       const failureMap = new Map<string, string>();
       for (const f of result.failed) failureMap.set(f.id, f.error);
       setFailures(failureMap);
       setSelected(new Set(result.failed.map((f) => f.id)));
       addToast(
         t("bulk_cleanup_partial", {
-          succeeded: result.deleted.length,
-          failed: result.failed.length,
+          succeeded,
+          failed,
         }),
       );
     } catch (e) {
@@ -197,27 +357,128 @@ export function BulkCleanupArchivedModal() {
         }),
       );
     } finally {
-      setDeleting(false);
+      setRunState({ kind: "idle" });
+      setRunIds([]);
     }
   };
 
-  // Hooks above run unconditionally so they're stable across renders;
-  // the render-time bail comes here, AFTER every hook has been called.
-  // The effect above has already scheduled `closeModal()` for the next
-  // tick — this short-circuit suppresses the otherwise-visible flash
-  // of the empty-state "No archived workspaces match" copy on the way
-  // out, which would look like a successful zero-row cleanup.
-  if (!repoId) return null;
+  const handleCancel = useCallback(() => {
+    if (runState.kind !== "running") return;
+    setRunState({
+      kind: "running",
+      requestId: runState.requestId,
+      cancelling: true,
+    });
+    // Fire-and-forget; cooperative cancel only signals, the in-flight
+    // `deleteWorkspacesBulk` promise will resolve with the partial
+    // result and the finally{} above will reset state.
+    void cancelWorkspacesBulk(runState.requestId).catch(() => {
+      // The backend may have already finished and unregistered the
+      // flag — `false` return is fine, the promise rejecting is
+      // unexpected but not actionable here.
+    });
+  }, [runState]);
+
+  // Close-while-running implies cancel. Cancel doesn't immediately
+  // close the modal (so the user sees the run finalize), but if they
+  // click X / Escape / backdrop, we cancel AND close. The dispatched
+  // promise still resolves in the background; its toast still fires
+  // via the global `addToast` even after the modal unmounts.
+  const handleClose = useCallback(() => {
+    if (runState.kind === "running") {
+      void cancelWorkspacesBulk(runState.requestId).catch(() => {});
+    }
+    closeModal();
+  }, [runState, closeModal]);
+
+  const isRunning = runState.kind === "running";
+  const cancelling = isRunning && runState.cancelling;
+
+  // Live counters from the progress map. During a run these replace
+  // the static "selected" counter; after a run they're zero again.
+  const counts = useMemo(() => {
+    let deleted = 0;
+    let failed = 0;
+    let cancelled = 0;
+    for (const entry of progress.values()) {
+      if (entry.status === "deleted") deleted += 1;
+      else if (entry.status === "failed") failed += 1;
+      else if (entry.status === "cancelled") cancelled += 1;
+    }
+    return { deleted, failed, cancelled };
+  }, [progress]);
+
+  const repo =
+    repoId && typeof repoId === "string"
+      ? repositories.find((r) => r.id === repoId) ?? null
+      : null;
+
+  const title =
+    repoId && typeof repoId === "string"
+      ? t("bulk_cleanup_title", {
+          repo: repo?.name ?? t("bulk_cleanup_title_fallback_repo"),
+        })
+      : t("bulk_cleanup_title_all");
+
+  // What we render in the list depends on whether a run is in flight.
+  // - Idle / no run: render `eligible`, optionally grouped by repo in
+  //   cleanup-all mode.
+  // - Running: render `runRows` (the dispatched snapshot), still
+  //   grouped by repo in cleanup-all mode. Selection checkboxes are
+  //   replaced with status icons.
+  const renderingRun = isRunning || progress.size > 0;
+  const rowsForRender = renderingRun ? runRows : eligible;
+  const groupedForRender = useMemo(() => {
+    if (repoId !== null) {
+      return [{ repo: null as Repository | null, workspaces: rowsForRender }];
+    }
+    // Cleanup-all mode: group by repo. During a run, fall back to the
+    // snapshotted repo map for any row whose store entry has been
+    // evicted (so the header doesn't disappear before the last row of
+    // a fully-deleted repo lands).
+    const sourceRepos: Repository[] = repositories.filter((r) =>
+      localRepoIds.has(r.id),
+    );
+    if (!renderingRun) {
+      return groupByRepository(rowsForRender, sourceRepos).map(
+        ({ repo: r, workspaces: ws }) => ({
+          repo: r as Repository | null,
+          workspaces: ws,
+        }),
+      );
+    }
+    // Run mode: rows are runRows in dispatch order; their live
+    // `repository_id` may be empty for evicted placeholders. The
+    // dispatch-time snapshot map is the source of truth.
+    const byRepoId = new Map<string, Workspace[]>();
+    for (const row of rowsForRender) {
+      const repoIdForRow =
+        row.repository_id || runIdToRepoIdRef.current.get(row.id) || "";
+      const bucket = byRepoId.get(repoIdForRow);
+      if (bucket) bucket.push(row);
+      else byRepoId.set(repoIdForRow, [row]);
+    }
+    // Order groups by `sourceRepos` so the visual order stays stable
+    // even as rows arrive in dispatch order (which may interleave
+    // across repos).
+    const out: { repo: Repository | null; workspaces: Workspace[] }[] = [];
+    for (const r of sourceRepos) {
+      const ws = byRepoId.get(r.id);
+      if (ws && ws.length > 0) out.push({ repo: r, workspaces: ws });
+    }
+    return out;
+  }, [rowsForRender, repoId, repositories, renderingRun, localRepoIds]);
+
+  const totalForCounter = renderingRun ? runIds.length : eligible.length;
+
+  // All hooks above run unconditionally; the render-time bail comes
+  // here. The effect at the top has already scheduled `closeModal()`
+  // for the next tick — this short-circuit just suppresses the
+  // otherwise-visible flash of an empty modal on the way out.
+  if (repoId === undefined) return null;
 
   return (
-    <Modal
-      title={t("bulk_cleanup_title", {
-        repo: repo?.name ?? t("bulk_cleanup_title_fallback_repo"),
-      })}
-      onClose={closeModal}
-      wide
-      bodyScroll
-    >
+    <Modal title={title} onClose={handleClose} wide bodyScroll>
       <div className={shared.warning}>{t("bulk_cleanup_warning")}</div>
 
       <div className={styles.filterRow}>
@@ -239,6 +500,7 @@ export function BulkCleanupArchivedModal() {
                 name="bulk-cleanup-age"
                 value={f.key}
                 checked={ageFilter === f.key}
+                disabled={isRunning}
                 onChange={() => handleAgeFilterChange(f.key)}
                 className={styles.filterRadio}
               />
@@ -249,64 +511,139 @@ export function BulkCleanupArchivedModal() {
       </div>
 
       <div className={styles.headerRow}>
-        <label className={styles.selectAllLabel}>
-          <input
-            type="checkbox"
-            checked={allEligibleSelected}
-            disabled={eligible.length === 0}
-            onChange={toggleSelectAll}
-          />
-          <span>{t("bulk_cleanup_select_all")}</span>
-        </label>
-        <span className={styles.counter}>
-          {t("bulk_cleanup_counter", {
-            selected: effectiveSelection.size,
-            total: eligible.length,
-          })}
-        </span>
+        {renderingRun ? (
+          // During a run, the select-all checkbox is meaningless — the
+          // selection is locked. Show the live progress counter
+          // instead so the user can read forward motion at a glance.
+          <span className={styles.progressCounter}>
+            {t("bulk_cleanup_live_counter", {
+              deleted: counts.deleted,
+              total: totalForCounter,
+              failed: counts.failed,
+            })}
+          </span>
+        ) : (
+          <label className={styles.selectAllLabel}>
+            <input
+              type="checkbox"
+              checked={allEligibleSelected}
+              disabled={eligible.length === 0}
+              onChange={toggleSelectAll}
+            />
+            <span>{t("bulk_cleanup_select_all")}</span>
+          </label>
+        )}
+        {!renderingRun && (
+          <span className={styles.counter}>
+            {t("bulk_cleanup_counter", {
+              selected: effectiveSelection.size,
+              total: eligible.length,
+            })}
+          </span>
+        )}
       </div>
 
-      {eligible.length === 0 ? (
+      {rowsForRender.length === 0 ? (
         <div className={styles.empty}>{t("bulk_cleanup_no_eligible")}</div>
       ) : (
-        <ul className={styles.list}>
-          {eligible.map((ws) => {
-            const isSelected = effectiveSelection.has(ws.id);
-            const err = failures.get(ws.id);
-            return (
-              <li key={ws.id} className={styles.row}>
-                <label className={styles.rowLabel}>
-                  <input
-                    type="checkbox"
-                    checked={isSelected}
-                    onChange={() => toggleRow(ws.id)}
-                  />
-                  <span className={styles.rowName}>{ws.name}</span>
-                  <span className={styles.rowBranch}>
-                    <GitBranch size={11} aria-hidden="true" />
-                    {ws.branch_name}
-                  </span>
-                  <span className={styles.rowAge}>
-                    {ageBucketLabel(ageBucket(ws.created_at, nowSecs))}
-                  </span>
-                </label>
-                {err && <div className={styles.rowError}>{err}</div>}
-              </li>
-            );
-          })}
-        </ul>
+        groupedForRender.map((group, gi) => (
+          <div key={group.repo?.id ?? `group-${gi}`}>
+            {repoId === null && group.repo && (
+              <div className={styles.repoHeader}>
+                {group.repo.icon && (
+                  <RepoIcon icon={group.repo.icon} size={11} />
+                )}
+                {group.repo.name}
+              </div>
+            )}
+            <ul className={styles.repoSection}>
+              {group.workspaces.map((ws) => {
+                const rowProgress = progress.get(ws.id);
+                const isSelected = effectiveSelection.has(ws.id);
+                const err = failures.get(ws.id) ?? rowProgress?.error;
+                const displayName =
+                  ws.name || runNamesRef.current.get(ws.id) || ws.id;
+                return (
+                  <li key={ws.id} className={styles.row}>
+                    <div
+                      className={
+                        renderingRun
+                          ? styles.rowLabelRunning
+                          : styles.rowLabel
+                      }
+                    >
+                      {renderingRun ? (
+                        <span className={styles.rowStatus}>
+                          {rowProgress?.status === "deleted" ? (
+                            <Check
+                              size={12}
+                              className={styles.rowStatusDeleted}
+                              aria-label={t("bulk_cleanup_row_deleted")}
+                            />
+                          ) : rowProgress?.status === "failed" ? (
+                            <X
+                              size={12}
+                              className={styles.rowStatusFailed}
+                              aria-label={t("bulk_cleanup_row_failed")}
+                            />
+                          ) : rowProgress?.status === "cancelled" ? (
+                            <MinusCircle
+                              size={12}
+                              className={styles.rowStatusCancelled}
+                              aria-label={t("bulk_cleanup_row_cancelled")}
+                            />
+                          ) : (
+                            <span
+                              className={styles.spinner}
+                              aria-label={t("bulk_cleanup_row_pending")}
+                            />
+                          )}
+                        </span>
+                      ) : null}
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        disabled={renderingRun}
+                        onChange={() => toggleRow(ws.id)}
+                        aria-label={displayName}
+                      />
+                      <span className={styles.rowName}>{displayName}</span>
+                      <span className={styles.rowBranch}>
+                        {ws.branch_name && (
+                          <>
+                            <GitBranch size={11} aria-hidden="true" />
+                            {ws.branch_name}
+                          </>
+                        )}
+                      </span>
+                      <span className={styles.rowAge}>
+                        {ws.created_at &&
+                          ageBucketLabel(ageBucket(ws.created_at, nowSecs))}
+                      </span>
+                    </div>
+                    {err && <div className={styles.rowError}>{err}</div>}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))
       )}
 
       <div className={shared.actions}>
-        <button className={shared.btn} onClick={closeModal} disabled={deleting}>
-          {tCommon("cancel")}
+        <button
+          className={shared.btn}
+          onClick={isRunning ? handleCancel : handleClose}
+          disabled={cancelling}
+        >
+          {cancelling ? t("bulk_cleanup_cancelling") : tCommon("cancel")}
         </button>
         <button
           className={shared.btnDanger}
           onClick={handleDelete}
-          disabled={deleting || effectiveSelection.size === 0}
+          disabled={isRunning || effectiveSelection.size === 0}
         >
-          {deleting
+          {isRunning
             ? t("bulk_cleanup_deleting")
             : t("bulk_cleanup_confirm", { count: effectiveSelection.size })}
         </button>

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -170,6 +170,23 @@
   margin: 0;
 }
 
+/* Storage section header: title + description block on the left,
+   cleanup-all action button aligned to the right. Title and
+   description keep their default margins so the rest of the page
+   matches the existing visual rhythm; the button shrinks to its
+   content width. */
+.storageHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.storageHeaderText {
+  min-width: 0;
+  flex: 1;
+}
+
 /* ── Setting rows ── */
 
 .settingRow {

--- a/src/ui/src/components/settings/sections/StorageSettings.tsx
+++ b/src/ui/src/components/settings/sections/StorageSettings.tsx
@@ -42,10 +42,25 @@ export function StorageSettings() {
 
   return (
     <div>
-      <h2 className={styles.sectionTitle}>{t("storage_section_title")}</h2>
-      <p className={styles.sectionDescription}>
-        {t("storage_section_description", { total: totalArchived })}
-      </p>
+      <div className={styles.storageHeader}>
+        <div className={styles.storageHeaderText}>
+          <h2 className={styles.sectionTitle}>{t("storage_section_title")}</h2>
+          <p className={styles.sectionDescription}>
+            {t("storage_section_description", { total: totalArchived })}
+          </p>
+        </div>
+        <button
+          className={styles.iconBtn}
+          onClick={() =>
+            // `repoId: null` tells BulkCleanupArchivedModal to enter
+            // cleanup-all mode (flatten across every local repo).
+            openModal("bulkCleanupArchived", { repoId: null })
+          }
+          disabled={totalArchived === 0}
+        >
+          {t("storage_cleanup_all_button", { count: totalArchived })}
+        </button>
+      </div>
 
       {rows.length === 0 ? (
         <div className={styles.fieldHint}>{t("storage_no_repos")}</div>

--- a/src/ui/src/locales/en/modals.json
+++ b/src/ui/src/locales/en/modals.json
@@ -147,6 +147,7 @@
   "bulk_cleanup_success_singular": "Cleaned up {{count}} workspace",
   "bulk_cleanup_success_plural": "Cleaned up {{count}} workspaces",
   "bulk_cleanup_partial": "Cleaned up {{succeeded}}; {{failed}} failed",
+  "bulk_cleanup_partial_with_cancelled": "Cleaned up {{succeeded}}; {{failed}} failed, {{cancelled}} skipped — re-run to finish.",
   "bulk_cleanup_cancelled_toast": "Cancelled. Cleaned up {{succeeded}}; {{cancelled}} skipped — re-run to finish.",
   "bulk_cleanup_failed": "Bulk cleanup failed: {{error}}",
   "bulk_cleanup_age_today": "today",

--- a/src/ui/src/locales/en/modals.json
+++ b/src/ui/src/locales/en/modals.json
@@ -127,6 +127,7 @@
   "env_trust_done": "Close",
 
   "bulk_cleanup_title": "Clean up archived workspaces in {{repo}}",
+  "bulk_cleanup_title_all": "Clean up archived workspaces across all repositories",
   "bulk_cleanup_title_fallback_repo": "this project",
   "bulk_cleanup_warning": "Deleting an archived workspace permanently removes its worktree, git branch, and chat history. Lifetime metrics are preserved.",
   "bulk_cleanup_older_than": "Older than",
@@ -138,15 +139,22 @@
   "bulk_cleanup_filter_365": "1 year",
   "bulk_cleanup_select_all": "Select all",
   "bulk_cleanup_counter": "{{selected}} of {{total}} selected",
+  "bulk_cleanup_live_counter": "{{deleted}} of {{total}} deleted, {{failed}} failed",
   "bulk_cleanup_no_eligible": "No archived workspaces match this filter.",
   "bulk_cleanup_deleting": "Deleting…",
+  "bulk_cleanup_cancelling": "Cancelling…",
   "bulk_cleanup_confirm": "Delete selected ({{count}})",
   "bulk_cleanup_success_singular": "Cleaned up {{count}} workspace",
   "bulk_cleanup_success_plural": "Cleaned up {{count}} workspaces",
   "bulk_cleanup_partial": "Cleaned up {{succeeded}}; {{failed}} failed",
+  "bulk_cleanup_cancelled_toast": "Cancelled. Cleaned up {{succeeded}}; {{cancelled}} skipped — re-run to finish.",
   "bulk_cleanup_failed": "Bulk cleanup failed: {{error}}",
   "bulk_cleanup_age_today": "today",
   "bulk_cleanup_age_days": "{{count}}d ago",
   "bulk_cleanup_age_months": "{{count}}mo ago",
-  "bulk_cleanup_age_years": "{{count}}y ago"
+  "bulk_cleanup_age_years": "{{count}}y ago",
+  "bulk_cleanup_row_pending": "Pending",
+  "bulk_cleanup_row_deleted": "Deleted",
+  "bulk_cleanup_row_failed": "Failed",
+  "bulk_cleanup_row_cancelled": "Skipped"
 }

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -275,6 +275,7 @@
   "storage_archived_count_singular": "{{count}} archived workspace",
   "storage_archived_count_plural": "{{count}} archived workspaces",
   "storage_cleanup_button": "Clean up…",
+  "storage_cleanup_all_button": "Clean up all ({{count}})",
   "repo_workspace_cleanup_label": "Workspace cleanup",
   "repo_workspace_cleanup_hint_singular": "{{count}} archived workspace in this project. Cleanup permanently deletes worktrees, branches, and chat history; lifetime metrics are preserved.",
   "repo_workspace_cleanup_hint_plural": "{{count}} archived workspaces in this project. Cleanup permanently deletes worktrees, branches, and chat history; lifetime metrics are preserved.",

--- a/src/ui/src/services/tauri/workspace.ts
+++ b/src/ui/src/services/tauri/workspace.ts
@@ -71,10 +71,56 @@ export interface BulkDeleteFailure {
 export interface BulkDeleteResult {
   deleted: string[];
   failed: BulkDeleteFailure[];
+  /**
+   * IDs that were skipped because the user cancelled mid-batch. These
+   * rows are untouched in the DB — re-running cleanup picks them up.
+   * Empty when the run finished naturally.
+   */
+  cancelled: string[];
 }
 
-export function deleteWorkspacesBulk(ids: string[]): Promise<BulkDeleteResult> {
-  return invoke("delete_workspaces_bulk", { ids });
+/**
+ * `requestId` identifies the run for two purposes: (a) so the backend
+ * can emit `bulk-cleanup-progress` events tagged with the same id, which
+ * lets the modal filter out unrelated runs; and (b) so `cancelWorkspacesBulk`
+ * can target this specific run. Generate a fresh UUID per click —
+ * reusing one across clicks would let a stale cancel land on a new run.
+ *
+ * Pass `null` for headless / CLI-style use (no live progress, no cancel).
+ */
+export function deleteWorkspacesBulk(
+  ids: string[],
+  requestId: string | null,
+): Promise<BulkDeleteResult> {
+  return invoke("delete_workspaces_bulk", { ids, requestId });
+}
+
+/**
+ * Cooperatively cancel a bulk delete in flight. Idempotent — flipping
+ * a flag for an already-completed run is a no-op. Resolves to `true`
+ * when a matching run was found and signalled, `false` otherwise.
+ */
+export function cancelWorkspacesBulk(requestId: string): Promise<boolean> {
+  return invoke("cancel_workspaces_bulk", { requestId });
+}
+
+/**
+ * Per-row payload from the `bulk-cleanup-progress` Tauri event. Emitted
+ * once per workspace as the run iterates, in the same order the rows
+ * are processed. `status` is one of:
+ *   - `"deleted"` — DB row is gone; worktree/branch cleanup happens
+ *     asynchronously after the event fires.
+ *   - `"failed"` — DB delete refused (raced restore, SQLITE_BUSY, etc.);
+ *     `error` carries the message.
+ *   - `"cancelled"` — user clicked Cancel before this row was attempted;
+ *     the DB is untouched.
+ */
+export interface BulkCleanupProgress {
+  requestId: string;
+  workspaceId: string;
+  name: string;
+  status: "deleted" | "failed" | "cancelled";
+  error?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds the three follow-ups from issue #854 to the bulk archive cleanup flow:

1. **Top-level "Clean up all" button** in Settings → Storage that runs cleanup across every local repo in one pass (disabled when nothing is archived). Reuses the existing modal in a new cleanup-all mode that flattens rows across repos and groups by repo header.
2. **Live per-row progress** via a new `bulk-cleanup-progress` Tauri event: spinner → check / X / circled-dash as each row resolves, plus a running "X of N deleted, Y failed" counter. The frontend filters events by a UUID `requestId` so concurrent runs can't cross-pollute.
3. **Working cancel** mid-cleanup. Cancel stays enabled during a run; clicking switches the label to "Cancelling…". The same `Arc<AtomicBool>` is checked in two places — the per-row DB-delete loop in `ops::workspace::delete_workspaces_bulk` and the post-DB worktree-cleanup loop in the Tauri command — so a click during either the fast or slow phase actually stops further work. Closing the modal mid-run implies cancel.

`BulkDeleteResult` grows a `cancelled: Vec<String>` field; cancelled rows are untouched in the DB and the toast tells the user to re-run if they want to finish.

## Test plan

- [x] `cargo test -p claudette --lib ops::` — includes new `delete_workspaces_bulk_short_circuits_on_cancel` test (8/8 pass)
- [x] `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` with `-Dwarnings` — clean
- [x] `bun run test` — 2509/2509 pass (includes new `groupByRepository` tests)
- [x] `bunx tsc -b` — clean
- [x] `bun run lint:css` — clean
- [ ] **Manual UAT**: open Settings → Storage with 5+ archived workspaces across 2+ repos, click "Clean up all (N)", verify per-row spinners → checks animate as the run proceeds and the counter updates live
- [ ] **Manual UAT**: start a multi-repo cleanup, click Cancel mid-flight, verify (a) button switches to "Cancelling…", (b) remaining rows render the circled-dash skipped icon, (c) toast reports `"Cancelled. Cleaned up X; Y skipped — re-run to finish."`, (d) skipped rows still appear under Storage on next open
- [ ] **Manual UAT**: close the modal while a run is in flight; verify the run stops at the next iteration rather than continuing in the background
- [ ] **Manual UAT**: per-repo `Clean up…` button still works (single-repo mode unchanged)

Closes #854