### PR TITLE
feat(codex): surface update_plan tasks

### DIFF
--- a/site/src/content/docs/features/task-history.mdx
+++ b/site/src/content/docs/features/task-history.mdx
@@ -1,13 +1,13 @@
 ---
 title: Task History
-description: Review current and previous Claude task lists for a workspace.
+description: Review current and previous agent task lists for a workspace.
 ---
 
-Claude often rewrites its task list as work shifts. Claudette keeps the latest checklist visible while preserving earlier runs in the workspace's **Tasks** tab.
+Agents often rewrite their task list as work shifts. Claudette keeps the latest checklist visible while preserving earlier runs in the workspace's **Tasks** tab.
 
 ## Current Tasks
 
-Open the right sidebar and choose **Tasks**. The **Current** section shows the selected chat session's active task list, including status updates from Claude's task and todo tools.
+Open the right sidebar and choose **Tasks**. The **Current** section shows the selected chat session's active task list, including status updates from Claude's task and todo tools and Codex's `update_plan` snapshots. When Codex includes a plan explanation, Claudette shows it above the checklist.
 
 The tab badge counts every task the panel would surface — the active checklist plus any subagent buckets plus every task across archived history runs — so a workspace with older task lists still signals that there is task context to review.
 
@@ -25,7 +25,7 @@ The right sidebar remembers which tab (**Files**, **Changes**, or **Tasks**) you
 
 ## Historical Runs
 
-When Claude replaces a checklist with a materially different one, Claudette moves the previous checklist into **History**. Runs are grouped by chat session and start collapsed so the current work stays easy to scan.
+When Claude replaces a checklist with a materially different one, Claudette moves the previous checklist into **History**. Codex plan updates are also full snapshots, but status-only updates to the same step list stay in **Current** so normal progress does not flood history; a materially different `update_plan` checklist archives the previous plan run. Runs are grouped by chat session and start collapsed so the current work stays easy to scan.
 
 Each run header shows the run number and completion count. Expand a run to see the final saved checklist snapshot, including completed and pending items. Archived chat sessions are included and labeled so long-running workspace history stays available even after you clean up old tabs.
 

