### PR TITLE
fix(command-palette): stop Escape from cancelling running agent and revealing main menu

### DIFF
--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -115,6 +115,14 @@ export function CommandPalette() {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [themes, setThemes] = useState<ThemeDefinition[]>([]);
   const [mode, setMode] = useState<"main" | "theme" | "model" | "effort" | "file">("main");
+  // Snapshot the mode the palette was opened in (main via Cmd+Shift+P,
+  // file via Cmd+P). Escape closes when we're back at the entry mode;
+  // otherwise it pops up one level to main. Read once via getState() so
+  // we capture the initial mode synchronously at mount, before the
+  // effect below clears `commandPaletteInitialMode`.
+  const [entryMode] = useState<"main" | "file">(() =>
+    useAppStore.getState().commandPaletteInitialMode === "file" ? "file" : "main",
+  );
   const [fileEntries, setFileEntries] = useState<FileEntry[]>([]);
   const [filesLoading, setFilesLoading] = useState(false);
   const [filesLoadError, setFilesLoadError] = useState<string | null>(null);
@@ -533,13 +541,16 @@ export function CommandPalette() {
       // Stop propagation so the global keyboard shortcut handler doesn't
       // also close the palette when we just want to exit theme mode.
       e.nativeEvent.stopImmediatePropagation();
-      if (mode !== "main") {
-        exitSubMenu();
-      } else {
+      // Close when we're at the mode the palette opened in. Otherwise
+      // pop one level back to main. This makes Cmd+P → Esc dismiss the
+      // palette instead of revealing the Cmd+Shift+P main menu.
+      if (mode === entryMode) {
         if (themes.length > 0) {
           applyThemeWithFonts(originalThemeIdRef.current);
         }
         close();
+      } else {
+        exitSubMenu();
       }
     } else if (e.key === "Backspace" && query === "" && mode !== "main") {
       // Backspace on empty input in sub-menu → go back

--- a/src/ui/src/components/fuzzy-finder/FuzzyFinder.test.tsx
+++ b/src/ui/src/components/fuzzy-finder/FuzzyFinder.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+
+// Regression test: pressing Escape inside the fuzzy finder used to bubble
+// through to the global `dismiss-or-stop` handler in `useKeyboardShortcuts`.
+// Because that listener captured `fuzzyFinderOpen` in a closure that didn't
+// update until React re-rendered, the global branch fell through to the
+// agent-stop path and cancelled the running workspace. The component now
+// calls preventDefault + stopImmediatePropagation so the global listener
+// never sees the event.
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FuzzyFinder } from "./FuzzyFinder";
+import { useAppStore } from "../../stores/useAppStore";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function mount() {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(createElement(FuzzyFinder));
+  });
+}
+
+describe("FuzzyFinder Escape handling", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    useAppStore.setState({
+      workspaces: [],
+      repositories: [],
+      fuzzyFinderOpen: true,
+    });
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root!.unmount();
+      });
+    }
+    root = null;
+    container = null;
+    document.body.innerHTML = "";
+    useAppStore.setState({ fuzzyFinderOpen: false });
+  });
+
+  it("closes the finder and stops the native event from bubbling to window", async () => {
+    await mount();
+
+    const input = container!.querySelector("input");
+    expect(input).toBeTruthy();
+
+    // Listen at the window so we can assert the event never reaches the
+    // global keyboard handler — `stopImmediatePropagation()` should prevent
+    // any window-level listener from firing.
+    let windowSawEscape = false;
+    const windowListener = (e: KeyboardEvent) => {
+      if (e.key === "Escape") windowSawEscape = true;
+    };
+    window.addEventListener("keydown", windowListener);
+
+    await act(async () => {
+      input!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Escape",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    window.removeEventListener("keydown", windowListener);
+
+    expect(useAppStore.getState().fuzzyFinderOpen).toBe(false);
+    expect(windowSawEscape).toBe(false);
+  });
+});

--- a/src/ui/src/components/fuzzy-finder/FuzzyFinder.tsx
+++ b/src/ui/src/components/fuzzy-finder/FuzzyFinder.tsx
@@ -34,6 +34,11 @@ export function FuzzyFinder() {
     } else if (e.key === "Enter" && results[selectedIndex]) {
       handleSelect(results[selectedIndex].id);
     } else if (e.key === "Escape") {
+      // Stop the native event so the global dismiss-or-stop handler in
+      // useKeyboardShortcuts doesn't also fire with a stale `fuzzyFinderOpen`
+      // closure and fall through to stopping the running agent.
+      e.preventDefault();
+      e.nativeEvent.stopImmediatePropagation();
       toggleFuzzyFinder();
     }
   };


### PR DESCRIPTION
## Summary

Fixes two Escape-key regressions in the command palette / fuzzy finder.

### Bug 1 — Cmd+K → Esc cancels the running workspace
The fuzzy finder's Escape handler (`FuzzyFinder.tsx:36`) closed itself but never called `preventDefault()` or `stopImmediatePropagation()` on the native event. The Escape then bubbled to the global `dismiss-or-stop` listener in `useKeyboardShortcuts`, which captured `fuzzyFinderOpen` in a stale closure and fell through to the agent-stop branch — silently cancelling whatever turn the workspace was running.

### Bug 2 — Cmd+P → Esc reveals the Cmd+Shift+P menu
Opening the palette in file mode via Cmd+P set `mode = "file"`. Pressing Escape treated any non-`main` mode as a sub-menu and called `exitSubMenu()` — landing the user on the main command palette instead of dismissing.

The palette now snapshots its **entry mode** at mount (`useState(() => …getState().commandPaletteInitialMode === "file" ? "file" : "main")`). Escape closes when `mode === entryMode` and only pops back to main when the user has navigated deeper. So:
- Cmd+P → Esc → closes
- Cmd+Shift+P → File command → Esc → still pops back to main (unchanged)

## Test plan

- [x] `bun run test` — 2522 passed (+1 new), 6 skipped
- [x] `bunx tsc -b` — clean
- [x] `bun run lint` — no new warnings (16 pre-existing)
- [x] Added regression test `FuzzyFinder.test.tsx` asserting Escape closes the finder *and* the native event never reaches a window-level listener
- [ ] Manual smoke: open fuzzy finder while an agent is running, press Esc — agent keeps running
- [ ] Manual smoke: Cmd+P, press Esc — palette closes
- [ ] Manual smoke: Cmd+Shift+P → Files command → Esc — back to main palette (regression check)