### PR TITLE
fix: keep Codex shell tab active during commands

### DIFF
--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -45,8 +45,9 @@ mod team_agents;
 
 use self::background_tasks::{
     BackgroundTaskInputTracker, append_agent_bash_output, apply_task_notification_status,
-    emit_agent_background_task_event, mirror_background_task_output, schedule_background_task_wake,
-    should_defer_persistent_restart, terminal_text,
+    emit_agent_background_task_event, get_or_create_agent_shell_terminal_tab,
+    mirror_background_task_output, schedule_background_task_wake, should_defer_persistent_restart,
+    terminal_text,
 };
 use self::team_agents::TeamAgentInputTracker;
 pub(super) use self::team_agents::team_agent_session_tabs_enabled;
@@ -447,6 +448,17 @@ fn tool_result_content_text(content: &serde_json::Value) -> String {
             .join("\n");
     }
     content.to_string()
+}
+
+fn shell_result_summary(content: &serde_json::Value) -> &'static str {
+    let exit_code = content
+        .get("exitCode")
+        .or_else(|| content.get("exit_code"))
+        .and_then(serde_json::Value::as_i64);
+    match exit_code {
+        Some(0) | None => "Command completed",
+        Some(_) => "Command failed",
+    }
 }
 
 #[derive(serde::Serialize)]
@@ -2546,6 +2558,9 @@ pub async fn send_chat_message(
                     output_file.as_deref(),
                 )
                 .await;
+                if status == "running" && tool_use_id.as_deref() == Some(task_id.as_str()) {
+                    background_task_inputs.mark_bash_tool_started(task_id);
+                }
             }
 
             background_task_inputs.observe_bash_input_delta(&event);
@@ -2811,6 +2826,10 @@ pub async fn send_chat_message(
                                 } => {
                                     let text = tool_result_content_text(content);
                                     let background_binding = parse_background_task_binding(&text);
+                                    let is_known_bash_tool_result =
+                                        background_task_inputs.is_bash_tool_result(tool_use_id);
+                                    let is_active_bash_tool_result =
+                                        background_task_inputs.is_bash_tool_active(tool_use_id);
                                     let is_trusted_background_binding =
                                         if background_binding.is_some() {
                                             let app_state = app.state::<AppState>();
@@ -2846,6 +2865,7 @@ pub async fn send_chat_message(
                                                 );
                                             }
                                         }
+                                        background_task_inputs.finish_bash_tool_result(tool_use_id);
                                         let aggregate_path =
                                             claudette::agent::background::workspace_terminal_output_path(&ws_id);
                                         mirror_background_task_output(
@@ -2871,7 +2891,7 @@ pub async fn send_chat_message(
                                                 );
                                             }
                                         }
-                                    } else {
+                                    } else if is_known_bash_tool_result {
                                         let path =
                                             claudette::agent::background::workspace_terminal_output_path(&ws_id);
                                         let text = terminal_text(&text);
@@ -2890,11 +2910,26 @@ pub async fn send_chat_message(
                                             );
                                         }
                                         if let Ok(db) = Database::open(&db_path) {
+                                            let status = if is_active_bash_tool_result {
+                                                "running"
+                                            } else {
+                                                "completed"
+                                            };
+                                            let summary = if is_active_bash_tool_result {
+                                                None
+                                            } else {
+                                                Some(shell_result_summary(content))
+                                            };
+                                            let _ = get_or_create_agent_shell_terminal_tab(
+                                                &db_path,
+                                                &ws_id,
+                                                &chat_session_id_for_stream,
+                                            );
                                             let _ = db.update_agent_shell_terminal_tab_status(
                                                 &chat_session_id_for_stream,
                                                 None,
-                                                "completed",
-                                                Some("Command completed"),
+                                                status,
+                                                summary,
                                             );
                                             if let Ok(Some(tab)) = db.get_agent_shell_terminal_tab(
                                                 &chat_session_id_for_stream,
@@ -2907,6 +2942,10 @@ pub async fn send_chat_message(
                                                     tab,
                                                 );
                                             }
+                                        }
+                                        if !is_active_bash_tool_result {
+                                            background_task_inputs
+                                                .finish_bash_tool_result(tool_use_id);
                                         }
                                     }
                                 }

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -46,8 +46,8 @@ mod team_agents;
 use self::background_tasks::{
     BackgroundTaskInputTracker, append_agent_bash_output, apply_task_notification_status,
     emit_agent_background_task_event, get_or_create_agent_shell_terminal_tab,
-    mirror_background_task_output, schedule_background_task_wake, should_defer_persistent_restart,
-    terminal_text,
+    is_final_terminal_task_status, mirror_background_task_output, schedule_background_task_wake,
+    should_defer_persistent_restart, terminal_text,
 };
 use self::team_agents::TeamAgentInputTracker;
 pub(super) use self::team_agents::team_agent_session_tabs_enabled;
