### PR TITLE
fix(command-palette): cache file search results

### DIFF
--- a/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useWorkspaceFileIndex } from "./useWorkspaceFileIndex";
 import { useAppStore } from "../../stores/useAppStore";
+import { clearWorkspaceFilesCacheForTests } from "../../utils/workspaceFileCache";
 
 const serviceMocks = vi.hoisted(() => ({
   listWorkspaceFiles: vi.fn(),
@@ -42,6 +43,7 @@ async function render(workspaceId: string): Promise<void> {
 
 beforeEach(() => {
   latestResolve = null;
+  clearWorkspaceFilesCacheForTests();
   serviceMocks.listWorkspaceFiles.mockReset();
   serviceMocks.listWorkspaceFiles.mockResolvedValue([
     { path: "Cargo.toml", is_directory: false },

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.test.tsx
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useWorkspaceFileIndex } from "./useWorkspaceFileIndex";
 import { useAppStore } from "../../stores/useAppStore";
-import { clearWorkspaceFilesCacheForTests } from "../../utils/workspaceFileCache";
+import { __testing as workspaceFileCacheTesting } from "../../utils/workspaceFileCache";
 
 const serviceMocks = vi.hoisted(() => ({
   listWorkspaceFiles: vi.fn(),
@@ -43,7 +43,7 @@ async function render(workspaceId: string): Promise<void> {
 
 beforeEach(() => {
   latestResolve = null;
-  clearWorkspaceFilesCacheForTests();
+  workspaceFileCacheTesting.reset();
   serviceMocks.listWorkspaceFiles.mockReset();
   serviceMocks.listWorkspaceFiles.mockResolvedValue([
     { path: "Cargo.toml", is_directory: false },

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.ts
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.ts
@@ -17,6 +17,14 @@ interface FileIndexData {
   uniqueBasenames: Map<string, string | null>;
 }
 
+interface FileIndexCacheEntry {
+  refreshNonce: number;
+  promise: Promise<FileIndexData>;
+}
+
+const MAX_CACHED_WORKSPACES = 20;
+const indexCache = new Map<string, FileIndexCacheEntry>();
+
 export function useWorkspaceFileIndex(
   workspaceId: string | null | undefined,
 ): WorkspaceFileIndex {
@@ -31,9 +39,7 @@ export function useWorkspaceFileIndex(
       return;
     }
     let cancelled = false;
-    const promise = loadWorkspaceFilesCached(workspaceId, refreshNonce).then(
-      buildFileIndex,
-    );
+    const promise = loadWorkspaceFileIndexCached(workspaceId, refreshNonce);
     promise
       .then((next) => {
         if (!cancelled) setData(next);
@@ -76,6 +82,45 @@ export function useWorkspaceFileIndex(
       },
     };
   }, [data]);
+}
+
+function loadWorkspaceFileIndexCached(
+  workspaceId: string,
+  refreshNonce: number,
+): Promise<FileIndexData> {
+  const cached = indexCache.get(workspaceId);
+  if (cached?.refreshNonce === refreshNonce) {
+    refreshIndexCacheLru(workspaceId, cached);
+    return cached.promise;
+  }
+  const promise = loadWorkspaceFilesCached(workspaceId, refreshNonce)
+    .then(buildFileIndex)
+    .catch((err) => {
+      const current = indexCache.get(workspaceId);
+      if (current?.promise === promise) {
+        indexCache.delete(workspaceId);
+      }
+      throw err;
+    });
+  indexCache.set(workspaceId, { refreshNonce, promise });
+  trimIndexCache();
+  return promise;
+}
+
+function refreshIndexCacheLru(
+  workspaceId: string,
+  entry: FileIndexCacheEntry,
+): void {
+  indexCache.delete(workspaceId);
+  indexCache.set(workspaceId, entry);
+}
+
+function trimIndexCache(): void {
+  while (indexCache.size > MAX_CACHED_WORKSPACES) {
+    const oldestKey = indexCache.keys().next().value;
+    if (!oldestKey) return;
+    indexCache.delete(oldestKey);
+  }
 }
 
 function formatLineSuffix(parsed: ReturnType<typeof parseFilePathTarget>): string {

--- a/src/ui/src/components/chat/useWorkspaceFileIndex.ts
+++ b/src/ui/src/components/chat/useWorkspaceFileIndex.ts
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
-import { listWorkspaceFiles } from "../../services/tauri";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   extractClaudetteWorktreeRelativePath,
   parseFilePathTarget,
 } from "../../utils/filePathLinks";
+import { loadWorkspaceFilesCached } from "../../utils/workspaceFileCache";
 
 export interface WorkspaceFileIndex {
   resolve: (path: string) => string | null;
@@ -16,14 +16,6 @@ interface FileIndexData {
   paths: Set<string>;
   uniqueBasenames: Map<string, string | null>;
 }
-
-interface FileIndexCacheEntry {
-  refreshNonce: number;
-  promise: Promise<FileIndexData>;
-}
-
-const MAX_CACHED_WORKSPACES = 20;
-const dataCache = new Map<string, FileIndexCacheEntry>();
 
 export function useWorkspaceFileIndex(
   workspaceId: string | null | undefined,
@@ -39,23 +31,14 @@ export function useWorkspaceFileIndex(
       return;
     }
     let cancelled = false;
-    const cached = dataCache.get(workspaceId);
-    let promise =
-      cached?.refreshNonce === refreshNonce ? cached.promise : undefined;
-    if (!promise) {
-      promise = listWorkspaceFiles(workspaceId).then(buildFileIndex);
-      dataCache.set(workspaceId, { refreshNonce, promise });
-      trimFileIndexCache();
-    }
+    const promise = loadWorkspaceFilesCached(workspaceId, refreshNonce).then(
+      buildFileIndex,
+    );
     promise
       .then((next) => {
         if (!cancelled) setData(next);
       })
       .catch((err) => {
-        const current = dataCache.get(workspaceId);
-        if (current?.promise === promise) {
-          dataCache.delete(workspaceId);
-        }
         if (cancelled) return;
         console.error("Failed to load workspace file index:", err);
         setData(null);
@@ -95,14 +78,6 @@ export function useWorkspaceFileIndex(
   }, [data]);
 }
 
-function trimFileIndexCache(): void {
-  while (dataCache.size > MAX_CACHED_WORKSPACES) {
-    const oldestKey = dataCache.keys().next().value;
-    if (!oldestKey) return;
-    dataCache.delete(oldestKey);
-  }
-}
-
 function formatLineSuffix(parsed: ReturnType<typeof parseFilePathTarget>): string {
   if (typeof parsed.startLine !== "number") return "";
   let suffix = `:${parsed.startLine}`;
@@ -123,7 +98,7 @@ function formatLineSuffix(parsed: ReturnType<typeof parseFilePathTarget>): strin
 }
 
 function buildFileIndex(
-  entries: Awaited<ReturnType<typeof listWorkspaceFiles>>,
+  entries: Awaited<ReturnType<typeof loadWorkspaceFilesCached>>,
 ): FileIndexData {
   const paths = new Set<string>();
   const uniqueBasenames = new Map<string, string | null>();

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -17,11 +17,15 @@ import {
   createWorkspace as createWorkspaceService,
   getRepoConfig,
   runWorkspaceSetup,
-  listWorkspaceFiles,
 } from "../../services/tauri";
 import { applySelectedModel } from "../chat/applySelectedModel";
 import { useModelRegistry } from "../chat/useModelRegistry";
 import { runAndRecordSetupScript } from "../../utils/setupScriptMessage";
+import {
+  getCachedWorkspaceFiles,
+  getStaleWorkspaceFiles,
+  loadWorkspaceFilesCached,
+} from "../../utils/workspaceFileCache";
 import type { ThemeDefinition } from "../../types/theme";
 import { scoreCommand } from "./searchScore";
 import {
@@ -45,6 +49,11 @@ export function CommandPalette() {
   const toggleFuzzyFinder = useAppStore((s) => s.toggleFuzzyFinder);
   const openModal = useAppStore((s) => s.openModal);
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const selectedWorkspaceFilesRefreshNonce = useAppStore((s) =>
+    s.selectedWorkspaceId
+      ? (s.fileTreeRefreshNonceByWorkspace[s.selectedWorkspaceId] ?? 0)
+      : 0,
+  );
   // Active chat session within the selected workspace. Agent-scoped
   // commands (stop, reset, model-change teardown) run against a session
   // id, not the workspace id.
@@ -246,10 +255,24 @@ export function CommandPalette() {
     setMode("file");
     setQuery("");
     setSelectedIndex(0);
-    setFilesLoading(true);
     setFilesLoadError(null);
+    const cached = getCachedWorkspaceFiles(
+      selectedWorkspaceId,
+      selectedWorkspaceFilesRefreshNonce,
+    );
+    const stale = cached ?? getStaleWorkspaceFiles(selectedWorkspaceId);
+    if (stale) {
+      setFileEntries(stale);
+      setFilesLoading(false);
+    } else {
+      setFileEntries([]);
+      setFilesLoading(true);
+    }
     const version = ++filesLoadVersionRef.current;
-    listWorkspaceFiles(selectedWorkspaceId)
+    loadWorkspaceFilesCached(
+      selectedWorkspaceId,
+      selectedWorkspaceFilesRefreshNonce,
+    )
       .then((entries) => {
         if (version !== filesLoadVersionRef.current) return;
         setFileEntries(entries);
@@ -258,11 +281,11 @@ export function CommandPalette() {
       .catch((err) => {
         if (version !== filesLoadVersionRef.current) return;
         console.error("[CommandPalette] Failed to load workspace files:", err);
-        setFileEntries([]);
+        if (!stale) setFileEntries([]);
         setFilesLoadError(String(err));
         setFilesLoading(false);
       });
-  }, [selectedWorkspaceId]);
+  }, [selectedWorkspaceId, selectedWorkspaceFilesRefreshNonce]);
 
   // If the palette was opened with an initial file mode (e.g. via Cmd+O), enter it.
   useEffect(() => {

--- a/src/ui/src/components/files/FilesPanel.cache.test.tsx
+++ b/src/ui/src/components/files/FilesPanel.cache.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore } from "../../stores/useAppStore";
 import type { FileEntry } from "../../services/tauri";
 import type { Workspace } from "../../types";
-import { clearWorkspaceFilesCacheForTests } from "../../utils/workspaceFileCache";
+import { __testing as workspaceFileCacheTesting } from "../../utils/workspaceFileCache";
 import { FilesPanel } from "./FilesPanel";
 
 const serviceMocks = vi.hoisted(() => ({
@@ -99,7 +99,7 @@ async function flushTimers(): Promise<void> {
 }
 
 beforeEach(() => {
-  clearWorkspaceFilesCacheForTests();
+  workspaceFileCacheTesting.reset();
   serviceMocks.listWorkspaceFiles.mockReset();
   useAppStore.setState({
     selectedWorkspaceId: "files-cache-ws-a",

--- a/src/ui/src/components/files/FilesPanel.cache.test.tsx
+++ b/src/ui/src/components/files/FilesPanel.cache.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore } from "../../stores/useAppStore";
 import type { FileEntry } from "../../services/tauri";
 import type { Workspace } from "../../types";
+import { clearWorkspaceFilesCacheForTests } from "../../utils/workspaceFileCache";
 import { FilesPanel } from "./FilesPanel";
 
 const serviceMocks = vi.hoisted(() => ({
@@ -98,6 +99,7 @@ async function flushTimers(): Promise<void> {
 }
 
 beforeEach(() => {
+  clearWorkspaceFilesCacheForTests();
   serviceMocks.listWorkspaceFiles.mockReset();
   useAppStore.setState({
     selectedWorkspaceId: "files-cache-ws-a",

--- a/src/ui/src/components/files/FilesPanel.tsx
+++ b/src/ui/src/components/files/FilesPanel.tsx
@@ -7,8 +7,13 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { useAppStore } from "../../stores/useAppStore";
-import { listWorkspaceFiles, type FileEntry } from "../../services/tauri";
+import type { FileEntry } from "../../services/tauri";
 import { isPendingPlaceholderWorkspace } from "../../utils/workspaceEnvironment";
+import {
+  getCachedWorkspaceFiles,
+  loadWorkspaceFilesCached,
+  pruneWorkspaceFilesCache,
+} from "../../utils/workspaceFileCache";
 import { resolveHotkeyAction } from "../../hotkeys/bindings";
 import { isAgentBusy } from "../../utils/agentStatus";
 import {
@@ -21,47 +26,6 @@ import type { FileContextTarget } from "./fileContextMenu";
 import { FileTree } from "./FileTree";
 import { useFilePathActions } from "./useFilePathActions";
 import styles from "./FilesPanel.module.css";
-
-interface CachedFileEntries {
-  refreshNonce: number;
-  entries: FileEntry[];
-}
-
-const MAX_CACHED_WORKSPACES = 20;
-const fileEntriesCache = new Map<string, CachedFileEntries>();
-
-function getCachedFileEntries(
-  workspaceId: string,
-  refreshNonce: number,
-): FileEntry[] | null {
-  const cached = fileEntriesCache.get(workspaceId);
-  if (cached?.refreshNonce !== refreshNonce) return null;
-  // Refresh LRU position.
-  fileEntriesCache.delete(workspaceId);
-  fileEntriesCache.set(workspaceId, cached);
-  return cached.entries;
-}
-
-function setCachedFileEntries(
-  workspaceId: string,
-  refreshNonce: number,
-  entries: FileEntry[],
-): void {
-  fileEntriesCache.set(workspaceId, { refreshNonce, entries });
-  while (fileEntriesCache.size > MAX_CACHED_WORKSPACES) {
-    const oldestKey = fileEntriesCache.keys().next().value;
-    if (!oldestKey) return;
-    fileEntriesCache.delete(oldestKey);
-  }
-}
-
-function pruneFileEntriesCache(activeWorkspaceIds: Set<string>): void {
-  for (const workspaceId of fileEntriesCache.keys()) {
-    if (!activeWorkspaceIds.has(workspaceId)) {
-      fileEntriesCache.delete(workspaceId);
-    }
-  }
-}
 
 export function FilesPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
@@ -151,10 +115,13 @@ export function FilesPanel() {
       }
       loadFilesInFlightCount.current += 1;
       try {
-        const result = await listWorkspaceFiles(workspaceId);
+        const result = await loadWorkspaceFilesCached(
+          workspaceId,
+          expectedRefreshNonce,
+          { forceRefresh: true },
+        );
         if (version !== loadVersionRef.current) return;
         if (useAppStore.getState().selectedWorkspaceId !== workspaceId) return;
-        setCachedFileEntries(workspaceId, expectedRefreshNonce, result);
         setEntries(result);
         setError(null);
         setLoading(false);
@@ -174,7 +141,7 @@ export function FilesPanel() {
   );
 
   useEffect(() => {
-    pruneFileEntriesCache(new Set(workspaces.map((workspace) => workspace.id)));
+    pruneWorkspaceFilesCache(new Set(workspaces.map((workspace) => workspace.id)));
   }, [workspaces]);
 
   useLayoutEffect(() => {
@@ -190,7 +157,7 @@ export function FilesPanel() {
       setLoading(false);
       return;
     }
-    const cachedEntries = getCachedFileEntries(selectedWorkspaceId, refreshNonce);
+    const cachedEntries = getCachedWorkspaceFiles(selectedWorkspaceId, refreshNonce);
     setError(null);
     if (cachedEntries) {
       setEntries(cachedEntries);
@@ -203,7 +170,7 @@ export function FilesPanel() {
 
   useEffect(() => {
     if (!selectedWorkspaceId || isPendingPlaceholder) return;
-    const cachedEntries = getCachedFileEntries(selectedWorkspaceId, refreshNonce);
+    const cachedEntries = getCachedWorkspaceFiles(selectedWorkspaceId, refreshNonce);
     const timer = window.setTimeout(() => {
       void loadFiles(selectedWorkspaceId, refreshNonce, cachedEntries === null);
     }, 0);

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -96,8 +96,11 @@ function notifyBackendSelection(workspaceId: string | null) {
 function prewarmWorkspaceSelection(
   workspaceId: string | null,
   refreshNonceByWorkspace: Record<string, number>,
+  pendingCreates: Record<string, string>,
+  pendingForks: Record<string, string>,
 ) {
   if (!workspaceId) return;
+  if (workspaceId in pendingCreates || workspaceId in pendingForks) return;
   prewarmWorkspaceFiles(
     workspaceId,
     refreshNonceByWorkspace[workspaceId] ?? 0,
@@ -605,7 +608,12 @@ export const createWorkspacesSlice: StateCreator<
     set((s) => {
       if (id === s.selectedWorkspaceId) return s;
       notifyBackendSelection(id);
-      prewarmWorkspaceSelection(id, s.fileTreeRefreshNonceByWorkspace);
+      prewarmWorkspaceSelection(
+        id,
+        s.fileTreeRefreshNonceByWorkspace,
+        s.pendingCreates,
+        s.pendingForks,
+      );
 
       // Save the outgoing workspace's active diff selection, or clear it if
       // the user left that workspace in chat view (e.g. they clicked a chat

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -1,6 +1,7 @@
 import type { StateCreator } from "zustand";
 import { notifyWorkspaceSelected } from "../../services/tauri";
 import type { Workspace } from "../../types";
+import { prewarmWorkspaceFiles } from "../../utils/workspaceFileCache";
 import type { AppState } from "../useAppStore";
 
 // Fire-and-forget wrapper around the typed service call. Errors are
@@ -90,6 +91,17 @@ export function findPendingPlaceholderForCreatedWorkspace(args: {
 
 function notifyBackendSelection(workspaceId: string | null) {
   notifyWorkspaceSelected(workspaceId).catch(() => {});
+}
+
+function prewarmWorkspaceSelection(
+  workspaceId: string | null,
+  refreshNonceByWorkspace: Record<string, number>,
+) {
+  if (!workspaceId) return;
+  prewarmWorkspaceFiles(
+    workspaceId,
+    refreshNonceByWorkspace[workspaceId] ?? 0,
+  );
 }
 
 export type WorkspaceEnvironmentStatus = "idle" | "preparing" | "ready" | "error";
@@ -593,6 +605,7 @@ export const createWorkspacesSlice: StateCreator<
     set((s) => {
       if (id === s.selectedWorkspaceId) return s;
       notifyBackendSelection(id);
+      prewarmWorkspaceSelection(id, s.fileTreeRefreshNonceByWorkspace);
 
       // Save the outgoing workspace's active diff selection, or clear it if
       // the user left that workspace in chat view (e.g. they clicked a chat

--- a/src/ui/src/utils/workspaceFileCache.test.ts
+++ b/src/ui/src/utils/workspaceFileCache.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearWorkspaceFilesCacheForTests,
+  getCachedWorkspaceFiles,
+  getStaleWorkspaceFiles,
+  loadWorkspaceFilesCached,
+} from "./workspaceFileCache";
+import type { FileEntry } from "../services/tauri";
+
+const serviceMocks = vi.hoisted(() => ({
+  listWorkspaceFiles: vi.fn(),
+}));
+
+vi.mock("../services/tauri", () => ({
+  listWorkspaceFiles: serviceMocks.listWorkspaceFiles,
+}));
+
+function entries(paths: string[]): FileEntry[] {
+  return paths.map((path) => ({ path, is_directory: false }));
+}
+
+beforeEach(() => {
+  clearWorkspaceFilesCacheForTests();
+  serviceMocks.listWorkspaceFiles.mockReset();
+});
+
+describe("workspaceFileCache", () => {
+  it("deduplicates concurrent loads for the same workspace and nonce", async () => {
+    const loaded = entries(["src/main.ts"]);
+    serviceMocks.listWorkspaceFiles.mockResolvedValue(loaded);
+
+    const [first, second] = await Promise.all([
+      loadWorkspaceFilesCached("ws-a", 0),
+      loadWorkspaceFilesCached("ws-a", 0),
+    ]);
+
+    expect(serviceMocks.listWorkspaceFiles).toHaveBeenCalledTimes(1);
+    expect(first).toBe(loaded);
+    expect(second).toBe(loaded);
+    expect(getCachedWorkspaceFiles("ws-a", 0)).toBe(loaded);
+  });
+
+  it("keeps stale entries visible while a newer nonce refresh is in flight", async () => {
+    const stale = entries(["src/stale.ts"]);
+    const fresh = entries(["src/fresh.ts"]);
+    serviceMocks.listWorkspaceFiles
+      .mockResolvedValueOnce(stale)
+      .mockResolvedValueOnce(fresh);
+
+    await loadWorkspaceFilesCached("ws-a", 0);
+    const refreshing = loadWorkspaceFilesCached("ws-a", 1);
+
+    expect(getCachedWorkspaceFiles("ws-a", 1)).toBeNull();
+    expect(getStaleWorkspaceFiles("ws-a")).toBe(stale);
+
+    await refreshing;
+    expect(getCachedWorkspaceFiles("ws-a", 1)).toBe(fresh);
+  });
+
+  it("does not cache failed refresh promises", async () => {
+    serviceMocks.listWorkspaceFiles
+      .mockRejectedValueOnce(new Error("git failed"))
+      .mockResolvedValueOnce(entries(["README.md"]));
+
+    await expect(loadWorkspaceFilesCached("ws-a", 0)).rejects.toThrow("git failed");
+    await expect(loadWorkspaceFilesCached("ws-a", 0)).resolves.toEqual([
+      { path: "README.md", is_directory: false },
+    ]);
+
+    expect(serviceMocks.listWorkspaceFiles).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/ui/src/utils/workspaceFileCache.test.ts
+++ b/src/ui/src/utils/workspaceFileCache.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  clearWorkspaceFilesCacheForTests,
+  __testing,
   getCachedWorkspaceFiles,
   getStaleWorkspaceFiles,
   loadWorkspaceFilesCached,
@@ -20,7 +20,7 @@ function entries(paths: string[]): FileEntry[] {
 }
 
 beforeEach(() => {
-  clearWorkspaceFilesCacheForTests();
+  __testing.reset();
   serviceMocks.listWorkspaceFiles.mockReset();
 });
 
@@ -68,5 +68,25 @@ describe("workspaceFileCache", () => {
     ]);
 
     expect(serviceMocks.listWorkspaceFiles).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps an older successful response as stale data when a newer uncached refresh is active", async () => {
+    const stale = entries(["src/older.ts"]);
+    const newer = new Promise<FileEntry[]>((_resolve, reject) => {
+      setTimeout(() => reject(new Error("newer failed")), 0);
+    });
+    serviceMocks.listWorkspaceFiles
+      .mockReturnValueOnce(Promise.resolve(stale))
+      .mockReturnValueOnce(newer);
+
+    const olderPromise = loadWorkspaceFilesCached("ws-a", 0);
+    const newerPromise = loadWorkspaceFilesCached("ws-a", 1);
+
+    await olderPromise;
+    expect(getCachedWorkspaceFiles("ws-a", 1)).toBeNull();
+    expect(getStaleWorkspaceFiles("ws-a")).toBe(stale);
+
+    await expect(newerPromise).rejects.toThrow("newer failed");
+    expect(getStaleWorkspaceFiles("ws-a")).toBe(stale);
   });
 });

--- a/src/ui/src/utils/workspaceFileCache.ts
+++ b/src/ui/src/utils/workspaceFileCache.ts
@@ -1,0 +1,124 @@
+import { listWorkspaceFiles, type FileEntry } from "../services/tauri";
+
+interface WorkspaceFilesCacheEntry {
+  entries?: FileEntry[];
+  entriesRefreshNonce?: number;
+  inFlightRefreshNonce?: number;
+  promise?: Promise<FileEntry[]>;
+}
+
+const MAX_CACHED_WORKSPACES = 20;
+const workspaceFilesCache = new Map<string, WorkspaceFilesCacheEntry>();
+
+export function getCachedWorkspaceFiles(
+  workspaceId: string,
+  refreshNonce: number,
+): FileEntry[] | null {
+  const cached = workspaceFilesCache.get(workspaceId);
+  if (cached?.entriesRefreshNonce !== refreshNonce || !cached.entries) {
+    return null;
+  }
+  refreshLru(workspaceId, cached);
+  return cached.entries;
+}
+
+export function getStaleWorkspaceFiles(workspaceId: string): FileEntry[] | null {
+  const cached = workspaceFilesCache.get(workspaceId);
+  if (!cached?.entries) return null;
+  refreshLru(workspaceId, cached);
+  return cached.entries;
+}
+
+export function loadWorkspaceFilesCached(
+  workspaceId: string,
+  refreshNonce: number,
+  options: { forceRefresh?: boolean } = {},
+): Promise<FileEntry[]> {
+  const cached = workspaceFilesCache.get(workspaceId);
+  if (
+    !options.forceRefresh &&
+    cached?.entriesRefreshNonce === refreshNonce &&
+    cached.entries
+  ) {
+    refreshLru(workspaceId, cached);
+    return Promise.resolve(cached.entries);
+  }
+  if (
+    cached?.inFlightRefreshNonce === refreshNonce &&
+    cached.promise
+  ) {
+    refreshLru(workspaceId, cached);
+    return cached.promise;
+  }
+
+  const nextEntry: WorkspaceFilesCacheEntry = {
+    entries: cached?.entries,
+    entriesRefreshNonce: cached?.entriesRefreshNonce,
+    inFlightRefreshNonce: refreshNonce,
+  };
+  const promise = listWorkspaceFiles(workspaceId)
+    .then((entries) => {
+      const current = workspaceFilesCache.get(workspaceId);
+      if (current?.promise === promise) {
+        workspaceFilesCache.set(workspaceId, {
+          entries,
+          entriesRefreshNonce: refreshNonce,
+        });
+        trimWorkspaceFilesCache();
+      }
+      return entries;
+    })
+    .catch((err) => {
+      const current = workspaceFilesCache.get(workspaceId);
+      if (current?.promise === promise) {
+        if (current.entries) {
+          workspaceFilesCache.set(workspaceId, {
+            entries: current.entries,
+            entriesRefreshNonce: current.entriesRefreshNonce,
+          });
+        } else {
+          workspaceFilesCache.delete(workspaceId);
+        }
+      }
+      throw err;
+    });
+
+  nextEntry.promise = promise;
+  workspaceFilesCache.set(workspaceId, nextEntry);
+  trimWorkspaceFilesCache();
+  return promise;
+}
+
+export function prewarmWorkspaceFiles(
+  workspaceId: string,
+  refreshNonce: number,
+): void {
+  loadWorkspaceFilesCached(workspaceId, refreshNonce).catch((err) => {
+    console.debug("[workspaceFileCache] Failed to prewarm workspace files:", err);
+  });
+}
+
+export function pruneWorkspaceFilesCache(activeWorkspaceIds: Set<string>): void {
+  for (const workspaceId of workspaceFilesCache.keys()) {
+    if (!activeWorkspaceIds.has(workspaceId)) {
+      workspaceFilesCache.delete(workspaceId);
+    }
+  }
+}
+
+export function clearWorkspaceFilesCacheForTests(): void {
+  workspaceFilesCache.clear();
+}
+
+function refreshLru(workspaceId: string, entry: WorkspaceFilesCacheEntry): void {
+  workspaceFilesCache.delete(workspaceId);
+  workspaceFilesCache.set(workspaceId, entry);
+}
+
+function trimWorkspaceFilesCache(): void {
+  while (workspaceFilesCache.size > MAX_CACHED_WORKSPACES) {
+    const oldestKey = workspaceFilesCache.keys().next().value;
+    if (!oldestKey) return;
+    workspaceFilesCache.delete(oldestKey);
+  }
+}

--- a/src/ui/src/utils/workspaceFileCache.ts
+++ b/src/ui/src/utils/workspaceFileCache.ts
@@ -65,6 +65,19 @@ export function loadWorkspaceFilesCached(
           entriesRefreshNonce: refreshNonce,
         });
         trimWorkspaceFilesCache();
+      } else if (current && !current.entries) {
+        workspaceFilesCache.set(workspaceId, {
+          ...current,
+          entries,
+          entriesRefreshNonce: refreshNonce,
+        });
+        trimWorkspaceFilesCache();
+      } else if (!current) {
+        workspaceFilesCache.set(workspaceId, {
+          entries,
+          entriesRefreshNonce: refreshNonce,
+        });
+        trimWorkspaceFilesCache();
       }
       return entries;
     })
@@ -106,10 +119,6 @@ export function pruneWorkspaceFilesCache(activeWorkspaceIds: Set<string>): void 
   }
 }
 
-export function clearWorkspaceFilesCacheForTests(): void {
-  workspaceFilesCache.clear();
-}
-
 function refreshLru(workspaceId: string, entry: WorkspaceFilesCacheEntry): void {
   workspaceFilesCache.delete(workspaceId);
   workspaceFilesCache.set(workspaceId, entry);
@@ -122,3 +131,9 @@ function trimWorkspaceFilesCache(): void {
     workspaceFilesCache.delete(oldestKey);
   }
 }
+
+export const __testing = {
+  reset() {
+    workspaceFilesCache.clear();
+  },
+};


### PR DESCRIPTION
## Summary
- Add a shared workspace file-list cache for consumers of `listWorkspaceFiles`, including in-flight request de-duplication, nonce-aware freshness, stale-result access, LRU pruning, and test-only reset support.
- Update Cmd+P file mode to render cached or stale files immediately and refresh quietly, so reopening Quick Open no longer re-runs the file-list IPC path when the nonce has not changed.
- Prewarm the selected workspace file list from `selectWorkspace`, so the first Cmd+P after a workspace switch can usually hit the warmed cache.
- Move the chat file-index hook and Files panel onto the shared cache while preserving the Files panel forced background refresh behavior for its polling path.

## Root Cause
Cmd+P file mode called `listWorkspaceFiles(selectedWorkspaceId)` every time the palette entered file mode. That meant every open paid the backend file-list cost even when the workspace file-tree refresh nonce had not changed. A separate chat file-index cache already existed, but it only cached the derived basename index, not the raw `FileEntry[]` list that the palette and Files panel also need.

## User Impact
- Reopening Cmd+P file search on an unchanged workspace now returns from memory instead of issuing another IPC request.
- If a stale list exists while a refresh is in flight, the palette keeps files visible and responsive instead of flashing only `Loading files...`.
- Workspace selection starts a background prewarm using the current file-tree nonce, reducing the chance that the first Quick Open interaction lands on the cold path.

## Notes
This implements the frontend share and prewarm tier from #860. Backend-side caching can still be added separately if we want to remove the cold-start git cost entirely.

Closes #860

## Validation
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run test` (2520 passed, 6 skipped)
- `cd src/ui && bun run lint` (0 errors, existing warnings only)
- `git diff --check`