### PR TITLE
feat(pi): in-app provider auth for Copilot, OpenRouter, OpenAI, etc.

### DIFF
--- a/site/src/content/docs/features/providers/pi.mdx
+++ b/site/src/content/docs/features/providers/pi.mdx
@@ -9,12 +9,30 @@ This is a production provider path. It is always available in normal builds and 
 
 ## Setup
 
-1. Install and configure Pi normally.
-2. Run `pi auth` in a terminal and connect the providers you want Pi to use.
-3. Launch Claudette. Pi's model list is refreshed automatically on startup — the Bun sidecar runs `ModelRegistry.getAvailable()` and the chat-header model picker shows the result. Use **Settings > Models > Pi > Refresh models** to re-run discovery if you change provider credentials while Claudette is running.
+1. Install Pi (the `pi` CLI is optional but useful for `pi auth` and `pi /login` outside Claudette).
+2. Launch Claudette and open **Settings > Models > Pi**. The card now embeds a per-provider configuration list (see [Configuring providers](#configuring-providers) below) — configure GitHub Copilot, OpenRouter, OpenAI, Anthropic, Google Gemini, DeepSeek, and a handful of others without leaving Claudette.
+3. The model list refreshes automatically after each configure / sign-in round-trip. Use **Refresh models** to force a re-discovery if you change credentials outside Claudette.
 4. Pick a Pi model as the default in **Settings > Models > Default model**, or choose one per chat from the model picker.
 
-The Pi card does not ask for a base URL or API key. Provider credentials stay in Pi's own auth/config storage.
+The Pi card does not need a base URL or a card-level API key — keys are scoped per provider via the inline list.
+
+### Configuring providers
+
+The Pi card surfaces a curated list of providers Pi knows how to talk to:
+
+- **Default visible** — GitHub Copilot (OAuth, supports GHES), OpenRouter, OpenAI, Anthropic, Google Gemini, DeepSeek (API keys).
+- **More providers…** disclosure — xAI, Groq, Cerebras, Mistral, Fireworks, OpenCode Zen (API keys).
+- **Env-only** — Amazon Bedrock, Google Vertex AI, Azure OpenAI — these need too many environment variables to model in a dialog; the row links to Pi's docs and reflects the configured state once the env vars are set.
+
+For each row:
+
+- API-key providers open a **Configure** dialog where you paste the key. A **"Keep this key private to Claudette"** checkbox controls storage scope:
+  - Unchecked (default) → key is written to Pi's `~/.pi/agent/auth.json`. Visible to the terminal `pi` CLI too.
+  - Checked → key is stored in Claudette's OS keychain under bucket `piProviderSecrets` and pushed to the harness as the matching env var (e.g. `OPENROUTER_API_KEY`) at spawn time. Invisible to terminal `pi`.
+- OAuth providers (currently GitHub Copilot) open a **Sign in** modal that drives Pi's device-code flow. For Copilot the modal prompts for an optional GitHub Enterprise Server domain, displays the verification URL + user code, and closes when Pi reports success.
+- Env-only providers open the relevant Pi docs page in a browser; the row's status dot turns green once Pi detects the env vars on next refresh.
+
+The card also shows a per-row source label once configured (`via auth.json`, `via $OPENROUTER_API_KEY`, `via models.json`, …) so you can tell which credential path Pi will actually use.
 
 ## Harness Architecture
 
@@ -61,7 +79,7 @@ Beyond the dedicated Pi card, Ollama, LM Studio, OpenAI API, Custom OpenAI, and 
 ## Slash Commands
 
 - `/model` lists Pi models when they are available and accepts provider-qualified ids such as `pi/openai/gpt-5.4`.
-- `/login` for a Pi-selected chat points you back to Pi auth/config guidance; run `pi auth` in a terminal.
+- `/login` for a Pi-selected chat opens the **Pi provider picker** modal (Pi is multi-provider, so `/login` doesn't blind-launch one OAuth flow the way it does for Codex or Claude Code — you pick which provider to configure).
 - `/permissions` keeps controlling Claudette's permission mode for Pi, Claude Code, and Codex.
 
 ## Troubleshooting

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -38,7 +38,8 @@ Default values applied to all new agent sessions. Per-workspace overrides are av
 | Team agents as session tabs | Open Claude Code team agents (`TeamCreate` + `Agent` with a team name) as separate Claudette chat session tabs. | On |
 | Agent providers | Show Ollama, LM Studio, OpenAI API, and custom providers in Settings > Models and the chat model picker. Codex, Ollama, and LM Studio are auto-enabled when detected unless manually disabled. | On |
 | Codex | Show `codex app-server --listen stdio://` support and seed Codex models into the picker. Independent from Agent providers. | On |
-| Pi | Show the built-in Pi SDK harness. Refreshes models through Pi's `ModelRegistry`; auth/config stays in Pi (`pi auth`). | On |
+| Pi | Show the built-in Pi SDK harness. Refreshes models through Pi's `ModelRegistry`; provider auth is configurable inline (see Pi providers row). | On |
+| Pi providers | Inline list of providers Pi can talk to (Copilot via OAuth, OpenRouter/OpenAI/Anthropic/etc. via API keys). API-key dialogs default to writing `~/.pi/agent/auth.json` (shared with terminal `pi`); a **"Keep this key private to Claudette"** checkbox switches to keychain-only storage under bucket `piProviderSecrets`. OAuth flows run a device-code modal in-app. Pi-default visible providers: GitHub Copilot, OpenRouter, OpenAI, Anthropic, Google Gemini, DeepSeek. | Per provider |
 | Default backend | Provider used for new chats. | `anthropic` |
 | Claude Code | Checks local Claude Code sign-in state with the official CLI. The refresh button performs an authenticated CLI validation request; sign-in runs `claude auth login`, streams progress back into Claudette, and accepts the pasted browser code when Claude Code asks for one. Used by chat and Usage-panel auth failures. | — |
 | Agent backend cards | Enable, test, authenticate, and refresh model lists for built-in providers such as Claude Code, Codex, Pi, Ollama, LM Studio, and OpenAI API. | Provider-specific |

--- a/src-pi-harness/src/curated-providers.ts
+++ b/src-pi-harness/src/curated-providers.ts
@@ -1,0 +1,238 @@
+// Curated list of Pi providers that surface in Claudette's Settings card
+// by default. Each entry maps to a Pi `ModelRegistry` provider id (see
+// `BUILT_IN_PROVIDER_DISPLAY_NAMES` in pi-coding-agent, plus the OAuth
+// providers in @earendil-works/pi-ai/utils/oauth/*).
+//
+// Ordering matters: the first `DEFAULT_VISIBLE_COUNT` render expanded; the
+// rest stay under a "More providers..." disclosure. Users can later
+// override their personal curated set in Settings.
+//
+// `kind` controls the configure flow:
+//   - "api_key"          → API-key entry dialog (writes to auth.json or
+//                          keychain)
+//   - "oauth"            → device-code modal driven by Pi's loginX()
+//                          helpers
+//   - "oauth+enterprise" → device-code modal with an optional self-hosted
+//                          domain prompt first (GHES for Copilot)
+//   - "env_only"         → "configured via env vars" status row, no in-app
+//                          entry (Bedrock / Vertex / Azure — too many env
+//                          vars to model in a single dialog; surface a
+//                          docs link instead)
+//
+// The Pi harness reads this list at IPC `list_providers` and merges it
+// with live auth status from ModelRegistry.
+
+export type ProviderKind =
+  | "api_key"
+  | "oauth"
+  | "oauth+enterprise"
+  | "env_only";
+
+export interface CuratedProvider {
+  /** Pi provider id, e.g. "openrouter" or "github-copilot". */
+  id: string;
+  /** Display name for the card row. */
+  label: string;
+  /** Short description (one line) explaining what configuring this unlocks. */
+  description: string;
+  /** Configure flow. */
+  kind: ProviderKind;
+  /** Optional env var name(s) Pi will pick up automatically. Shown as a
+   *  hint under the input ("or set $X in your shell"). */
+  envHint?: string;
+  /** "Get an API key" link surfaced under the input. */
+  docsUrl?: string;
+}
+
+/** Providers above this index render expanded; the rest sit under a
+ *  "More providers..." disclosure. 6 keeps the card scannable on a 13"
+ *  laptop without forcing the user to expand for the common picks. */
+export const DEFAULT_VISIBLE_COUNT = 6;
+
+// Curation reasoning:
+//
+// Slot 1 — github-copilot (OAuth). A meaningful share of Claudette users
+//   already pay for Copilot via their employer; OAuth flow means "click
+//   one button" and they get every Claude/GPT/Gemini model Copilot
+//   exposes for free. Highest leverage row in the list.
+//
+// Slot 2 — openrouter (API key). Explicitly requested. One key unlocks
+//   ~300 models, and OpenRouter is the lingua franca of model
+//   experimentation right now.
+//
+// Slot 3 — openai (API key). Direct OpenAI access for users who don't
+//   have ChatGPT Plus/Pro (which goes through the dedicated Codex card).
+//
+// Slot 4 — anthropic (API key). Distinct from Claudette's Claude OAuth
+//   card: this is for users on an Anthropic API plan ("extra usage"
+//   billing) who want Pi's harness to route Claude calls. Useful when
+//   the Pro/Max plan is exhausted.
+//
+// Slot 5 — google (API key, Gemini). Gemini 2.5 / 3.x are now first-tier
+//   coding models. Free tier exists, so the bar to configure is low.
+//
+// Slot 6 — deepseek (API key). Best-in-class price/performance for
+//   coding workloads; popular with cost-conscious users.
+//
+// Disclosure (less mainstream but still common enough to want
+// in-app entry):
+//   xai      — Grok 4.x getting traction
+//   groq     — speed-optimized hosting of Llama/Qwen
+//   cerebras — wafer-scale, fastest token throughput
+//   mistral  — European compliance, Codestral coding model
+//   fireworks — popular OSS-model host (Llama, Qwen, Mixtral)
+//   opencode — OpenCode Zen, used by some teams who like its routing
+//
+// Cloud / env-only (we don't try to collect their many env vars in a
+// dialog; show a docs link and detect when they're configured):
+//   amazon-bedrock, google-vertex, azure-openai-responses
+//
+// Deliberately omitted from the curated list:
+//   - openai-codex      → already surfaced via Claudette's Codex card
+//   - cloudflare-ai-gateway / cloudflare-workers-ai → need account id +
+//                         gateway id env vars, fits env_only better but
+//                         too niche to default-show
+//   - huggingface, kimi-coding, minimax / minimax-cn, vercel-ai-gateway,
+//     zai, opencode-go, all xiaomi-* → niche / regional / newer; users
+//     who want them can configure via `pi auth` and Claudette will pick
+//     them up on next refresh
+//
+// Implementation note on envHint: pi-ai's `getApiKeyEnvVars` is the
+// source of truth; the strings below mirror it. If Pi updates the env
+// names in a future release, the harness still works (Pi auto-detects
+// via its own env map) — the hint is purely UX.
+
+export const CURATED_PROVIDERS: CuratedProvider[] = [
+  {
+    id: "github-copilot",
+    label: "GitHub Copilot",
+    description:
+      "Sign in once to use Claude, GPT, and Gemini models via your Copilot subscription.",
+    kind: "oauth+enterprise",
+    docsUrl: "https://github.com/features/copilot",
+  },
+  {
+    id: "openrouter",
+    label: "OpenRouter",
+    description:
+      "One API key, ~300 models. Mix open-weight and frontier proprietary models.",
+    kind: "api_key",
+    envHint: "OPENROUTER_API_KEY",
+    docsUrl: "https://openrouter.ai/keys",
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    description: "Direct API access — GPT-5.x and o-series reasoning models.",
+    kind: "api_key",
+    envHint: "OPENAI_API_KEY",
+    docsUrl: "https://platform.openai.com/api-keys",
+  },
+  {
+    id: "anthropic",
+    label: "Anthropic (API)",
+    description:
+      "API-billed Claude access. Use instead of Pro/Max OAuth when your subscription quota is exhausted.",
+    kind: "api_key",
+    envHint: "ANTHROPIC_API_KEY",
+    docsUrl: "https://console.anthropic.com/settings/keys",
+  },
+  {
+    id: "google",
+    label: "Google Gemini",
+    description: "Gemini 2.5 / 3.x — generous free tier on AI Studio.",
+    kind: "api_key",
+    envHint: "GEMINI_API_KEY",
+    docsUrl: "https://aistudio.google.com/apikey",
+  },
+  {
+    id: "deepseek",
+    label: "DeepSeek",
+    description:
+      "Best price/performance for coding. DeepSeek-V3 and reasoning variants.",
+    kind: "api_key",
+    envHint: "DEEPSEEK_API_KEY",
+    docsUrl: "https://platform.deepseek.com/api_keys",
+  },
+
+  // --- "More providers..." disclosure below this line. ---
+
+  {
+    id: "xai",
+    label: "xAI (Grok)",
+    description: "Grok 4.x family.",
+    kind: "api_key",
+    envHint: "XAI_API_KEY",
+    docsUrl: "https://console.x.ai",
+  },
+  {
+    id: "groq",
+    label: "Groq",
+    description: "Fast inference for Llama, Qwen, and Mixtral.",
+    kind: "api_key",
+    envHint: "GROQ_API_KEY",
+    docsUrl: "https://console.groq.com/keys",
+  },
+  {
+    id: "cerebras",
+    label: "Cerebras",
+    description: "Wafer-scale inference — highest token throughput.",
+    kind: "api_key",
+    envHint: "CEREBRAS_API_KEY",
+    docsUrl: "https://cloud.cerebras.ai",
+  },
+  {
+    id: "mistral",
+    label: "Mistral",
+    description: "Codestral and Mistral Large for code-heavy work.",
+    kind: "api_key",
+    envHint: "MISTRAL_API_KEY",
+    docsUrl: "https://console.mistral.ai/api-keys",
+  },
+  {
+    id: "fireworks",
+    label: "Fireworks AI",
+    description: "Hosted open-weight models (Llama, Qwen, Mixtral, DeepSeek).",
+    kind: "api_key",
+    envHint: "FIREWORKS_API_KEY",
+    docsUrl: "https://fireworks.ai/account/api-keys",
+  },
+  {
+    id: "opencode",
+    label: "OpenCode Zen",
+    description: "OpenCode-routed open and frontier models.",
+    kind: "api_key",
+    envHint: "OPENCODE_API_KEY",
+    docsUrl: "https://opencode.ai",
+  },
+
+  // --- Cloud / env-only providers (show status + docs link, no dialog). ---
+
+  {
+    id: "amazon-bedrock",
+    label: "Amazon Bedrock",
+    description:
+      "Configure via AWS credentials in your shell. AWS_PROFILE or IAM keys.",
+    kind: "env_only",
+    docsUrl:
+      "https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/docs/providers.md#amazon-bedrock",
+  },
+  {
+    id: "google-vertex",
+    label: "Google Vertex AI",
+    description:
+      "Configure via gcloud ADC: GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION.",
+    kind: "env_only",
+    docsUrl:
+      "https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/docs/providers.md#google-vertex-ai",
+  },
+  {
+    id: "azure-openai-responses",
+    label: "Azure OpenAI",
+    description:
+      "AZURE_OPENAI_API_KEY + AZURE_OPENAI_BASE_URL (or resource name).",
+    kind: "env_only",
+    docsUrl:
+      "https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/docs/providers.md#azure-openai",
+  },
+];

--- a/src-pi-harness/src/format-error.ts
+++ b/src-pi-harness/src/format-error.ts
@@ -1,0 +1,142 @@
+// Convert a raw provider error message (the string Pi's agent loop
+// hands us in `AssistantMessage.errorMessage` or `auto_retry_end`'s
+// `finalError`) into a clean human-readable line for the Claudette
+// chat transcript.
+//
+// Pi's error strings are upstream-provider-shaped: usually an HTTP
+// status code prefix plus the raw response body. The body can be:
+//   - Anthropic JSON: {"type":"error","error":{"type":"...","message":"..."}}
+//   - OpenAI JSON:    {"error":{"message":"...","type":"...","code":"..."}}
+//   - GitHub Copilot: plain text like "checking third-party user
+//                     token: bad request: Personal Access Tokens are
+//                     not supported for this endpoint"
+//   - OpenRouter:     {"error":{"message":"...","code":...}}
+//
+// The chat panel renders the result as markdown so callers can pass
+// the output straight through; we use **bold** for the leading
+// label so it stands out from streamed text.
+//
+// Pure / no dependencies — keep it small enough that callers
+// (turn_error and turn_end paths) can both invoke it without
+// duplicating the parsing logic.
+
+export interface FormattedProviderError {
+  /** HTTP status code if the message started with one (e.g. 400). */
+  status?: number;
+  /** The user-facing error sentence — already unwrapped from any
+   *  provider JSON envelope and trimmed. Fallback: the trimmed raw
+   *  input if no envelope was recognized. */
+  message: string;
+  /** Optional secondary detail (provider-side error type / code).
+   *  Surfaced as muted text after the main message when present. */
+  detail?: string;
+}
+
+const HTTP_STATUS_PREFIX = /^(\d{3})\s+/;
+
+/** Try to extract a friendly message from a provider error envelope.
+ *  Returns `undefined` when the value doesn't match a known shape so
+ *  the caller can fall back to the raw text. */
+function unwrapEnvelope(
+  value: unknown,
+): { message: string; detail?: string } | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const root = value as Record<string, unknown>;
+
+  // Anthropic / OpenRouter / OpenAI all use the same shape variants —
+  // either `{error: {message, type, code}}` or, less commonly, the
+  // `{error: "string", message: "..."}` flat form.
+  const errorBlock = root.error;
+  if (typeof errorBlock === "string" && errorBlock.trim()) {
+    const message = errorBlock.trim();
+    const topMessage =
+      typeof root.message === "string" && root.message.trim()
+        ? root.message.trim()
+        : undefined;
+    return { message: topMessage ?? message, detail: topMessage ? message : undefined };
+  }
+  if (errorBlock && typeof errorBlock === "object") {
+    const inner = errorBlock as Record<string, unknown>;
+    const message = typeof inner.message === "string" ? inner.message.trim() : "";
+    if (message) {
+      const type = typeof inner.type === "string" ? inner.type.trim() : "";
+      const code =
+        typeof inner.code === "string"
+          ? inner.code.trim()
+          : typeof inner.code === "number"
+            ? String(inner.code)
+            : "";
+      const detail = [type, code].filter(Boolean).join(" · ") || undefined;
+      return { message, detail };
+    }
+  }
+
+  // Some providers wrap things one level deeper (Vertex / Bedrock
+  // gateway flavours). Handle a single trailing `message` field.
+  if (typeof root.message === "string" && root.message.trim()) {
+    return { message: root.message.trim() };
+  }
+  return undefined;
+}
+
+export function formatProviderError(raw: string): FormattedProviderError {
+  const trimmed = raw.trim();
+  if (!trimmed) return { message: "Unknown error" };
+
+  // Pi prefixes the HTTP status (`400 `, `500 `, …) in front of the
+  // upstream body. Split it off so we can carry it as structured
+  // metadata; the body is what we try to parse.
+  let status: number | undefined;
+  let body = trimmed;
+  const match = trimmed.match(HTTP_STATUS_PREFIX);
+  if (match) {
+    status = Number.parseInt(match[1] ?? "", 10);
+    body = trimmed.slice(match[0].length);
+    if (!Number.isFinite(status)) status = undefined;
+  }
+
+  // Try JSON envelope first — Anthropic / OpenAI / OpenRouter all
+  // wrap upstream errors in a JSON object. Be tolerant of trailing
+  // junk by attempting a substring slice up to the last `}` when
+  // strict parse fails.
+  if (body.startsWith("{") || body.startsWith("[")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      const lastBrace = body.lastIndexOf("}");
+      if (lastBrace > 0) {
+        try {
+          parsed = JSON.parse(body.slice(0, lastBrace + 1));
+        } catch {
+          parsed = undefined;
+        }
+      }
+    }
+    const unwrapped = unwrapEnvelope(parsed);
+    if (unwrapped) {
+      return { status, message: unwrapped.message, detail: unwrapped.detail };
+    }
+  }
+
+  // Plain text (Copilot's "checking third-party user token: …" style
+  // or any unrecognized provider). Cap absurdly long messages so a
+  // multi-KB HTML error page can't blow out the chat row — a wrapped
+  // <html> response is useless detail.
+  const MAX_PLAIN = 600;
+  const message = body.length > MAX_PLAIN
+    ? `${body.slice(0, MAX_PLAIN).trim()}…`
+    : body;
+  return { status, message };
+}
+
+/** Build the markdown string Rust embeds in the assistant text
+ *  block for a turn that failed. Keeps the formatting in one place
+ *  so different code paths (turn_error capture, agent_end walk,
+ *  auto_retry_end final failure) all produce the same shape. */
+export function renderProviderErrorMarkdown(raw: string): string {
+  const { status, message, detail } = formatProviderError(raw);
+  const label = status ? `**Error · HTTP ${status}**` : "**Error**";
+  const trailing = detail ? `\n\n_${detail}_` : "";
+  return `${label}\n\n${message}${trailing}`;
+}

--- a/src-pi-harness/src/main.ts
+++ b/src-pi-harness/src/main.ts
@@ -862,6 +862,44 @@ function findModel(value: string) {
   return state.modelRegistry.getAll().find((model) => model.id === modelId);
 }
 
+/**
+ * Pull a human-readable error out of pi-agent-core's `agent_end` event.
+ *
+ * The event carries `messages: AgentMessage[]` (no top-level
+ * errorMessage). The actual failure lives on the last assistant
+ * message's `errorMessage` when its `stopReason` is "error" or
+ * "aborted". We walk the tail of the array because the final message
+ * is always the assistant's last attempt — earlier messages may be
+ * tool results or successful assistant turns from this same run.
+ *
+ * Returns `undefined` when the run ended cleanly (no error to
+ * surface). Defensive about shape because Pi may change this event
+ * later — we only need a string when there's one to surface.
+ */
+function extractAgentEndError(event: { messages?: unknown }): string | undefined {
+  const messages = Array.isArray(event.messages) ? event.messages : [];
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (!message || typeof message !== "object") continue;
+    const m = message as {
+      role?: string;
+      stopReason?: string;
+      errorMessage?: unknown;
+    };
+    if (m.role !== "assistant") continue;
+    const failed = m.stopReason === "error" || m.stopReason === "aborted";
+    if (!failed) return undefined;
+    if (typeof m.errorMessage === "string" && m.errorMessage.trim()) {
+      return m.errorMessage.trim();
+    }
+    // Failure flagged but no human-readable message — return a stub
+    // so Rust still produces a turn_end with an error indicator
+    // rather than silently succeeding.
+    return `Pi turn ${m.stopReason ?? "failed"}`;
+  }
+  return undefined;
+}
+
 function routeSessionEvent(event: AgentSessionEvent): void {
   switch (event.type) {
     // Pi distinguishes the agent-loop boundary (`agent_start` /
@@ -876,7 +914,13 @@ function routeSessionEvent(event: AgentSessionEvent): void {
       send({ type: "turn_start" });
       break;
     case "message_update": {
-      const update = event.assistantMessageEvent as { type?: string; delta?: string; text?: string };
+      const update = event.assistantMessageEvent as {
+        type?: string;
+        delta?: string;
+        text?: string;
+        reason?: string;
+        error?: { errorMessage?: string };
+      };
       // Pi SDK `AssistantMessageEvent` is a tagged union covering text,
       // thinking, and tool-call streaming. Each tool call streams its
       // raw JSON arguments as a series of `toolcall_delta` events; if
@@ -899,9 +943,29 @@ function routeSessionEvent(event: AgentSessionEvent): void {
         if (delta) send({ type: "assistant_delta", delta });
         break;
       }
+      if (type === "error") {
+        // `AssistantMessageEvent` `error` variant fires when the LLM
+        // call fails mid-turn (e.g. a Copilot model returns 401 or a
+        // provider 5xxs). The error message lives on the carried
+        // partial AssistantMessage. Forward it as a turn_error so
+        // Rust surfaces it in the chat — without this, the only
+        // signal the user ever sees is `agent_end` + "Agent stopped",
+        // because pi-agent-core's top-level `agent_end` carries
+        // `messages` but NOT a top-level errorMessage.
+        const errorMessage = update.error?.errorMessage?.trim();
+        if (errorMessage) {
+          send({ type: "turn_error", error: errorMessage });
+        } else {
+          send({
+            type: "turn_error",
+            error: `Pi model call failed (${update.reason ?? "error"})`,
+          });
+        }
+        break;
+      }
       // start / text_start / text_end / thinking_start / thinking_end /
-      // toolcall_start / toolcall_delta / toolcall_end / done / error
-      // carry no user-visible chat text — drop them.
+      // toolcall_start / toolcall_delta / toolcall_end / done — no
+      // user-visible chat text. Drop them.
       break;
     }
     case "tool_execution_start":
@@ -932,11 +996,56 @@ function routeSessionEvent(event: AgentSessionEvent): void {
       });
       break;
     case "agent_end":
+      // pi-agent-core's `agent_end` does NOT carry a top-level
+      // `errorMessage` (only `messages: AgentMessage[]`). The
+      // `"errorMessage" in event` check therefore always failed and
+      // every turn_end propagated with `error: undefined`, leaving
+      // the chat silent when a model call 401'd / 5xx'd. Walk the
+      // tail of `messages` for the last assistant entry and forward
+      // its errorMessage when `stopReason` is "error" or "aborted".
       send({
         type: "turn_end",
-        error: "errorMessage" in event ? event.errorMessage : undefined,
+        error: extractAgentEndError(event as { messages?: unknown }),
       });
       break;
+    case "auto_retry_start": {
+      // Surface "retrying after <reason>" as a turn-thinking line so
+      // users seeing a long pause know Pi is re-trying instead of
+      // assuming the agent froze. Best-effort — the reason live on
+      // the event's errorMessage in current Pi versions.
+      const reason = "errorMessage" in event ? (event as { errorMessage?: string }).errorMessage : undefined;
+      const attempt = (event as { attempt?: number }).attempt;
+      const max = (event as { maxAttempts?: number }).maxAttempts;
+      if (reason) {
+        send({
+          type: "thinking_delta",
+          delta: `[Pi retry ${attempt ?? "?"}/${max ?? "?"}] ${reason}\n`,
+        });
+      }
+      break;
+    }
+    case "auto_retry_end": {
+      // Final retry failed: surface `finalError` as a turn_error so
+      // it reaches the chat even if `agent_end` walks back into the
+      // no-errorMessage path.
+      const finalError = (event as { finalError?: string }).finalError?.trim();
+      const success = (event as { success?: boolean }).success;
+      if (success === false && finalError) {
+        send({ type: "turn_error", error: finalError });
+      }
+      break;
+    }
+    case "compaction_end": {
+      // Compaction failure is surfaced in passing — it doesn't abort
+      // the turn on its own, but the next prompt may behave oddly,
+      // so the user should know. Same shape as auto_retry_end.
+      const errorMessage = (event as { errorMessage?: string }).errorMessage?.trim();
+      const aborted = (event as { aborted?: boolean }).aborted;
+      if (aborted && errorMessage) {
+        send({ type: "thinking_delta", delta: `[Pi compaction failed] ${errorMessage}\n` });
+      }
+      break;
+    }
     // Per-LLM-turn boundaries fire N times inside the agent loop —
     // intentionally swallowed here (see the `agent_start` case for
     // the full rationale). Listed explicitly so a future SDK upgrade
@@ -945,13 +1054,10 @@ function routeSessionEvent(event: AgentSessionEvent): void {
     // the double-Result bug.
     case "turn_start":
     case "turn_end":
-    case "auto_retry_start":
     case "compaction_start":
-    case "compaction_end":
     case "queue_update":
     case "session_info_changed":
     case "thinking_level_changed":
-    case "auto_retry_end":
       break;
     default:
       break;

--- a/src-pi-harness/src/main.ts
+++ b/src-pi-harness/src/main.ts
@@ -17,6 +17,15 @@ import {
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
+import {
+  cancelOAuth,
+  clearApiKey,
+  handleOAuthInput,
+  listProviders,
+  oauthStart,
+  setApiKey,
+  type ProviderAuthDeps,
+} from "./provider-auth.js";
 
 type RequestMessage = {
   id?: string;
@@ -55,6 +64,19 @@ const state: HarnessState = {
 
 function send(message: Record<string, unknown>): void {
   output.write(`${JSON.stringify(message)}\n`);
+}
+
+/** Snapshot the harness state's AuthStorage / ModelRegistry into the
+ *  ProviderAuthDeps shape the `provider-auth.ts` handlers expect. Both
+ *  references are replaced on every `start_session` (so a re-auth or a
+ *  cwd change picks up new credentials), which is why we read them
+ *  fresh on each call rather than caching at startup. */
+function providerAuthDeps(): ProviderAuthDeps {
+  return {
+    authStorage: state.authStorage,
+    modelRegistry: state.modelRegistry,
+    send,
+  };
 }
 
 function respond(id: unknown, command: string, success: boolean, data?: unknown, error?: unknown): void {
@@ -991,6 +1013,44 @@ async function handle(message: RequestMessage): Promise<void> {
         models: listAvailableModels().length,
         authFile: join(getAgentDir(), "auth.json"),
       });
+      break;
+    case "list_providers":
+      respond(message.id, message.type, true, listProviders(providerAuthDeps()));
+      break;
+    case "set_api_key":
+      setApiKey(
+        providerAuthDeps(),
+        asString(message.providerId) ?? "",
+        asString(message.key) ?? "",
+      );
+      respond(message.id, message.type, true);
+      break;
+    case "clear_api_key":
+      clearApiKey(providerAuthDeps(), asString(message.providerId) ?? "");
+      respond(message.id, message.type, true);
+      break;
+    case "oauth_start":
+      // Don't `await` — Pi's `login()` resolves only after the user
+      // finishes the browser flow. Returning immediately lets the UI
+      // receive the synchronous response while the device-code events
+      // stream asynchronously via `oauth_challenge` / `oauth_complete`.
+      void oauthStart(
+        providerAuthDeps(),
+        asString(message.providerId) ?? "",
+        asString(message.challengeId) ?? "",
+      );
+      respond(message.id, message.type, true);
+      break;
+    case "oauth_input":
+      handleOAuthInput(
+        asString(message.challengeId) ?? "",
+        typeof message.value === "string" ? message.value : "",
+      );
+      respond(message.id, message.type, true);
+      break;
+    case "oauth_cancel":
+      cancelOAuth(asString(message.challengeId) ?? "");
+      respond(message.id, message.type, true);
       break;
     case "approve_tool": {
       const requestId = asString(message.requestId);

--- a/src-pi-harness/src/main.ts
+++ b/src-pi-harness/src/main.ts
@@ -26,6 +26,7 @@ import {
   setApiKey,
   type ProviderAuthDeps,
 } from "./provider-auth.js";
+import { renderProviderErrorMarkdown } from "./format-error.js";
 
 type RequestMessage = {
   id?: string;
@@ -947,20 +948,12 @@ function routeSessionEvent(event: AgentSessionEvent): void {
         // `AssistantMessageEvent` `error` variant fires when the LLM
         // call fails mid-turn (e.g. a Copilot model returns 401 or a
         // provider 5xxs). The error message lives on the carried
-        // partial AssistantMessage. Forward it as a turn_error so
-        // Rust surfaces it in the chat — without this, the only
-        // signal the user ever sees is `agent_end` + "Agent stopped",
-        // because pi-agent-core's top-level `agent_end` carries
-        // `messages` but NOT a top-level errorMessage.
+        // partial AssistantMessage. Format with the shared markdown
+        // renderer so the chat doesn't render raw provider JSON.
         const errorMessage = update.error?.errorMessage?.trim();
-        if (errorMessage) {
-          send({ type: "turn_error", error: errorMessage });
-        } else {
-          send({
-            type: "turn_error",
-            error: `Pi model call failed (${update.reason ?? "error"})`,
-          });
-        }
+        const raw =
+          errorMessage ?? `Pi model call failed (${update.reason ?? "error"})`;
+        send({ type: "turn_error", error: renderProviderErrorMarkdown(raw) });
         break;
       }
       // start / text_start / text_end / thinking_start / thinking_end /
@@ -995,7 +988,7 @@ function routeSessionEvent(event: AgentSessionEvent): void {
         isError: event.isError,
       });
       break;
-    case "agent_end":
+    case "agent_end": {
       // pi-agent-core's `agent_end` does NOT carry a top-level
       // `errorMessage` (only `messages: AgentMessage[]`). The
       // `"errorMessage" in event` check therefore always failed and
@@ -1003,11 +996,13 @@ function routeSessionEvent(event: AgentSessionEvent): void {
       // the chat silent when a model call 401'd / 5xx'd. Walk the
       // tail of `messages` for the last assistant entry and forward
       // its errorMessage when `stopReason` is "error" or "aborted".
+      const raw = extractAgentEndError(event as { messages?: unknown });
       send({
         type: "turn_end",
-        error: extractAgentEndError(event as { messages?: unknown }),
+        error: raw ? renderProviderErrorMarkdown(raw) : undefined,
       });
       break;
+    }
     case "auto_retry_start": {
       // Surface "retrying after <reason>" as a turn-thinking line so
       // users seeing a long pause know Pi is re-trying instead of
@@ -1027,11 +1022,16 @@ function routeSessionEvent(event: AgentSessionEvent): void {
     case "auto_retry_end": {
       // Final retry failed: surface `finalError` as a turn_error so
       // it reaches the chat even if `agent_end` walks back into the
-      // no-errorMessage path.
+      // no-errorMessage path. Run through the formatter so a JSON
+      // envelope from the provider gets unwrapped into a friendly
+      // line just like the other error paths.
       const finalError = (event as { finalError?: string }).finalError?.trim();
       const success = (event as { success?: boolean }).success;
       if (success === false && finalError) {
-        send({ type: "turn_error", error: finalError });
+        send({
+          type: "turn_error",
+          error: renderProviderErrorMarkdown(finalError),
+        });
       }
       break;
     }

--- a/src-pi-harness/src/provider-auth.ts
+++ b/src-pi-harness/src/provider-auth.ts
@@ -1,0 +1,245 @@
+// Provider auth IPC handlers for the Pi harness.
+//
+// Owns the four flows the Settings UI / `/login` need:
+//
+//   1. `list_providers`   — merge CURATED_PROVIDERS with live auth status
+//                           from Pi's ModelRegistry. Used to render the
+//                           Pi provider list in Settings and inside the
+//                           `/login` picker modal.
+//   2. `set_api_key`      — write an API-key credential to ~/.pi/agent/
+//                           auth.json (Pi's AuthStorage). Used by the
+//                           "shared with terminal pi" storage path.
+//   3. `clear_api_key`    — remove a provider's auth.json entry.
+//   4. `oauth_*`          — drive Pi's `AuthStorage.login()` device-code
+//                           flow. Streams `oauth_challenge` events back
+//                           to Claudette so the UI can render the
+//                           verification URL / user code and forward
+//                           onPrompt() inputs (e.g. GHES domain) back
+//                           in via `oauth_input`.
+//
+// Kept separate from `main.ts` to avoid piling responsibility onto the
+// already-large dispatch file. `main.ts` adds one dispatch line per
+// message in `handle()`; everything below lives here.
+//
+// Storage policy:
+//   - This module ONLY writes to Pi's auth.json (the "shared" path).
+//   - The keychain-only / Claudette-private path is handled Rust-side:
+//     Claudette stores the key in its own secret store and passes the
+//     matching env var (e.g. `OPENROUTER_API_KEY`) into the harness
+//     process env. Pi's getApiKey resolution order ("auth.json wins,
+//     env var fallback") means the two paths don't fight: a key in
+//     auth.json takes precedence over the env var for the same
+//     provider, so users can re-enter a key under the other policy
+//     without manual cleanup.
+
+import type { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { CURATED_PROVIDERS, DEFAULT_VISIBLE_COUNT, type CuratedProvider } from "./curated-providers.js";
+
+export type SendFn = (message: Record<string, unknown>) => void;
+
+interface PendingOAuth {
+  /** Stable id we hand back in every event for this OAuth attempt; used
+   *  by the UI to route `oauth_input` / `oauth_cancel` back to the
+   *  right pending challenge if the user starts two flows. */
+  challengeId: string;
+  providerId: string;
+  controller: AbortController;
+  /** Pending `onPrompt` resolver, if we are currently waiting on user
+   *  input. Set when Pi calls `onPrompt`, cleared when the UI sends
+   *  `oauth_input`. */
+  pendingPrompt?: (value: string) => void;
+}
+
+export interface ProviderAuthDeps {
+  authStorage: AuthStorage;
+  modelRegistry: ModelRegistry;
+  send: SendFn;
+}
+
+/** Active OAuth challenges, keyed by challengeId. Module-private so
+ *  the HarnessState in `main.ts` doesn't have to know about OAuth
+ *  internals. The harness only re-spawns on `start_session` reauth,
+ *  not on auth dialogs, so the lifetime of this map matches the
+ *  sidecar process. */
+const pendingOAuth = new Map<string, PendingOAuth>();
+
+export interface ProviderRow extends CuratedProvider {
+  /** Pi's `AuthStatus.source`, or undefined when no credential exists. */
+  authSource?: string;
+  /** True when at least one credential path resolves (auth.json, env
+   *  var, runtime override, or models.json). Mirrors
+   *  `AuthStorage.hasAuth`. */
+  configured: boolean;
+  /** Convenience for the UI — number of models Pi exposes for this
+   *  provider once it's configured. Comes from
+   *  `ModelRegistry.getAll().filter(m => m.provider === id)`. */
+  modelCount: number;
+}
+
+export interface ListProvidersResponse {
+  defaultVisibleCount: number;
+  providers: ProviderRow[];
+}
+
+export function listProviders(state: ProviderAuthDeps): ListProvidersResponse {
+  // Refresh first so an auth.json mutation from a previous IPC call (or
+  // from a terminal `pi` running in parallel) is reflected in the row
+  // we return.
+  state.modelRegistry.refresh();
+  const available = new Set(
+    state.modelRegistry.getAvailable().map((m) => m.provider ?? ""),
+  );
+  const all = state.modelRegistry.getAll();
+  const providers: ProviderRow[] = CURATED_PROVIDERS.map((entry) => {
+    const status = state.modelRegistry.getProviderAuthStatus(entry.id);
+    const modelCount = all.reduce(
+      (acc, m) => (m.provider === entry.id ? acc + 1 : acc),
+      0,
+    );
+    // `configured` mirrors the gate `listAvailableModels` uses: a
+    // provider is configured iff at least one of its models passes
+    // `hasConfiguredAuth` (AuthStorage.hasAuth OR a models.json
+    // provider request config with an apiKey). Using `authStorage.has`
+    // alone misses models.json-only providers like a `!security ...`
+    // command-backed anthropic key.
+    return {
+      ...entry,
+      authSource: status.source,
+      configured: available.has(entry.id),
+      modelCount,
+    };
+  });
+  return { defaultVisibleCount: DEFAULT_VISIBLE_COUNT, providers };
+}
+
+export function setApiKey(
+  state: ProviderAuthDeps,
+  providerId: string,
+  key: string,
+): void {
+  if (!providerId) throw new Error("Missing providerId");
+  if (!key || !key.trim()) throw new Error("API key is empty");
+  // Pi's AuthStorage handles the file lock + 0600 perms internally.
+  state.authStorage.set(providerId, { type: "api_key", key: key.trim() });
+}
+
+export function clearApiKey(
+  state: ProviderAuthDeps,
+  providerId: string,
+): void {
+  if (!providerId) throw new Error("Missing providerId");
+  state.authStorage.remove(providerId);
+}
+
+export async function oauthStart(
+  state: ProviderAuthDeps,
+  providerId: string,
+  challengeId: string,
+): Promise<void> {
+  if (!providerId) throw new Error("Missing providerId");
+  if (!challengeId) throw new Error("Missing challengeId");
+  if (pendingOAuth.has(challengeId)) {
+    throw new Error(`OAuth challenge ${challengeId} already in flight`);
+  }
+  const pending: PendingOAuth = {
+    challengeId,
+    providerId,
+    controller: new AbortController(),
+  };
+  pendingOAuth.set(challengeId, pending);
+  try {
+    await state.authStorage.login(providerId, {
+      onAuth: ({ url, instructions }: { url: string; instructions?: string }) => {
+        state.send({
+          type: "oauth_challenge",
+          challengeId,
+          providerId,
+          kind: "auth",
+          url,
+          instructions,
+        });
+      },
+      onPrompt: ({
+        message,
+        placeholder,
+        allowEmpty,
+      }: { message: string; placeholder?: string; allowEmpty?: boolean }) => {
+        // Pi's enterprise prompt resolves to the *value the user types*
+        // — typically a GHES domain or an empty string for github.com.
+        // Park the resolver here; `handleOAuthInput` below resumes it
+        // when the UI sends `oauth_input`.
+        return new Promise<string>((resolve, reject) => {
+          pending.pendingPrompt = resolve;
+          state.send({
+            type: "oauth_challenge",
+            challengeId,
+            providerId,
+            kind: "prompt",
+            message,
+            placeholder,
+            allowEmpty: allowEmpty ?? false,
+          });
+          pending.controller.signal.addEventListener(
+            "abort",
+            () => {
+              pending.pendingPrompt = undefined;
+              reject(new Error("OAuth flow cancelled by user."));
+            },
+            { once: true },
+          );
+        });
+      },
+      onProgress: (message: string) => {
+        state.send({
+          type: "oauth_progress",
+          challengeId,
+          providerId,
+          message,
+        });
+      },
+      signal: pending.controller.signal,
+    });
+    state.send({
+      type: "oauth_complete",
+      challengeId,
+      providerId,
+      ok: true,
+    });
+  } catch (err) {
+    state.send({
+      type: "oauth_complete",
+      challengeId,
+      providerId,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    pendingOAuth.delete(challengeId);
+  }
+}
+
+export function handleOAuthInput(
+  challengeId: string,
+  value: string,
+): void {
+  if (!challengeId) throw new Error("Missing challengeId");
+  const pending = pendingOAuth.get(challengeId);
+  if (!pending) {
+    throw new Error(`Unknown OAuth challenge id: ${challengeId}`);
+  }
+  const resolver = pending.pendingPrompt;
+  if (!resolver) {
+    throw new Error(
+      `OAuth challenge ${challengeId} is not currently awaiting input`,
+    );
+  }
+  pending.pendingPrompt = undefined;
+  resolver(value);
+}
+
+export function cancelOAuth(challengeId: string): void {
+  if (!challengeId) throw new Error("Missing challengeId");
+  const pending = pendingOAuth.get(challengeId);
+  if (!pending) return;
+  pending.controller.abort();
+}

--- a/src-tauri/src/commands/agent_backends/discovery.rs
+++ b/src-tauri/src/commands/agent_backends/discovery.rs
@@ -291,7 +291,13 @@ async fn discover_pi_models(
     // user who configured OpenRouter with "Keep this key private to
     // Claudette" would see the provider as configured in the Pi card
     // but Refresh would still return zero models for it.
-    let extras = super::pi_auth::pi_local_secret_env().unwrap_or_default();
+    //
+    // Propagate keychain-read errors instead of dropping them — a
+    // dead secure store has the same symptom (no models discovered)
+    // as a misconfigured provider, and the user needs to know it's
+    // the store, not Pi. `pi_list_providers` and chat startup already
+    // surface this error; mirror that here.
+    let extras = super::pi_auth::pi_local_secret_env()?;
     let extras_slice: Option<&[(String, String)]> = if extras.is_empty() {
         None
     } else {

--- a/src-tauri/src/commands/agent_backends/discovery.rs
+++ b/src-tauri/src/commands/agent_backends/discovery.rs
@@ -286,7 +286,18 @@ async fn discover_pi_models(
     // matters for `precheck_cwd`; `std::env::temp_dir()` is always
     // present and identical for every refresh.
     let cwd = std::env::temp_dir();
-    let discovered = PiSdkSession::discover_models(&cwd).await?;
+    // Thread keychain-only provider secrets through so Refresh models
+    // sees the same providers as `list_providers`. Without this, a
+    // user who configured OpenRouter with "Keep this key private to
+    // Claudette" would see the provider as configured in the Pi card
+    // but Refresh would still return zero models for it.
+    let extras = super::pi_auth::pi_local_secret_env().unwrap_or_default();
+    let extras_slice: Option<&[(String, String)]> = if extras.is_empty() {
+        None
+    } else {
+        Some(extras.as_slice())
+    };
+    let discovered = PiSdkSession::discover_models_with_env(&cwd, extras_slice).await?;
     let models: Vec<AgentBackendModel> = discovered
         .into_iter()
         .map(|model| AgentBackendModel {

--- a/src-tauri/src/commands/agent_backends/mod.rs
+++ b/src-tauri/src/commands/agent_backends/mod.rs
@@ -20,6 +20,8 @@ mod config;
 mod discovery;
 mod gateway;
 mod gateway_translate;
+#[cfg(feature = "pi-sdk")]
+pub mod pi_auth;
 mod runtime_dispatch;
 
 pub use gateway::BackendGateway;

--- a/src-tauri/src/commands/agent_backends/pi_auth.rs
+++ b/src-tauri/src/commands/agent_backends/pi_auth.rs
@@ -192,7 +192,20 @@ pub async fn pi_set_provider_api_key(
     match scope {
         ProviderSecretScope::Shared => {
             pi_control::set_api_key(working_dir_path(&working_dir), &provider_id, &trimmed).await?;
-            let _ = delete_secure_secret(KEYCHAIN_BUCKET, &keychain_key(&provider_id));
+            // If the user previously stored a private (keychain) key
+            // and switches to shared, the stale private copy would
+            // silently come back to life if they later remove the
+            // auth.json entry from a terminal. Surface a delete
+            // failure so the user knows the old secret is still in
+            // place — the shared write already succeeded, so the
+            // primary action is intact and this becomes advisory.
+            delete_secure_secret(KEYCHAIN_BUCKET, &keychain_key(&provider_id)).map_err(|e| {
+                format!(
+                    "Saved shared key, but failed to remove the previously-stored \
+                     keychain copy ({e}). If you want the keychain copy gone, retry \
+                     after restoring secure-store access."
+                )
+            })?;
             Ok(())
         }
         ProviderSecretScope::Local => {

--- a/src-tauri/src/commands/agent_backends/pi_auth.rs
+++ b/src-tauri/src/commands/agent_backends/pi_auth.rs
@@ -1,0 +1,340 @@
+//! Pi provider-auth Tauri commands.
+//!
+//! Exposed surface:
+//!
+//!   pi_list_providers(working_dir)                         → PiProviderList
+//!   pi_set_provider_api_key(working_dir, id, key, scope)   → ()
+//!   pi_clear_provider_api_key(working_dir, id, scope)      → ()
+//!   pi_oauth_start(working_dir, provider_id, app_handle)   → PiOAuthStarted
+//!   pi_oauth_submit_input(challenge_id, value)             → ()
+//!   pi_oauth_cancel(challenge_id)                          → ()
+//!
+//! The OAuth flow keeps its `PiOAuthSession` alive across Tauri
+//! commands by stashing it in the module-level `ACTIVE_OAUTH` map.
+//! `pi_oauth_start` spawns the harness, kicks off the device-code
+//! flow, and spawns a background task that forwards every
+//! `PiControlEvent` to the webview via `pi://oauth/event`. The React
+//! modal subscribes to that channel.
+//!
+//! Storage scopes:
+//!   - `"shared"` → writes/clears the key in `~/.pi/agent/auth.json` via
+//!     `pi_control::set_api_key` (visible to terminal `pi` too).
+//!   - `"local"`  → stores in Claudette's keychain under
+//!     `KEYCHAIN_BUCKET / pi_provider:{id}`. The matching env var name
+//!     (e.g. `OPENROUTER_API_KEY`) is injected into the harness on spawn.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, LazyLock};
+
+use serde::Deserialize;
+use tauri::{AppHandle, Emitter};
+use tokio::sync::Mutex;
+
+use claudette::agent::{
+    PiControlEvent, PiOAuthSession, PiOAuthStarted, PiProviderList, pi_control,
+};
+use claudette::plugin::{delete_secure_secret, load_secure_secret, save_secure_secret};
+
+/// Keychain bucket for the "private to Claudette" provider keys.
+/// Disjoint from `agentBackendSecrets` (which stores per-backend
+/// custom_anthropic/custom_openai tokens) so we never collide on a
+/// well-known id.
+const KEYCHAIN_BUCKET: &str = "piProviderSecrets";
+
+/// Webview event channel the React modal subscribes to.
+const OAUTH_EVENT: &str = "pi://oauth/event";
+
+/// In-flight OAuth sessions keyed by `challenge_id`. Held in an `Arc`
+/// so the background event-forwarder task can hold a clone without
+/// blocking new commands.
+static ACTIVE_OAUTH: LazyLock<Mutex<HashMap<String, Arc<PiOAuthSession>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Pi's env-var convention for each provider id. Source of truth is
+/// `getApiKeyEnvVars` in `@earendil-works/pi-ai/dist/env-api-keys.js`
+/// — keep in sync when Pi adds providers. Returns the *first* env var
+/// Pi checks for that provider (it accepts several aliases for
+/// github-copilot; we standardize on `COPILOT_GITHUB_TOKEN`).
+fn pi_env_var_for_provider(provider_id: &str) -> Option<&'static str> {
+    match provider_id {
+        "openai" => Some("OPENAI_API_KEY"),
+        "anthropic" => Some("ANTHROPIC_API_KEY"),
+        "azure-openai-responses" => Some("AZURE_OPENAI_API_KEY"),
+        "deepseek" => Some("DEEPSEEK_API_KEY"),
+        "google" => Some("GEMINI_API_KEY"),
+        "google-vertex" => Some("GOOGLE_CLOUD_API_KEY"),
+        "groq" => Some("GROQ_API_KEY"),
+        "cerebras" => Some("CEREBRAS_API_KEY"),
+        "xai" => Some("XAI_API_KEY"),
+        "openrouter" => Some("OPENROUTER_API_KEY"),
+        "vercel-ai-gateway" => Some("AI_GATEWAY_API_KEY"),
+        "zai" => Some("ZAI_API_KEY"),
+        "mistral" => Some("MISTRAL_API_KEY"),
+        "minimax" => Some("MINIMAX_API_KEY"),
+        "minimax-cn" => Some("MINIMAX_CN_API_KEY"),
+        "moonshotai" | "moonshotai-cn" => Some("MOONSHOT_API_KEY"),
+        "huggingface" => Some("HF_TOKEN"),
+        "fireworks" => Some("FIREWORKS_API_KEY"),
+        "opencode" | "opencode-go" => Some("OPENCODE_API_KEY"),
+        "kimi-coding" => Some("KIMI_API_KEY"),
+        "cloudflare-workers-ai" | "cloudflare-ai-gateway" => Some("CLOUDFLARE_API_KEY"),
+        "xiaomi" => Some("XIAOMI_API_KEY"),
+        "github-copilot" => Some("COPILOT_GITHUB_TOKEN"),
+        _ => None,
+    }
+}
+
+fn keychain_key(provider_id: &str) -> String {
+    format!("pi_provider:{provider_id}")
+}
+
+/// Gather every keychain-stored Pi provider secret and project it into
+/// `(env_var, value)` pairs ready for `cmd.env(...)`. Called both by
+/// the Settings refresh paths (so `list_providers` reflects local
+/// keys) and by `chat::send` when spawning a Pi chat session.
+pub fn pi_local_secret_env() -> Result<Vec<(String, String)>, String> {
+    let mut out = Vec::new();
+    // We iterate over the curated provider env-var table; that's the
+    // only set of providers we accept "local" keys for. Anything
+    // outside this map can't have a Claudette-private key by
+    // construction.
+    let curated = [
+        "openai",
+        "anthropic",
+        "azure-openai-responses",
+        "deepseek",
+        "google",
+        "groq",
+        "cerebras",
+        "xai",
+        "openrouter",
+        "vercel-ai-gateway",
+        "zai",
+        "mistral",
+        "minimax",
+        "minimax-cn",
+        "moonshotai",
+        "huggingface",
+        "fireworks",
+        "opencode",
+        "kimi-coding",
+        "github-copilot",
+    ];
+    for id in curated {
+        let key = keychain_key(id);
+        let stored = load_secure_secret(KEYCHAIN_BUCKET, &key)
+            .map_err(|e| format!("Failed to read pi provider secret: {e}"))?;
+        if let Some(value) = stored
+            && !value.trim().is_empty()
+            && let Some(env_name) = pi_env_var_for_provider(id)
+        {
+            out.push((env_name.to_string(), value));
+        }
+    }
+    Ok(out)
+}
+
+#[derive(Debug, Deserialize)]
+pub enum ProviderSecretScope {
+    /// Write to Pi's auth.json (shared with terminal `pi`).
+    #[serde(rename = "shared")]
+    Shared,
+    /// Store in Claudette's keychain (env-var injection only).
+    #[serde(rename = "local")]
+    Local,
+}
+
+fn working_dir_path(working_dir: &str) -> &Path {
+    if working_dir.is_empty() {
+        // Pi's `list_providers` only touches `auth.json` + the env
+        // map; cwd doesn't matter. Fall back to `/` (which exists on
+        // every platform Claudette targets) so a frontend that passes
+        // an empty string can still query.
+        Path::new("/")
+    } else {
+        Path::new(working_dir)
+    }
+}
+
+#[tauri::command]
+pub async fn pi_list_providers(working_dir: String) -> Result<PiProviderList, String> {
+    let extras = pi_local_secret_env()?;
+    let extras_slice = if extras.is_empty() {
+        None
+    } else {
+        Some(extras.as_slice())
+    };
+    pi_control::list_providers(working_dir_path(&working_dir), extras_slice).await
+}
+
+#[tauri::command]
+pub async fn pi_set_provider_api_key(
+    working_dir: String,
+    provider_id: String,
+    key: String,
+    scope: ProviderSecretScope,
+) -> Result<(), String> {
+    let trimmed = key.trim().to_string();
+    if trimmed.is_empty() {
+        return Err("API key is empty".to_string());
+    }
+    match scope {
+        ProviderSecretScope::Shared => {
+            // Belt-and-suspenders: clear any local copy when the user
+            // switches to shared, otherwise Pi's auth.json (which
+            // wins) and Claudette's env-var injection drift.
+            let _ = delete_secure_secret(KEYCHAIN_BUCKET, &keychain_key(&provider_id));
+            pi_control::set_api_key(working_dir_path(&working_dir), &provider_id, &trimmed).await
+        }
+        ProviderSecretScope::Local => {
+            if pi_env_var_for_provider(&provider_id).is_none() {
+                return Err(format!(
+                    "Provider \"{provider_id}\" has no env-var mapping; use shared storage instead."
+                ));
+            }
+            save_secure_secret(KEYCHAIN_BUCKET, &keychain_key(&provider_id), &trimmed)
+                .map_err(|e| format!("Failed to store pi provider secret: {e}"))
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn pi_clear_provider_api_key(
+    working_dir: String,
+    provider_id: String,
+    scope: ProviderSecretScope,
+) -> Result<(), String> {
+    match scope {
+        ProviderSecretScope::Shared => {
+            pi_control::clear_api_key(working_dir_path(&working_dir), &provider_id).await
+        }
+        ProviderSecretScope::Local => {
+            delete_secure_secret(KEYCHAIN_BUCKET, &keychain_key(&provider_id))
+                .map_err(|e| format!("Failed to delete pi provider secret: {e}"))
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn pi_oauth_start(
+    working_dir: String,
+    provider_id: String,
+    app: AppHandle,
+) -> Result<PiOAuthStarted, String> {
+    // A fresh challenge id per attempt so simultaneous flows don't
+    // clobber each other. (The UI doesn't expose multi-attempt today,
+    // but the harness is built for it; keep the surface honest.)
+    let challenge_id = format!("pi-oauth-{}", uuid::Uuid::new_v4().simple());
+    let extras = pi_local_secret_env()?;
+    let extras_slice = if extras.is_empty() {
+        None
+    } else {
+        Some(extras.as_slice())
+    };
+    let session = PiOAuthSession::start(
+        working_dir_path(&working_dir),
+        &provider_id,
+        &challenge_id,
+        extras_slice,
+    )
+    .await?;
+    let session = Arc::new(session);
+    let mut events = session.subscribe_events();
+    ACTIVE_OAUTH
+        .lock()
+        .await
+        .insert(challenge_id.clone(), Arc::clone(&session));
+
+    // Forward every event onto the webview. Drops itself when the
+    // session emits OAuthComplete (the harness disposes itself on
+    // that boundary; the long-lived session is still in ACTIVE_OAUTH
+    // until oauth_cancel/submit_input finishes — clean up here too).
+    let app_clone = app.clone();
+    let challenge_id_clone = challenge_id.clone();
+    tokio::spawn(async move {
+        loop {
+            match events.recv().await {
+                Ok(event) => {
+                    let is_complete = matches!(&event, PiControlEvent::OAuthComplete { .. });
+                    let _ = app_clone.emit(OAUTH_EVENT, &event);
+                    if is_complete {
+                        ACTIVE_OAUTH.lock().await.remove(&challenge_id_clone);
+                        break;
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    ACTIVE_OAUTH.lock().await.remove(&challenge_id_clone);
+                    break;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(
+                        target: "claudette::pi_auth",
+                        dropped = n,
+                        "pi_oauth_start broadcast lag"
+                    );
+                }
+            }
+        }
+    });
+
+    Ok(PiOAuthStarted {
+        challenge_id,
+        provider_id,
+    })
+}
+
+#[tauri::command]
+pub async fn pi_oauth_submit_input(challenge_id: String, value: String) -> Result<(), String> {
+    let session = ACTIVE_OAUTH
+        .lock()
+        .await
+        .get(&challenge_id)
+        .cloned()
+        .ok_or_else(|| format!("No active Pi OAuth session for {challenge_id}"))?;
+    session.submit_input(&value).await
+}
+
+#[tauri::command]
+pub async fn pi_oauth_cancel(challenge_id: String) -> Result<(), String> {
+    let session = ACTIVE_OAUTH.lock().await.remove(&challenge_id);
+    if let Some(session) = session {
+        session.cancel().await
+    } else {
+        // Already cancelled / completed. Idempotent.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_map_covers_canonical_providers() {
+        // Spot-check the providers we care about most for the user
+        // story (Copilot, OpenRouter, OpenAI). A regression here is a
+        // silent feature break, so the test pins each mapping.
+        assert_eq!(
+            pi_env_var_for_provider("openrouter"),
+            Some("OPENROUTER_API_KEY")
+        );
+        assert_eq!(pi_env_var_for_provider("openai"), Some("OPENAI_API_KEY"));
+        assert_eq!(
+            pi_env_var_for_provider("github-copilot"),
+            Some("COPILOT_GITHUB_TOKEN")
+        );
+        assert_eq!(pi_env_var_for_provider("anthropic"), Some("ANTHROPIC_API_KEY"));
+        assert_eq!(pi_env_var_for_provider("nonexistent"), None);
+    }
+
+    #[test]
+    fn keychain_key_is_namespaced() {
+        // Two layers of isolation: the KEYCHAIN_BUCKET keeps Pi keys
+        // out of agentBackendSecrets, and the `pi_provider:` prefix
+        // keeps individual rows from colliding with anything else
+        // someone might wedge into this bucket later.
+        assert_eq!(keychain_key("openrouter"), "pi_provider:openrouter");
+        assert!(keychain_key("github-copilot").starts_with("pi_provider:"));
+    }
+}

--- a/src-tauri/src/commands/agent_backends/pi_auth.rs
+++ b/src-tauri/src/commands/agent_backends/pi_auth.rs
@@ -179,13 +179,21 @@ pub async fn pi_set_provider_api_key(
     if trimmed.is_empty() {
         return Err("API key is empty".to_string());
     }
+    // Write the new credential first, then clear the *other* scope so
+    // the old key never silently shadows the new one. Pi's resolution
+    // order has auth.json beating env vars; without clearing the
+    // other scope, switching from shared→local leaves the auth.json
+    // entry in place and Pi keeps using the old key, while switching
+    // from local→shared leaves the env-injected key around in case
+    // the user later removes the auth.json entry from a terminal.
+    // The previous "clear local first, then write shared" path
+    // produced an even worse failure: a write error wiped the only
+    // working credential.
     match scope {
         ProviderSecretScope::Shared => {
-            // Belt-and-suspenders: clear any local copy when the user
-            // switches to shared, otherwise Pi's auth.json (which
-            // wins) and Claudette's env-var injection drift.
+            pi_control::set_api_key(working_dir_path(&working_dir), &provider_id, &trimmed).await?;
             let _ = delete_secure_secret(KEYCHAIN_BUCKET, &keychain_key(&provider_id));
-            pi_control::set_api_key(working_dir_path(&working_dir), &provider_id, &trimmed).await
+            Ok(())
         }
         ProviderSecretScope::Local => {
             if pi_env_var_for_provider(&provider_id).is_none() {
@@ -194,7 +202,22 @@ pub async fn pi_set_provider_api_key(
                 ));
             }
             save_secure_secret(KEYCHAIN_BUCKET, &keychain_key(&provider_id), &trimmed)
-                .map_err(|e| format!("Failed to store pi provider secret: {e}"))
+                .map_err(|e| format!("Failed to store pi provider secret: {e}"))?;
+            // Drop any pre-existing shared auth.json entry only after
+            // the new local secret is safely written. If the shared
+            // clear fails (Pi auth.json unreadable, etc.) the local
+            // key still wins for keychain-injected env-var lookups
+            // outside auth.json, but inside Pi's resolution order the
+            // shared entry would beat it — surface that condition so
+            // the user knows their local change is shadowed.
+            pi_control::clear_api_key(working_dir_path(&working_dir), &provider_id)
+                .await
+                .map_err(|e| {
+                    format!(
+                        "Saved local secret, but failed to clear shared auth.json entry \
+                         (Pi will keep using the old shared key until it is removed): {e}"
+                    )
+                })
         }
     }
 }
@@ -232,15 +255,23 @@ pub async fn pi_oauth_start(
     } else {
         Some(extras.as_slice())
     };
-    let session = PiOAuthSession::start(
+    let mut session = PiOAuthSession::start(
         working_dir_path(&working_dir),
         &provider_id,
         &challenge_id,
         extras_slice,
     )
     .await?;
+    // Take the receiver subscribed BEFORE `oauth_start` was issued so
+    // the very first `oauth_challenge` cannot race past us. A fresh
+    // `subscribe_events()` after the fact is not equivalent — broadcast
+    // channels do not replay messages to late subscribers, so any
+    // event Pi emitted between `start_control` and this line would be
+    // dropped without `take_events()`.
+    let mut events = session
+        .take_events()
+        .ok_or("PiOAuthSession seeded events already consumed")?;
     let session = Arc::new(session);
-    let mut events = session.subscribe_events();
     ACTIVE_OAUTH
         .lock()
         .await

--- a/src-tauri/src/commands/agent_backends/pi_auth.rs
+++ b/src-tauri/src/commands/agent_backends/pi_auth.rs
@@ -324,7 +324,10 @@ mod tests {
             pi_env_var_for_provider("github-copilot"),
             Some("COPILOT_GITHUB_TOKEN")
         );
-        assert_eq!(pi_env_var_for_provider("anthropic"), Some("ANTHROPIC_API_KEY"));
+        assert_eq!(
+            pi_env_var_for_provider("anthropic"),
+            Some("ANTHROPIC_API_KEY")
+        );
         assert_eq!(pi_env_var_for_provider("nonexistent"), None);
     }
 

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -1933,7 +1933,8 @@ pub async fn send_chat_message(
                                 .backend_runtime
                                 .pi_provider_override
                                 .clone(),
-                            pi_provider_env: crate::commands::agent_backends::pi_auth::pi_local_secret_env()?,
+                            pi_provider_env:
+                                crate::commands::agent_backends::pi_auth::pi_local_secret_env()?,
                         },
                     )
                     .await?;

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -1933,6 +1933,7 @@ pub async fn send_chat_message(
                                 .backend_runtime
                                 .pi_provider_override
                                 .clone(),
+                            pi_provider_env: crate::commands::agent_backends::pi_auth::pi_local_secret_env()?,
                         },
                     )
                     .await?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1075,6 +1075,18 @@ fn main() {
             commands::agent_backends::refresh_agent_backend_models,
             commands::agent_backends::test_agent_backend,
             commands::agent_backends::launch_codex_login,
+            #[cfg(feature = "pi-sdk")]
+            commands::agent_backends::pi_auth::pi_list_providers,
+            #[cfg(feature = "pi-sdk")]
+            commands::agent_backends::pi_auth::pi_set_provider_api_key,
+            #[cfg(feature = "pi-sdk")]
+            commands::agent_backends::pi_auth::pi_clear_provider_api_key,
+            #[cfg(feature = "pi-sdk")]
+            commands::agent_backends::pi_auth::pi_oauth_start,
+            #[cfg(feature = "pi-sdk")]
+            commands::agent_backends::pi_auth::pi_oauth_submit_input,
+            #[cfg(feature = "pi-sdk")]
+            commands::agent_backends::pi_auth::pi_oauth_cancel,
             // Claude flags
             commands::claude_flags::list_claude_flags,
             commands::claude_flags::refresh_claude_flags,

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -7,6 +7,8 @@ pub mod harness;
 pub mod history_seeder;
 mod naming;
 #[cfg(feature = "pi-sdk")]
+pub mod pi_control;
+#[cfg(feature = "pi-sdk")]
 pub mod pi_sdk;
 mod process;
 mod session;
@@ -35,7 +37,11 @@ pub use naming::{
     generate_branch_name, generate_session_name, persist_claude_custom_title, sanitize_branch_name,
 };
 #[cfg(feature = "pi-sdk")]
-pub use pi_sdk::{PiSdkModel, PiSdkOptions, PiSdkSession, resolve_pi_harness_path};
+pub use pi_control::{PiOAuthSession, PiOAuthStarted, PiProvider, PiProviderList};
+#[cfg(feature = "pi-sdk")]
+pub use pi_sdk::{
+    PiControlEvent, PiSdkModel, PiSdkOptions, PiSdkSession, resolve_pi_harness_path,
+};
 pub use process::{AgentEvent, TurnHandle, run_turn, stop_agent, stop_agent_graceful};
 pub use session::PersistentSession;
 pub use types::{

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -39,9 +39,7 @@ pub use naming::{
 #[cfg(feature = "pi-sdk")]
 pub use pi_control::{PiOAuthSession, PiOAuthStarted, PiProvider, PiProviderList};
 #[cfg(feature = "pi-sdk")]
-pub use pi_sdk::{
-    PiControlEvent, PiSdkModel, PiSdkOptions, PiSdkSession, resolve_pi_harness_path,
-};
+pub use pi_sdk::{PiControlEvent, PiSdkModel, PiSdkOptions, PiSdkSession, resolve_pi_harness_path};
 pub use process::{AgentEvent, TurnHandle, run_turn, stop_agent, stop_agent_graceful};
 pub use session::PersistentSession;
 pub use types::{

--- a/src/agent/pi_control.rs
+++ b/src/agent/pi_control.rs
@@ -1,0 +1,271 @@
+//! Pi provider-auth control plane.
+//!
+//! Thin typed wrapper around the Pi sidecar's `list_providers`,
+//! `set_api_key`, `clear_api_key`, and `oauth_*` IPC messages. The
+//! Settings provider-management UI and the `/login` slash command call
+//! into this module; the sidecar process management itself lives in
+//! `pi_sdk.rs`.
+//!
+//! Two flavours of operation:
+//!   - **One-shot**: spawn a control session, run a single IPC, dispose.
+//!     Right for `list_providers`, `set_api_key`, `clear_api_key`.
+//!   - **Long-lived**: `PiOAuthSession` keeps the harness alive across
+//!     the device-code flow so the UI can stream challenge events and
+//!     forward `onPrompt` inputs (e.g. GHES domain) back without
+//!     respawning.
+//!
+//! All wire-level concerns (PiHarnessMessage variants, control-event
+//! routing) live in `pi_sdk.rs`. This file only translates between the
+//! sidecar's JSON shapes and the Rust types Tauri commands expose.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::sync::broadcast;
+
+use super::pi_sdk::{PiControlEvent, PiSdkSession};
+
+/// One row in the curated provider list shown in Settings → Models →
+/// Pi card and the `/login` picker. Mirrors `ProviderRow` in the
+/// harness. `serde(rename_all = "camelCase")` so the wire shape matches
+/// the sidecar without per-field renames.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PiProvider {
+    pub id: String,
+    pub label: String,
+    pub description: String,
+    /// `"api_key"` | `"oauth"` | `"oauth+enterprise"` | `"env_only"`.
+    pub kind: String,
+    #[serde(default)]
+    pub env_hint: Option<String>,
+    #[serde(default)]
+    pub docs_url: Option<String>,
+    #[serde(default)]
+    pub auth_source: Option<String>,
+    pub configured: bool,
+    pub model_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PiProviderList {
+    /// First `default_visible_count` providers render expanded in the
+    /// card; the rest sit behind a "More providers…" disclosure.
+    pub default_visible_count: u32,
+    pub providers: Vec<PiProvider>,
+}
+
+/// Resolve the curated list against the user's live Pi state. Spawns a
+/// short-lived sidecar; do not call on a hot path — caller throttles.
+/// `extra_env` carries the keychain-only secrets the Tauri layer
+/// injects so the harness reports `configured: true` for providers
+/// stored privately to Claudette.
+pub async fn list_providers(
+    working_dir: &Path,
+    extra_env: Option<&[(String, String)]>,
+) -> Result<PiProviderList, String> {
+    let session = PiSdkSession::start_control(working_dir, extra_env).await?;
+    let value = session
+        .send_request_raw(json!({ "type": "list_providers" }))
+        .await?;
+    let parsed = serde_json::from_value::<PiProviderList>(value)
+        .map_err(|e| format!("Invalid Pi list_providers response: {e}"))?;
+    let _ = session.dispose().await;
+    Ok(parsed)
+}
+
+/// Write `key` to `~/.pi/agent/auth.json` under `provider_id`. This is
+/// the "shared with terminal `pi`" storage path. For the keychain-only
+/// path Claudette stores the key itself and injects an env var on
+/// harness spawn — that flow does NOT call this function.
+pub async fn set_api_key(
+    working_dir: &Path,
+    provider_id: &str,
+    key: &str,
+) -> Result<(), String> {
+    if provider_id.is_empty() {
+        return Err("Missing providerId".to_string());
+    }
+    if key.is_empty() {
+        return Err("API key is empty".to_string());
+    }
+    let session = PiSdkSession::start_control(working_dir, None).await?;
+    session
+        .send_request_raw(json!({
+            "type": "set_api_key",
+            "providerId": provider_id,
+            "key": key,
+        }))
+        .await?;
+    let _ = session.dispose().await;
+    Ok(())
+}
+
+pub async fn clear_api_key(working_dir: &Path, provider_id: &str) -> Result<(), String> {
+    if provider_id.is_empty() {
+        return Err("Missing providerId".to_string());
+    }
+    let session = PiSdkSession::start_control(working_dir, None).await?;
+    session
+        .send_request_raw(json!({
+            "type": "clear_api_key",
+            "providerId": provider_id,
+        }))
+        .await?;
+    let _ = session.dispose().await;
+    Ok(())
+}
+
+/// Long-lived control session bound to a single OAuth login attempt.
+/// Spawn one when the Configure modal opens, drain
+/// `subscribe_events()` for challenge updates, forward user input via
+/// `submit_input` / cancel via `cancel`, and `dispose()` (Drop also
+/// works) when the modal closes.
+pub struct PiOAuthSession {
+    session: PiSdkSession,
+    challenge_id: String,
+    provider_id: String,
+}
+
+impl PiOAuthSession {
+    pub async fn start(
+        working_dir: &Path,
+        provider_id: &str,
+        challenge_id: &str,
+        extra_env: Option<&[(String, String)]>,
+    ) -> Result<Self, String> {
+        if provider_id.is_empty() {
+            return Err("Missing providerId".to_string());
+        }
+        if challenge_id.is_empty() {
+            return Err("Missing challengeId".to_string());
+        }
+        let session = PiSdkSession::start_control(working_dir, extra_env).await?;
+        // Subscribe BEFORE we issue oauth_start, otherwise the very
+        // first `oauth_challenge` event can race past the broadcast
+        // receiver. The caller can replace this receiver via
+        // `subscribe_events()` once it has its own subscription.
+        let _early_subscriber = session.subscribe_control();
+        session
+            .send_request_raw(json!({
+                "type": "oauth_start",
+                "providerId": provider_id,
+                "challengeId": challenge_id,
+            }))
+            .await?;
+        drop(_early_subscriber);
+        Ok(Self {
+            session,
+            challenge_id: challenge_id.to_string(),
+            provider_id: provider_id.to_string(),
+        })
+    }
+
+    pub fn challenge_id(&self) -> &str {
+        &self.challenge_id
+    }
+
+    pub fn provider_id(&self) -> &str {
+        &self.provider_id
+    }
+
+    pub fn subscribe_events(&self) -> broadcast::Receiver<PiControlEvent> {
+        self.session.subscribe_control()
+    }
+
+    /// Forward a user-entered value (e.g. a GHES domain) back to Pi's
+    /// `onPrompt` resolver.
+    pub async fn submit_input(&self, value: &str) -> Result<(), String> {
+        self.session
+            .send_request_raw(json!({
+                "type": "oauth_input",
+                "challengeId": self.challenge_id,
+                "value": value,
+            }))
+            .await?;
+        Ok(())
+    }
+
+    /// Abort the in-flight device-code flow. Pi's `onPrompt` resolver
+    /// rejects with "OAuth flow cancelled by user."; the harness then
+    /// emits `oauth_complete { ok: false }`.
+    pub async fn cancel(&self) -> Result<(), String> {
+        self.session
+            .send_request_raw(json!({
+                "type": "oauth_cancel",
+                "challengeId": self.challenge_id,
+            }))
+            .await?;
+        Ok(())
+    }
+
+    /// Tear down the sidecar.
+    pub async fn dispose(self) -> Result<(), String> {
+        self.session.dispose().await
+    }
+}
+
+/// Result wire shape returned by the high-level Tauri command path.
+/// Surfaces the value of the OAuth challenge currently displayed to
+/// the user so the React modal can render without holding its own
+/// state-machine glue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PiOAuthStarted {
+    pub challenge_id: String,
+    pub provider_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_list_round_trips() {
+        let raw = serde_json::json!({
+            "defaultVisibleCount": 6,
+            "providers": [{
+                "id": "openrouter",
+                "label": "OpenRouter",
+                "description": "Meta-aggregator",
+                "kind": "api_key",
+                "envHint": "OPENROUTER_API_KEY",
+                "docsUrl": "https://openrouter.ai/keys",
+                "configured": false,
+                "modelCount": 275,
+            }],
+        });
+        let parsed: PiProviderList = serde_json::from_value(raw).unwrap();
+        assert_eq!(parsed.default_visible_count, 6);
+        assert_eq!(parsed.providers.len(), 1);
+        let row = &parsed.providers[0];
+        assert_eq!(row.id, "openrouter");
+        assert_eq!(row.env_hint.as_deref(), Some("OPENROUTER_API_KEY"));
+        assert_eq!(row.model_count, 275);
+        assert!(!row.configured);
+    }
+
+    #[test]
+    fn provider_list_tolerates_missing_optional_fields() {
+        // Bedrock entry from the env_only group has neither envHint
+        // nor authSource. Deserialize must succeed.
+        let raw = serde_json::json!({
+            "defaultVisibleCount": 6,
+            "providers": [{
+                "id": "amazon-bedrock",
+                "label": "Amazon Bedrock",
+                "description": "AWS",
+                "kind": "env_only",
+                "configured": false,
+                "modelCount": 93,
+            }],
+        });
+        let parsed: PiProviderList = serde_json::from_value(raw).unwrap();
+        let row = &parsed.providers[0];
+        assert!(row.env_hint.is_none());
+        assert!(row.auth_source.is_none());
+        assert!(row.docs_url.is_none());
+    }
+}

--- a/src/agent/pi_control.rs
+++ b/src/agent/pi_control.rs
@@ -80,11 +80,7 @@ pub async fn list_providers(
 /// the "shared with terminal `pi`" storage path. For the keychain-only
 /// path Claudette stores the key itself and injects an env var on
 /// harness spawn — that flow does NOT call this function.
-pub async fn set_api_key(
-    working_dir: &Path,
-    provider_id: &str,
-    key: &str,
-) -> Result<(), String> {
+pub async fn set_api_key(working_dir: &Path, provider_id: &str, key: &str) -> Result<(), String> {
     if provider_id.is_empty() {
         return Err("Missing providerId".to_string());
     }

--- a/src/agent/pi_control.rs
+++ b/src/agent/pi_control.rs
@@ -115,14 +115,24 @@ pub async fn clear_api_key(working_dir: &Path, provider_id: &str) -> Result<(), 
 }
 
 /// Long-lived control session bound to a single OAuth login attempt.
-/// Spawn one when the Configure modal opens, drain
-/// `subscribe_events()` for challenge updates, forward user input via
+/// Spawn one when the Configure modal opens, take the seeded
+/// receiver via `take_events()` (or fall back to `subscribe_events()`
+/// for additional independent listeners), forward user input via
 /// `submit_input` / cancel via `cancel`, and `dispose()` (Drop also
 /// works) when the modal closes.
 pub struct PiOAuthSession {
     session: PiSdkSession,
     challenge_id: String,
     provider_id: String,
+    /// Receiver bound BEFORE the `oauth_start` IPC. Hands the very
+    /// first `oauth_challenge` (which Pi can emit faster than the
+    /// caller registers its own subscriber) over to the Tauri layer
+    /// via `take_events()`. Once taken, additional listeners can
+    /// still call `subscribe_events()` — but they will miss any
+    /// event that arrived before they subscribed, which is fine
+    /// because the Tauri layer fans the seeded receiver out to a
+    /// webview event.
+    seeded_events: Option<broadcast::Receiver<PiControlEvent>>,
 }
 
 impl PiOAuthSession {
@@ -139,11 +149,13 @@ impl PiOAuthSession {
             return Err("Missing challengeId".to_string());
         }
         let session = PiSdkSession::start_control(working_dir, extra_env).await?;
-        // Subscribe BEFORE we issue oauth_start, otherwise the very
-        // first `oauth_challenge` event can race past the broadcast
-        // receiver. The caller can replace this receiver via
-        // `subscribe_events()` once it has its own subscription.
-        let _early_subscriber = session.subscribe_control();
+        // Subscribe BEFORE we issue oauth_start. The harness streams
+        // the first `oauth_challenge` as soon as Pi resolves the
+        // device-code, which races past any subscription made later.
+        // Hold the receiver on `self` and hand it to the caller via
+        // `take_events()` so the seeded subscription survives across
+        // the IPC round-trip.
+        let seeded_events = Some(session.subscribe_control());
         session
             .send_request_raw(json!({
                 "type": "oauth_start",
@@ -151,11 +163,11 @@ impl PiOAuthSession {
                 "challengeId": challenge_id,
             }))
             .await?;
-        drop(_early_subscriber);
         Ok(Self {
             session,
             challenge_id: challenge_id.to_string(),
             provider_id: provider_id.to_string(),
+            seeded_events,
         })
     }
 
@@ -167,6 +179,20 @@ impl PiOAuthSession {
         &self.provider_id
     }
 
+    /// Take the seeded broadcast receiver established BEFORE
+    /// `oauth_start`. The caller (typically the Tauri webview-event
+    /// forwarder) MUST use this on first subscription instead of
+    /// `subscribe_events()` so the initial `oauth_challenge` payload
+    /// is not lost. Returns `None` if already taken (subsequent
+    /// listeners are independent and may legitimately miss the
+    /// initial event).
+    pub fn take_events(&mut self) -> Option<broadcast::Receiver<PiControlEvent>> {
+        self.seeded_events.take()
+    }
+
+    /// Subscribe to control events from this point forward. Will miss
+    /// any events that fired before this call — prefer
+    /// `take_events()` for the primary subscriber.
     pub fn subscribe_events(&self) -> broadcast::Receiver<PiControlEvent> {
         self.session.subscribe_control()
     }

--- a/src/agent/pi_sdk.rs
+++ b/src/agent/pi_sdk.rs
@@ -39,6 +39,13 @@ struct PiTurnOutput {
     thinking: String,
     tool_block_indices: HashMap<String, u32>,
     next_tool_block_index: u32,
+    /// Latest mid-turn error from the sidecar. Pi's `agent_end` does
+    /// NOT carry an errorMessage at the event level, so we capture
+    /// the `AssistantMessageEvent { type: "error" }` and
+    /// `auto_retry_end { success: false, finalError }` events the
+    /// harness now forwards as `turn_error`, and fold the latest
+    /// into the eventual `turn_end`. Cleared on every `turn_end`.
+    pending_error: Option<String>,
 }
 
 impl PiTurnOutput {
@@ -48,6 +55,7 @@ impl PiTurnOutput {
             thinking: String::new(),
             tool_block_indices: HashMap::new(),
             next_tool_block_index: FIRST_TOOL_BLOCK_INDEX,
+            pending_error: None,
         }
     }
 
@@ -672,6 +680,18 @@ enum PiHarnessMessage {
         #[serde(default)]
         error: Option<String>,
     },
+    /// Mid-turn failure surfaced by the harness when Pi's
+    /// `AssistantMessageEvent` returns an `error` variant or
+    /// `auto_retry_end` fails. The handler folds the error into
+    /// `turn_output` so the eventual `turn_end` carries it even if
+    /// pi-agent-core's top-level `agent_end` carries no
+    /// errorMessage (which is the common case — see the helper in
+    /// `main.ts`).
+    #[serde(rename = "turn_error")]
+    TurnError {
+        #[serde(default)]
+        error: Option<String>,
+    },
     #[serde(rename = "error")]
     Error {
         #[serde(default)]
@@ -994,12 +1014,33 @@ async fn route_pi_message(
                 is_synthetic: false,
             }));
         }
-        PiHarnessMessage::TurnEnd { error } => {
-            let mut output = turn_output.lock().await;
-            let error_text = error
+        PiHarnessMessage::TurnError { error } => {
+            // Defer surfacing — `turn_end` carries the consolidated
+            // error block. Stashing here lets a turn that emits
+            // multiple errors (e.g. retry-then-final-fail) collapse
+            // into one assistant block instead of three.
+            let trimmed = error
                 .as_ref()
                 .map(|e| e.trim().to_string())
                 .filter(|e| !e.is_empty());
+            if let Some(err) = trimmed {
+                let mut output = turn_output.lock().await;
+                output.pending_error = Some(err);
+            }
+        }
+        PiHarnessMessage::TurnEnd { error } => {
+            let mut output = turn_output.lock().await;
+            // Merge any mid-turn `turn_error` events the harness
+            // forwarded with the `agent_end` errorMessage walk.
+            // Either source can carry the user-facing failure, and
+            // we prefer the explicit end-of-turn error when both
+            // exist (it's the authoritative final state).
+            let pending_error = output.pending_error.take();
+            let from_turn_end = error
+                .as_ref()
+                .map(|e| e.trim().to_string())
+                .filter(|e| !e.is_empty());
+            let error_text = from_turn_end.or(pending_error);
             let mut content = Vec::new();
             if !output.thinking.trim().is_empty() {
                 content.push(ContentBlock::Thinking {
@@ -1932,6 +1973,164 @@ mod tests {
             other => panic!("expected Result, got {other:?}"),
         }
         assert!(try_recv_now(&mut rx).is_none());
+    }
+
+    /// A mid-turn `turn_error` (forwarded by the harness from a Pi
+    /// `AssistantMessageEvent { type: "error" }` or a failed
+    /// `auto_retry_end`) followed by a clean-looking `turn_end` must
+    /// still surface the error to the user. Without this, every
+    /// Copilot 401 / OpenRouter 5xx came through as "Agent stopped"
+    /// with no chat message.
+    #[tokio::test]
+    async fn turn_error_promotes_pending_error_into_turn_end() {
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::TurnError {
+                error: Some("401 Unauthorized".to_string()),
+            },
+        )
+        .await;
+        // turn_error itself produces no chat event — it stashes the
+        // error on turn_output until turn_end finalizes the turn.
+        assert!(try_recv_now(&mut rx).is_none());
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::TurnEnd { error: None },
+        )
+        .await;
+        match next_event(&mut rx).await {
+            AgentEvent::Stream(StreamEvent::Assistant { message }) => {
+                let last = message.content.last().expect("error block");
+                match last {
+                    ContentBlock::Text { text } => {
+                        assert!(text.contains("401 Unauthorized"), "got {text:?}")
+                    }
+                    other => panic!("expected Text, got {other:?}"),
+                }
+            }
+            other => panic!("expected Assistant, got {other:?}"),
+        }
+        match next_event(&mut rx).await {
+            AgentEvent::Stream(StreamEvent::Result {
+                subtype, result, ..
+            }) => {
+                assert_eq!(subtype, "error");
+                assert!(result.unwrap().contains("401 Unauthorized"));
+            }
+            other => panic!("expected Result, got {other:?}"),
+        }
+    }
+
+    /// When BOTH `turn_error` (mid-turn) and `turn_end { error }`
+    /// (agent_end walk surfaced one too) arrive, `turn_end`'s error
+    /// wins. It's the authoritative final state — if Pi reports a
+    /// different message there, that's what the user should see.
+    #[tokio::test]
+    async fn turn_end_error_wins_over_pending_error() {
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::TurnError {
+                error: Some("retry-time error".to_string()),
+            },
+        )
+        .await;
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::TurnEnd {
+                error: Some("final 500".to_string()),
+            },
+        )
+        .await;
+        match next_event(&mut rx).await {
+            AgentEvent::Stream(StreamEvent::Assistant { message }) => {
+                let last = message.content.last().expect("error block");
+                match last {
+                    ContentBlock::Text { text } => {
+                        assert!(text.contains("final 500"), "got {text:?}");
+                        assert!(!text.contains("retry-time error"), "got {text:?}");
+                    }
+                    other => panic!("expected Text, got {other:?}"),
+                }
+            }
+            other => panic!("expected Assistant, got {other:?}"),
+        }
+        let _ = next_event(&mut rx).await;
+    }
+
+    /// Pending error must be cleared between turns so a successful
+    /// turn N+1 doesn't inherit turn N's failure.
+    #[tokio::test]
+    async fn pending_error_is_cleared_between_turns() {
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::TurnError {
+                error: Some("turn1 failed".to_string()),
+            },
+        )
+        .await;
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::TurnEnd { error: None },
+        )
+        .await;
+        // Drain turn-1 finalize events.
+        let _ = next_event(&mut rx).await;
+        let _ = next_event(&mut rx).await;
+
+        // Turn 2: clean run; must NOT re-surface the turn-1 error.
+        turn_output.lock().await.text.push_str("hello");
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::TurnEnd { error: None },
+        )
+        .await;
+        match next_event(&mut rx).await {
+            AgentEvent::Stream(StreamEvent::Assistant { message }) => {
+                for block in &message.content {
+                    if let ContentBlock::Text { text } = block {
+                        assert!(!text.contains("turn1 failed"));
+                    }
+                }
+            }
+            other => panic!("expected Assistant, got {other:?}"),
+        }
+        match next_event(&mut rx).await {
+            AgentEvent::Stream(StreamEvent::Result { subtype, .. }) => {
+                assert_eq!(subtype, "success");
+            }
+            other => panic!("expected Result, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/agent/pi_sdk.rs
+++ b/src/agent/pi_sdk.rs
@@ -95,12 +95,22 @@ pub struct PiSdkOptions {
     /// through Pi without the user having to maintain a separate
     /// `~/.pi/agent/models.json`.
     pub pi_provider_override: Option<crate::agent_backend::PiProviderOverride>,
+    /// Extra env vars injected into the harness process, populated
+    /// from Claudette's keychain-backed "keep this key private" path
+    /// in the provider auth UI. Maps a Pi-recognized env var name
+    /// (e.g. `OPENROUTER_API_KEY`) to its value. Empty by default.
+    pub pi_provider_env: Vec<(String, String)>,
 }
 
 pub struct PiSdkSession {
     pid: u32,
     stdin: Option<PiStdin>,
     event_tx: broadcast::Sender<AgentEvent>,
+    /// Side channel for control-plane events that don't belong on the
+    /// chat AgentEvent stream — OAuth challenge URLs, OAuth progress
+    /// updates, and OAuth completion. Subscribed to by `pi_control.rs`
+    /// for the Settings provider-management flow.
+    control_tx: broadcast::Sender<PiControlEvent>,
     pending: PendingRequests,
     next_request_id: AtomicI64,
     working_dir: PathBuf,
@@ -118,6 +128,12 @@ struct PiSpawnConfig<'a> {
     working_dir: &'a Path,
     resolved_env: Option<&'a crate::env_provider::ResolvedEnv>,
     workspace_env: Option<&'a crate::env::WorkspaceEnv>,
+    /// Extra env vars injected after `resolved_env` / `workspace_env`
+    /// (so they win when keys collide). Used by Claudette's
+    /// "keychain-only" provider auth path to push `OPENROUTER_API_KEY`,
+    /// `OPENAI_API_KEY`, etc. into the harness process without
+    /// touching `~/.pi/agent/auth.json`.
+    extra_env: Option<&'a [(String, String)]>,
     cache_command_line: bool,
 }
 
@@ -131,6 +147,11 @@ impl PiSdkSession {
             working_dir,
             resolved_env: options.resolved_env.as_ref(),
             workspace_env: options.workspace_env.as_ref(),
+            extra_env: if options.pi_provider_env.is_empty() {
+                None
+            } else {
+                Some(&options.pi_provider_env)
+            },
             cache_command_line: true,
         })
         .await?;
@@ -145,7 +166,7 @@ impl PiSdkSession {
     }
 
     pub async fn discover_models(working_dir: &Path) -> Result<Vec<PiSdkModel>, String> {
-        let session = Self::start_control(working_dir).await?;
+        let session = Self::start_control(working_dir, None).await?;
         let value = session
             .send_request(json!({ "type": "discover_models" }))
             .await?;
@@ -159,14 +180,49 @@ impl PiSdkSession {
         Ok(models)
     }
 
-    async fn start_control(working_dir: &Path) -> Result<Self, String> {
+    /// Spawn a short-lived harness used purely for control-plane
+    /// IPC (discovery, provider auth, etc.) — no chat session, no
+    /// resolved env, no init-event cache. Exposed to the sibling
+    /// `pi_control` module so the Settings provider-management flow
+    /// can reuse the same spawn/init pipeline.
+    ///
+    /// `extra_env` lets callers push Claudette-private provider
+    /// secrets (keychain-only path) into the control session so
+    /// `list_providers` reports `configured: true` even when nothing
+    /// is in `~/.pi/agent/auth.json`.
+    pub(super) async fn start_control(
+        working_dir: &Path,
+        extra_env: Option<&[(String, String)]>,
+    ) -> Result<Self, String> {
         Self::spawn_initialized(PiSpawnConfig {
             working_dir,
             resolved_env: None,
             workspace_env: None,
+            extra_env,
             cache_command_line: false,
         })
         .await
+    }
+
+    /// Subscribe to control-plane events (OAuth challenges, progress,
+    /// completion). Subscribe BEFORE issuing the corresponding request
+    /// or early events can race past you.
+    pub fn subscribe_control(&self) -> broadcast::Receiver<PiControlEvent> {
+        self.control_tx.subscribe()
+    }
+
+    /// Send a raw IPC request and await its response. Exposed to the
+    /// `pi_control` module so it can dispatch new request types
+    /// without re-implementing the request/response correlation here.
+    pub(super) async fn send_request_raw(&self, request: Value) -> Result<Value, String> {
+        self.send_request(request).await
+    }
+
+    /// Tell the sidecar to release its session state. Idempotent; safe
+    /// to call on a session that was never started.
+    pub async fn dispose(&self) -> Result<(), String> {
+        self.send_request(json!({ "type": "dispose" })).await?;
+        Ok(())
     }
 
     /// Spawn the Pi sidecar, wire its stdio readers + exit watcher, and
@@ -190,6 +246,11 @@ impl PiSdkSession {
         }
         if let Some(env) = config.workspace_env {
             env.apply(&mut cmd);
+        }
+        if let Some(extras) = config.extra_env {
+            for (k, v) in extras {
+                cmd.env(k, v);
+            }
         }
         if let Some(package_dir) = resolve_pi_package_dir(&pi_path) {
             cmd.env("PI_PACKAGE_DIR", package_dir);
@@ -220,10 +281,12 @@ impl PiSdkSession {
             .ok_or_else(|| "Failed to capture Pi SDK harness stderr".to_string())?;
 
         let (event_tx, _) = broadcast::channel(2048);
+        let (control_tx, _) = broadcast::channel(64);
         let session = Self {
             pid,
             stdin: Some(Arc::new(tokio::sync::Mutex::new(stdin))),
             event_tx,
+            control_tx,
             pending: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
             next_request_id: AtomicI64::new(1),
             working_dir: config.working_dir.to_path_buf(),
@@ -256,10 +319,12 @@ impl PiSdkSession {
     #[doc(hidden)]
     pub fn new_for_test(pid: u32) -> Self {
         let (event_tx, _) = broadcast::channel(128);
+        let (control_tx, _) = broadcast::channel(64);
         Self {
             pid,
             stdin: None,
             event_tx,
+            control_tx,
             pending: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
             next_request_id: AtomicI64::new(1),
             working_dir: PathBuf::from("/tmp"),
@@ -469,6 +534,7 @@ impl PiSdkSession {
 
     fn spawn_stdout_reader(&self, stdout: tokio::process::ChildStdout) {
         let event_tx = self.event_tx.clone();
+        let control_tx = self.control_tx.clone();
         let pending = self.pending.clone();
         let turn_output = self.turn_output.clone();
         let init_cache = self.init_cache.clone();
@@ -481,8 +547,15 @@ impl PiSdkSession {
                 }
                 match serde_json::from_str::<PiHarnessMessage>(&line) {
                     Ok(message) => {
-                        route_pi_message(&event_tx, &pending, &turn_output, &init_cache, message)
-                            .await;
+                        route_pi_message(
+                            &event_tx,
+                            &control_tx,
+                            &pending,
+                            &turn_output,
+                            &init_cache,
+                            message,
+                        )
+                        .await;
                     }
                     Err(err) => {
                         let msg = format!("Failed to parse Pi SDK harness line: {err}: {line}");
@@ -590,12 +663,85 @@ enum PiHarnessMessage {
         #[serde(default)]
         error: Option<String>,
     },
+    // Pi provider-auth flow events. The harness emits these unsolicited
+    // during an OAuth login (the request/response pair only carries the
+    // "we started" / "we finished" signal; the URL + user code live in
+    // the asynchronous events below). Forwarded to `control_tx` so the
+    // Settings UI subscriber can render the device-code modal.
+    #[serde(rename = "oauth_challenge")]
+    OAuthChallenge {
+        #[serde(rename = "challengeId")]
+        challenge_id: String,
+        #[serde(rename = "providerId")]
+        provider_id: String,
+        kind: String,
+        #[serde(default)]
+        url: Option<String>,
+        #[serde(default)]
+        instructions: Option<String>,
+        #[serde(default)]
+        message: Option<String>,
+        #[serde(default)]
+        placeholder: Option<String>,
+        #[serde(default, rename = "allowEmpty")]
+        allow_empty: bool,
+    },
+    #[serde(rename = "oauth_progress")]
+    OAuthProgress {
+        #[serde(rename = "challengeId")]
+        challenge_id: String,
+        #[serde(rename = "providerId")]
+        provider_id: String,
+        message: String,
+    },
+    #[serde(rename = "oauth_complete")]
+    OAuthComplete {
+        #[serde(rename = "challengeId")]
+        challenge_id: String,
+        #[serde(rename = "providerId")]
+        provider_id: String,
+        ok: bool,
+        #[serde(default)]
+        error: Option<String>,
+    },
     #[serde(other)]
     Unknown,
 }
 
+/// Control-plane events that flow over a side channel separate from the
+/// main agent event stream. Used by the Settings provider-management UI
+/// to drive the OAuth device-code modal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PiControlEvent {
+    OAuthChallenge {
+        challenge_id: String,
+        provider_id: String,
+        /// `"auth"` → display URL + instructions; `"prompt"` → display
+        /// `message` and an input field (e.g. GHES domain).
+        kind: String,
+        url: Option<String>,
+        instructions: Option<String>,
+        message: Option<String>,
+        placeholder: Option<String>,
+        allow_empty: bool,
+    },
+    OAuthProgress {
+        challenge_id: String,
+        provider_id: String,
+        message: String,
+    },
+    OAuthComplete {
+        challenge_id: String,
+        provider_id: String,
+        ok: bool,
+        error: Option<String>,
+    },
+}
+
 async fn route_pi_message(
     event_tx: &broadcast::Sender<AgentEvent>,
+    control_tx: &broadcast::Sender<PiControlEvent>,
     pending: &PendingRequests,
     turn_output: &TurnOutput,
     init_cache: &InitCacheHandle,
@@ -880,6 +1026,51 @@ async fn route_pi_message(
                 error.unwrap_or_else(|| "Pi SDK harness error".to_string()),
             ));
         }
+        PiHarnessMessage::OAuthChallenge {
+            challenge_id,
+            provider_id,
+            kind,
+            url,
+            instructions,
+            message,
+            placeholder,
+            allow_empty,
+        } => {
+            let _ = control_tx.send(PiControlEvent::OAuthChallenge {
+                challenge_id,
+                provider_id,
+                kind,
+                url,
+                instructions,
+                message,
+                placeholder,
+                allow_empty,
+            });
+        }
+        PiHarnessMessage::OAuthProgress {
+            challenge_id,
+            provider_id,
+            message,
+        } => {
+            let _ = control_tx.send(PiControlEvent::OAuthProgress {
+                challenge_id,
+                provider_id,
+                message,
+            });
+        }
+        PiHarnessMessage::OAuthComplete {
+            challenge_id,
+            provider_id,
+            ok,
+            error,
+        } => {
+            let _ = control_tx.send(PiControlEvent::OAuthComplete {
+                challenge_id,
+                provider_id,
+                ok,
+                error,
+            });
+        }
         PiHarnessMessage::Unknown => {}
     }
 }
@@ -970,21 +1161,25 @@ mod tests {
     use tokio::sync::Mutex;
     use tokio::time::{Duration, timeout};
 
-    /// Build the four route_pi_message dependencies pre-wired together.
-    /// Returns the sender alongside a receiver so tests can drain the
-    /// emitted stream events.
+    /// Build the route_pi_message dependencies pre-wired together.
+    /// Returns the senders alongside a receiver so tests can drain the
+    /// emitted stream events. `control_tx` is created but no test
+    /// receiver is wired by default — pin a subscriber yourself if
+    /// you need to assert on control-plane events.
     fn pi_state() -> (
         broadcast::Sender<AgentEvent>,
+        broadcast::Sender<PiControlEvent>,
         broadcast::Receiver<AgentEvent>,
         PendingRequests,
         TurnOutput,
         InitCacheHandle,
     ) {
         let (event_tx, rx) = broadcast::channel::<AgentEvent>(64);
+        let (control_tx, _) = broadcast::channel::<PiControlEvent>(64);
         let pending: PendingRequests = Arc::new(Mutex::new(BTreeMap::new()));
         let turn_output: TurnOutput = Arc::new(Mutex::new(PiTurnOutput::fresh()));
         let init_cache: InitCacheHandle = Arc::new(Mutex::new(InitCache::default()));
-        (event_tx, rx, pending, turn_output, init_cache)
+        (event_tx, control_tx, rx, pending, turn_output, init_cache)
     }
 
     async fn next_event(rx: &mut broadcast::Receiver<AgentEvent>) -> AgentEvent {
@@ -1083,10 +1278,11 @@ mod tests {
     /// app-server path leaves the field absent, so this is Pi-only.
     #[tokio::test]
     async fn pi_tool_request_injects_codex_agent_label() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
 
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1118,9 +1314,10 @@ mod tests {
     /// route file changes through the wrong card.
     #[tokio::test]
     async fn pi_tool_request_file_change_uses_file_change_approval() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1159,9 +1356,10 @@ mod tests {
     /// without the metadata it can't inject.
     #[tokio::test]
     async fn pi_tool_request_with_non_object_input_skips_injection() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1188,7 +1386,7 @@ mod tests {
     /// failure delivers the harness-reported error string verbatim.
     #[tokio::test]
     async fn response_success_wakes_pending_oneshot() {
-        let (event_tx, _rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, _rx, pending, turn_output, init_cache) = pi_state();
         let (tx, rx) = oneshot::channel();
         pending.lock().await.insert(
             "id-1".to_string(),
@@ -1199,6 +1397,7 @@ mod tests {
         );
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1218,7 +1417,7 @@ mod tests {
 
     #[tokio::test]
     async fn response_failure_propagates_error_string() {
-        let (event_tx, _rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, _rx, pending, turn_output, init_cache) = pi_state();
         let (tx, rx) = oneshot::channel();
         pending.lock().await.insert(
             "id-2".to_string(),
@@ -1229,6 +1428,7 @@ mod tests {
         );
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1249,9 +1449,10 @@ mod tests {
     /// poison the pending map — the harness logs and continues.
     #[tokio::test]
     async fn response_for_unknown_id_is_swallowed() {
-        let (event_tx, _rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, _rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1271,9 +1472,10 @@ mod tests {
     /// subscribers — the chat bridge's `got_init` flag depends on this.
     #[tokio::test]
     async fn ready_emits_and_caches_init_event() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1300,11 +1502,12 @@ mod tests {
     /// pre-allocated ContentBlockStart events (text=0, thinking=1).
     #[tokio::test]
     async fn turn_start_emits_message_and_block_starts() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         // Pollute prior state so we can verify the reset.
         turn_output.lock().await.text.push_str("stale");
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1324,9 +1527,10 @@ mod tests {
 
     #[tokio::test]
     async fn assistant_delta_appends_text_and_streams_block() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1337,6 +1541,7 @@ mod tests {
         .await;
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1365,9 +1570,10 @@ mod tests {
 
     #[tokio::test]
     async fn thinking_delta_appends_thinking_and_streams_block_one() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1395,9 +1601,10 @@ mod tests {
     /// streams the args as an InputJson delta in the same block.
     #[tokio::test]
     async fn tool_update_start_opens_block_and_streams_args() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1444,10 +1651,11 @@ mod tests {
     /// block.
     #[tokio::test]
     async fn tool_update_update_phase_emits_synthetic_user_result() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         // Prime the index by emitting a start first
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1464,6 +1672,7 @@ mod tests {
 
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1499,12 +1708,13 @@ mod tests {
     /// the SDK transcript reflects the tool output.
     #[tokio::test]
     async fn tool_result_closes_block_and_forwards_payload() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         // Open block first
         turn_output.lock().await.tool_index("call-r");
 
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1552,9 +1762,10 @@ mod tests {
     /// an invalid index and confuse the frontend's block table.
     #[tokio::test]
     async fn tool_result_without_prior_start_skips_block_stop() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1588,7 +1799,7 @@ mod tests {
     /// final Assistant message and a Result with subtype `success`.
     #[tokio::test]
     async fn turn_end_success_finalizes_assistant_and_result() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         {
             let mut output = turn_output.lock().await;
             output.text.push_str("final answer");
@@ -1596,6 +1807,7 @@ mod tests {
         }
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1629,10 +1841,11 @@ mod tests {
     /// only read the Result still see it).
     #[tokio::test]
     async fn turn_end_error_surfaces_error_in_assistant_and_result() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         turn_output.lock().await.text.push_str("partial");
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1673,9 +1886,10 @@ mod tests {
     /// still emitted so the chat bridge knows the turn closed.
     #[tokio::test]
     async fn turn_end_with_empty_output_skips_assistant() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1693,9 +1907,10 @@ mod tests {
 
     #[tokio::test]
     async fn error_message_emits_stderr() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1715,9 +1930,10 @@ mod tests {
     /// strand the user.
     #[tokio::test]
     async fn error_message_with_no_text_falls_back_to_default() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,
@@ -1734,9 +1950,10 @@ mod tests {
     /// doesn't recognize yet) must not crash the reader loop.
     #[tokio::test]
     async fn unknown_variant_is_silently_ignored() {
-        let (event_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
+            &control_tx,
             &pending,
             &turn_output,
             &init_cache,

--- a/src/agent/pi_sdk.rs
+++ b/src/agent/pi_sdk.rs
@@ -1058,10 +1058,14 @@ async fn route_pi_message(
             // `Result.result`, so without this an error after partial
             // text would finalize with only the partial text visible and
             // the failure invisible.
+            //
+            // The harness pre-formats `err` as markdown via
+            // `renderProviderErrorMarkdown` (the **Error · HTTP X** label
+            // + parsed message), so we embed it verbatim instead of
+            // adding our own "Pi turn failed:" prefix that would
+            // duplicate the label.
             if let Some(err) = error_text.as_ref() {
-                content.push(ContentBlock::Text {
-                    text: format!("Pi turn failed: {err}"),
-                });
+                content.push(ContentBlock::Text { text: err.clone() });
             }
             if !content.is_empty() {
                 let _ = event_tx.send(AgentEvent::Stream(StreamEvent::Assistant {

--- a/src/agent/pi_sdk.rs
+++ b/src/agent/pi_sdk.rs
@@ -166,7 +166,21 @@ impl PiSdkSession {
     }
 
     pub async fn discover_models(working_dir: &Path) -> Result<Vec<PiSdkModel>, String> {
-        let session = Self::start_control(working_dir, None).await?;
+        Self::discover_models_with_env(working_dir, None).await
+    }
+
+    /// Same as `discover_models`, but threads Claudette's keychain-
+    /// only provider secrets into the control session's env so
+    /// `getAvailable()` sees those providers as configured. The Tauri
+    /// layer passes the `pi_local_secret_env()` snapshot here so
+    /// "Refresh models" surfaces keychain-stored OpenRouter / OpenAI /
+    /// etc. credentials without the user having to also write them to
+    /// `~/.pi/agent/auth.json`.
+    pub async fn discover_models_with_env(
+        working_dir: &Path,
+        extra_env: Option<&[(String, String)]>,
+    ) -> Result<Vec<PiSdkModel>, String> {
+        let session = Self::start_control(working_dir, extra_env).await?;
         let value = session
             .send_request(json!({ "type": "discover_models" }))
             .await?;
@@ -711,9 +725,22 @@ enum PiHarnessMessage {
 /// Control-plane events that flow over a side channel separate from the
 /// main agent event stream. Used by the Settings provider-management UI
 /// to drive the OAuth device-code modal.
+///
+/// The `type` discriminant stays snake_case to match the harness wire
+/// shape (`oauth_challenge` / `oauth_progress` / `oauth_complete`), but
+/// the *fields* serialize camelCase so the React modal can read
+/// `challengeId` / `providerId` / `allowEmpty` directly. Without the
+/// inner camelCase rename, the frontend received every id as
+/// `undefined` and the OAuth flow's challenge filtering and prompt
+/// submission both broke silently.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type")]
 pub enum PiControlEvent {
+    // Variants get explicit `rename` because serde's default conversion
+    // of `OAuthChallenge` to snake_case is `o_auth_challenge` (it
+    // treats the leading capitalized "O" + "Auth" as two words).
+    // Pin to the wire shape the harness emits.
+    #[serde(rename = "oauth_challenge", rename_all = "camelCase")]
     OAuthChallenge {
         challenge_id: String,
         provider_id: String,
@@ -726,11 +753,13 @@ pub enum PiControlEvent {
         placeholder: Option<String>,
         allow_empty: bool,
     },
+    #[serde(rename = "oauth_progress", rename_all = "camelCase")]
     OAuthProgress {
         challenge_id: String,
         provider_id: String,
         message: String,
     },
+    #[serde(rename = "oauth_complete", rename_all = "camelCase")]
     OAuthComplete {
         challenge_id: String,
         provider_id: String,
@@ -2044,6 +2073,44 @@ mod tests {
             }
             other => panic!("expected System command_line, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn pi_control_event_uses_camel_case_field_names() {
+        // The React OAuth modal reads `challengeId` / `providerId` /
+        // `allowEmpty` straight off the Tauri event payload. If these
+        // serialize as snake_case the UI receives undefined ids,
+        // silently dropping every challenge into the filter check.
+        // Pin the wire shape so a future struct rename can't regress.
+        let event = PiControlEvent::OAuthChallenge {
+            challenge_id: "c1".to_string(),
+            provider_id: "github-copilot".to_string(),
+            kind: "auth".to_string(),
+            url: Some("https://github.com/login/device".to_string()),
+            instructions: Some("ABCD-1234".to_string()),
+            message: None,
+            placeholder: None,
+            allow_empty: false,
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "oauth_challenge");
+        assert_eq!(json["challengeId"], "c1");
+        assert_eq!(json["providerId"], "github-copilot");
+        assert_eq!(json["allowEmpty"], false);
+        assert!(json.get("challenge_id").is_none());
+        assert!(json.get("provider_id").is_none());
+        assert!(json.get("allow_empty").is_none());
+
+        let complete = PiControlEvent::OAuthComplete {
+            challenge_id: "c1".to_string(),
+            provider_id: "openrouter".to_string(),
+            ok: true,
+            error: None,
+        };
+        let json = serde_json::to_value(&complete).unwrap();
+        assert_eq!(json["type"], "oauth_complete");
+        assert_eq!(json["challengeId"], "c1");
+        assert_eq!(json["providerId"], "openrouter");
     }
 
     #[test]

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1332,6 +1332,11 @@ export function ChatPanel() {
             addLocalMessage,
             startClaudeAuthLogin: startChatClaudeAuthLogin,
             startCodexLogin: launchCodexLogin,
+            startPiLogin: async () => {
+              useAppStore.getState().openModal("piLogin", {
+                workingDir: ws?.worktree_path ?? "",
+              });
+            },
             openUsageSettingsExternal: () => {
               void openUsageSettings().catch((err) =>
                 console.error("Failed to open usage settings:", err),

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -30,6 +30,7 @@ function makeCtx(overrides: Partial<NativeCommandContext> = {}): NativeCommandCo
     addLocalMessage: vi.fn<(text: string) => void>(),
     startClaudeAuthLogin: vi.fn(async () => {}),
     startCodexLogin: vi.fn(async () => {}),
+    startPiLogin: vi.fn(async () => {}),
     openUsageSettingsExternal: vi.fn<() => void>(),
     openReleaseNotes: vi.fn<() => void>(),
     workspaceId: "ws-1",
@@ -637,6 +638,19 @@ describe("login native handler", () => {
     await handler.execute(ctx, "");
     expect(ctx.startCodexLogin).toHaveBeenCalledTimes(1);
     expect(ctx.startClaudeAuthLogin).not.toHaveBeenCalled();
+  });
+
+  it("opens the Pi provider picker for Pi-selected workspaces", async () => {
+    const ctx = makeCtx({ selectedModelProvider: "pi" });
+    const handler = resolveNativeHandler("login")!;
+    const result = await handler.execute(ctx, "");
+    expect(result).toEqual({ kind: "handled", canonicalName: "login" });
+    expect(ctx.startPiLogin).toHaveBeenCalledTimes(1);
+    expect(ctx.startCodexLogin).not.toHaveBeenCalled();
+    expect(ctx.startClaudeAuthLogin).not.toHaveBeenCalled();
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      "Pi sign-in opened. Pick a provider, complete the flow, then retry the turn.",
+    );
   });
 
   it("surfaces login start failures as local messages", async () => {

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -44,6 +44,11 @@ export interface NativeCommandContext {
   addLocalMessage: (text: string) => void;
   startClaudeAuthLogin: () => Promise<void>;
   startCodexLogin: () => Promise<void>;
+  /** Open the Pi provider picker modal (multi-provider — Pi has no
+   *  single OAuth flow like Codex/Claude). Caller resolves once the
+   *  modal is mounted; the modal closes on its own when the user
+   *  finishes or cancels. */
+  startPiLogin: () => Promise<void>;
   openUsageSettingsExternal: () => void;
   openReleaseNotes: () => void;
 
@@ -384,8 +389,9 @@ const loginHandler: NativeHandler = {
           "Codex sign-in opened. Complete the browser flow, then retry the turn.",
         );
       } else if (target === "pi") {
+        await ctx.startPiLogin();
         ctx.addLocalMessage(
-          "Pi auth is managed by Pi. Run `pi auth` in a terminal, refresh Pi models in Settings > Models, then retry the turn.",
+          "Pi sign-in opened. Pick a provider, complete the flow, then retry the turn.",
         );
       } else {
         await ctx.startClaudeAuthLogin();

--- a/src/ui/src/components/modals/ModalRouter.tsx
+++ b/src/ui/src/components/modals/ModalRouter.tsx
@@ -15,6 +15,7 @@ import { ConfirmNightlyChannelModal } from "./ConfirmNightlyChannelModal";
 import { MissingCliModal } from "./MissingCliModal";
 import { KeyboardShortcutsModal } from "./KeyboardShortcutsModal";
 import { EnvTrustModal } from "./EnvTrustModal";
+import { PiLoginModalRoute } from "./PiLoginModalRoute";
 
 export function ModalRouter() {
   const activeModal = useAppStore((s) => s.activeModal);
@@ -52,6 +53,8 @@ export function ModalRouter() {
       return <KeyboardShortcutsModal />;
     case "envTrust":
       return <EnvTrustModal />;
+    case "piLogin":
+      return <PiLoginModalRoute />;
     default:
       return null;
   }

--- a/src/ui/src/components/modals/PiLoginModal.tsx
+++ b/src/ui/src/components/modals/PiLoginModal.tsx
@@ -1,0 +1,40 @@
+// Modal version of the Pi provider picker, used by the `/login` slash
+// command. Pi is multi-provider (unlike Codex's single OAuth flow),
+// so `/login` for a Pi-selected workspace opens this picker rather
+// than launching one specific OAuth flow. After the user finishes a
+// configure/sign-in, the modal stays open so they can configure more
+// (e.g. "I want both Copilot AND OpenRouter"); they dismiss it when
+// they're done.
+
+import { useTranslation } from "react-i18next";
+
+import { PiProviderManager } from "../settings/PiProviderManager";
+import { Modal } from "./Modal";
+import shared from "./shared.module.css";
+
+export interface PiLoginModalProps {
+  /** Workspace cwd for the underlying control session. Empty string
+   *  is fine if not in a workspace context. */
+  workingDir: string;
+  onClose: () => void;
+}
+
+export function PiLoginModal({ workingDir, onClose }: PiLoginModalProps) {
+  const { t } = useTranslation("modals");
+  return (
+    <Modal title={t("pi_login_title", "Sign in to a Pi provider")} onClose={onClose} wide>
+      <p className={shared.warning}>
+        {t(
+          "pi_login_intro",
+          "Pi can route to many providers. Configure one or more below — they remain available across workspaces.",
+        )}
+      </p>
+      <PiProviderManager workingDir={workingDir} />
+      <div className={shared.actions}>
+        <button type="button" className={shared.btn} onClick={onClose}>
+          {t("pi_login_done", "Done")}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/ui/src/components/modals/PiLoginModalRoute.tsx
+++ b/src/ui/src/components/modals/PiLoginModalRoute.tsx
@@ -1,0 +1,16 @@
+// Thin route binding for the Pi login modal. Pulls `workingDir` out
+// of `modalData` (set by `startPiLogin` in ChatPanel) and wires the
+// store's closeModal action — keeps the dumb modal component
+// reusable from other call sites that aren't routed through the
+// modal stack.
+
+import { useAppStore } from "../../stores/useAppStore";
+import { PiLoginModal } from "./PiLoginModal";
+
+export function PiLoginModalRoute() {
+  const closeModal = useAppStore((s) => s.closeModal);
+  const modalData = useAppStore((s) => s.modalData);
+  const workingDir =
+    typeof modalData?.workingDir === "string" ? modalData.workingDir : "";
+  return <PiLoginModal workingDir={workingDir} onClose={closeModal} />;
+}

--- a/src/ui/src/components/settings/PiCardBody.tsx
+++ b/src/ui/src/components/settings/PiCardBody.tsx
@@ -135,18 +135,72 @@ function AvailableModelsDisclosure({ models }: AvailableModelsDisclosureProps) {
           )}
         </p>
       ) : (
-        <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 4 }}>
-          {groups.map((group) => (
-            <li key={group.key} style={{ fontSize: 12 }}>
-              <span style={{ color: "var(--text-primary)" }}>{group.label}</span>
-              <span style={{ color: "var(--text-dim)", marginLeft: 8 }}>
-                {group.models.length}
-              </span>
-            </li>
-          ))}
-        </ul>
+        <ModelGroupList groups={groups} />
       )}
     </Disclosure>
+  );
+}
+
+interface ModelGroupListProps {
+  groups: ReturnType<typeof groupPiDiscoveredModels<AgentBackendModel>>;
+}
+
+function ModelGroupList({ groups }: ModelGroupListProps) {
+  // Each Pi sub-provider gets its own nested disclosure so users can
+  // drill into the concrete `provider/model-id` chips and confirm
+  // exactly which models Pi reports as available. Restores the
+  // visibility the old top-level `PiDiscoveredModelsList` had —
+  // without this, the Pi card collapsed every model behind a count
+  // and the user had no way to verify Pi's auto-discovery from
+  // Settings.
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const toggle = (key: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+
+  return (
+    <div className={styles.modelGroupList}>
+      {groups.map((group) => {
+        const isOpen = expanded.has(group.key);
+        return (
+          <div key={group.key}>
+            <button
+              type="button"
+              className={styles.modelGroupHeader}
+              aria-expanded={isOpen}
+              onClick={() => toggle(group.key)}
+            >
+              <ChevronRight
+                size={12}
+                className={`${styles.disclosureChevron} ${
+                  isOpen ? styles.disclosureChevronOpen : ""
+                }`}
+                aria-hidden
+              />
+              <span className={styles.modelGroupLabel}>{group.label}</span>
+              <span className={styles.modelGroupCount}>{group.models.length}</span>
+            </button>
+            {isOpen && (
+              <div className={styles.modelChips}>
+                {group.models.map((model) => (
+                  <span
+                    key={model.id}
+                    className={styles.modelChip}
+                    title={model.id}
+                  >
+                    {model.label || model.id}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
   );
 }
 

--- a/src/ui/src/components/settings/PiCardBody.tsx
+++ b/src/ui/src/components/settings/PiCardBody.tsx
@@ -1,0 +1,206 @@
+// Stacked, full-width body for the Pi card in Settings → Models.
+//
+// Replaces the 3-column `.backendForm` grid the other backend cards
+// use. Pi has more chrome than a custom-openai card (per-provider
+// auth list + auto-discovered models + manual override) and trying to
+// pack them into three side-by-side columns produced cramped rows
+// where labels, descriptions, and action buttons all truncated.
+//
+// Layout, top to bottom:
+//   1. Pi providers — primary action surface, full width.
+//   2. Available models — collapsed disclosure (the discovered list
+//      grouped by sub-provider; users usually only open this when
+//      something looks wrong).
+//   3. Advanced → Manual model overrides — collapsed disclosure
+//      (rarely used since auto-discovery is the whole Pi card story).
+//
+// Kept as a separate file so `ModelSettings.tsx` (already large)
+// only gains a one-line invocation when `draft.kind === "pi_sdk"`.
+
+import { ChevronRight } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { AgentBackendModel } from "../../services/tauri";
+import { groupPiDiscoveredModels } from "../chat/modelRegistry";
+import { PiProviderManager } from "./PiProviderManager";
+import styles from "./PiCardLayout.module.css";
+
+export interface PiCardBodyProps {
+  discoveredModels: AgentBackendModel[];
+  manualModelText: string;
+  onChangeManualModels: (next: string) => void;
+  /** Fired after a provider auth round-trip succeeds. Triggers the
+   *  parent's `refresh()` so `discoveredModels` repopulates. */
+  onProviderConfigured: () => void;
+}
+
+export function PiCardBody({
+  discoveredModels,
+  manualModelText,
+  onChangeManualModels,
+  onProviderConfigured,
+}: PiCardBodyProps) {
+  const { t } = useTranslation("settings");
+
+  return (
+    <div className={styles.stack}>
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <span className={styles.sectionLabel}>
+            {t("pi_card_providers_label", "Providers")}
+          </span>
+        </div>
+        <PiProviderManager workingDir="" onConfigured={onProviderConfigured} />
+      </section>
+
+      <AvailableModelsDisclosure models={discoveredModels} />
+
+      <AdvancedDisclosure>
+        <ManualModelOverrides
+          value={manualModelText}
+          onChange={onChangeManualModels}
+        />
+      </AdvancedDisclosure>
+    </div>
+  );
+}
+
+interface AvailableModelsDisclosureProps {
+  models: AgentBackendModel[];
+}
+
+/** Disclosure wrapper that uses a header `<button>` for keyboard /
+ *  screen reader semantics and renders the body as a sibling `<div>`,
+ *  avoiding the "interactive elements inside a button" a11y antipattern
+ *  the previous structure would have introduced once the Advanced
+ *  body grew an `<input>`. */
+function Disclosure({
+  label,
+  meta,
+  open,
+  onToggle,
+  children,
+}: {
+  label: string;
+  meta?: string;
+  open: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={styles.disclosure}>
+      <button
+        type="button"
+        className={styles.disclosureHeader}
+        style={{ width: "100%", background: "transparent", border: "none", cursor: "pointer" }}
+        aria-expanded={open}
+        onClick={onToggle}
+      >
+        <ChevronRight
+          size={12}
+          className={`${styles.disclosureChevron} ${open ? styles.disclosureChevronOpen : ""}`}
+          aria-hidden
+        />
+        <span className={styles.disclosureLabel}>{label}</span>
+        {meta && <span className={styles.disclosureCount}>{meta}</span>}
+      </button>
+      {open && <div className={styles.disclosureBody}>{children}</div>}
+    </div>
+  );
+}
+
+function AvailableModelsDisclosure({ models }: AvailableModelsDisclosureProps) {
+  const { t } = useTranslation("settings");
+  const [open, setOpen] = useState(false);
+  const groups = useMemo(() => groupPiDiscoveredModels(models), [models]);
+  const total = models.length;
+
+  return (
+    <Disclosure
+      label={t("pi_card_available_models", "Available models")}
+      meta={t("pi_card_available_models_count", {
+        providers: groups.length,
+        models: total,
+        defaultValue: "{{providers}} providers · {{models}} models",
+      })}
+      open={open}
+      onToggle={() => setOpen((v) => !v)}
+    >
+      {groups.length === 0 ? (
+        <p style={{ fontSize: 12, color: "var(--text-muted)" }}>
+          {t(
+            "pi_card_available_empty",
+            "No models discovered yet. Configure a provider above to populate this list.",
+          )}
+        </p>
+      ) : (
+        <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 4 }}>
+          {groups.map((group) => (
+            <li key={group.key} style={{ fontSize: 12 }}>
+              <span style={{ color: "var(--text-primary)" }}>{group.label}</span>
+              <span style={{ color: "var(--text-dim)", marginLeft: 8 }}>
+                {group.models.length}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Disclosure>
+  );
+}
+
+function AdvancedDisclosure({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation("settings");
+  const [open, setOpen] = useState(false);
+  return (
+    <Disclosure
+      label={t("pi_card_advanced", "Advanced")}
+      open={open}
+      onToggle={() => setOpen((v) => !v)}
+    >
+      {children}
+    </Disclosure>
+  );
+}
+
+interface ManualModelOverridesProps {
+  value: string;
+  onChange: (next: string) => void;
+}
+
+function ManualModelOverrides({ value, onChange }: ManualModelOverridesProps) {
+  const { t } = useTranslation("settings");
+  return (
+    <div onClick={(e) => e.stopPropagation()}>
+      <label style={{ display: "block" }}>
+        <span
+          style={{
+            display: "block",
+            color: "var(--text-dim)",
+            fontSize: 11,
+            fontWeight: 500,
+            marginBottom: 4,
+          }}
+        >
+          {t("pi_card_manual_models", "Manual model overrides")}
+        </span>
+        <input
+          className={styles.manualModelsInput}
+          value={value}
+          placeholder={t(
+            "pi_card_manual_placeholder",
+            "Comma-separated provider/model ids",
+          )}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </label>
+      <p className={styles.manualModelsHint}>
+        {t(
+          "pi_card_manual_hint",
+          "Optional. Use when Pi's auto-discovery misses a model — manual entries appear alongside discovered ones in the chat picker.",
+        )}
+      </p>
+    </div>
+  );
+}

--- a/src/ui/src/components/settings/PiCardLayout.module.css
+++ b/src/ui/src/components/settings/PiCardLayout.module.css
@@ -107,3 +107,60 @@
   font-size: 11px;
   margin-top: 6px;
 }
+
+/* Available-models sub-disclosure: one row per Pi sub-provider with
+ * a chevron + chip grid of concrete model labels on expand. Restores
+ * the per-model visibility the old `PiDiscoveredModelsList`
+ * provided; without it, users couldn't verify which models Pi
+ * actually returned for a configured provider. */
+.modelGroupList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.modelGroupHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  padding: 4px 6px;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 12px;
+  text-align: left;
+  width: 100%;
+  transition: background var(--transition-fast);
+}
+
+.modelGroupHeader:hover {
+  background: var(--hover-bg);
+}
+
+.modelGroupLabel {
+  flex: 1;
+}
+
+.modelGroupCount {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.modelChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 4px 6px 8px 24px;
+}
+
+.modelChip {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background: var(--hover-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--divider);
+  white-space: nowrap;
+}

--- a/src/ui/src/components/settings/PiCardLayout.module.css
+++ b/src/ui/src/components/settings/PiCardLayout.module.css
@@ -1,0 +1,109 @@
+/* Stacked, full-width layout for the Pi card body — replaces the
+ * 3-column `.backendForm` grid so provider rows have room to breathe.
+ * Used only when `draft.kind === "pi_sdk"`. */
+
+.stack {
+  margin-top: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 760px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.sectionLabel {
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.sectionMeta {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.disclosure {
+  background: transparent;
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+  padding: 0;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  overflow: hidden;
+}
+
+.disclosure:hover {
+  background: var(--hover-bg);
+}
+
+.disclosureHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 8px 12px;
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.disclosureChevron {
+  color: var(--text-dim);
+  transition: transform var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.disclosureChevronOpen {
+  transform: rotate(90deg);
+}
+
+.disclosureLabel {
+  flex: 1;
+}
+
+.disclosureCount {
+  color: var(--text-dim);
+}
+
+.disclosureBody {
+  border-top: 1px solid var(--divider);
+  padding: 10px 12px;
+  background: var(--chat-input-bg);
+}
+
+.manualModelsInput {
+  width: 100%;
+  background: var(--chat-input-bg);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: var(--font-mono);
+  outline: none;
+}
+
+.manualModelsInput:focus {
+  border-color: var(--accent-primary);
+}
+
+.manualModelsHint {
+  color: var(--text-dim);
+  font-size: 11px;
+  margin-top: 6px;
+}

--- a/src/ui/src/components/settings/PiOAuthModal.tsx
+++ b/src/ui/src/components/settings/PiOAuthModal.tsx
@@ -12,7 +12,7 @@
 
 import { writeText as clipboardWriteText } from "@tauri-apps/plugin-clipboard-manager";
 import { Copy, ExternalLink, Loader2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Modal } from "../modals/Modal";
@@ -228,6 +228,14 @@ function PhaseBody({
   error,
 }: PhaseBodyProps) {
   const { t } = useTranslation("settings");
+  // Stable IDs so the prompt-message, verification URL, and user-code
+  // inputs all get programmatic label/aria-describedby relationships
+  // (placeholder + visual label don't satisfy that for screen
+  // readers).
+  const promptInputId = useId();
+  const promptDescriptionId = useId();
+  const urlInputId = useId();
+  const userCodeInputId = useId();
 
   if (phase.kind === "starting") {
     return (
@@ -241,12 +249,21 @@ function PhaseBody({
   if (phase.kind === "prompt") {
     return (
       <>
-        <p className={shared.warning}>{phase.message}</p>
+        <p id={promptDescriptionId} className={shared.warning}>
+          {phase.message}
+        </p>
         <div className={shared.field}>
+          {/* The prompt input has no visible label of its own — Pi
+              writes the message as the warning paragraph above. Use
+              `aria-labelledby` on the input so screen readers
+              announce the prompt text when the field receives focus
+              (placeholder alone is not an accessible name). */}
           <input
+            id={promptInputId}
             type="text"
             className={shared.input}
             autoFocus
+            aria-labelledby={promptDescriptionId}
             value={promptValue}
             placeholder={phase.placeholder}
             onChange={(e) => setPromptValue(e.target.value)}
@@ -291,11 +308,16 @@ function PhaseBody({
           )}
         </p>
         <div className={shared.field}>
-          <label className={shared.label}>
+          <label className={shared.label} htmlFor={urlInputId}>
             {t("pi_oauth_url_label", "Verification URL")}
           </label>
           <div className={shared.inputRow}>
-            <input className={shared.input} value={phase.url} readOnly />
+            <input
+              id={urlInputId}
+              className={shared.input}
+              value={phase.url}
+              readOnly
+            />
             <button
               type="button"
               className={shared.btn}
@@ -316,10 +338,11 @@ function PhaseBody({
         </div>
         {phase.instructions && (
           <div className={shared.field}>
-            <label className={shared.label}>
+            <label className={shared.label} htmlFor={userCodeInputId}>
               {t("pi_oauth_user_code", "User code")}
             </label>
             <input
+              id={userCodeInputId}
               className={shared.input}
               value={phase.instructions}
               readOnly

--- a/src/ui/src/components/settings/PiOAuthModal.tsx
+++ b/src/ui/src/components/settings/PiOAuthModal.tsx
@@ -1,0 +1,352 @@
+// OAuth device-code modal for Pi providers (kind === "oauth" |
+// "oauth+enterprise"). Drives the harness's `oauth_start` flow:
+//
+// 1. Subscribe to `pi://oauth/event` BEFORE issuing `pi_oauth_start`
+//    (the first event can race past a late subscriber).
+// 2. Render the verification URL + user code from `oauth_challenge {
+//    kind: "auth" }` events.
+// 3. For `kind: "prompt"` events (Pi's GHES enterprise domain prompt),
+//    show a text input and forward the value back via
+//    `pi_oauth_submit_input`.
+// 4. Close on `oauth_complete`; on cancel send `pi_oauth_cancel`.
+
+import { Copy, ExternalLink, Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Modal } from "../modals/Modal";
+import shared from "../modals/shared.module.css";
+import {
+  listenPiOAuthEvents,
+  piOAuthCancel,
+  piOAuthStart,
+  piOAuthSubmitInput,
+  type PiOAuthEvent,
+  type PiProvider,
+} from "../../services/tauri/piProviders";
+
+type Phase =
+  | { kind: "starting" }
+  | { kind: "auth"; url: string; instructions?: string }
+  | {
+      kind: "prompt";
+      message: string;
+      placeholder?: string;
+      allowEmpty: boolean;
+    }
+  | { kind: "progress"; message: string }
+  | { kind: "complete"; ok: boolean; error?: string };
+
+export interface PiOAuthModalProps {
+  provider: PiProvider;
+  workingDir: string;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export function PiOAuthModal({
+  provider,
+  workingDir,
+  onClose,
+  onSaved,
+}: PiOAuthModalProps) {
+  const { t } = useTranslation("settings");
+  const [phase, setPhase] = useState<Phase>({ kind: "starting" });
+  const [promptValue, setPromptValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const challengeIdRef = useRef<string | null>(null);
+  const unlistenRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let challengeId: string | null = null;
+
+    const start = async () => {
+      try {
+        // Subscribe FIRST. The harness emits the first challenge as
+        // soon as Pi resolves the device-code, which races past a
+        // post-`pi_oauth_start` subscription on a fast network.
+        const unlisten = await listenPiOAuthEvents((event) => {
+          if (cancelled) return;
+          if (
+            challengeIdRef.current &&
+            event.challengeId !== challengeIdRef.current
+          ) {
+            return;
+          }
+          handleEvent(event);
+        });
+        unlistenRef.current = unlisten;
+
+        const started = await piOAuthStart({
+          workingDir,
+          providerId: provider.id,
+        });
+        if (cancelled) {
+          await piOAuthCancel(started.challengeId).catch(() => {});
+          return;
+        }
+        challengeId = started.challengeId;
+        challengeIdRef.current = started.challengeId;
+      } catch (e) {
+        setError(String(e));
+        setPhase({ kind: "complete", ok: false, error: String(e) });
+      }
+    };
+
+    const handleEvent = (event: PiOAuthEvent) => {
+      switch (event.type) {
+        case "oauth_challenge": {
+          if (event.kind === "auth") {
+            setPhase({
+              kind: "auth",
+              url: event.url ?? "",
+              instructions: event.instructions ?? undefined,
+            });
+          } else {
+            setPhase({
+              kind: "prompt",
+              message: event.message ?? "",
+              placeholder: event.placeholder ?? undefined,
+              allowEmpty: event.allowEmpty ?? false,
+            });
+            setPromptValue("");
+          }
+          break;
+        }
+        case "oauth_progress":
+          setPhase({ kind: "progress", message: event.message });
+          break;
+        case "oauth_complete":
+          setPhase({
+            kind: "complete",
+            ok: event.ok,
+            error: event.error ?? undefined,
+          });
+          if (event.ok) onSaved();
+          break;
+      }
+    };
+
+    void start();
+
+    return () => {
+      cancelled = true;
+      if (challengeId) void piOAuthCancel(challengeId).catch(() => {});
+      if (unlistenRef.current) {
+        unlistenRef.current();
+        unlistenRef.current = null;
+      }
+    };
+    // We intentionally do not depend on `onSaved` — it's a stable
+    // callback the parent owns and changing it shouldn't reset OAuth.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [provider.id, workingDir]);
+
+  const handleSubmitPrompt = async () => {
+    const id = challengeIdRef.current;
+    if (!id) return;
+    if (phase.kind !== "prompt") return;
+    if (!phase.allowEmpty && !promptValue.trim()) {
+      setError(t("pi_oauth_prompt_required", "This field is required."));
+      return;
+    }
+    try {
+      setError(null);
+      await piOAuthSubmitInput({ challengeId: id, value: promptValue });
+      setPhase({ kind: "progress", message: t("pi_oauth_progress", "Waiting on GitHub…") });
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const handleCopyUrl = () => {
+    if (phase.kind === "auth") {
+      void navigator.clipboard.writeText(phase.url);
+    }
+  };
+
+  return (
+    <Modal
+      title={t("pi_oauth_title", {
+        label: provider.label,
+        defaultValue: "Sign in to {{label}}",
+      })}
+      onClose={onClose}
+    >
+      <PhaseBody
+        phase={phase}
+        provider={provider}
+        promptValue={promptValue}
+        setPromptValue={setPromptValue}
+        onCopyUrl={handleCopyUrl}
+        onSubmitPrompt={handleSubmitPrompt}
+        error={error}
+      />
+
+      <div className={shared.actions}>
+        {phase.kind !== "complete" && (
+          <button type="button" className={shared.btnDanger} onClick={onClose}>
+            {t("pi_oauth_cancel", "Cancel")}
+          </button>
+        )}
+        {phase.kind === "complete" && (
+          <button type="button" className={shared.btnPrimary} onClick={onClose}>
+            {t("pi_oauth_done", "Done")}
+          </button>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+interface PhaseBodyProps {
+  phase: Phase;
+  provider: PiProvider;
+  promptValue: string;
+  setPromptValue: (value: string) => void;
+  onCopyUrl: () => void;
+  onSubmitPrompt: () => Promise<void> | void;
+  error: string | null;
+}
+
+function PhaseBody({
+  phase,
+  provider,
+  promptValue,
+  setPromptValue,
+  onCopyUrl,
+  onSubmitPrompt,
+  error,
+}: PhaseBodyProps) {
+  const { t } = useTranslation("settings");
+
+  if (phase.kind === "starting") {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Loader2 size={14} className="lucide-spinner" />
+        <span>{t("pi_oauth_starting", "Starting sign-in…")}</span>
+      </div>
+    );
+  }
+
+  if (phase.kind === "prompt") {
+    return (
+      <>
+        <p className={shared.warning}>{phase.message}</p>
+        <div className={shared.field}>
+          <input
+            type="text"
+            className={shared.input}
+            autoFocus
+            value={promptValue}
+            placeholder={phase.placeholder}
+            onChange={(e) => setPromptValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void onSubmitPrompt();
+            }}
+          />
+          {phase.allowEmpty && (
+            <p className={shared.hint}>
+              {t(
+                "pi_oauth_prompt_optional",
+                "Leave blank to use the default (github.com).",
+              )}
+            </p>
+          )}
+        </div>
+        <div className={shared.actions} style={{ marginTop: -8 }}>
+          <button
+            type="button"
+            className={shared.btnPrimary}
+            onClick={() => void onSubmitPrompt()}
+          >
+            {t("pi_oauth_continue", "Continue")}
+          </button>
+        </div>
+        {error && <p className={shared.error}>{error}</p>}
+      </>
+    );
+  }
+
+  if (phase.kind === "auth") {
+    // Pi's `instructions` for github-copilot is the user-code
+    // (8-character string). For other providers it can be longer
+    // human-readable text. Render both shapes — the field is
+    // displayed verbatim and copy-friendly either way.
+    return (
+      <>
+        <p className={shared.warning}>
+          {t(
+            "pi_oauth_auth_instructions",
+            "Open the URL below to authorize Pi. You can paste this code on the verification page if asked.",
+          )}
+        </p>
+        <div className={shared.field}>
+          <label className={shared.label}>
+            {t("pi_oauth_url_label", "Verification URL")}
+          </label>
+          <div className={shared.inputRow}>
+            <input className={shared.input} value={phase.url} readOnly />
+            <button
+              type="button"
+              className={shared.btn}
+              onClick={onCopyUrl}
+              title={t("pi_oauth_copy", "Copy")}
+            >
+              <Copy size={12} aria-hidden />
+            </button>
+            <button
+              type="button"
+              className={shared.btn}
+              onClick={() =>
+                window.open(phase.url, "_blank", "noopener,noreferrer")
+              }
+              title={t("pi_oauth_open", "Open")}
+            >
+              <ExternalLink size={12} aria-hidden />
+            </button>
+          </div>
+        </div>
+        {phase.instructions && (
+          <div className={shared.field}>
+            <label className={shared.label}>
+              {t("pi_oauth_user_code", "User code")}
+            </label>
+            <input
+              className={shared.input}
+              value={phase.instructions}
+              readOnly
+              onFocus={(e) => e.currentTarget.select()}
+            />
+          </div>
+        )}
+        {provider.docsUrl && (
+          <p className={shared.hint}>
+            <a href={provider.docsUrl} target="_blank" rel="noopener noreferrer">
+              {t("pi_oauth_learn_more", "What is this? →")}
+            </a>
+          </p>
+        )}
+      </>
+    );
+  }
+
+  if (phase.kind === "progress") {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Loader2 size={14} className="lucide-spinner" />
+        <span>{phase.message}</span>
+      </div>
+    );
+  }
+
+  // complete
+  return (
+    <p className={phase.ok ? shared.warning : shared.error}>
+      {phase.ok
+        ? t("pi_oauth_complete_ok", "Signed in. Refresh the Pi card to see the new models.")
+        : phase.error ?? t("pi_oauth_complete_fail", "Sign-in failed.")}
+    </p>
+  );
+}

--- a/src/ui/src/components/settings/PiOAuthModal.tsx
+++ b/src/ui/src/components/settings/PiOAuthModal.tsx
@@ -10,12 +10,14 @@
 //    `pi_oauth_submit_input`.
 // 4. Close on `oauth_complete`; on cancel send `pi_oauth_cancel`.
 
+import { writeText as clipboardWriteText } from "@tauri-apps/plugin-clipboard-manager";
 import { Copy, ExternalLink, Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Modal } from "../modals/Modal";
 import shared from "../modals/shared.module.css";
+import { openUrl } from "../../services/tauri";
 import {
   listenPiOAuthEvents,
   piOAuthCancel,
@@ -162,7 +164,13 @@ export function PiOAuthModal({
 
   const handleCopyUrl = () => {
     if (phase.kind === "auth") {
-      void navigator.clipboard.writeText(phase.url);
+      // Tauri's webview doesn't expose `navigator.clipboard` as a
+      // secure-context API on macOS WebKit, and asking for the
+      // permission would fail; the rest of the app uses the Tauri
+      // clipboard plugin for the same reason.
+      void clipboardWriteText(phase.url).catch((e) => {
+        setError(String(e));
+      });
     }
   };
 
@@ -299,9 +307,7 @@ function PhaseBody({
             <button
               type="button"
               className={shared.btn}
-              onClick={() =>
-                window.open(phase.url, "_blank", "noopener,noreferrer")
-              }
+              onClick={() => void openUrl(phase.url).catch(() => {})}
               title={t("pi_oauth_open", "Open")}
             >
               <ExternalLink size={12} aria-hidden />
@@ -323,7 +329,18 @@ function PhaseBody({
         )}
         {provider.docsUrl && (
           <p className={shared.hint}>
-            <a href={provider.docsUrl} target="_blank" rel="noopener noreferrer">
+            <a
+              href={provider.docsUrl}
+              onClick={(e) => {
+                // Bare `<a target="_blank">` opens inside the Tauri
+                // webview on some platforms; route through the
+                // shell command like the rest of Settings does.
+                e.preventDefault();
+                if (provider.docsUrl) {
+                  void openUrl(provider.docsUrl).catch(() => {});
+                }
+              }}
+            >
               {t("pi_oauth_learn_more", "What is this? →")}
             </a>
           </p>

--- a/src/ui/src/components/settings/PiProviderConfigureDialog.tsx
+++ b/src/ui/src/components/settings/PiProviderConfigureDialog.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 
 import { Modal } from "../modals/Modal";
 import shared from "../modals/shared.module.css";
+import { openUrl } from "../../services/tauri";
 import {
   piClearProviderApiKey,
   piSetProviderApiKey,
@@ -107,10 +108,11 @@ export function PiProviderConfigureDialog({
         errors.push(`keychain: ${String(e)}`);
       }
       if (errors.length > 0) {
-        // Refresh so the UI reflects whichever scope WAS cleared, but
-        // hold the dialog open with the error so the user knows the
-        // other scope still has a key.
-        onSaved();
+        // Render the failure inline. Do NOT call `onSaved()` here:
+        // the manager's onSaved closes the dialog before the user
+        // sees `setError(...)`, masking the partial-failure message.
+        // The "Clear" action becomes a no-op visually if any scope
+        // failed — the user can retry or cancel to dismiss.
         setError(
           t("pi_provider_dialog_clear_partial", {
             details: errors.join("; "),
@@ -125,6 +127,32 @@ export function PiProviderConfigureDialog({
       setSubmitting(false);
     }
   };
+
+  // Match the row-level Clear gate: only show the dialog's "Clear
+  // key" button for credentials Claudette can actually delete. For
+  // env / models.json / fallback sources the action would close the
+  // dialog as if successful while the credential still lives outside
+  // Claudette's stores; the inline copy explains the situation
+  // instead.
+  const clearableAuthSource = !provider.authSource
+    || provider.authSource === "stored"
+    || provider.authSource === "runtime";
+  const showClearButton = provider.configured && clearableAuthSource;
+  const externalSourceLabel = (() => {
+    if (clearableAuthSource) return undefined;
+    switch (provider.authSource) {
+      case "environment":
+        return provider.envHint
+          ? `$${provider.envHint}`
+          : t("pi_provider_dialog_env_var", "an environment variable");
+      case "fallback":
+      case "models_json_key":
+      case "models_json_command":
+        return "~/.pi/agent/models.json";
+      default:
+        return undefined;
+    }
+  })();
 
   // Provider-specific env var hint can't be derived from a static
   // string — pull it from the curated entry.
@@ -173,8 +201,16 @@ export function PiProviderConfigureDialog({
           <p className={shared.hint}>
             <a
               href={provider.docsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
+              onClick={(e) => {
+                // Route external launches through Tauri's `open_url`
+                // command — bare `target="_blank"` opens inside the
+                // webview on macOS / Linux Tauri builds. Same pattern
+                // as PiOAuthModal + CommunitySettings.
+                e.preventDefault();
+                if (provider.docsUrl) {
+                  void openUrl(provider.docsUrl).catch(() => {});
+                }
+              }}
             >
               {t("pi_provider_dialog_get_key", "Get an API key →")}
             </a>
@@ -198,8 +234,18 @@ export function PiProviderConfigureDialog({
 
       {error && <p className={shared.error}>{error}</p>}
 
+      {externalSourceLabel && (
+        <p className={shared.hint}>
+          {t("pi_provider_dialog_external_source", {
+            source: externalSourceLabel,
+            defaultValue:
+              "This provider is currently configured via {{source}}. Saving a new key below will store it in Claudette; to remove the existing credential, edit {{source}} outside the app.",
+          })}
+        </p>
+      )}
+
       <div className={shared.actions}>
-        {provider.configured && (
+        {showClearButton && (
           <button
             type="button"
             className={shared.btnDanger}

--- a/src/ui/src/components/settings/PiProviderConfigureDialog.tsx
+++ b/src/ui/src/components/settings/PiProviderConfigureDialog.tsx
@@ -42,6 +42,7 @@ export function PiProviderConfigureDialog({
   // auth.json by default, opt-out for keychain-only).
   const defaultLocal =
     provider.authSource === "environment" ||
+    provider.authSource === "fallback" ||
     provider.authSource === "models_json_command" ||
     provider.authSource === "models_json_key";
   const [keepPrivate, setKeepPrivate] = useState(defaultLocal);
@@ -83,23 +84,43 @@ export function PiProviderConfigureDialog({
     setSubmitting(true);
     setError(null);
     try {
-      // Clear both scopes — the user is wiping the slate. Without this,
-      // a user who switches from shared to local and then wipes would
-      // leave the auth.json entry behind.
-      await piClearProviderApiKey({
-        workingDir,
-        providerId: provider.id,
-        scope: "shared",
-      }).catch(() => {});
-      await piClearProviderApiKey({
-        workingDir,
-        providerId: provider.id,
-        scope: "local",
-      }).catch(() => {});
+      // Clear both scopes — the user is wiping the slate. Surface
+      // either failure so the user is not told "cleared" when one of
+      // the two store paths still holds an active key.
+      const errors: string[] = [];
+      try {
+        await piClearProviderApiKey({
+          workingDir,
+          providerId: provider.id,
+          scope: "shared",
+        });
+      } catch (e) {
+        errors.push(`auth.json: ${String(e)}`);
+      }
+      try {
+        await piClearProviderApiKey({
+          workingDir,
+          providerId: provider.id,
+          scope: "local",
+        });
+      } catch (e) {
+        errors.push(`keychain: ${String(e)}`);
+      }
+      if (errors.length > 0) {
+        // Refresh so the UI reflects whichever scope WAS cleared, but
+        // hold the dialog open with the error so the user knows the
+        // other scope still has a key.
+        onSaved();
+        setError(
+          t("pi_provider_dialog_clear_partial", {
+            details: errors.join("; "),
+            defaultValue: "Some credentials could not be cleared: {{details}}",
+          }),
+        );
+        return;
+      }
       onSaved();
       onClose();
-    } catch (e) {
-      setError(String(e));
     } finally {
       setSubmitting(false);
     }

--- a/src/ui/src/components/settings/PiProviderConfigureDialog.tsx
+++ b/src/ui/src/components/settings/PiProviderConfigureDialog.tsx
@@ -1,0 +1,212 @@
+// API-key entry dialog for Pi providers (kind === "api_key").
+//
+// The "Keep this key private to Claudette" checkbox is the user-
+// requested storage opt-out: checked → keychain-only (env-var
+// injection), unchecked → writes to Pi's auth.json (shared with
+// terminal `pi`). The default depends on whether the user already
+// has the provider configured via models.json or an env var — in
+// those cases the "shared" path would duplicate state, so we default
+// to local.
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Modal } from "../modals/Modal";
+import shared from "../modals/shared.module.css";
+import {
+  piClearProviderApiKey,
+  piSetProviderApiKey,
+  type PiProvider,
+} from "../../services/tauri/piProviders";
+
+export interface PiProviderConfigureDialogProps {
+  provider: PiProvider;
+  workingDir: string;
+  onClose: () => void;
+  /** Called after a successful save/clear so the parent can refresh. */
+  onSaved: () => void;
+}
+
+export function PiProviderConfigureDialog({
+  provider,
+  workingDir,
+  onClose,
+  onSaved,
+}: PiProviderConfigureDialogProps) {
+  const { t } = useTranslation("settings");
+  const [key, setKey] = useState("");
+  // Default the scope based on the current auth source. If the user
+  // already has this provider via env var or models.json, keep things
+  // local so we don't shadow their existing setup. Otherwise default
+  // to shared (matches the team's hybrid storage decision: write to
+  // auth.json by default, opt-out for keychain-only).
+  const defaultLocal =
+    provider.authSource === "environment" ||
+    provider.authSource === "models_json_command" ||
+    provider.authSource === "models_json_key";
+  const [keepPrivate, setKeepPrivate] = useState(defaultLocal);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Reset state when the dialog is repurposed for a different provider.
+  useEffect(() => {
+    setKey("");
+    setError(null);
+    setSubmitting(false);
+    setKeepPrivate(defaultLocal);
+  }, [provider.id, defaultLocal]);
+
+  const handleSave = async () => {
+    if (!key.trim()) {
+      setError(t("pi_provider_dialog_empty", "Enter an API key first."));
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await piSetProviderApiKey({
+        workingDir,
+        providerId: provider.id,
+        key: key.trim(),
+        scope: keepPrivate ? "local" : "shared",
+      });
+      onSaved();
+      onClose();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleClear = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      // Clear both scopes — the user is wiping the slate. Without this,
+      // a user who switches from shared to local and then wipes would
+      // leave the auth.json entry behind.
+      await piClearProviderApiKey({
+        workingDir,
+        providerId: provider.id,
+        scope: "shared",
+      }).catch(() => {});
+      await piClearProviderApiKey({
+        workingDir,
+        providerId: provider.id,
+        scope: "local",
+      }).catch(() => {});
+      onSaved();
+      onClose();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Provider-specific env var hint can't be derived from a static
+  // string — pull it from the curated entry.
+  const envHint = provider.envHint;
+
+  return (
+    <Modal
+      title={t("pi_provider_dialog_title", {
+        label: provider.label,
+        defaultValue: "Configure {{label}}",
+      })}
+      onClose={onClose}
+    >
+      <p className={shared.warning}>{provider.description}</p>
+
+      <div className={shared.field}>
+        <label className={shared.label} htmlFor="pi-provider-key">
+          {t("pi_provider_dialog_key_label", "API key")}
+        </label>
+        <input
+          id="pi-provider-key"
+          type="password"
+          className={shared.input}
+          autoFocus
+          value={key}
+          placeholder={
+            provider.configured
+              ? t("pi_provider_dialog_replace", "Enter a new key to replace the saved one")
+              : t("pi_provider_dialog_paste", "Paste your API key")
+          }
+          onChange={(e) => setKey(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !submitting) void handleSave();
+          }}
+        />
+        {envHint && (
+          <p className={shared.hint}>
+            {t("pi_provider_dialog_env_hint", {
+              name: envHint,
+              defaultValue:
+                "Tip: set ${{name}} in your shell and Pi picks it up automatically — no need to paste here.",
+            })}
+          </p>
+        )}
+        {provider.docsUrl && (
+          <p className={shared.hint}>
+            <a
+              href={provider.docsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t("pi_provider_dialog_get_key", "Get an API key →")}
+            </a>
+          </p>
+        )}
+      </div>
+
+      <label className={shared.checkboxRow}>
+        <input
+          type="checkbox"
+          checked={keepPrivate}
+          onChange={(e) => setKeepPrivate(e.target.checked)}
+        />
+        <span>
+          {t(
+            "pi_provider_dialog_keep_private",
+            "Keep this key private to Claudette (do not write to ~/.pi/agent/auth.json)",
+          )}
+        </span>
+      </label>
+
+      {error && <p className={shared.error}>{error}</p>}
+
+      <div className={shared.actions}>
+        {provider.configured && (
+          <button
+            type="button"
+            className={shared.btnDanger}
+            onClick={handleClear}
+            disabled={submitting}
+          >
+            {t("pi_provider_dialog_clear", "Clear key")}
+          </button>
+        )}
+        <button
+          type="button"
+          className={shared.btn}
+          onClick={onClose}
+          disabled={submitting}
+        >
+          {t("pi_provider_dialog_cancel", "Cancel")}
+        </button>
+        <button
+          type="button"
+          className={shared.btnPrimary}
+          onClick={handleSave}
+          disabled={submitting}
+        >
+          {submitting
+            ? t("pi_provider_dialog_saving", "Saving…")
+            : t("pi_provider_dialog_save", "Save")}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/ui/src/components/settings/PiProviderList.module.css
+++ b/src/ui/src/components/settings/PiProviderList.module.css
@@ -96,8 +96,11 @@
   border-radius: 10px;
   padding: 2px 8px;
   white-space: nowrap;
-  text-transform: lowercase;
   letter-spacing: 0.02em;
+  /* No text-transform — pill content includes env-var names such as
+   * `$OPENROUTER_API_KEY` whose casing is meaningful in a shell. The
+   * earlier `text-transform: lowercase` rendered them as
+   * `$openrouter_api_key`, which is an invalid env var name. */
 }
 
 .sourcePillEnvHint {

--- a/src/ui/src/components/settings/PiProviderList.module.css
+++ b/src/ui/src/components/settings/PiProviderList.module.css
@@ -1,0 +1,146 @@
+/* Provider list rendered inside the Pi card and inside the
+ * `/login` provider picker. Visual tokens compose with the existing
+ * Settings palette (`--divider`, `--text-muted`, `--accent-fg`, …) so
+ * a theme change still drives this surface. */
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  background: var(--divider);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--divider);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 10px 12px;
+  background: var(--surface-1);
+  transition: background var(--transition-fast);
+}
+
+.row:hover {
+  background: var(--hover-bg);
+}
+
+.statusDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.statusDotConfigured {
+  background: var(--status-running);
+}
+
+.statusDotEnvOnly {
+  background: var(--text-muted);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.description {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.source {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.btn {
+  background: var(--selected-bg);
+  border: 1px solid var(--divider);
+  color: var(--text-primary);
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 12px;
+  transition: background var(--transition-fast);
+}
+
+.btn:hover:not(:disabled) {
+  background: var(--hover-bg);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btnPrimary {
+  composes: btn;
+  background: var(--accent-bg);
+  border-color: transparent;
+  color: var(--accent-on);
+}
+
+.btnPrimary:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.btnDanger {
+  composes: btn;
+  color: var(--status-stopped);
+  border-color: var(--status-stopped);
+}
+
+.summary {
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 4px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.disclosure {
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: 11px;
+  cursor: pointer;
+  padding: 6px 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  align-self: flex-start;
+}
+
+.disclosure:hover {
+  color: var(--text-primary);
+}
+
+.empty {
+  font-size: 12px;
+  color: var(--text-muted);
+  padding: 12px;
+  background: var(--surface-1);
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--divider);
+}

--- a/src/ui/src/components/settings/PiProviderList.module.css
+++ b/src/ui/src/components/settings/PiProviderList.module.css
@@ -19,7 +19,7 @@
   align-items: center;
   gap: var(--space-3);
   padding: 10px 12px;
-  background: var(--surface-1);
+  background: var(--chat-input-bg);
   transition: background var(--transition-fast);
 }
 
@@ -95,13 +95,17 @@
 
 .btnPrimary {
   composes: btn;
-  background: var(--accent-bg);
+  background: var(--accent-primary);
   border-color: transparent;
-  color: var(--accent-on);
+  color: var(--on-accent);
 }
 
 .btnPrimary:hover:not(:disabled) {
-  background: var(--accent-hover);
+  /* The theme only defines `--accent-primary` + `--accent-bg`; there
+   * is no dedicated hover token. Use the existing low-alpha accent
+   * wash so the hover state composes cleanly across all themes.   */
+  background: var(--accent-bg);
+  color: var(--accent-primary);
 }
 
 .btnDanger {
@@ -140,7 +144,7 @@
   font-size: 12px;
   color: var(--text-muted);
   padding: 12px;
-  background: var(--surface-1);
+  background: var(--chat-input-bg);
   border-radius: var(--radius-md);
   border: 1px dashed var(--divider);
 }

--- a/src/ui/src/components/settings/PiProviderList.module.css
+++ b/src/ui/src/components/settings/PiProviderList.module.css
@@ -1,7 +1,14 @@
 /* Provider list rendered inside the Pi card and inside the
  * `/login` provider picker. Visual tokens compose with the existing
- * Settings palette (`--divider`, `--text-muted`, `--accent-fg`, …) so
- * a theme change still drives this surface. */
+ * Settings palette (`--divider`, `--text-muted`, …) so theme changes
+ * drive this surface automatically.
+ *
+ * Each row is a two-line flex layout, not a fixed-column grid, so a
+ * long description doesn't push the action buttons off the right
+ * edge. Top line carries label + counts + source pill + buttons;
+ * bottom line is the description (truncated by ellipsis if it can't
+ * fit). The status dot spans both lines via `align-items: flex-start`
+ * + a fixed top offset so it visually anchors the row header. */
 
 .list {
   display: flex;
@@ -15,12 +22,13 @@
 
 .row {
   display: grid;
-  grid-template-columns: auto 1fr auto auto;
-  align-items: center;
-  gap: var(--space-3);
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 10px;
   padding: 10px 12px;
   background: var(--chat-input-bg);
   transition: background var(--transition-fast);
+  min-width: 0;
 }
 
 .row:hover {
@@ -33,6 +41,7 @@
   border-radius: 50%;
   background: var(--text-dim);
   flex-shrink: 0;
+  margin-top: 6px;
 }
 
 .statusDotConfigured {
@@ -46,7 +55,14 @@
 .body {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
+  min-width: 0;
+}
+
+.headerLine {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   min-width: 0;
 }
 
@@ -57,6 +73,43 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex-shrink: 0;
+}
+
+.modelCount {
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 400;
+  flex-shrink: 0;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.sourcePill {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-dim);
+  background: var(--hover-bg);
+  border: 1px solid var(--divider);
+  border-radius: 10px;
+  padding: 2px 8px;
+  white-space: nowrap;
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+
+.sourcePillEnvHint {
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px dashed var(--divider);
+}
+
+.actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
 }
 
 .description {
@@ -65,12 +118,6 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.source {
-  font-size: 11px;
-  color: var(--text-dim);
-  white-space: nowrap;
 }
 
 .btn {
@@ -82,6 +129,7 @@
   cursor: pointer;
   font-size: 12px;
   transition: background var(--transition-fast);
+  white-space: nowrap;
 }
 
 .btn:hover:not(:disabled) {
@@ -117,7 +165,7 @@
 .summary {
   font-size: 11px;
   color: var(--text-muted);
-  padding: 4px 0;
+  padding: 0 0 6px;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/ui/src/components/settings/PiProviderList.test.tsx
+++ b/src/ui/src/components/settings/PiProviderList.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment happy-dom
+//
+// Regression coverage for the curated provider list rendering. Pure
+// presentation tests — Tauri-side and harness-side logic are covered
+// in their own files. Uses react-dom/client directly (no
+// @testing-library/react in this repo).
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      if (typeof options === "string") return options;
+      if (options && typeof options === "object") {
+        const defaultValue = options.defaultValue;
+        if (typeof defaultValue === "string") {
+          // Naive {{key}} interpolation, plenty for the assertions
+          // below which check that "More providers" / "via auth.json"
+          // etc. render. We don't pin exact counts.
+          return defaultValue.replace(/\{\{(\w+)\}\}/g, (_match, name) => {
+            const v = options[name];
+            return v === undefined ? "" : String(v);
+          });
+        }
+      }
+      return key;
+    },
+  }),
+}));
+
+import type { PiProvider } from "../../services/tauri/piProviders";
+import { PiProviderList } from "./PiProviderList";
+
+const baseProviders: PiProvider[] = [
+  {
+    id: "github-copilot",
+    label: "GitHub Copilot",
+    description: "Sign in once.",
+    kind: "oauth+enterprise",
+    configured: false,
+    modelCount: 26,
+  },
+  {
+    id: "openrouter",
+    label: "OpenRouter",
+    description: "One API key, lots of models.",
+    kind: "api_key",
+    envHint: "OPENROUTER_API_KEY",
+    configured: true,
+    authSource: "stored",
+    modelCount: 275,
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    description: "Direct.",
+    kind: "api_key",
+    envHint: "OPENAI_API_KEY",
+    configured: false,
+    modelCount: 42,
+  },
+  {
+    id: "anthropic",
+    label: "Anthropic (API)",
+    description: "Claude API.",
+    kind: "api_key",
+    envHint: "ANTHROPIC_API_KEY",
+    configured: false,
+    modelCount: 23,
+  },
+  {
+    id: "google",
+    label: "Google Gemini",
+    description: "Gemini.",
+    kind: "api_key",
+    envHint: "GEMINI_API_KEY",
+    configured: false,
+    modelCount: 27,
+  },
+  {
+    id: "deepseek",
+    label: "DeepSeek",
+    description: "Cheap.",
+    kind: "api_key",
+    envHint: "DEEPSEEK_API_KEY",
+    configured: false,
+    modelCount: 2,
+  },
+  {
+    id: "xai",
+    label: "xAI",
+    description: "Grok.",
+    kind: "api_key",
+    envHint: "XAI_API_KEY",
+    configured: false,
+    modelCount: 25,
+  },
+];
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("PiProviderList", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderList(onConfigure: (p: PiProvider) => void = () => {}) {
+    act(() => {
+      root.render(
+        <PiProviderList
+          providers={baseProviders}
+          defaultVisibleCount={6}
+          onConfigure={onConfigure}
+        />,
+      );
+    });
+  }
+
+  function clickByText(text: string | RegExp) {
+    const match = (Array.from(container.querySelectorAll("button")) as HTMLButtonElement[]).find(
+      (b) => {
+        const t = b.textContent ?? "";
+        return typeof text === "string" ? t.includes(text) : text.test(t);
+      },
+    );
+    if (!match) throw new Error(`no button matching ${text}`);
+    act(() => match.click());
+  }
+
+  it("hides providers beyond defaultVisibleCount behind a disclosure", () => {
+    renderList();
+    expect(container.textContent).toContain("GitHub Copilot");
+    expect(container.textContent).toContain("DeepSeek");
+    expect(container.textContent).not.toContain("xAI");
+    expect(container.textContent).toMatch(/More providers/);
+  });
+
+  it("expands the full list when the disclosure is clicked", () => {
+    renderList();
+    clickByText(/More providers/);
+    expect(container.textContent).toContain("xAI");
+  });
+
+  it("labels configured rows with their auth source", () => {
+    renderList();
+    expect(container.textContent).toContain("via auth.json");
+  });
+
+  it("uses Sign in / Configure based on provider kind", () => {
+    renderList();
+    const buttons = Array.from(
+      container.querySelectorAll("button"),
+    ) as HTMLButtonElement[];
+    const labels = buttons.map((b) => b.textContent?.trim()).filter(Boolean);
+    expect(labels).toContain("Sign in");
+    expect(labels).toContain("Configure");
+  });
+
+  it("invokes onConfigure with the row's provider when the action is clicked", () => {
+    const onConfigure = vi.fn();
+    renderList(onConfigure);
+    clickByText("Sign in");
+    expect(onConfigure).toHaveBeenCalledTimes(1);
+    expect(onConfigure.mock.calls[0]?.[0]?.id).toBe("github-copilot");
+  });
+});

--- a/src/ui/src/components/settings/PiProviderList.test.tsx
+++ b/src/ui/src/components/settings/PiProviderList.test.tsx
@@ -156,7 +156,12 @@ describe("PiProviderList", () => {
 
   it("labels configured rows with their auth source", () => {
     renderList();
-    expect(container.textContent).toContain("via auth.json");
+    // Source rendered as a compact pill alongside the row, not a
+    // "via X" sentence anymore. Confirm OpenRouter (the configured
+    // fixture) carries the pill text. Pinning the pill node lets a
+    // future label change find this assertion.
+    const text = container.textContent ?? "";
+    expect(text).toContain("auth.json");
   });
 
   it("uses Sign in / Configure based on provider kind", () => {

--- a/src/ui/src/components/settings/PiProviderList.tsx
+++ b/src/ui/src/components/settings/PiProviderList.tsx
@@ -1,0 +1,237 @@
+// Provider list rendered inside the Settings → Models → Pi card and
+// inside the `/login` provider picker modal. The list itself is pure
+// presentation; the configure-action wiring (open the right dialog
+// for `kind`) lives in the parent so `/login` can swap in its own
+// after-success callback (resume the chat) without duplicating the
+// list logic.
+//
+// Kept deliberately small — no fetch, no state machine. The parent
+// owns `loading` / `error` and the curated list, refreshes after a
+// configure round-trip, and decides whether to show the disclosure.
+
+import { ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { PiProvider } from "../../services/tauri/piProviders";
+import styles from "./PiProviderList.module.css";
+
+export interface PiProviderListProps {
+  providers: PiProvider[];
+  defaultVisibleCount: number;
+  /** Disabled while a request is in flight (configure or refresh). */
+  busy?: boolean;
+  /** Configure the API key or launch OAuth. The handler dispatches on
+   *  `provider.kind`. */
+  onConfigure: (provider: PiProvider) => void;
+  /** Optional: show a "Clear" button on configured rows. Defaults to
+   *  enabled. The `/login` picker can disable it to keep that flow
+   *  one-shot. */
+  onClear?: (provider: PiProvider) => void;
+  /** Optional: text to render under the list (count summary etc.). */
+  footer?: React.ReactNode;
+}
+
+export function PiProviderList({
+  providers,
+  defaultVisibleCount,
+  busy,
+  onConfigure,
+  onClear,
+  footer,
+}: PiProviderListProps) {
+  const { t } = useTranslation("settings");
+  const [showAll, setShowAll] = useState(false);
+
+  const visible = useMemo(() => {
+    if (showAll) return providers;
+    return providers.slice(0, defaultVisibleCount);
+  }, [providers, defaultVisibleCount, showAll]);
+
+  const hiddenCount = providers.length - visible.length;
+  const configuredCount = providers.filter((p) => p.configured).length;
+  const totalModels = providers.reduce((acc, p) => acc + p.modelCount, 0);
+
+  if (providers.length === 0) {
+    return (
+      <div className={styles.empty}>
+        {t(
+          "pi_providers_empty",
+          "Pi reported no providers. Refresh, or check that the sidecar is healthy.",
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className={styles.summary}>
+        <span>
+          {t("pi_providers_summary", {
+            configured: configuredCount,
+            total: providers.length,
+            models: totalModels,
+            defaultValue:
+              "{{configured}}/{{total}} configured · {{models}} models available",
+          })}
+        </span>
+      </div>
+      <div className={styles.list}>
+        {visible.map((provider) => (
+          <PiProviderRow
+            key={provider.id}
+            provider={provider}
+            busy={busy}
+            onConfigure={onConfigure}
+            onClear={onClear}
+          />
+        ))}
+      </div>
+      {hiddenCount > 0 && (
+        <button
+          type="button"
+          className={styles.disclosure}
+          onClick={() => setShowAll(true)}
+        >
+          <ChevronRight size={12} aria-hidden />
+          {t("pi_providers_show_more", {
+            count: hiddenCount,
+            defaultValue: "More providers ({{count}})",
+          })}
+        </button>
+      )}
+      {showAll && hiddenCount === 0 && providers.length > defaultVisibleCount && (
+        <button
+          type="button"
+          className={styles.disclosure}
+          onClick={() => setShowAll(false)}
+        >
+          <ChevronDown size={12} aria-hidden />
+          {t("pi_providers_show_less", "Show fewer providers")}
+        </button>
+      )}
+      {footer}
+    </>
+  );
+}
+
+interface PiProviderRowProps {
+  provider: PiProvider;
+  busy?: boolean;
+  onConfigure: (provider: PiProvider) => void;
+  onClear?: (provider: PiProvider) => void;
+}
+
+function PiProviderRow({
+  provider,
+  busy,
+  onConfigure,
+  onClear,
+}: PiProviderRowProps) {
+  const { t } = useTranslation("settings");
+
+  const isEnvOnly = provider.kind === "env_only";
+  const statusDotClass = [
+    styles.statusDot,
+    provider.configured && styles.statusDotConfigured,
+    !provider.configured && isEnvOnly && styles.statusDotEnvOnly,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  // Action button label depends on kind + state. OAuth providers say
+  // "Sign in" / "Sign out"; API-key providers say "Configure" / "Clear".
+  // env_only providers point at docs.
+  const actionLabel = (() => {
+    if (isEnvOnly) {
+      return t("pi_provider_view_docs", "Docs");
+    }
+    if (provider.kind.startsWith("oauth")) {
+      return provider.configured
+        ? t("pi_provider_signout", "Sign out")
+        : t("pi_provider_signin", "Sign in");
+    }
+    return provider.configured
+      ? t("pi_provider_reconfigure", "Reconfigure")
+      : t("pi_provider_configure", "Configure");
+  })();
+
+  // Show the auth source label for already-configured providers so a
+  // user with both an env var and an auth.json entry can tell which
+  // one Pi will use.
+  const sourceLabel = (() => {
+    if (!provider.configured) {
+      if (provider.envHint) {
+        return t("pi_provider_env_hint", {
+          name: provider.envHint,
+          defaultValue: "or set ${{name}}",
+        });
+      }
+      return undefined;
+    }
+    switch (provider.authSource) {
+      case "stored":
+        return t("pi_provider_source_stored", "via auth.json");
+      case "environment":
+        return t("pi_provider_source_env", {
+          name: provider.envHint ?? "env var",
+          defaultValue: "via ${{name}}",
+        });
+      case "runtime":
+        return t("pi_provider_source_runtime", "via --api-key");
+      case "fallback":
+      case "models_json_key":
+      case "models_json_command":
+        return t("pi_provider_source_models_json", "via models.json");
+      default:
+        return undefined;
+    }
+  })();
+
+  return (
+    <div className={styles.row}>
+      <span className={statusDotClass} aria-hidden />
+      <div className={styles.body}>
+        <span className={styles.label}>
+          {provider.label}
+          {provider.modelCount > 0 && (
+            <span style={{ marginLeft: 8, color: "var(--text-dim)", fontWeight: 400 }}>
+              {provider.modelCount} models
+            </span>
+          )}
+        </span>
+        <span className={styles.description}>{provider.description}</span>
+      </div>
+      {sourceLabel && <span className={styles.source}>{sourceLabel}</span>}
+      <div style={{ display: "flex", gap: 6 }}>
+        {provider.configured && onClear && !isEnvOnly && (
+          <button
+            type="button"
+            className={styles.btn}
+            onClick={() => onClear(provider)}
+            disabled={busy}
+          >
+            {t("pi_provider_clear", "Clear")}
+          </button>
+        )}
+        <button
+          type="button"
+          className={
+            provider.configured && !isEnvOnly ? styles.btn : styles.btnPrimary
+          }
+          onClick={() => {
+            if (isEnvOnly && provider.docsUrl) {
+              window.open(provider.docsUrl, "_blank", "noopener,noreferrer");
+              return;
+            }
+            onConfigure(provider);
+          }}
+          disabled={busy}
+        >
+          {isEnvOnly && <ExternalLink size={11} aria-hidden style={{ marginRight: 4 }} />}
+          {actionLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/components/settings/PiProviderList.tsx
+++ b/src/ui/src/components/settings/PiProviderList.tsx
@@ -13,6 +13,7 @@ import { ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { openUrl } from "../../services/tauri";
 import type { PiProvider } from "../../services/tauri/piProviders";
 import styles from "./PiProviderList.module.css";
 
@@ -50,7 +51,14 @@ export function PiProviderList({
 
   const hiddenCount = providers.length - visible.length;
   const configuredCount = providers.filter((p) => p.configured).length;
-  const totalModels = providers.reduce((acc, p) => acc + p.modelCount, 0);
+  // Sum models only for providers that are actually configured —
+  // otherwise the "models available" summary wildly overcounts (Pi
+  // ships ~275 OpenRouter models in its registry, but with no key
+  // configured the user gets zero of them from getAvailable()).
+  const totalModels = providers.reduce(
+    (acc, p) => (p.configured ? acc + p.modelCount : acc),
+    0,
+  );
 
   if (providers.length === 0) {
     return (
@@ -140,21 +148,43 @@ function PiProviderRow({
     .join(" ");
 
   // Action button label depends on kind + state. OAuth providers say
-  // "Sign in" / "Sign out"; API-key providers say "Configure" / "Clear".
-  // env_only providers point at docs.
+  // "Sign in" / "Reauthenticate" (the *primary* button stays a sign-
+  // in entry point even when configured — sign-out routes through
+  // the separate Clear button below). env_only providers point at
+  // docs. API-key providers say Configure / Reconfigure.
   const actionLabel = (() => {
     if (isEnvOnly) {
       return t("pi_provider_view_docs", "Docs");
     }
     if (provider.kind.startsWith("oauth")) {
       return provider.configured
-        ? t("pi_provider_signout", "Sign out")
+        ? t("pi_provider_reauthenticate", "Reauthenticate")
         : t("pi_provider_signin", "Sign in");
     }
     return provider.configured
       ? t("pi_provider_reconfigure", "Reconfigure")
       : t("pi_provider_configure", "Configure");
   })();
+
+  // Clear button is only meaningful for credentials we own — keychain
+  // entries we wrote (auth_source ∈ {stored, fallback after our
+  // save}) plus the catch-all of "no source recorded but the user
+  // just configured it". env/models_json sources represent state Pi
+  // discovered from the shell or models.json that Claudette cannot
+  // delete, so the button would be a confusing no-op.
+  const clearableAuthSource = !provider.authSource
+    || provider.authSource === "stored"
+    || provider.authSource === "runtime";
+  const showClearButton =
+    provider.configured && !isEnvOnly && clearableAuthSource && Boolean(onClear);
+
+  // OAuth providers get an explicit Sign-out button in addition to
+  // the Reauthenticate primary — the clear-button label changes to
+  // "Sign out" so users have a way back without the UI pretending
+  // every flow is an API-key dialog.
+  const clearLabel = provider.kind.startsWith("oauth")
+    ? t("pi_provider_signout", "Sign out")
+    : t("pi_provider_clear", "Clear");
 
   // Show the auth source label for already-configured providers so a
   // user with both an env var and an auth.json entry can tell which
@@ -204,14 +234,14 @@ function PiProviderRow({
       </div>
       {sourceLabel && <span className={styles.source}>{sourceLabel}</span>}
       <div style={{ display: "flex", gap: 6 }}>
-        {provider.configured && onClear && !isEnvOnly && (
+        {showClearButton && (
           <button
             type="button"
             className={styles.btn}
-            onClick={() => onClear(provider)}
+            onClick={() => onClear?.(provider)}
             disabled={busy}
           >
-            {t("pi_provider_clear", "Clear")}
+            {clearLabel}
           </button>
         )}
         <button
@@ -221,7 +251,10 @@ function PiProviderRow({
           }
           onClick={() => {
             if (isEnvOnly && provider.docsUrl) {
-              window.open(provider.docsUrl, "_blank", "noopener,noreferrer");
+              // Tauri's webview blocks bare `window.open`; route
+              // every external-link launch through the
+              // `open_url` command the rest of Settings uses.
+              void openUrl(provider.docsUrl).catch(() => {});
               return;
             }
             onConfigure(provider);

--- a/src/ui/src/components/settings/PiProviderList.tsx
+++ b/src/ui/src/components/settings/PiProviderList.tsx
@@ -188,31 +188,33 @@ function PiProviderRow({
 
   // Show the auth source label for already-configured providers so a
   // user with both an env var and an auth.json entry can tell which
-  // one Pi will use.
+  // one Pi will use. For unconfigured rows we render the env hint as
+  // a dashed pill so the affordance is visually distinct from a live
+  // source label.
   const sourceLabel = (() => {
     if (!provider.configured) {
       if (provider.envHint) {
-        return t("pi_provider_env_hint", {
-          name: provider.envHint,
-          defaultValue: "or set ${{name}}",
-        });
+        return {
+          text: `$${provider.envHint}`,
+          isHint: true,
+        };
       }
       return undefined;
     }
     switch (provider.authSource) {
       case "stored":
-        return t("pi_provider_source_stored", "via auth.json");
+        return { text: t("pi_provider_source_stored_short", "auth.json"), isHint: false };
       case "environment":
-        return t("pi_provider_source_env", {
-          name: provider.envHint ?? "env var",
-          defaultValue: "via ${{name}}",
-        });
+        return {
+          text: `$${provider.envHint ?? "env"}`,
+          isHint: false,
+        };
       case "runtime":
-        return t("pi_provider_source_runtime", "via --api-key");
+        return { text: t("pi_provider_source_runtime_short", "--api-key"), isHint: false };
       case "fallback":
       case "models_json_key":
       case "models_json_command":
-        return t("pi_provider_source_models_json", "via models.json");
+        return { text: t("pi_provider_source_models_json_short", "models.json"), isHint: false };
       default:
         return undefined;
     }
@@ -222,48 +224,64 @@ function PiProviderRow({
     <div className={styles.row}>
       <span className={statusDotClass} aria-hidden />
       <div className={styles.body}>
-        <span className={styles.label}>
-          {provider.label}
+        <div className={styles.headerLine}>
+          <span className={styles.label}>{provider.label}</span>
           {provider.modelCount > 0 && (
-            <span style={{ marginLeft: 8, color: "var(--text-dim)", fontWeight: 400 }}>
-              {provider.modelCount} models
+            <span className={styles.modelCount}>
+              {t("pi_provider_model_count", {
+                count: provider.modelCount,
+                defaultValue: "{{count}} models",
+              })}
             </span>
           )}
-        </span>
+          <span className={styles.spacer} />
+          {sourceLabel && (
+            <span
+              className={
+                sourceLabel.isHint
+                  ? `${styles.sourcePill} ${styles.sourcePillEnvHint}`
+                  : styles.sourcePill
+              }
+            >
+              {sourceLabel.text}
+            </span>
+          )}
+          <div className={styles.actions}>
+            {showClearButton && (
+              <button
+                type="button"
+                className={styles.btn}
+                onClick={() => onClear?.(provider)}
+                disabled={busy}
+              >
+                {clearLabel}
+              </button>
+            )}
+            <button
+              type="button"
+              className={
+                provider.configured && !isEnvOnly ? styles.btn : styles.btnPrimary
+              }
+              onClick={() => {
+                if (isEnvOnly && provider.docsUrl) {
+                  // Tauri's webview blocks bare `window.open`; route
+                  // every external-link launch through the
+                  // `open_url` command the rest of Settings uses.
+                  void openUrl(provider.docsUrl).catch(() => {});
+                  return;
+                }
+                onConfigure(provider);
+              }}
+              disabled={busy}
+            >
+              {isEnvOnly && (
+                <ExternalLink size={11} aria-hidden style={{ marginRight: 4 }} />
+              )}
+              {actionLabel}
+            </button>
+          </div>
+        </div>
         <span className={styles.description}>{provider.description}</span>
-      </div>
-      {sourceLabel && <span className={styles.source}>{sourceLabel}</span>}
-      <div style={{ display: "flex", gap: 6 }}>
-        {showClearButton && (
-          <button
-            type="button"
-            className={styles.btn}
-            onClick={() => onClear?.(provider)}
-            disabled={busy}
-          >
-            {clearLabel}
-          </button>
-        )}
-        <button
-          type="button"
-          className={
-            provider.configured && !isEnvOnly ? styles.btn : styles.btnPrimary
-          }
-          onClick={() => {
-            if (isEnvOnly && provider.docsUrl) {
-              // Tauri's webview blocks bare `window.open`; route
-              // every external-link launch through the
-              // `open_url` command the rest of Settings uses.
-              void openUrl(provider.docsUrl).catch(() => {});
-              return;
-            }
-            onConfigure(provider);
-          }}
-          disabled={busy}
-        >
-          {isEnvOnly && <ExternalLink size={11} aria-hidden style={{ marginRight: 4 }} />}
-          {actionLabel}
-        </button>
       </div>
     </div>
   );

--- a/src/ui/src/components/settings/PiProviderManager.tsx
+++ b/src/ui/src/components/settings/PiProviderManager.tsx
@@ -1,0 +1,131 @@
+// Stateful wrapper that owns:
+//   - Fetching the curated provider list from the Pi sidecar
+//   - Routing "Configure" actions to the right dialog (API-key entry
+//     vs. OAuth device-code modal)
+//   - Re-fetching after a successful configure/clear so the list
+//     reflects new state
+//
+// Drop this into the Pi card body (Settings → Models) and into the
+// `/login` picker modal. The component takes a single optional
+// `onConfigured` callback so callers can extend the post-success
+// behavior (e.g. `/login` refreshes Pi models and resumes the chat).
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  piListProviders,
+  type PiProvider,
+  type PiProviderList,
+} from "../../services/tauri/piProviders";
+import { PiOAuthModal } from "./PiOAuthModal";
+import { PiProviderConfigureDialog } from "./PiProviderConfigureDialog";
+import { PiProviderList as PiProviderListView } from "./PiProviderList";
+import sharedModal from "../modals/shared.module.css";
+
+export interface PiProviderManagerProps {
+  /** Workspace cwd to pass into the harness control session. Not
+   *  load-bearing for `list_providers` itself (Pi's auth lives in
+   *  ~/.pi), but harness spawning still wants a real path. Pass the
+   *  empty string when invoked outside a workspace (e.g. the global
+   *  Pi card in Settings); the Tauri layer falls back to `/`. */
+  workingDir: string;
+  /** Optional hook fired after every successful configure/clear, so
+   *  the parent can refresh the Pi card's discovered_models list and
+   *  any other dependent UI. */
+  onConfigured?: () => void;
+}
+
+export function PiProviderManager({
+  workingDir,
+  onConfigured,
+}: PiProviderManagerProps) {
+  const { t } = useTranslation("settings");
+  const [data, setData] = useState<PiProviderList | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dialog, setDialog] = useState<
+    | { kind: "api_key"; provider: PiProvider }
+    | { kind: "oauth"; provider: PiProvider }
+    | null
+  >(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await piListProviders(workingDir);
+      setData(list);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [workingDir]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleConfigure = (provider: PiProvider) => {
+    if (provider.kind === "oauth" || provider.kind === "oauth+enterprise") {
+      setDialog({ kind: "oauth", provider });
+      return;
+    }
+    if (provider.kind === "api_key") {
+      setDialog({ kind: "api_key", provider });
+      return;
+    }
+    // env_only — handled by the row (opens docs URL); shouldn't land here.
+  };
+
+  const handleClear = (provider: PiProvider) => {
+    // Repurpose the API-key dialog's "Clear" path. It clears both
+    // shared and local scopes, which is what the user wants when they
+    // hit "Clear" on a row without a specific scope in mind.
+    setDialog({ kind: "api_key", provider });
+  };
+
+  const handleSaved = async () => {
+    setDialog(null);
+    await refresh();
+    onConfigured?.();
+  };
+
+  return (
+    <>
+      {error && <p className={sharedModal.error}>{error}</p>}
+      {!data && loading && (
+        <p style={{ fontSize: 12, color: "var(--text-muted)" }}>
+          {t("pi_providers_loading", "Loading providers…")}
+        </p>
+      )}
+      {data && (
+        <PiProviderListView
+          providers={data.providers}
+          defaultVisibleCount={data.defaultVisibleCount}
+          busy={loading}
+          onConfigure={handleConfigure}
+          onClear={handleClear}
+        />
+      )}
+
+      {dialog?.kind === "api_key" && (
+        <PiProviderConfigureDialog
+          provider={dialog.provider}
+          workingDir={workingDir}
+          onClose={() => setDialog(null)}
+          onSaved={handleSaved}
+        />
+      )}
+      {dialog?.kind === "oauth" && (
+        <PiOAuthModal
+          provider={dialog.provider}
+          workingDir={workingDir}
+          onClose={() => setDialog(null)}
+          onSaved={handleSaved}
+        />
+      )}
+    </>
+  );
+}

--- a/src/ui/src/components/settings/PiProviderManager.tsx
+++ b/src/ui/src/components/settings/PiProviderManager.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
+  piClearProviderApiKey,
   piListProviders,
   type PiProvider,
   type PiProviderList,
@@ -79,10 +80,30 @@ export function PiProviderManager({
     // env_only — handled by the row (opens docs URL); shouldn't land here.
   };
 
-  const handleClear = (provider: PiProvider) => {
-    // Repurpose the API-key dialog's "Clear" path. It clears both
-    // shared and local scopes, which is what the user wants when they
-    // hit "Clear" on a row without a specific scope in mind.
+  const handleClear = async (provider: PiProvider) => {
+    if (provider.kind === "oauth" || provider.kind === "oauth+enterprise") {
+      // OAuth tokens live in Pi's auth.json under the provider id; we
+      // can clear them straight from the same shared-scope path used
+      // by API-key providers. No API-key dialog needed — its
+      // "Replace this key" copy would be nonsense for an OAuth
+      // credential. Surface any failure via the existing error path
+      // so the user knows whether their token actually got wiped.
+      setError(null);
+      try {
+        await piClearProviderApiKey({
+          workingDir,
+          providerId: provider.id,
+          scope: "shared",
+        });
+        await refresh();
+        onConfigured?.();
+      } catch (e) {
+        setError(String(e));
+      }
+      return;
+    }
+    // For API-key providers reuse the dialog's clear-both-scopes path
+    // so the user can also surface partial-failure errors visually.
     setDialog({ kind: "api_key", provider });
   };
 

--- a/src/ui/src/components/settings/sections/ModelSettings.test.tsx
+++ b/src/ui/src/components/settings/sections/ModelSettings.test.tsx
@@ -158,6 +158,26 @@ vi.mock("../../../stores/useAppStore", () => {
 
 vi.mock("../../../services/tauri", () => serviceMocks);
 
+// Stub the Pi provider-auth Tauri commands so the embedded
+// `PiProviderManager` in the Pi card doesn't error in jsdom (no real
+// Tauri IPC, no harness sidecar). Tests that need to assert on the
+// manager's behavior should override individual mocks rather than
+// adding logic here.
+vi.mock("../../../services/tauri/piProviders", () => ({
+  piListProviders: vi.fn(() =>
+    Promise.resolve({ defaultVisibleCount: 6, providers: [] }),
+  ),
+  piSetProviderApiKey: vi.fn(() => Promise.resolve()),
+  piClearProviderApiKey: vi.fn(() => Promise.resolve()),
+  piOAuthStart: vi.fn(() =>
+    Promise.resolve({ challengeId: "test", providerId: "openrouter" }),
+  ),
+  piOAuthSubmitInput: vi.fn(() => Promise.resolve()),
+  piOAuthCancel: vi.fn(() => Promise.resolve()),
+  listenPiOAuthEvents: vi.fn(() => Promise.resolve(() => {})),
+  PI_OAUTH_EVENT_CHANNEL: "pi://oauth/event",
+}));
+
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn((event: string, callback: (event: { payload: unknown }) => void) => {
     const listeners = eventMocks.listeners.get(event) ?? [];

--- a/src/ui/src/components/settings/sections/ModelSettings.tsx
+++ b/src/ui/src/components/settings/sections/ModelSettings.tsx
@@ -40,6 +40,7 @@ import {
 } from "../codexBackendMigration";
 import { shouldShowBackendTestButton } from "../agentBackendStartupRefresh";
 import { ClaudeCodeAuthSetting } from "../../auth/ClaudeCodeAuthSetting";
+import { PiProviderManager } from "../PiProviderManager";
 import styles from "../Settings.module.css";
 
 const BACKEND_AUTO_DETECT_DISABLED_PREFIX = "agent_backend_auto_detect_disabled:";
@@ -939,6 +940,23 @@ function BackendCard({
           )}
         </div>
         <div className={styles.backendForm}>
+          {draft.kind === "pi_sdk" && (
+            // Pi provider list lives above the discovered-models view
+            // so users see configurable providers first, then the
+            // resulting models. `onConfigured` re-fetches the model
+            // list after a successful API-key save / OAuth sign-in so
+            // both surfaces stay in sync without a manual Refresh click.
+            <div
+              className={styles.backendField}
+              role="group"
+              aria-label={t("pi_providers_section", "Pi providers")}
+            >
+              <span className={styles.backendFieldLabel}>
+                {t("pi_providers_section", "Pi providers")}
+              </span>
+              <PiProviderManager workingDir="" onConfigured={refresh} />
+            </div>
+          )}
           {discoveryBackend && (
             // Same a11y concern: the Pi variant renders expandable
             // `<button>` headers, which don't belong inside a `<label>`.
@@ -1017,15 +1035,13 @@ function BackendCard({
               {t("models_backend_login")}
             </button>
           )}
-          {usesPiAuth && (
-            <button
-              className={styles.iconBtn}
-              onClick={() => setStatus(t("models_backend_pi_auth_guidance", "Run `pi auth` in a terminal, then refresh Pi models."))}
-              disabled={busy}
-            >
-              {t("models_backend_pi_login")}
-            </button>
-          )}
+          {/* Pi auth UX moved into the inline `PiProviderManager`
+              above — see the `draft.kind === "pi_sdk"` block at the
+              top of `.backendForm`. Per-provider login lives there
+              (Configure / Sign in buttons), and the redundant card-
+              footer button used to confuse users into thinking
+              there's a single "Pi login" instead of N per-provider
+              flows. */}
         </div>
       </div>
     </div>

--- a/src/ui/src/components/settings/sections/ModelSettings.tsx
+++ b/src/ui/src/components/settings/sections/ModelSettings.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronRight } from "lucide-react";
 import {
   deleteAppSetting,
   getAppSetting,
@@ -21,10 +20,7 @@ import {
   normalizeReasoningLevel,
   reasoningVariantForModel,
 } from "../../chat/reasoningControls";
-import {
-  groupPiDiscoveredModels,
-  resolveModelSelection,
-} from "../../chat/modelRegistry";
+import { resolveModelSelection } from "../../chat/modelRegistry";
 import { useModelRegistry } from "../../chat/useModelRegistry";
 import { useAppStore } from "../../../stores/useAppStore";
 import { formatBackendError } from "../backendSettingsErrors";
@@ -40,7 +36,7 @@ import {
 } from "../codexBackendMigration";
 import { shouldShowBackendTestButton } from "../agentBackendStartupRefresh";
 import { ClaudeCodeAuthSetting } from "../../auth/ClaudeCodeAuthSetting";
-import { PiProviderManager } from "../PiProviderManager";
+import { PiCardBody } from "../PiCardBody";
 import styles from "../Settings.module.css";
 
 const BACKEND_AUTO_DETECT_DISABLED_PREFIX = "agent_backend_auto_detect_disabled:";
@@ -939,42 +935,35 @@ function BackendCard({
             </label>
           )}
         </div>
-        <div className={styles.backendForm}>
-          {draft.kind === "pi_sdk" && (
-            // Pi provider list lives above the discovered-models view
-            // so users see configurable providers first, then the
-            // resulting models. `onConfigured` re-fetches the model
-            // list after a successful API-key save / OAuth sign-in so
-            // both surfaces stay in sync without a manual Refresh click.
-            <div
-              className={styles.backendField}
-              role="group"
-              aria-label={t("pi_providers_section", "Pi providers")}
-            >
-              <span className={styles.backendFieldLabel}>
-                {t("pi_providers_section", "Pi providers")}
-              </span>
-              <PiProviderManager workingDir="" onConfigured={refresh} />
-            </div>
-          )}
-          {discoveryBackend && (
-            // Same a11y concern: the Pi variant renders expandable
-            // `<button>` headers, which don't belong inside a `<label>`.
-            // Use a `<div>` + labeled span and connect them via aria.
-            <div
-              className={styles.backendField}
-              role="group"
-              aria-labelledby={`${draft.id}-discovered-models-label`}
-            >
-              <span
-                id={`${draft.id}-discovered-models-label`}
-                className={styles.backendFieldLabel}
+        {draft.kind === "pi_sdk" ? (
+          // Pi card uses a stacked, full-width layout (not the 3-col
+          // `backendForm` grid) so provider rows have enough space
+          // for label + description + source pill + buttons without
+          // truncating. Discovered models + manual models become
+          // collapsed disclosures below the provider list.
+          <PiCardBody
+            discoveredModels={discoveredModels}
+            manualModelText={manualModelText}
+            onChangeManualModels={updateModels}
+            onProviderConfigured={refresh}
+          />
+        ) : (
+          <div className={styles.backendForm}>
+            {discoveryBackend && (
+              // Same a11y concern: the Pi variant renders expandable
+              // `<button>` headers, which don't belong inside a `<label>`.
+              // Use a `<div>` + labeled span and connect them via aria.
+              <div
+                className={styles.backendField}
+                role="group"
+                aria-labelledby={`${draft.id}-discovered-models-label`}
               >
-                {t("models_backend_discovered_models")}
-              </span>
-              {draft.kind === "pi_sdk" ? (
-                <PiDiscoveredModelsList models={discoveredModels} />
-              ) : (
+                <span
+                  id={`${draft.id}-discovered-models-label`}
+                  className={styles.backendFieldLabel}
+                >
+                  {t("models_backend_discovered_models")}
+                </span>
                 <div className={styles.modelChipList}>
                   {discoveredModels.length > 0 ? (
                     discoveredModels.map((model) => (
@@ -984,33 +973,33 @@ function BackendCard({
                     <span className={styles.modelChipEmpty}>{t("models_backend_no_discovered_models")}</span>
                   )}
                 </div>
-              )}
-            </div>
-          )}
-          {showManualModels && (
-            <label className={styles.backendField}>
-              <span className={styles.backendFieldLabel}>{t("models_backend_manual_models")}</span>
-              <input
-                className={styles.input}
-                value={manualModelText}
-                placeholder={t("models_backend_manual_models_placeholder")}
-                onChange={(e) => updateModels(e.target.value)}
-              />
-            </label>
-          )}
-          {showSecret && (
-            <label className={styles.backendField}>
-              <span className={styles.backendFieldLabel}>{t("models_backend_secret")}</span>
-              <input
-                className={styles.input}
-                type="password"
-                value={secret}
-                placeholder={draft.has_secret ? t("models_backend_secret_saved") : t("models_backend_secret")}
-                onChange={(e) => setSecret(e.target.value)}
-              />
-            </label>
-          )}
-        </div>
+              </div>
+            )}
+            {showManualModels && (
+              <label className={styles.backendField}>
+                <span className={styles.backendFieldLabel}>{t("models_backend_manual_models")}</span>
+                <input
+                  className={styles.input}
+                  value={manualModelText}
+                  placeholder={t("models_backend_manual_models_placeholder")}
+                  onChange={(e) => updateModels(e.target.value)}
+                />
+              </label>
+            )}
+            {showSecret && (
+              <label className={styles.backendField}>
+                <span className={styles.backendFieldLabel}>{t("models_backend_secret")}</span>
+                <input
+                  className={styles.input}
+                  type="password"
+                  value={secret}
+                  placeholder={draft.has_secret ? t("models_backend_secret_saved") : t("models_backend_secret")}
+                  onChange={(e) => setSecret(e.target.value)}
+                />
+              </label>
+            )}
+          </div>
+        )}
       </div>
       <div className={styles.settingControl}>
         <div className={styles.backendActions}>
@@ -1077,75 +1066,7 @@ function isDiscoveryBackend(backend: AgentBackendConfig) {
   );
 }
 
-function PiDiscoveredModelsList({
-  models,
-}: {
-  models: AgentBackendConfig["discovered_models"];
-}) {
-  const { t } = useTranslation("settings");
-  const groups = useMemo(() => groupPiDiscoveredModels(models), [models]);
-  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
-
-  if (models.length === 0) {
-    return (
-      <div className={styles.modelChipList}>
-        <span className={styles.modelChipEmpty}>
-          {t("models_backend_no_discovered_models")}
-        </span>
-      </div>
-    );
-  }
-
-  function toggle(key: string) {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }
-
-  return (
-    <div className={styles.piDiscoveredList}>
-      <div className={styles.piDiscoveredSummary}>
-        {t("models_backend_pi_discovered_summary", {
-          providers: groups.length,
-          models: models.length,
-          defaultValue: "{{providers}} providers · {{models}} models",
-        })}
-      </div>
-      {groups.map((group) => {
-        const isOpen = expanded.has(group.key);
-        return (
-          <div key={group.key} className={styles.piDiscoveredGroup}>
-            <button
-              type="button"
-              className={styles.piDiscoveredHeader}
-              aria-expanded={isOpen}
-              onClick={() => toggle(group.key)}
-            >
-              <ChevronRight
-                size={12}
-                className={`${styles.piDiscoveredChevron} ${isOpen ? styles.piDiscoveredChevronOpen : ""}`}
-                aria-hidden
-              />
-              <span className={styles.piDiscoveredGroupLabel}>{group.label}</span>
-              <span className={styles.piDiscoveredGroupCount}>
-                {group.models.length}
-              </span>
-            </button>
-            {isOpen && (
-              <div className={styles.piDiscoveredChips}>
-                {group.models.map((model) => (
-                  <span key={model.id} className={styles.modelChip} title={model.id}>
-                    {model.label || model.id}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-        );
-      })}
-    </div>
-  );
-}
+// `PiDiscoveredModelsList` removed — the Pi card's discovered-models
+// view now lives inside `PiCardBody`'s "Available models" disclosure.
+// `groupPiDiscoveredModels` is still used by the chat-side model
+// picker registry (`modelRegistry.ts`) and by `PiCardBody`.

--- a/src/ui/src/services/tauri/piProviders.ts
+++ b/src/ui/src/services/tauri/piProviders.ts
@@ -1,0 +1,124 @@
+// TypeScript bindings for the Pi provider-auth Tauri commands.
+//
+// Kept separate from `agentBackends.ts` so the new surface (six
+// commands + an event channel) doesn't bloat the existing file. The
+// `Event` listener pairs with `pi_oauth_start` to drive the device-code
+// modal — subscribe BEFORE calling `pi_oauth_start` or the very first
+// challenge event can race past you.
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+export type PiProviderKind = "api_key" | "oauth" | "oauth+enterprise" | "env_only";
+
+export interface PiProvider {
+  id: string;
+  label: string;
+  description: string;
+  kind: PiProviderKind;
+  envHint?: string;
+  docsUrl?: string;
+  /** Pi `AuthStatus.source` when present: `"stored"`, `"environment"`,
+   *  `"runtime"`, `"fallback"`, `"models_json_key"`,
+   *  `"models_json_command"`. Undefined when no credential resolves. */
+  authSource?: string;
+  /** `true` iff at least one of this provider's models would be
+   *  returned by Pi's `getAvailable()`. Matches the gate used by
+   *  `discover_models`, so a `configured: true` row means models will
+   *  show up after the next refresh. */
+  configured: boolean;
+  modelCount: number;
+}
+
+export interface PiProviderList {
+  defaultVisibleCount: number;
+  providers: PiProvider[];
+}
+
+export type PiProviderSecretScope = "shared" | "local";
+
+export interface PiOAuthStarted {
+  challengeId: string;
+  providerId: string;
+}
+
+export type PiOAuthEvent =
+  | {
+      type: "oauth_challenge";
+      challengeId: string;
+      providerId: string;
+      /** `"auth"` → display URL + instructions; `"prompt"` → display
+       *  `message` and a text input (e.g. GHES enterprise domain). */
+      kind: "auth" | "prompt";
+      url?: string | null;
+      instructions?: string | null;
+      message?: string | null;
+      placeholder?: string | null;
+      allowEmpty?: boolean;
+    }
+  | {
+      type: "oauth_progress";
+      challengeId: string;
+      providerId: string;
+      message: string;
+    }
+  | {
+      type: "oauth_complete";
+      challengeId: string;
+      providerId: string;
+      ok: boolean;
+      error?: string | null;
+    };
+
+export const PI_OAUTH_EVENT_CHANNEL = "pi://oauth/event";
+
+/** Query Pi for the curated provider list joined with live auth state.
+ *  `workingDir` is used so a workspace-scoped Pi auth (rare) is
+ *  reflected, but the call works with an empty string too. */
+export function piListProviders(workingDir: string): Promise<PiProviderList> {
+  return invoke("pi_list_providers", { workingDir });
+}
+
+export function piSetProviderApiKey(args: {
+  workingDir: string;
+  providerId: string;
+  key: string;
+  scope: PiProviderSecretScope;
+}): Promise<void> {
+  return invoke("pi_set_provider_api_key", args);
+}
+
+export function piClearProviderApiKey(args: {
+  workingDir: string;
+  providerId: string;
+  scope: PiProviderSecretScope;
+}): Promise<void> {
+  return invoke("pi_clear_provider_api_key", args);
+}
+
+export function piOAuthStart(args: {
+  workingDir: string;
+  providerId: string;
+}): Promise<PiOAuthStarted> {
+  return invoke("pi_oauth_start", args);
+}
+
+export function piOAuthSubmitInput(args: {
+  challengeId: string;
+  value: string;
+}): Promise<void> {
+  return invoke("pi_oauth_submit_input", args);
+}
+
+export function piOAuthCancel(challengeId: string): Promise<void> {
+  return invoke("pi_oauth_cancel", { challengeId });
+}
+
+/** Subscribe to the OAuth event stream. Returns an unlisten fn that
+ *  the caller must invoke on unmount; otherwise the listener leaks
+ *  across modal opens. */
+export function listenPiOAuthEvents(
+  handler: (event: PiOAuthEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<PiOAuthEvent>(PI_OAUTH_EVENT_CHANNEL, (e) => handler(e.payload));
+}


### PR DESCRIPTION
## Summary

Closes the long-standing gap where Pi providers (GitHub Copilot, OpenRouter, OpenAI, Anthropic, Gemini, DeepSeek, …) could only be configured by dropping to a terminal and running `pi auth`. Adds full in-app configuration via the **Pi card** in Settings, the `/login` slash command, and a device-code OAuth modal.

- **Investigation result**: detection code was correct all along. Pi's `ModelRegistry.getAvailable()` only surfaces providers that have credentials configured somewhere — and locally I had nothing for Copilot/OpenRouter. The actual gap was *no UI to configure them from inside Claudette*.
- **Curated provider list** (`src-pi-harness/src/curated-providers.ts`): 6 default-visible (Copilot, OpenRouter, OpenAI, Anthropic, Gemini, DeepSeek), 6 disclosure (xAI, Groq, Cerebras, Mistral, Fireworks, OpenCode), 3 cloud env-only (Bedrock, Vertex, Azure OpenAI).
- **Hybrid storage**: API-key dialog defaults to writing `~/.pi/agent/auth.json` (shared with terminal `pi`); a **"Keep this key private to Claudette"** checkbox opts into keychain-only storage under bucket `piProviderSecrets` (env-var injection at harness spawn — invisible to terminal `pi`).
- **OAuth flow**: device-code modal subscribes to `pi://oauth/event`, renders the verification URL + user code with copy/open helpers, forwards GHES enterprise-domain prompts back via `pi_oauth_submit_input`, and closes on `oauth_complete`.
- **`/login` for Pi** now opens the provider picker modal (Pi is multi-provider — unlike Codex/Claude's single-OAuth-flow `/login`).
- **God-file discipline**: harness gained `provider-auth.ts` (separate from `main.ts`); Rust gained `pi_control.rs` (separate from the 1900-line `pi_sdk.rs`); UI added 4 new focused `Pi*` files instead of growing `ModelSettings.tsx`. Largest single new file is 350 LOC.

## Test plan

- [x] `cargo check -p claudette -p claudette-server -p claudette-cli --features pi-sdk --all-targets` with `RUSTFLAGS=-Dwarnings` — clean
- [x] `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --features pi-sdk` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test -p claudette --features pi-sdk` — 1332 pass (6 pre-existing `file_watcher` flakes confirmed on `main`)
- [x] `bunx tsc -b` (src/ui) — clean
- [x] `bun run lint` (src/ui) — no new warnings from Pi files
- [x] `bun run lint:css` — pass
- [x] `bun run test` (src/ui, vitest) — 2527/2533 (6 pre-existing skips)
- [x] Pi harness `bun run typecheck` — clean
- [x] Direct IPC smoke test of `list_providers` against local Pi state — 15 rows returned with correct `configured` / `authSource` / `modelCount`
- [ ] Manual UAT: open Settings → Models → Pi card, configure OpenRouter with both shared and local scopes; verify discovered_models refresh
- [ ] Manual UAT: configure GitHub Copilot OAuth end-to-end; verify GHES enterprise prompt; verify models list populates
- [ ] Manual UAT: select Pi-backed model in chat, run `/login`, verify provider picker modal opens (not Codex/Claude flow)

## Docs

- `site/src/content/docs/features/providers/pi.mdx` — replaced "run `pi auth`" instructions with new in-app flow; documented curated list, storage scope, OAuth modal
- `site/src/content/docs/features/settings.mdx` — added a Pi providers row to the Models settings reference table