@@ -2560,6 +2560,11 @@ pub async fn send_chat_message(
                 .await;
                 if status == "running" && tool_use_id.as_deref() == Some(task_id.as_str()) {
                     background_task_inputs.mark_bash_tool_started(task_id);
+                }
+                if is_final_terminal_task_status(status)
+                    && tool_use_id.as_deref() == Some(task_id.as_str())
+                {
+                    background_task_inputs.finish_bash_tool_result(task_id);
                 }
             }
 

--- a/src-tauri/src/commands/chat/send/background_tasks.rs
+++ b/src-tauri/src/commands/chat/send/background_tasks.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, path::Path, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+    time::Duration,
+};
 
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -198,7 +202,14 @@ fn should_defer_persistent_restart_for_state(
 
 #[derive(Default)]
 pub(super) struct BackgroundTaskInputTracker {
-    bash_inputs: HashMap<usize, (String, String)>,
+    bash_inputs: HashMap<usize, BashInput>,
+    bash_tool_use_ids: HashSet<String>,
+}
+
+struct BashInput {
+    tool_use_id: String,
+    input_json: String,
+    start_observed: bool,
 }
 
 impl BackgroundTaskInputTracker {
@@ -212,13 +223,21 @@ impl BackgroundTaskInputTracker {
         }) = event
             && name == "Bash"
         {
-            self.bash_inputs.insert(*index, (id.clone(), String::new()));
+            self.bash_tool_use_ids.insert(id.clone());
+            self.bash_inputs.insert(
+                *index,
+                BashInput {
+                    tool_use_id: id.clone(),
+                    input_json: String::new(),
+                    start_observed: false,
+                },
+            );
         }
 
         if let AgentEvent::Stream(StreamEvent::Stream {
             event: InnerStreamEvent::ContentBlockDelta { index, delta },
         }) = event
-            && let Some((_tool_use_id, input)) = self.bash_inputs.get_mut(index)
+            && let Some(input) = self.bash_inputs.get_mut(index)
         {
             match delta {
                 claudette::agent::Delta::ToolUse {
@@ -226,8 +245,30 @@ impl BackgroundTaskInputTracker {
                 }
                 | claudette::agent::Delta::InputJson {
                     partial_json: Some(part),
-                } => input.push_str(part),
+                } => input.input_json.push_str(part),
                 _ => {}
+            }
+        }
+    }
+
+    pub(super) fn is_bash_tool_result(&self, tool_use_id: &str) -> bool {
+        self.bash_tool_use_ids.contains(tool_use_id)
+    }
+
+    pub(super) fn is_bash_tool_active(&self, tool_use_id: &str) -> bool {
+        self.bash_inputs
+            .values()
+            .any(|input| input.tool_use_id == tool_use_id)
+    }
+
+    pub(super) fn finish_bash_tool_result(&mut self, tool_use_id: &str) {
+        self.bash_tool_use_ids.remove(tool_use_id);
+    }
+
+    pub(super) fn mark_bash_tool_started(&mut self, tool_use_id: &str) {
+        for input in self.bash_inputs.values_mut() {
+            if input.tool_use_id == tool_use_id {
+                input.start_observed = true;
             }
         }
     }