--- a/src/agent/codex_app_server.rs
+++ b/src/agent/codex_app_server.rs
@@ -1792,6 +1792,12 @@ pub fn model_list_from_response(
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct CodexPlanStep {
+    pub step: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum CodexNotificationEvent {
     AgentMessageDelta {
         thread_id: String,
@@ -1833,6 +1839,12 @@ pub enum CodexNotificationEvent {
         thread_id: String,
         turn_id: Option<String>,
         message: String,
+    },
+    TurnPlanUpdated {
+        thread_id: String,
+        turn_id: String,
+        explanation: Option<String>,
+        plan: Vec<CodexPlanStep>,
     },
     ItemStarted {
         thread_id: String,
@@ -2109,6 +2121,37 @@ pub fn decode_notification(notification: JsonRpcNotification) -> CodexNotificati
                 },
             }
         }
+        ("turn/plan/updated", Some(params)) => CodexNotificationEvent::TurnPlanUpdated {
+            thread_id: string_field(params, "threadId"),
+            turn_id: string_field(params, "turnId"),
+            explanation: params
+                .get("explanation")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            plan: params
+                .get("plan")
+                .and_then(Value::as_array)
+                .map(|steps| {
+                    steps
+                        .iter()
+                        .filter_map(|step| {
+                            let label = string_field(step, "step");
+                            if label.is_empty() {
+                                return None;
+                            }
+                            let raw_status = step
+                                .get("status")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default();
+                            Some(CodexPlanStep {
+                                step: label,
+                                status: normalize_codex_plan_status(raw_status),
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+        },
         ("item/started", Some(params)) => CodexNotificationEvent::ItemStarted {
             thread_id: string_field(params, "threadId"),
             turn_id: string_field(params, "turnId"),
@@ -2190,6 +2233,9 @@ pub fn map_notification_to_agent_events(event: CodexNotificationEvent) -> Vec<Ag
                 usage: None,
             })]
         }
+        CodexNotificationEvent::TurnPlanUpdated {
+            explanation, plan, ..
+        } => map_codex_plan_updated_to_agent_events(explanation, plan),
         CodexNotificationEvent::ItemStarted { item, .. } => {
             map_codex_item_started_to_agent_events(&item)
         }
@@ -2207,6 +2253,76 @@ pub fn map_notification_to_agent_events(event: CodexNotificationEvent) -> Vec<Ag
         | CodexNotificationEvent::RateLimitsUpdated { .. }
         | CodexNotificationEvent::Unknown { .. } => Vec::new(),
     }
+}
+
+fn normalize_codex_plan_status(status: &str) -> String {
+    match status {
+        "pending" | "Pending" => "pending".to_string(),
+        "completed" | "Completed" => "completed".to_string(),
+        "in_progress" | "inProgress" | "InProgress" => "in_progress".to_string(),
+        other => {
+            tracing::warn!(
+                target: "claudette::codex",
+                status = %other,
+                "unknown Codex plan step status"
+            );
+            other.to_string()
+        }
+    }
+}
+
+fn map_codex_plan_updated_to_agent_events(
+    explanation: Option<String>,
+    plan: Vec<CodexPlanStep>,
+) -> Vec<AgentEvent> {
+    let tool_use_id = format!("update_plan-{}", uuid::Uuid::new_v4());
+    let input = json!({
+        "explanation": explanation,
+        "plan": plan
+            .iter()
+            .map(|step| json!({
+                "step": step.step,
+                "status": step.status,
+            }))
+            .collect::<Vec<_>>(),
+    });
+    let index = codex_item_index(&tool_use_id);
+
+    vec![
+        AgentEvent::Stream(StreamEvent::Stream {
+            event: InnerStreamEvent::ContentBlockStart {
+                index,
+                content_block: Some(StartContentBlock::ToolUse {
+                    id: tool_use_id.clone(),
+                    name: "update_plan".to_string(),
+                }),
+            },
+        }),
+        AgentEvent::Stream(StreamEvent::Stream {
+            event: InnerStreamEvent::ContentBlockDelta {
+                index,
+                delta: Delta::ToolUse {
+                    partial_json: Some(input.to_string()),
+                },
+            },
+        }),
+        AgentEvent::Stream(StreamEvent::Stream {
+            event: InnerStreamEvent::ContentBlockStop { index },
+        }),
+        AgentEvent::Stream(StreamEvent::User {
+            message: super::UserEventMessage {
+                content: super::UserMessageContent::Blocks(vec![
+                    super::UserContentBlock::ToolResult {
+                        tool_use_id,
+                        content: Value::String("Plan updated".to_string()),
+                    },
+                ]),
+            },
+            uuid: None,
+            is_replay: false,
+            is_synthetic: true,
+        }),
+    ]
 }
 
 fn map_codex_item_started_to_agent_events(item: &Value) -> Vec<AgentEvent> {
@@ -3397,6 +3513,51 @@ mod tests {
     }
 
     #[test]
+    fn parses_turn_plan_updated_notification() {
+        let event = decode_notification(JsonRpcNotification {
+            method: "turn/plan/updated".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "explanation": "Working in phases.",
+                "plan": [
+                    {"step": "Read the issue", "status": "completed"},
+                    {"step": "Patch the bridge", "status": "inProgress"},
+                    {"step": "Validate", "status": "pending"},
+                    {"step": "Handle drift", "status": "cancelled"}
+                ]
+            })),
+        });
+
+        assert_eq!(
+            event,
+            CodexNotificationEvent::TurnPlanUpdated {
+                thread_id: "thread-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                explanation: Some("Working in phases.".to_string()),
+                plan: vec![
+                    CodexPlanStep {
+                        step: "Read the issue".to_string(),
+                        status: "completed".to_string(),
+                    },
+                    CodexPlanStep {
+                        step: "Patch the bridge".to_string(),
+                        status: "in_progress".to_string(),
+                    },
+                    CodexPlanStep {
+                        step: "Validate".to_string(),
+                        status: "pending".to_string(),
+                    },
+                    CodexPlanStep {
+                        step: "Handle drift".to_string(),
+                        status: "cancelled".to_string(),
+                    },
+                ],
+            }
+        );
+    }
+
+    #[test]
     fn maps_token_usage_notification_to_claudette_usage() {
         let event = decode_notification(JsonRpcNotification {
             method: "thread/tokenUsage/updated".to_string(),
@@ -3799,6 +3960,72 @@ mod tests {
             session.interrupt_turn().await.unwrap_err(),
             "Codex app-server has no thread to interrupt"
         );
+    }
+
+    #[test]
+    fn maps_turn_plan_updated_to_update_plan_tool_activity() {
+        let events = map_notification_to_agent_events(CodexNotificationEvent::TurnPlanUpdated {
+            thread_id: "thread-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            explanation: Some("Working in phases.".to_string()),
+            plan: vec![
+                CodexPlanStep {
+                    step: "Read the issue".to_string(),
+                    status: "completed".to_string(),
+                },
+                CodexPlanStep {
+                    step: "Patch the bridge".to_string(),
+                    status: "in_progress".to_string(),
+                },
+            ],
+        });
+
+        assert_eq!(events.len(), 4);
+        let AgentEvent::Stream(StreamEvent::Stream {
+            event:
+                InnerStreamEvent::ContentBlockStart {
+                    content_block: Some(StartContentBlock::ToolUse { id, name }),
+                    ..
+                },
+        }) = &events[0]
+        else {
+            panic!("expected tool-use start");
+        };
+        assert!(id.starts_with("update_plan-"));
+        assert_eq!(name, "update_plan");
+
+        let AgentEvent::Stream(StreamEvent::Stream {
+            event:
+                InnerStreamEvent::ContentBlockDelta {
+                    delta: Delta::ToolUse { partial_json },
+                    ..
+                },
+        }) = &events[1]
+        else {
+            panic!("expected tool-use input");
+        };
+        let input: Value =
+            serde_json::from_str(partial_json.as_deref().expect("plan input")).unwrap();
+        assert_eq!(input["explanation"], "Working in phases.");
+        assert_eq!(input["plan"][0]["step"], "Read the issue");
+        assert_eq!(input["plan"][0]["status"], "completed");
+        assert_eq!(input["plan"][1]["status"], "in_progress");
+
+        let AgentEvent::Stream(StreamEvent::User { message, .. }) = &events[3] else {
+            panic!("expected synthetic tool result");
+        };
+        let crate::agent::UserMessageContent::Blocks(blocks) = &message.content else {
+            panic!("expected tool-result block");
+        };
+        let crate::agent::UserContentBlock::ToolResult {
+            tool_use_id,
+            content,
+        } = &blocks[0]
+        else {
+            panic!("expected tool-result block");
+        };
+        assert_eq!(tool_use_id, id);
+        assert_eq!(content, &Value::String("Plan updated".to_string()));
     }
 
     #[tokio::test]

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -38,7 +38,10 @@ import {
   processActivities,
   turnHasTaskActivity,
 } from "../../hooks/useTaskTracker";
-import type { TaskTrackerResult, TrackedTask } from "../../hooks/useTaskTracker";
+import type {
+  TaskTrackerResult,
+  TrackedTask,
+} from "../../hooks/useTaskTracker";
 import { debugChat } from "../../utils/chatDebug";
 import styles from "./ChatPanel.module.css";
 import { TurnSummary } from "./TurnSummary";
@@ -46,9 +49,7 @@ import { ToolActivityRow } from "./ToolActivityRow";
 import { ToolActivitiesSection } from "./ToolActivitiesSection";
 import { TurnFooter } from "./TurnFooter";
 import { TurnEditSummaryCard } from "./EditChangeSummary";
-import {
-  summarizeTurnEdits,
-} from "./editActivitySummary";
+import { summarizeTurnEdits } from "./editActivitySummary";
 import { PdfThumbnail } from "./PdfThumbnail";
 import { MessageCopyButton } from "./MessageCopyButton";
 import {
@@ -298,7 +299,10 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
         return assistantPositions[safeOrdinal - 1] ?? turn.afterMessageIndex;
       };
 
-      const activitiesByPosition = new Map<number, CompletedTurn["activities"]>();
+      const activitiesByPosition = new Map<
+        number,
+        CompletedTurn["activities"]
+      >();
       for (const activity of turn.activities) {
         const position = positionForOrdinal(activity.assistantMessageOrdinal);
         const existing = activitiesByPosition.get(position);
@@ -348,7 +352,13 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     });
 
     return { groupsByPosition, finalFooterByPosition, positions };
-  }, [completedTurns, findTriggeringUserIdx, globalOffset, messages, toolDisplayMode]);
+  }, [
+    completedTurns,
+    findTriggeringUserIdx,
+    globalOffset,
+    messages,
+    toolDisplayMode,
+  ]);
 
   const completedTurnPositions = chronologicalTurnLayout.positions;
 
@@ -517,7 +527,12 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
       localCompletedTurnPositions,
       checkpoints,
     );
-  }, [checkpoints, localCompletedTurnPositions, messages, rollbackCheckpointByIdx]);
+  }, [
+    checkpoints,
+    localCompletedTurnPositions,
+    messages,
+    rollbackCheckpointByIdx,
+  ]);
 
   const renderPlainTurnFooter = (position: number) => {
     const data = plainTurnFootersByPosition.get(position);
@@ -565,18 +580,38 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     const map = new Map<number, TaskTrackerResult>();
     const taskMap = new Map<string, TrackedTask>();
     const todoMap = new Map<string, TrackedTask>();
+    const planMap = new Map<string, TrackedTask>();
+    const planMeta: { explanation?: string } = {};
     const nextSyntheticId = { value: 1 };
     let anyTasksSoFar = false;
 
     for (let i = 0; i < completedTurns.length; i++) {
-      processActivities(completedTurns[i].activities, taskMap, todoMap, nextSyntheticId);
+      processActivities(
+        completedTurns[i].activities,
+        taskMap,
+        todoMap,
+        nextSyntheticId,
+        planMap,
+        planMeta,
+      );
       if (turnHasTaskActivity(completedTurns[i])) {
         anyTasksSoFar = true;
       }
       if (anyTasksSoFar) {
-        const tasks = [...taskMap.values(), ...todoMap.values()];
-        const completedCount = tasks.filter((task) => task.status === "completed").length;
-        map.set(i, { tasks, completedCount, totalCount: tasks.length });
+        const tasks = [
+          ...taskMap.values(),
+          ...todoMap.values(),
+          ...planMap.values(),
+        ];
+        const completedCount = tasks.filter(
+          (task) => task.status === "completed",
+        ).length;
+        map.set(i, {
+          tasks,
+          completedCount,
+          totalCount: tasks.length,
+          explanation: planMeta.explanation,
+        });
       }
     }
     return map;
@@ -590,97 +625,110 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
       turnLayout: completedTurns.map((turn) => ({
         id: turn.id,
         afterMessageIndex: turn.afterMessageIndex,
-        postLastMessage: turn.afterMessageIndex >= globalOffset + messages.length,
+        postLastMessage:
+          turn.afterMessageIndex >= globalOffset + messages.length,
         toolCount: turn.activities.length,
       })),
     });
   }, [workspaceId, sessionId, messages, completedTurns, globalOffset]);
 
   const renderTurns = (position: number) => {
-    const groupEntries = chronologicalTurnLayout.groupsByPosition[position] ?? [];
-    const footerEntries = chronologicalTurnLayout.finalFooterByPosition[position] ?? [];
+    const groupEntries =
+      chronologicalTurnLayout.groupsByPosition[position] ?? [];
+    const footerEntries =
+      chronologicalTurnLayout.finalFooterByPosition[position] ?? [];
     if (groupEntries.length === 0 && footerEntries.length === 0) return null;
     return (
       <>
-        {groupEntries.map(({ turn, globalIdx, activities, label, kind, showFooter }) => {
-          // Skills aren't tool calls — render the flat "<skill> activated"
-          // marker, never a collapsible TurnSummary. (`showFooter` is
-          // always false for skill groups; see the layout builder.)
-          if (kind === "skill" && activities[0]) {
+        {groupEntries.map(
+          ({ turn, globalIdx, activities, label, kind, showFooter }) => {
+            // Skills aren't tool calls — render the flat "<skill> activated"
+            // marker, never a collapsible TurnSummary. (`showFooter` is
+            // always false for skill groups; see the layout builder.)
+            if (kind === "skill" && activities[0]) {
+              return (
+                <ToolActivityRow
+                  key={`${turn.id}:${position}:skill:${activities[0].toolUseId}`}
+                  activity={activities[0]}
+                  searchQuery={searchQuery}
+                  worktreePath={worktreePath}
+                  inline={toolDisplayMode === "inline"}
+                />
+              );
+            }
+            // A single turn can produce multiple display groups when
+            // chronologically-interleaved messages split its activities;
+            // each group needs its own collapse state so clicking one
+            // chevron doesn't drag every sibling group's expansion with
+            // it.
+            //
+            // The key intentionally drops `turn.id` and matches the live
+            // `GroupedToolActivityRows` key format — see
+            // `collapsedToolGroupKey` for the rationale: the same
+            // activity moves from `toolActivities[sessionId]` into
+            // `completedTurns[sessionId][N].activities` when the turn
+            // ends, but its `toolUseId` is preserved verbatim. Sharing
+            // the key across both surfaces means a user-toggled
+            // expand/collapse choice made while running survives the
+            // turn-end transition.
+            //
+            // When no override has been set yet, fall back to
+            // `turn.collapsed` so the turn-level persisted state still
+            // seeds the initial view of replayed-from-DB completed turns.
+            const groupKey =
+              collapsedToolGroupKey(activities) ??
+              // Synthetic fallback for the (impossible-in-practice)
+              // empty-activities case — keep keys session-unique without
+              // accidentally colliding with a real tool group.
+              `tools:__empty__:${turn.id}`;
+            const userOverride = collapsedToolGroups?.[groupKey];
+            const collapsed = userOverride ?? turn.collapsed;
+            // Single-group turns also flip the legacy `turn.collapsed`
+            // flag so persistence-aware code (Cmd-A "collapse all" etc.)
+            // sees the same state without needing to consult the override
+            // map. Multi-group turns only mutate the per-group override —
+            // touching `turn.collapsed` there would re-create the original
+            // bug.
+            const isSingleGroupTurn =
+              (chronologicalTurnLayout.groupsByPosition[position] ?? []).filter(
+                (g) => g.globalIdx === globalIdx,
+              ).length === 1;
+            const onToggle = () => {
+              const next = !collapsed;
+              setCollapsedToolGroup(sessionId, groupKey, next);
+              if (isSingleGroupTurn && next !== turn.collapsed) {
+                toggleCompletedTurn(sessionId, globalIdx);
+              }
+            };
             return (
-              <ToolActivityRow
-                key={`${turn.id}:${position}:skill:${activities[0].toolUseId}`}
-                activity={activities[0]}
+              <TurnSummary
+                key={`${turn.id}:${position}:${label}:${activities[0]?.toolUseId ?? "empty"}`}
+                turn={turn}
+                activities={activities}
+                label={label}
+                inline={toolDisplayMode === "inline"}
+                showFooter={showFooter}
+                collapsed={collapsed}
+                onToggle={onToggle}
+                taskProgress={
+                  showFooter ? taskProgressByTurn.get(globalIdx) : undefined
+                }
+                assistantText={
+                  showFooter ? (assistantTextByTurnId.get(turn.id) ?? "") : ""
+                }
+                onFork={
+                  showFooter && onForkTurn
+                    ? () => onForkTurn(turn.id)
+                    : undefined
+                }
+                onRollback={showFooter ? buildOnRollback(turn.id) : undefined}
                 searchQuery={searchQuery}
                 worktreePath={worktreePath}
-                inline={toolDisplayMode === "inline"}
+                onOpenEditFile={showFooter ? openFileInMonaco : undefined}
               />
             );
-          }
-          // A single turn can produce multiple display groups when
-          // chronologically-interleaved messages split its activities;
-          // each group needs its own collapse state so clicking one
-          // chevron doesn't drag every sibling group's expansion with
-          // it.
-          //
-          // The key intentionally drops `turn.id` and matches the live
-          // `GroupedToolActivityRows` key format — see
-          // `collapsedToolGroupKey` for the rationale: the same
-          // activity moves from `toolActivities[sessionId]` into
-          // `completedTurns[sessionId][N].activities` when the turn
-          // ends, but its `toolUseId` is preserved verbatim. Sharing
-          // the key across both surfaces means a user-toggled
-          // expand/collapse choice made while running survives the
-          // turn-end transition.
-          //
-          // When no override has been set yet, fall back to
-          // `turn.collapsed` so the turn-level persisted state still
-          // seeds the initial view of replayed-from-DB completed turns.
-          const groupKey =
-            collapsedToolGroupKey(activities) ??
-            // Synthetic fallback for the (impossible-in-practice)
-            // empty-activities case — keep keys session-unique without
-            // accidentally colliding with a real tool group.
-            `tools:__empty__:${turn.id}`;
-          const userOverride = collapsedToolGroups?.[groupKey];
-          const collapsed = userOverride ?? turn.collapsed;
-          // Single-group turns also flip the legacy `turn.collapsed`
-          // flag so persistence-aware code (Cmd-A "collapse all" etc.)
-          // sees the same state without needing to consult the override
-          // map. Multi-group turns only mutate the per-group override —
-          // touching `turn.collapsed` there would re-create the original
-          // bug.
-          const isSingleGroupTurn =
-            (chronologicalTurnLayout.groupsByPosition[position] ?? []).filter(
-              (g) => g.globalIdx === globalIdx,
-            ).length === 1;
-          const onToggle = () => {
-            const next = !collapsed;
-            setCollapsedToolGroup(sessionId, groupKey, next);
-            if (isSingleGroupTurn && next !== turn.collapsed) {
-              toggleCompletedTurn(sessionId, globalIdx);
-            }
-          };
-          return (
-            <TurnSummary
-              key={`${turn.id}:${position}:${label}:${activities[0]?.toolUseId ?? "empty"}`}
-              turn={turn}
-              activities={activities}
-              label={label}
-              inline={toolDisplayMode === "inline"}
-              showFooter={showFooter}
-              collapsed={collapsed}
-              onToggle={onToggle}
-              taskProgress={showFooter ? taskProgressByTurn.get(globalIdx) : undefined}
-              assistantText={showFooter ? (assistantTextByTurnId.get(turn.id) ?? "") : ""}
-              onFork={showFooter && onForkTurn ? () => onForkTurn(turn.id) : undefined}
-              onRollback={showFooter ? buildOnRollback(turn.id) : undefined}
-              searchQuery={searchQuery}
-              worktreePath={worktreePath}
-              onOpenEditFile={showFooter ? openFileInMonaco : undefined}
-            />
-          );
-        })}
+          },
+        )}
         {footerEntries.map(({ turn }) => {
           const turnActivitySummary = editSummaryByTurnId.get(turn.id) ?? null;
           return (
@@ -725,7 +773,8 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   };
 
   const pendingMessageInWindow = useMemo(
-    () => !!pendingMessageId && messages.some((msg) => msg.id === pendingMessageId),
+    () =>
+      !!pendingMessageId && messages.some((msg) => msg.id === pendingMessageId),
     [messages, pendingMessageId],
   );
 
@@ -794,7 +843,9 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
           <React.Fragment key={msg.id}>
             {renderTurns(globalOffset + idx)}
             {renderLiveToolActivity(globalOffset + idx)}
-            {msg.id === pendingMessageId ? streamingMessageNode : (
+            {msg.id === pendingMessageId ? (
+              streamingMessageNode
+            ) : (
               <div
                 className={`${styles.message} ${styles[roleClassKey(msg.role, msg.content)]}${
                   msg.role === "Assistant" && msg.thinking && showThinkingBlocks
@@ -811,14 +862,16 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                     className={styles.userMessageCopyButton}
                   />
                 )}
-                {msg.role === "Assistant" && msg.thinking && showThinkingBlocks && (
-                  <ThinkingBlock
-                    content={msg.thinking}
-                    isStreaming={false}
-                    inline={toolDisplayMode === "inline"}
-                    searchQuery={searchQuery}
-                  />
-                )}
+                {msg.role === "Assistant" &&
+                  msg.thinking &&
+                  showThinkingBlocks && (
+                    <ThinkingBlock
+                      content={msg.thinking}
+                      isStreaming={false}
+                      inline={toolDisplayMode === "inline"}
+                      searchQuery={searchQuery}
+                    />
+                  )}
                 <div className={styles.content}>
                   {attachmentsByMessage.has(msg.id) && (
                     <div className={styles.messageImages}>
@@ -867,7 +920,9 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                             <MessageAttachment
                               key={att.id}
                               attachment={att}
-                              handlers={{ onContextMenu: onAttachmentContextMenu }}
+                              handlers={{
+                                onContextMenu: onAttachmentContextMenu,
+                              }}
                             />
                           );
                         }
@@ -944,7 +999,10 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                     // highlighted text so matches inside them get marked. The
                     // ultrathink rainbow animation is suppressed in this mode —
                     // searchability wins over the easter egg.
-                    <HighlightedPlainText text={msg.content} query={searchQuery} />
+                    <HighlightedPlainText
+                      text={msg.content}
+                      query={searchQuery}
+                    />
                   ) : (
                     renderFileLinkedPlainText(msg.content, {
                       animated: false,

--- a/src/ui/src/components/chat/toolMetadata.ts
+++ b/src/ui/src/components/chat/toolMetadata.ts
@@ -67,6 +67,7 @@ export const TOOL_METADATA: Readonly<Record<string, ToolDisplayMeta>> = {
   Skill: { contentField: "skill" },
   AskUserQuestion: { contentField: "question" },
   TodoWrite: { contentField: "todos" }, // array; renderer falls back to count
+  update_plan: { contentField: "plan" }, // array; renderer falls back to count
   ToolSearch: { contentField: "query" },
   CronCreate: { contentField: "schedule" },
 
@@ -144,7 +145,8 @@ const TOOL_NAME_HEURISTICS: ReadonlyArray<{
 
   // Browser automation / JS evaluation
   {
-    test: (n) => n.startsWith("mcp__") && /__(evaluate|run_code|exec_js)/.test(n),
+    test: (n) =>
+      n.startsWith("mcp__") && /__(evaluate|run_code|exec_js)/.test(n),
     meta: { contentField: "code", contentLang: "javascript" },
   },
 
@@ -161,7 +163,9 @@ const TOOL_NAME_HEURISTICS: ReadonlyArray<{
  * wins; later entries are tie-broken by registry order. If no known
  * field matches, callers fall back to the longest string-valued field.
  */
-const FIELD_NAME_HEURISTICS: ReadonlyArray<[field: string, lang: string | null]> = [
+const FIELD_NAME_HEURISTICS: ReadonlyArray<
+  [field: string, lang: string | null]
+> = [
   ["sql", "sql"],
   ["code", "javascript"],
   ["function", "javascript"],
@@ -228,7 +232,11 @@ export function resolveToolSummary(
   // Layer 1: exact-name registry.
   const exact = TOOL_METADATA[toolName];
   if (exact) {
-    const display = displayFromField(record, exact.contentField, exact.contentLang ?? null);
+    const display = displayFromField(
+      record,
+      exact.contentField,
+      exact.contentLang ?? null,
+    );
     if (display) return display;
   }
 

--- a/src/ui/src/components/right-sidebar/TaskList.module.css
+++ b/src/ui/src/components/right-sidebar/TaskList.module.css
@@ -66,7 +66,8 @@
 }
 
 @keyframes liveDotPulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 0.55;
   }
   50% {
@@ -157,6 +158,13 @@
 
 .runTasks {
   padding-left: 18px;
+}
+
+.explanation {
+  padding: 4px 8px 6px;
+  color: var(--text-muted);
+  font-size: var(--caption-size);
+  line-height: 1.35;
 }
 
 .task {

--- a/src/ui/src/components/right-sidebar/TaskList.test.tsx
+++ b/src/ui/src/components/right-sidebar/TaskList.test.tsx
@@ -192,4 +192,47 @@ describe("TaskList", () => {
 
     expect(container.textContent).toContain("Preserve old checklist");
   });
+
+  it("renders Codex plan explanations for current and historical runs", async () => {
+    const history = taskHistory();
+    history.current = {
+      explanation: "Working through the issue in order.",
+      tasks: [
+        {
+          id: "plan-1",
+          description: "Patch the bridge",
+          status: "in_progress",
+          source: "plan",
+        },
+      ],
+      completedCount: 0,
+      totalCount: 1,
+    };
+    history.sessions[0].runs[0] = {
+      ...history.sessions[0].runs[0],
+      explanation: "Initial plan snapshot.",
+      tasks: [
+        {
+          id: "plan-old-1",
+          description: "Read the issue",
+          status: "completed",
+          source: "plan",
+        },
+      ],
+    };
+
+    const container = await render(<TaskList taskHistory={history} />);
+    expect(container.textContent).toContain(
+      "Working through the issue in order.",
+    );
+
+    const runButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Run 1"),
+    ) as HTMLButtonElement;
+    await act(async () => {
+      runButton.click();
+    });
+
+    expect(container.textContent).toContain("Initial plan snapshot.");
+  });
 });

--- a/src/ui/src/components/right-sidebar/TaskList.tsx
+++ b/src/ui/src/components/right-sidebar/TaskList.tsx
@@ -76,7 +76,10 @@ function TaskRows({ tasks }: { tasks: TrackedTask[] }) {
   return (
     <>
       {tasks.map((task) => (
-        <TaskItem key={`${task.source}-${task.id}-${task.description}`} task={task} />
+        <TaskItem
+          key={`${task.source}-${task.id}-${task.description}`}
+          task={task}
+        />
       ))}
     </>
   );
@@ -132,6 +135,9 @@ function RunSummary({
       </button>
       {expanded && (
         <div className={styles.runTasks}>
+          {run.explanation && (
+            <div className={styles.explanation}>{run.explanation}</div>
+          )}
           <TaskRows tasks={run.tasks} />
         </div>
       )}
@@ -154,7 +160,9 @@ export const TaskList = memo(function TaskList({
   if (!hasCurrent && !hasHistory && !hasSubagents && !hasSiblings) {
     return (
       <div className={styles.list}>
-        <div className={styles.empty}>{loading ? "Loading tasks..." : "No tasks"}</div>
+        <div className={styles.empty}>
+          {loading ? "Loading tasks..." : "No tasks"}
+        </div>
       </div>
     );
   }
@@ -169,14 +177,15 @@ export const TaskList = memo(function TaskList({
               {current.completedCount}/{current.totalCount}
             </span>
           </div>
+          {current.explanation && (
+            <div className={styles.explanation}>{current.explanation}</div>
+          )}
           <TaskRows tasks={current.tasks} />
         </section>
       )}
 
       {hasSubagents &&
-        subagents.map((run) => (
-          <SubagentSection key={run.id} run={run} />
-        ))}
+        subagents.map((run) => <SubagentSection key={run.id} run={run} />)}
 
       {hasSiblings &&
         siblings.map((sibling) => (
@@ -186,7 +195,10 @@ export const TaskList = memo(function TaskList({
             aria-label={`Sibling session: ${sibling.session.name}`}
           >
             <div className={styles.sectionHeader}>
-              <span className={styles.subagentLabel} title={sibling.session.name}>
+              <span
+                className={styles.subagentLabel}
+                title={sibling.session.name}
+              >
                 {sibling.session.name}
                 <span className={styles.liveDot} aria-hidden="true" />
               </span>

--- a/src/ui/src/hooks/useTaskTracker.test.ts
+++ b/src/ui/src/hooks/useTaskTracker.test.ts
@@ -12,7 +12,7 @@ import type { ToolActivity, CompletedTurn } from "../stores/useAppStore";
 function activity(
   toolName: string,
   inputJson: Record<string, unknown>,
-  resultText = ""
+  resultText = "",
 ): ToolActivity {
   return {
     toolUseId: crypto.randomUUID(),
@@ -253,9 +253,7 @@ describe("deriveTasks", () => {
     ];
     const second = [
       activity("TodoWrite", {
-        todos: [
-          { id: "c", content: "Replaced", status: "in_progress" },
-        ],
+        todos: [{ id: "c", content: "Replaced", status: "in_progress" }],
       }),
     ];
     const result = deriveTasks([turn(first)], second);
@@ -283,16 +281,101 @@ describe("deriveTasks", () => {
     expect(result.tasks[1].priority).toBe("low");
   });
 
+  it("handles Codex update_plan snapshots with explanations", () => {
+    const activities = [
+      activity("update_plan", {
+        explanation: "Working through the issue in order.",
+        plan: [
+          { step: "Read the issue", status: "completed" },
+          { step: "Patch the bridge", status: "inProgress" },
+          { step: "Validate", status: "pending" },
+        ],
+      }),
+    ];
+
+    const result = deriveTasks([], activities);
+
+    expect(result.explanation).toBe("Working through the issue in order.");
+    expect(result.tasks).toMatchObject([
+      {
+        description: "Read the issue",
+        status: "completed",
+        source: "plan",
+      },
+      {
+        description: "Patch the bridge",
+        status: "in_progress",
+        source: "plan",
+      },
+      {
+        description: "Validate",
+        status: "pending",
+        source: "plan",
+      },
+    ]);
+  });
+
+  it("treats Codex update_plan as a full snapshot for explanations and ids", () => {
+    const first = turn([
+      activity("update_plan", {
+        explanation: "Initial plan.",
+        plan: [{ id: "ignored-wire-id", step: "Read", status: "completed" }],
+      }),
+    ]);
+    const result = deriveTasks(
+      [first],
+      [
+        activity("update_plan", {
+          plan: [
+            { id: "ignored-wire-id", step: "Validate", status: "pending" },
+          ],
+        }),
+      ],
+    );
+
+    expect(result.explanation).toBeUndefined();
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      id: "_p2",
+      description: "Validate",
+      source: "plan",
+    });
+  });
+
+  it("keeps at most one Codex plan item in progress", () => {
+    const result = deriveTasks(
+      [],
+      [
+        activity("update_plan", {
+          plan: [
+            { step: "First", status: "in_progress" },
+            { step: "Second", status: "inProgress" },
+            { step: "Third", status: "completed" },
+          ],
+        }),
+      ],
+    );
+
+    expect(result.tasks.map((task) => task.status)).toEqual([
+      "in_progress",
+      "pending",
+      "completed",
+    ]);
+  });
+
   it("merges task and todo sources", () => {
     const activities = [
       activity("TaskCreate", { description: "A task" }, '{"task_id": 1}'),
       activity("TodoWrite", {
         todos: [{ id: "t1", content: "A todo", status: "pending" }],
       }),
+      activity("update_plan", {
+        plan: [{ step: "A plan item", status: "pending" }],
+      }),
     ];
     const result = deriveTasks([], activities);
-    expect(result.totalCount).toBe(2);
-    expect(result.tasks.map((t) => t.source)).toEqual(["task", "todo"]);
+    expect(result.totalCount).toBe(3);
+    expect(result.tasks.map((t) => t.source)).toEqual(["task", "todo", "plan"]);
   });
 
   it("processes completed turns before current activities", () => {
@@ -329,19 +412,33 @@ describe("deriveTasks", () => {
   });
 
   it("handles TodoWrite with non-array todos field", () => {
-    const activities = [
-      activity("TodoWrite", { todos: "not-an-array" }),
-    ];
+    const activities = [activity("TodoWrite", { todos: "not-an-array" })];
     const result = deriveTasks([], activities);
     expect(result.totalCount).toBe(0);
   });
 
   it("normalizes various status strings", () => {
     const activities = [
-      activity("TaskCreate", { description: "A", status: "done" }, '{"task_id": 1}'),
-      activity("TaskCreate", { description: "B", status: "started" }, '{"task_id": 2}'),
-      activity("TaskCreate", { description: "C", status: "canceled" }, '{"task_id": 3}'),
-      activity("TaskCreate", { description: "D", status: "running" }, '{"task_id": 4}'),
+      activity(
+        "TaskCreate",
+        { description: "A", status: "done" },
+        '{"task_id": 1}',
+      ),
+      activity(
+        "TaskCreate",
+        { description: "B", status: "started" },
+        '{"task_id": 2}',
+      ),
+      activity(
+        "TaskCreate",
+        { description: "C", status: "canceled" },
+        '{"task_id": 3}',
+      ),
+      activity(
+        "TaskCreate",
+        { description: "D", status: "running" },
+        '{"task_id": 4}',
+      ),
     ];
     const result = deriveTasks([], activities);
     expect(result.tasks[0].status).toBe("completed");
@@ -398,6 +495,144 @@ describe("deriveTaskState", () => {
       "Write release notes",
       "Update screenshots",
     ]);
+  });
+
+  it("archives Codex update_plan only when the checklist is materially replaced", () => {
+    const first = turn([
+      activity("update_plan", {
+        explanation: "Initial pass.",
+        plan: [
+          { step: "Read the issue", status: "completed" },
+          { step: "Patch the bridge", status: "in_progress" },
+        ],
+      }),
+    ]);
+    const second = [
+      activity("update_plan", {
+        explanation: "Validation pass.",
+        plan: [
+          { step: "Write release notes", status: "completed" },
+          { step: "Update screenshots", status: "inProgress" },
+        ],
+      }),
+    ];
+
+    const result = deriveTaskState([first], second);
+
+    expect(result.history).toHaveLength(1);
+    expect(result.history[0]).toMatchObject({
+      explanation: "Initial pass.",
+      completedCount: 1,
+      totalCount: 2,
+    });
+    expect(result.history[0].tasks.map((task) => task.source)).toEqual([
+      "plan",
+      "plan",
+    ]);
+    expect(result.current.explanation).toBe("Validation pass.");
+    expect(result.current.tasks.map((task) => task.description)).toEqual([
+      "Write release notes",
+      "Update screenshots",
+    ]);
+  });
+
+  it("does not archive status-only Codex update_plan updates", () => {
+    const first = turn([
+      activity("update_plan", {
+        explanation: "Initial pass.",
+        plan: [
+          { step: "Inspect fake project", status: "in_progress" },
+          { step: "Draft fake implementation", status: "pending" },
+          { step: "Run fake verification", status: "pending" },
+        ],
+      }),
+    ]);
+    const second = [
+      activity("update_plan", {
+        explanation: "Initial pass.",
+        plan: [
+          { step: "Inspect fake project", status: "completed" },
+          { step: "Draft fake implementation", status: "inProgress" },
+          { step: "Run fake verification", status: "pending" },
+        ],
+      }),
+      activity("update_plan", {
+        explanation: "Initial pass.",
+        plan: [
+          { step: "Inspect fake project", status: "completed" },
+          { step: "Draft fake implementation", status: "completed" },
+          { step: "Run fake verification", status: "completed" },
+        ],
+      }),
+    ];
+
+    const result = deriveTaskState([first], second);
+
+    expect(result.history).toHaveLength(0);
+    expect(result.current).toMatchObject({
+      explanation: "Initial pass.",
+      completedCount: 3,
+      totalCount: 3,
+    });
+    expect(result.current.tasks.map((task) => task.description)).toEqual([
+      "Inspect fake project",
+      "Draft fake implementation",
+      "Run fake verification",
+    ]);
+  });
+
+  it("keeps Claude TodoWrite replacement history independent from Codex plan updates", () => {
+    const first = turn([
+      activity("TodoWrite", {
+        todos: [
+          { content: "Inspect auth flow", status: "completed" },
+          { content: "Patch token refresh", status: "completed" },
+        ],
+      }),
+      activity("update_plan", {
+        plan: [
+          { step: "Inspect fake project", status: "in_progress" },
+          { step: "Draft fake implementation", status: "pending" },
+        ],
+      }),
+    ]);
+    const second = [
+      activity("TodoWrite", {
+        todos: [
+          { content: "Write release notes", status: "in_progress" },
+          { content: "Update screenshots", status: "pending" },
+        ],
+      }),
+      activity("update_plan", {
+        plan: [
+          { step: "Inspect fake project", status: "completed" },
+          { step: "Draft fake implementation", status: "inProgress" },
+        ],
+      }),
+    ];
+
+    const result = deriveTaskState([first], second);
+
+    expect(result.history).toHaveLength(1);
+    expect(result.history[0].tasks.map((task) => task.source)).toEqual([
+      "todo",
+      "todo",
+    ]);
+    expect(result.history[0].tasks.map((task) => task.description)).toEqual([
+      "Inspect auth flow",
+      "Patch token refresh",
+    ]);
+    expect(result.current.tasks.map((task) => task.source)).toEqual([
+      "todo",
+      "todo",
+      "plan",
+      "plan",
+    ]);
+    expect(
+      result.current.tasks
+        .filter((task) => task.source === "plan")
+        .map((task) => task.status),
+    ).toEqual(["completed", "in_progress"]);
   });
 
   it("does not archive status-only TodoWrite updates", () => {
@@ -918,9 +1153,7 @@ describe("deriveTaskState — TaskCreate/TaskUpdate history regression", () => {
     );
 
     expect(result.history).toHaveLength(0);
-    expect(
-      result.current.tasks.map((t) => [t.description, t.status]),
-    ).toEqual([
+    expect(result.current.tasks.map((t) => [t.description, t.status])).toEqual([
       ["A", "completed"],
       ["B", "cancelled"],
       ["C", "pending"],
@@ -998,9 +1231,7 @@ describe("deriveTaskState — TaskCreate/TaskUpdate history regression", () => {
       ],
     });
     const todoReplacement = activity("TodoWrite", {
-      todos: [
-        { content: "fresh todo X", status: "pending" },
-      ],
+      todos: [{ content: "fresh todo X", status: "pending" }],
     });
 
     const result = deriveTaskState(
@@ -1076,7 +1307,10 @@ describe("deriveTaskState — subagent task tracking", () => {
   });
 
   /** Build a parent `Agent` activity wrapping a list of subagent calls. */
-  const agentActivity = (description: string, calls: ReturnType<typeof agentCall>[]) => {
+  const agentActivity = (
+    description: string,
+    calls: ReturnType<typeof agentCall>[],
+  ) => {
     const act = activity("Agent", { prompt: description }, "agent done");
     return {
       ...act,
@@ -1101,7 +1335,9 @@ describe("deriveTaskState — subagent task tracking", () => {
             description: "Cursor-based, page size 25.",
             activeForm: "Adding pagination",
           },
-          response: { task: { id: "9", subject: "Add pagination to /api/sessions" } },
+          response: {
+            task: { id: "9", subject: "Add pagination to /api/sessions" },
+          },
         }),
         agentCall({
           toolName: "TaskCreate",
@@ -1273,7 +1509,9 @@ describe("deriveTaskState — subagent task tracking", () => {
 
     const result = deriveTaskState([], [mainCreate, subagent]);
 
-    expect(result.current.tasks.map((t) => t.description)).toEqual(["Main task"]);
+    expect(result.current.tasks.map((t) => t.description)).toEqual([
+      "Main task",
+    ]);
     expect(result.subagents).toHaveLength(1);
     expect(result.subagents[0].tasks.map((t) => t.description)).toEqual([
       "Subagent task",
@@ -1282,8 +1520,16 @@ describe("deriveTaskState — subagent task tracking", () => {
 
   it("ignores subagent calls that aren't task-related", () => {
     const subagent = agentActivity("Agent E", [
-      agentCall({ toolName: "Bash", agentId: "sub-e", input: { command: "ls" } }),
-      agentCall({ toolName: "Read", agentId: "sub-e", input: { file_path: "/tmp/x" } }),
+      agentCall({
+        toolName: "Bash",
+        agentId: "sub-e",
+        input: { command: "ls" },
+      }),
+      agentCall({
+        toolName: "Read",
+        agentId: "sub-e",
+        input: { file_path: "/tmp/x" },
+      }),
     ]);
     const result = deriveTaskState([], [subagent]);
     // No task tools → no subagent run.

--- a/src/ui/src/hooks/useTaskTracker.ts
+++ b/src/ui/src/hooks/useTaskTracker.ts
@@ -14,13 +14,14 @@ export interface TrackedTask {
   description: string;
   status: TaskStatus;
   priority?: "high" | "medium" | "low";
-  source: "task" | "todo";
+  source: "task" | "todo" | "plan";
 }
 
 export interface TaskTrackerResult {
   tasks: TrackedTask[];
   completedCount: number;
   totalCount: number;
+  explanation?: string;
 }
 
 export interface TaskRun extends TaskTrackerResult {
@@ -95,9 +96,13 @@ const EMPTY_WITH_HISTORY: TaskTrackerWithHistory = {
 /** Normalise status strings from Claude's TaskCreate/TaskUpdate/TodoWrite inputs. */
 function normalizeStatus(raw: string | undefined): TaskStatus {
   if (!raw) return "pending";
-  const s = raw.toLowerCase().replace(/[\s_-]+/g, "_");
+  const s = raw
+    .replace(/([a-z])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .replace(/[\s_-]+/g, "_");
   if (s === "completed" || s === "done") return "completed";
-  if (s === "in_progress" || s === "started" || s === "running") return "in_progress";
+  if (s === "in_progress" || s === "started" || s === "running")
+    return "in_progress";
   if (s === "blocked") return "blocked";
   if (
     s === "cancelled" ||
@@ -152,14 +157,17 @@ export function processActivities(
   activities: ToolActivity[],
   taskMap: Map<string, TrackedTask>,
   todoMap: Map<string, TrackedTask>,
-  nextSyntheticId: { value: number }
+  nextSyntheticId: { value: number },
+  planMap?: Map<string, TrackedTask>,
+  planMeta?: { explanation?: string },
 ) {
   for (const act of activities) {
     if (
       act.toolName !== "TaskCreate" &&
       act.toolName !== "TaskUpdate" &&
       act.toolName !== "TaskStop" &&
-      act.toolName !== "TodoWrite"
+      act.toolName !== "TodoWrite" &&
+      act.toolName !== "update_plan"
     ) {
       continue;
     }
@@ -236,6 +244,22 @@ export function processActivities(
         }
         break;
       }
+      case "update_plan": {
+        if (!planMap) break;
+        const plan = input.plan;
+        if (!Array.isArray(plan)) break;
+        planMap.clear();
+        for (const task of parsePlanTasks(plan, nextSyntheticId)) {
+          planMap.set(task.id, task);
+        }
+        if (planMeta) {
+          planMeta.explanation =
+            typeof input.explanation === "string" && input.explanation.trim()
+              ? input.explanation.trim()
+              : undefined;
+        }
+        break;
+      }
     }
   }
 }
@@ -260,8 +284,34 @@ function parseTodoTasks(
   return tasks;
 }
 
+function parsePlanTasks(
+  plan: unknown[],
+  nextSyntheticId: { value: number },
+): TrackedTask[] {
+  const tasks: TrackedTask[] = [];
+  let hasInProgress = false;
+  for (const item of plan) {
+    if (!item || typeof item !== "object") continue;
+    const raw = item as Record<string, unknown>;
+    const description = String(raw.step ?? "");
+    const id = `_p${nextSyntheticId.value++}`;
+    let status = normalizeStatus(raw.status as string | undefined);
+    if (status === "in_progress") {
+      if (hasInProgress) status = "pending";
+      else hasInProgress = true;
+    }
+    tasks.push({
+      id,
+      description,
+      status,
+      source: "plan",
+    });
+  }
+  return tasks;
+}
+
 function normalizePriority(
-  raw: string | undefined
+  raw: string | undefined,
 ): "high" | "medium" | "low" | undefined {
   if (!raw) return undefined;
   const s = raw.toLowerCase();
@@ -271,19 +321,24 @@ function normalizePriority(
   return undefined;
 }
 
-function taskResult(tasks: TrackedTask[]): TaskTrackerResult {
+function taskResult(
+  tasks: TrackedTask[],
+  explanation?: string,
+): TaskTrackerResult {
   if (tasks.length === 0) return EMPTY_RESULT;
   return {
     tasks,
     completedCount: tasks.filter((t) => t.status === "completed").length,
     totalCount: tasks.length,
+    explanation,
   };
 }
 
-interface TodoRunDraft {
+interface SnapshotRunDraft {
   id: string;
   sequence: number;
   tasks: TrackedTask[];
+  explanation?: string;
   startedAt?: string;
   updatedAt?: string;
   turnId?: string;
@@ -295,13 +350,14 @@ function normalizeTaskContent(value: string): string {
 
 function taskContentSet(tasks: TrackedTask[]): Set<string> {
   return new Set(
-    tasks
-      .map((task) => normalizeTaskContent(task.description))
-      .filter(Boolean),
+    tasks.map((task) => normalizeTaskContent(task.description)).filter(Boolean),
   );
 }
 
-function isReplacedTodoRun(previous: TrackedTask[], next: TrackedTask[]): boolean {
+function isReplacedTodoRun(
+  previous: TrackedTask[],
+  next: TrackedTask[],
+): boolean {
   if (previous.length === 0 || next.length === 0) return false;
 
   const previousSet = taskContentSet(previous);
@@ -321,8 +377,8 @@ function isReplacedTodoRun(previous: TrackedTask[], next: TrackedTask[]): boolea
   return union > 0 && intersection / union < 0.25;
 }
 
-function finalizeTodoRun(run: TodoRunDraft): TaskRun {
-  const result = taskResult(run.tasks);
+function finalizeSnapshotRun(run: SnapshotRunDraft): TaskRun {
+  const result = taskResult(run.tasks, run.explanation);
   return {
     ...result,
     id: run.id,
@@ -358,6 +414,8 @@ function deriveSubagentRunFromActivity(
 
   const taskMap = new Map<string, TrackedTask>();
   const todoMap = new Map<string, TrackedTask>();
+  const planMap = new Map<string, TrackedTask>();
+  const planMeta: { explanation?: string } = {};
 
   for (const call of calls) {
     if (!TASK_TOOL_NAMES.has(call.toolName)) continue;
@@ -433,15 +491,28 @@ function deriveSubagentRunFromActivity(
         }
         break;
       }
+      case "update_plan": {
+        const plan = input.plan;
+        if (!Array.isArray(plan)) break;
+        planMap.clear();
+        for (const task of parsePlanTasks(plan, syntheticIdSeed)) {
+          planMap.set(task.id, task);
+        }
+        planMeta.explanation =
+          typeof input.explanation === "string" && input.explanation.trim()
+            ? input.explanation.trim()
+            : undefined;
+        break;
+      }
     }
   }
 
-  const tasks = [...taskMap.values(), ...todoMap.values()];
+  const tasks = [...taskMap.values(), ...todoMap.values(), ...planMap.values()];
   if (tasks.length === 0) return null;
 
   const { label, tooltip } = formatSubagentLabel(activity);
   return {
-    ...taskResult(tasks),
+    ...taskResult(tasks, planMeta.explanation),
     id: activity.toolUseId,
     // Never render blank: fall back through the activity's own metadata
     // so subagents that arrived without a description still get a chip.
@@ -499,9 +570,11 @@ function deriveTaskStateFromEntries(
 ): TaskTrackerWithHistory {
   const taskMap = new Map<string, TrackedTask>();
   const todoMap = new Map<string, TrackedTask>();
+  const planMap = new Map<string, TrackedTask>();
   const nextSyntheticId = { value: 1 };
   const history: TaskRun[] = [];
-  let todoRun: TodoRunDraft | null = null;
+  let todoRun: SnapshotRunDraft | null = null;
+  let planRun: SnapshotRunDraft | null = null;
   let runSequence = 1;
 
   // Buffer of tasks deleted via `TaskUpdate({ status: "deleted" })` since
@@ -573,6 +646,66 @@ function deriveTaskStateFromEntries(
 
   for (const entry of entries) {
     for (const act of entry.activities) {
+      if (act.toolName === "update_plan") {
+        let input: Record<string, unknown>;
+        try {
+          input = JSON.parse(act.inputJson);
+        } catch {
+          continue;
+        }
+        const plan = input.plan;
+        if (!Array.isArray(plan)) continue;
+
+        const tasks = parsePlanTasks(plan, nextSyntheticId);
+        planMap.clear();
+        for (const task of tasks) {
+          planMap.set(task.id, task);
+        }
+        const explanation =
+          typeof input.explanation === "string" && input.explanation.trim()
+            ? input.explanation.trim()
+            : undefined;
+
+        if (tasks.length === 0) {
+          if (planRun) {
+            history.push(finalizeSnapshotRun(planRun));
+            planRun = null;
+          }
+        } else if (!planRun) {
+          planRun = {
+            id: `plan-run-${runSequence}`,
+            sequence: runSequence++,
+            tasks,
+            explanation,
+            startedAt: act.startedAt,
+            updatedAt: act.startedAt,
+            turnId: entry.turnId,
+          };
+        } else if (isReplacedTodoRun(planRun.tasks, tasks)) {
+          history.push(finalizeSnapshotRun(planRun));
+          planRun = {
+            id: `plan-run-${runSequence}`,
+            sequence: runSequence++,
+            tasks,
+            explanation,
+            startedAt: act.startedAt,
+            updatedAt: act.startedAt,
+            turnId: entry.turnId,
+          };
+        } else {
+          planRun = {
+            id: planRun.id,
+            sequence: planRun.sequence,
+            tasks,
+            explanation,
+            startedAt: planRun.startedAt,
+            updatedAt: act.startedAt ?? planRun.updatedAt,
+            turnId: entry.turnId,
+          };
+        }
+        continue;
+      }
+
       if (act.toolName === "TodoWrite") {
         let input: Record<string, unknown>;
         try {
@@ -591,7 +724,7 @@ function deriveTaskStateFromEntries(
 
         if (tasks.length === 0) {
           if (todoRun) {
-            history.push(finalizeTodoRun(todoRun));
+            history.push(finalizeSnapshotRun(todoRun));
             todoRun = null;
           }
           continue;
@@ -610,7 +743,7 @@ function deriveTaskStateFromEntries(
         }
 
         if (isReplacedTodoRun(todoRun.tasks, tasks)) {
-          history.push(finalizeTodoRun(todoRun));
+          history.push(finalizeSnapshotRun(todoRun));
           todoRun = {
             id: `todo-run-${runSequence}`,
             sequence: runSequence++,
@@ -772,9 +905,11 @@ function deriveTaskStateFromEntries(
     }
   }
 
-  const tasks = [...taskMap.values(), ...todoMap.values()];
   return {
-    current: taskResult(tasks),
+    current: taskResult(
+      [...taskMap.values(), ...todoMap.values(), ...planMap.values()],
+      planRun?.explanation,
+    ),
     history,
     subagents,
   };
@@ -786,19 +921,35 @@ function deriveTaskStateFromEntries(
  */
 export function deriveTasks(
   completedTurns: CompletedTurn[],
-  toolActivities: ToolActivity[]
+  toolActivities: ToolActivity[],
 ): TaskTrackerResult {
   const taskMap = new Map<string, TrackedTask>();
   const todoMap = new Map<string, TrackedTask>();
+  const planMap = new Map<string, TrackedTask>();
   const nextSyntheticId = { value: 1 };
+  const planMeta: { explanation?: string } = {};
 
   for (const turn of completedTurns) {
-    processActivities(turn.activities, taskMap, todoMap, nextSyntheticId);
+    processActivities(
+      turn.activities,
+      taskMap,
+      todoMap,
+      nextSyntheticId,
+      planMap,
+      planMeta,
+    );
   }
-  processActivities(toolActivities, taskMap, todoMap, nextSyntheticId);
+  processActivities(
+    toolActivities,
+    taskMap,
+    todoMap,
+    nextSyntheticId,
+    planMap,
+    planMeta,
+  );
 
-  const tasks = [...taskMap.values(), ...todoMap.values()];
-  return taskResult(tasks);
+  const tasks = [...taskMap.values(), ...todoMap.values(), ...planMap.values()];
+  return taskResult(tasks, planMeta.explanation);
 }
 
 /**
@@ -873,6 +1024,7 @@ const TASK_TOOL_NAMES = new Set([
   "TaskUpdate",
   "TaskStop",
   "TodoWrite",
+  "update_plan",
 ]);
 
 /** Check whether a completed turn contains any task-related tool calls. */
@@ -898,14 +1050,17 @@ export function useTaskTrackerWithHistory(
   sessionId: string | null,
 ): TaskTrackerWithHistory {
   const completedTurns = useAppStore(
-    (s) => (sessionId ? s.completedTurns[sessionId] : null) ?? EMPTY_TURNS
+    (s) => (sessionId ? s.completedTurns[sessionId] : null) ?? EMPTY_TURNS,
   );
   const toolActivities = useAppStore(
-    (s) => (sessionId ? s.toolActivities[sessionId] : null) ?? EMPTY_ACTIVITIES
+    (s) => (sessionId ? s.toolActivities[sessionId] : null) ?? EMPTY_ACTIVITIES,
   );
 
   return useMemo(
-    () => (sessionId ? deriveTaskState(completedTurns, toolActivities) : EMPTY_WITH_HISTORY),
-    [sessionId, completedTurns, toolActivities]
+    () =>
+      sessionId
+        ? deriveTaskState(completedTurns, toolActivities)
+        : EMPTY_WITH_HISTORY,
+    [sessionId, completedTurns, toolActivities],
   );
 }


### PR DESCRIPTION
## Summary

Implements #867 by surfacing native Codex `update_plan` snapshots as first-class task activity in Claudette.

- Decode Codex `turn/plan/updated` notifications in the app-server bridge and synthesize honest `update_plan` tool activity events instead of mislabeling them as Claude `TodoWrite`.
- Teach the task tracker about a new `plan` source, including full-snapshot replacement semantics, Codex plan explanations, at-most-one `in_progress` plan item normalization, and material-replacement history archival. Status-only updates to the same Codex plan stay in Current so normal progress does not create mid-run History entries.
- Carry plan task progress into the chat-side turn progress derivation and the right-sidebar Tasks panel, including explanation text above current and expanded historical plan runs.
- Add `update_plan` tool metadata and update the public Task History docs for Codex behavior.

## Validation

- `nix develop -c cargo fmt --all`
- `nix develop -c cargo test -p claudette codex_app_server -- --nocapture`
- `cd src/ui && bunx vitest run src/hooks/useTaskTracker.test.ts src/components/right-sidebar/TaskList.test.tsx`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run lint:css`
- `cd src/ui && bun run lint` (passes with existing warnings only)
- `git diff --check`
- GitHub PR checks green on commit `4f5865af`

## Notes

The persisted-history path uses Claudette's existing turn tool-activity save flow: each synthesized `update_plan` call is saved with the turn checkpoint and rehydrated like other tool activity. The task-history UI keeps status-only updates in the active plan run and archives only when the checklist is materially replaced.

Closes #867