@@ -246,10 +287,10 @@ impl BackgroundTaskInputTracker {
         else {
             return;
         };
-        let Some((tool_use_id, input_json)) = self.bash_inputs.remove(index) else {
+        let Some(input) = self.bash_inputs.remove(index) else {
             return;
         };
-        let Some(start) = parse_bash_start(&input_json) else {
+        let Some(start) = parse_bash_start(&input.input_json) else {
             return;
         };
 
@@ -258,8 +299,13 @@ impl BackgroundTaskInputTracker {
             let app_state = app.state::<AppState>();
             let mut agents = app_state.agents.write().await;
             if let Some(session) = agents.get_mut(chat_session_id) {
-                session.running_background_tasks.insert(tool_use_id.clone());
+                session
+                    .running_background_tasks
+                    .insert(input.tool_use_id.clone());
             }
+        }
+        if input.start_observed {
+            return;
         }
         // Workspace-scoped path: every agent shell command across every
         // chat session appends to the same workspace transcript. The
@@ -313,6 +359,7 @@ pub(super) async fn apply_task_notification_status(
     summary: Option<&str>,
     output_file: Option<&str>,
 ) {
+    let _ = get_or_create_agent_shell_terminal_tab(db_path, workspace_id, chat_session_id);
     let Ok(db) = Database::open(db_path) else {
         return;
     };
@@ -849,9 +896,15 @@ pub(super) fn schedule_background_task_wake(
 #[cfg(test)]
 mod tests {
     use super::{
-        BackgroundTaskCompletion, build_background_task_completion_prompt, markdown_code_fence_for,
+        BackgroundTaskCompletion, BackgroundTaskInputTracker,
+        build_background_task_completion_prompt, markdown_code_fence_for,
         should_defer_persistent_restart_for_state, terminal_text,
     };
+    use claudette::agent::{
+        AgentEvent, InnerStreamEvent, StartContentBlock, StreamEvent, UserContentBlock,
+        UserEventMessage, UserMessageContent,
+    };
+    use serde_json::json;
     #[test]
     fn terminal_text_converts_newlines_to_terminal_newlines() {
         assert_eq!(terminal_text("one\ntwo\r\nthree"), "one\r\ntwo\r\nthree");
@@ -884,6 +937,40 @@ mod tests {
         assert!(!should_defer_persistent_restart_for_state(true, false));
         assert!(!should_defer_persistent_restart_for_state(false, true));
         assert!(!should_defer_persistent_restart_for_state(false, false));
+    }
+
+    #[test]
+    fn tool_results_are_shell_owned_only_after_bash_tool_start() {
+        let mut tracker = BackgroundTaskInputTracker::default();
+        let non_bash_result = AgentEvent::Stream(StreamEvent::User {
+            message: UserEventMessage {
+                content: UserMessageContent::Blocks(vec![UserContentBlock::ToolResult {
+                    tool_use_id: "file-1".to_string(),
+                    content: json!({"status": "completed"}),
+                }]),
+            },
+            uuid: None,
+            is_replay: false,
+            is_synthetic: true,
+        });
+
+        tracker.observe_bash_input_delta(&non_bash_result);
+        assert!(!tracker.is_bash_tool_result("file-1"));
+
+        tracker.observe_bash_input_delta(&AgentEvent::Stream(StreamEvent::Stream {
+            event: InnerStreamEvent::ContentBlockStart {
+                index: 7,
+                content_block: Some(StartContentBlock::ToolUse {
+                    id: "cmd-1".to_string(),
+                    name: "Bash".to_string(),
+                }),
+            },
+        }));
+
+        assert!(tracker.is_bash_tool_result("cmd-1"));
+        assert!(tracker.is_bash_tool_active("cmd-1"));
+        tracker.finish_bash_tool_result("cmd-1");
+        assert!(!tracker.is_bash_tool_result("cmd-1"));
     }
 
     #[test]

--- a/src-tauri/src/commands/chat/send/background_tasks.rs
+++ b/src-tauri/src/commands/chat/send/background_tasks.rs
@@ -186,6 +186,10 @@ fn is_terminal_task_status(status: &str) -> bool {
     )
 }
 
+pub(super) fn is_final_terminal_task_status(status: &str) -> bool {
+    is_terminal_task_status(status)
+}
+
 pub(super) fn should_defer_persistent_restart(session: &AgentSessionState) -> bool {
     should_defer_persistent_restart_for_state(
         session.persistent_session.is_some(),
@@ -971,6 +975,29 @@ mod tests {
         assert!(tracker.is_bash_tool_active("cmd-1"));
         tracker.finish_bash_tool_result("cmd-1");
         assert!(!tracker.is_bash_tool_result("cmd-1"));
+    }
+
+    #[test]
+    fn completed_structured_status_can_claim_bash_tool_result_before_fallback() {
+        let mut tracker = BackgroundTaskInputTracker::default();
+
+        tracker.observe_bash_input_delta(&AgentEvent::Stream(StreamEvent::Stream {
+            event: InnerStreamEvent::ContentBlockStart {
+                index: 3,
+                content_block: Some(StartContentBlock::ToolUse {
+                    id: "cmd-1".to_string(),
+                    name: "Bash".to_string(),
+                }),
+            },
+        }));
+        tracker.mark_bash_tool_started("cmd-1");
+
+        assert!(tracker.is_bash_tool_result("cmd-1"));
+        tracker.finish_bash_tool_result("cmd-1");
+        assert!(
+            !tracker.is_bash_tool_result("cmd-1"),
+            "a structured Codex terminal completion must prevent the legacy ToolResult fallback"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -792,7 +792,7 @@ pub async fn restore_workspace(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
-    let mut db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
 
     // Find the row + repo BEFORE flipping status, so we know what git
     // restore is about to run against and can roll back cleanly on

--- a/src/agent/codex_app_server.rs
+++ b/src/agent/codex_app_server.rs
@@ -2136,6 +2136,14 @@ fn map_codex_item_started_to_agent_events(item: &Value) -> Vec<AgentEvent> {
             },
         }));
     }
+    if item_type == Some("commandExecution") {
+        events.push(codex_command_execution_status_event(
+            item,
+            item.get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("running"),
+        ));
+    }
     events
 }
 
@@ -2145,6 +2153,14 @@ fn map_codex_item_completed_to_agent_events(item: &Value) -> Vec<AgentEvent> {
     };
     let index = codex_item_index(&item_id);
     let mut events = Vec::new();
+    if item.get("type").and_then(Value::as_str) == Some("commandExecution") {
+        events.push(codex_command_execution_status_event(
+            item,
+            item.get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("completed"),
+        ));
+    }
     if item.get("type").and_then(Value::as_str) == Some("fileChange") {
         events.push(AgentEvent::Stream(StreamEvent::Stream {
             event: InnerStreamEvent::ContentBlockDelta {
@@ -2174,6 +2190,48 @@ fn map_codex_item_completed_to_agent_events(item: &Value) -> Vec<AgentEvent> {
         }),
     ]);
     events
+}
+
+fn codex_command_execution_status_event(item: &Value, status: &str) -> AgentEvent {
+    let item_id = string_field(item, "id");
+    let terminal_status = match status {
+        "inProgress" | "starting" | "running" => "running",
+        "failed" => "failed",
+        "cancelled" | "canceled" => "cancelled",
+        "completed" => "completed",
+        other => other,
+    };
+    let command = item
+        .get("command")
+        .and_then(Value::as_str)
+        .filter(|command| !command.trim().is_empty());
+    let exit_code = item.get("exitCode").and_then(Value::as_i64);
+    let summary = match (terminal_status, exit_code, command) {
+        ("completed", Some(0), _) => Some("Command completed".to_string()),
+        ("completed", Some(code), _) => Some(format!("Command failed ({code})")),
+        ("failed", Some(code), _) => Some(format!("Command failed ({code})")),
+        ("failed", None, _) => Some("Command failed".to_string()),
+        (_, _, Some(command)) => Some(command.to_string()),
+        _ => None,
+    };
+
+    AgentEvent::Stream(StreamEvent::System {
+        subtype: "task_notification".to_string(),
+        session_id: None,
+        state: None,
+        detail: None,
+        task_id: Some(item_id.clone()),
+        tool_use_id: Some(item_id),
+        output_file: None,
+        summary,
+        description: None,
+        last_tool_name: None,
+        usage: None,
+        status: Some(terminal_status.to_string()),
+        compact_result: None,
+        compact_metadata: None,
+        command_line: None,
+    })
 }
 
 fn codex_item_tool_use(item: &Value) -> Option<(String, String, Value)> {
@@ -3448,6 +3506,70 @@ mod tests {
     }
 
     #[test]
+    fn maps_command_execution_started_to_running_task_notification() {
+        let events = map_notification_to_agent_events(CodexNotificationEvent::ItemStarted {
+            thread_id: "thread-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            item: json!({
+                "type": "commandExecution",
+                "id": "cmd-1",
+                "status": "inProgress",
+                "command": "rg completed src",
+                "cwd": "/repo"
+            }),
+        });
+
+        assert_eq!(events.len(), 3);
+        let AgentEvent::Stream(StreamEvent::System {
+            subtype,
+            task_id,
+            tool_use_id,
+            status,
+            summary,
+            ..
+        }) = &events[2]
+        else {
+            panic!("expected task notification");
+        };
+        assert_eq!(subtype, "task_notification");
+        assert_eq!(task_id.as_deref(), Some("cmd-1"));
+        assert_eq!(tool_use_id.as_deref(), Some("cmd-1"));
+        assert_eq!(status.as_deref(), Some("running"));
+        assert_eq!(summary.as_deref(), Some("rg completed src"));
+    }
+
+    #[test]
+    fn maps_command_execution_completed_to_completed_task_notification() {
+        let events = map_notification_to_agent_events(CodexNotificationEvent::ItemCompleted {
+            thread_id: "thread-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            item: json!({
+                "type": "commandExecution",
+                "id": "cmd-1",
+                "status": "completed",
+                "exitCode": 0,
+                "aggregatedOutput": "done\n"
+            }),
+        });
+
+        assert_eq!(events.len(), 3);
+        let AgentEvent::Stream(StreamEvent::System {
+            subtype,
+            task_id,
+            status,
+            summary,
+            ..
+        }) = &events[0]
+        else {
+            panic!("expected task notification");
+        };
+        assert_eq!(subtype, "task_notification");
+        assert_eq!(task_id.as_deref(), Some("cmd-1"));
+        assert_eq!(status.as_deref(), Some("completed"));
+        assert_eq!(summary.as_deref(), Some("Command completed"));
+    }
+
+    #[test]
     fn maps_file_change_completed_to_tool_result() {
         let events = map_notification_to_agent_events(CodexNotificationEvent::ItemCompleted {
             thread_id: "thread-1".to_string(),
@@ -3461,6 +3583,14 @@ mod tests {
         });
 
         assert_eq!(events.len(), 3);
+        assert!(
+            !events.iter().any(|event| matches!(
+                event,
+                AgentEvent::Stream(StreamEvent::System { subtype, .. })
+                    if subtype == "task_notification"
+            )),
+            "file changes must not drive the terminal task badge"
+        );
         let AgentEvent::Stream(StreamEvent::Stream {
             event:
                 InnerStreamEvent::ContentBlockDelta {


### PR DESCRIPTION
## Summary

Fixes #862.

Codex app-server sessions were translating every completed Codex item into a generic `ToolResult`, including file changes and MCP calls. The chat sender treated any unrecognized tool result as agent shell output and immediately stamped the Claudette terminal tab as `completed`. That made the terminal tab look idle after the first Codex tool result even while the Codex turn was still active and shell output was still streaming.

This PR makes the terminal badge follow actual shell execution instead of generic tool-result lifecycle events.

## What changed

- Emit structured `task_notification` status events for Codex `commandExecution` items:
  - `inProgress` maps to terminal status `running` with the command line as the summary.
  - `completed` / `failed` maps to terminal completion status with a command result summary.
- Gate the legacy user-message tool-result fallback so it only appends output and updates the terminal tab for tool results that were previously observed as `Bash` tool uses.
- Keep arbitrary Codex file-change and MCP tool results from touching the shell terminal status.
- Track Bash tool-use ownership inside `BackgroundTaskInputTracker`, including active-vs-finished state so streaming command output keeps the badge `running` until the command item actually finishes.
- Create the shared agent shell terminal tab before applying task-notification status so Codex command lifecycle events can drive the badge even before the final tool-result fallback arrives.
- Remove one unrelated stale `mut` in `restore_workspace` that surfaced as a warning while compiling the focused Tauri test target.

## Regression coverage

Added/updated Rust unit coverage for:

- Codex `commandExecution` start emits a `running` task notification.
- Codex `commandExecution` completion emits a completed task notification.
- Codex `fileChange` completion does not emit a terminal task notification.
- Non-Bash tool results are not considered shell-owned by the Tauri background task tracker.

## Validation

- `nix develop -c cargo fmt --all --check`
- `git diff --check`
- `nix develop -c cargo test -p claudette codex_app_server`
- `nix develop -c cargo test -p claudette-tauri background_tasks --all-features`

Notes:

- The first Tauri test attempt failed before compiling tests because the local Tauri sidecar binary was not staged. I ran `nix develop -c scripts/stage-cli-sidecar.sh` and reran the focused Tauri tests successfully.
- Nix printed an eval-cache `SQLite database ... is busy` warning as ignored during a couple of shell invocations; the commands continued normally.
