### PR TITLE
fix(settings): sidebar scrolls under macOS window controls; dialog badge overflow

### DIFF
--- a/src/ui/src/components/modals/ImportWorktreesModal.module.css
+++ b/src/ui/src/components/modals/ImportWorktreesModal.module.css
@@ -87,7 +87,11 @@
   color: var(--text-dim);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  flex-shrink: 0;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .worktreePath {
@@ -106,6 +110,7 @@
   text-transform: none;
   letter-spacing: 0;
   font-variant-numeric: tabular-nums;
+  flex: none;
 }
 
 .deleteButton {

--- a/src/ui/src/components/modals/ImportWorktreesModal.tsx
+++ b/src/ui/src/components/modals/ImportWorktreesModal.tsx
@@ -156,7 +156,7 @@ export function ImportWorktreesModal() {
   }
 
   return (
-    <Modal title={t("import_worktrees_found_title")} onClose={chainOrClose}>
+    <Modal title={t("import_worktrees_found_title")} onClose={chainOrClose} wide>
       <p className={styles.description}>
         {t("import_worktrees_found_desc")}
       </p>

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -30,39 +30,49 @@
   width: 220px;
   flex-shrink: 0;
   border-right: 1px solid var(--divider);
-  padding: 16px 0;
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 [data-platform="mac"] .sidebar {
   background: color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
 }
 
-/* Sticky spacer that covers the macOS traffic-light zone while the
-   sidebar scrolls. padding-top alone would scroll away; a sticky
-   child stays pinned to the top of the scroll viewport. */
-.sidebarTopSpacer {
-  display: none;
+/* Non-scrolling header — lives outside the scrollable nav so macOS
+   elastic-bounce scroll never moves it. On macOS the top padding
+   clears the 38px overlay title bar zone. */
+.sidebarHeader {
+  flex-shrink: 0;
+  padding: 16px 0 8px;
+  border-bottom: 1px solid var(--divider);
 }
 
-[data-platform="mac"] .sidebarTopSpacer {
-  display: block;
-  position: sticky;
-  top: 0;
-  height: 38px;
-  flex-shrink: 0;
-  background: color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
-  z-index: 2;
-  margin: -16px 0 0;
+[data-platform="mac"] .sidebarHeader {
+  padding-top: 38px;
+}
+
+.sidebarTitle {
+  margin: 0;
+  padding: 4px 16px 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.2px;
+}
+
+/* Scrollable nav list below the fixed header. */
+.sidebarNav {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0 16px;
 }
 
 .backLink {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 16px 16px;
+  padding: 4px 16px;
   color: var(--text-dim);
   font-size: 13px;
   cursor: pointer;

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -37,8 +37,25 @@
 }
 
 [data-platform="mac"] .sidebar {
-  padding-top: 38px;
   background: color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
+}
+
+/* Sticky spacer that covers the macOS traffic-light zone while the
+   sidebar scrolls. padding-top alone would scroll away; a sticky
+   child stays pinned to the top of the scroll viewport. */
+.sidebarTopSpacer {
+  display: none;
+}
+
+[data-platform="mac"] .sidebarTopSpacer {
+  display: block;
+  position: sticky;
+  top: 0;
+  height: 38px;
+  flex-shrink: 0;
+  background: color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
+  z-index: 2;
+  margin: -16px 0 0;
 }
 
 .backLink {

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -44,45 +44,54 @@
    clears the 38px overlay title bar zone. */
 .sidebarHeader {
   flex-shrink: 0;
-  padding: 16px 0 8px;
+  display: flex;
+  flex-direction: column;
+  padding: 10px 0 10px;
   border-bottom: 1px solid var(--divider);
 }
 
 [data-platform="mac"] .sidebarHeader {
-  padding-top: 38px;
+  padding-top: 42px;
 }
 
 .sidebarTitle {
   margin: 0;
-  padding: 4px 16px 0;
-  font-size: 18px;
+  padding: 6px 16px 0;
+  font-size: 17px;
   font-weight: 600;
   color: var(--text-primary);
   letter-spacing: -0.2px;
 }
 
-/* Scrollable nav list below the fixed header. */
+/* Scrollable nav list below the fixed header. The JS hook on
+   BoundedScrollPane handles WebKit's elastic gesture; this CSS rule
+   catches the trackpad-flick edge before the wheel listener fires. */
 .sidebarNav {
   flex: 1;
   overflow-y: auto;
+  overscroll-behavior-y: none;
   padding: 8px 0 16px;
 }
 
 .backLink {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 16px;
+  margin: 0 8px 2px;
+  padding: 4px 8px;
+  border-radius: 6px;
   color: var(--text-dim);
-  font-size: 13px;
+  font-size: 12px;
   cursor: pointer;
   border: none;
   background: none;
   text-align: left;
+  align-self: flex-start;
 }
 
 .backLink:hover {
   color: var(--text-primary);
+  background: var(--hover-bg);
 }
 
 .groupLabel {
@@ -146,6 +155,7 @@
 .content {
   flex: 1;
   overflow-y: auto;
+  overscroll-behavior-y: none;
   padding: 32px 48px;
   background: var(--app-bg);
 }

--- a/src/ui/src/components/settings/SettingsPage.tsx
+++ b/src/ui/src/components/settings/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import { SettingsSidebar } from "./SettingsSidebar";
+import { BoundedScrollPane } from "../shared/BoundedScrollPane";
 import styles from "./Settings.module.css";
 
 // Each section is split into its own chunk so cold start doesn't pay for
@@ -120,7 +121,7 @@ export function SettingsPage() {
       <div className={styles.dragRegion} data-tauri-drag-region />
       <SettingsSidebar />
       <div className={styles.contentArea}>
-        <div className={styles.content}>
+        <BoundedScrollPane className={styles.content}>
           <Suspense
             fallback={
               <div
@@ -135,7 +136,7 @@ export function SettingsPage() {
           >
             <SectionContent section={settingsSection} />
           </Suspense>
-        </div>
+        </BoundedScrollPane>
         <div className={styles.attributionBar}>{t("attribution")}</div>
       </div>
     </div>

--- a/src/ui/src/components/settings/SettingsSidebar.tsx
+++ b/src/ui/src/components/settings/SettingsSidebar.tsx
@@ -18,10 +18,12 @@ import {
   Flag,
   Stethoscope,
   HardDrive,
+  ArrowLeft,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import { RepoIcon } from "../shared/RepoIcon";
+import { BoundedScrollPane } from "../shared/BoundedScrollPane";
 import styles from "./Settings.module.css";
 
 export function getAppSections() {
@@ -81,11 +83,12 @@ export function SettingsSidebar() {
     <div className={styles.sidebar}>
       <div className={styles.sidebarHeader}>
         <button className={styles.backLink} onClick={closeSettings}>
-          {t("common:back_to_app")}
+          <ArrowLeft size={13} aria-hidden="true" />
+          <span>{t("common:back_to_app")}</span>
         </button>
         <h2 className={styles.sidebarTitle}>{t("settings:settings_title")}</h2>
       </div>
-      <div className={styles.sidebarNav}>
+      <BoundedScrollPane className={styles.sidebarNav}>
 
       {getAppSections().map((s) => (
         <button
@@ -141,7 +144,7 @@ export function SettingsSidebar() {
           </button>
         );
       })}
-      </div>
+      </BoundedScrollPane>
     </div>
   );
 }

--- a/src/ui/src/components/settings/SettingsSidebar.tsx
+++ b/src/ui/src/components/settings/SettingsSidebar.tsx
@@ -79,6 +79,7 @@ export function SettingsSidebar() {
 
   return (
     <div className={styles.sidebar}>
+      <div className={styles.sidebarTopSpacer} />
       <button className={styles.backLink} onClick={closeSettings}>
         {t("common:back_to_app")}
       </button>

--- a/src/ui/src/components/settings/SettingsSidebar.tsx
+++ b/src/ui/src/components/settings/SettingsSidebar.tsx
@@ -79,10 +79,13 @@ export function SettingsSidebar() {
 
   return (
     <div className={styles.sidebar}>
-      <div className={styles.sidebarTopSpacer} data-tauri-drag-region aria-hidden="true" />
-      <button className={styles.backLink} onClick={closeSettings}>
-        {t("common:back_to_app")}
-      </button>
+      <div className={styles.sidebarHeader}>
+        <button className={styles.backLink} onClick={closeSettings}>
+          {t("common:back_to_app")}
+        </button>
+        <h2 className={styles.sidebarTitle}>{t("settings:settings_title")}</h2>
+      </div>
+      <div className={styles.sidebarNav}>
 
       {getAppSections().map((s) => (
         <button
@@ -138,6 +141,7 @@ export function SettingsSidebar() {
           </button>
         );
       })}
+      </div>
     </div>
   );
 }

--- a/src/ui/src/components/settings/SettingsSidebar.tsx
+++ b/src/ui/src/components/settings/SettingsSidebar.tsx
@@ -79,7 +79,7 @@ export function SettingsSidebar() {
 
   return (
     <div className={styles.sidebar}>
-      <div className={styles.sidebarTopSpacer} />
+      <div className={styles.sidebarTopSpacer} data-tauri-drag-region aria-hidden="true" />
       <button className={styles.backLink} onClick={closeSettings}>
         {t("common:back_to_app")}
       </button>

--- a/src/ui/src/locales/en/common.json
+++ b/src/ui/src/locales/en/common.json
@@ -19,5 +19,5 @@
   "retry": "Retry",
   "skip": "Skip",
   "done": "Done",
-  "back_to_app": "← Back to app"
+  "back_to_app": "Back to app"
 }

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -1,4 +1,5 @@
 {
+  "settings_title": "Settings",
   "nav_general": "General",
   "nav_apps": "Apps",
   "nav_models": "Models",

--- a/src/ui/src/locales/es/common.json
+++ b/src/ui/src/locales/es/common.json
@@ -17,5 +17,5 @@
   "retry": "Reintentar",
   "skip": "Omitir",
   "done": "Listo",
-  "back_to_app": "← Volver a la app"
+  "back_to_app": "Volver a la app"
 }

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -1,4 +1,5 @@
 {
+  "settings_title": "Configuración",
   "nav_general": "General",
   "nav_apps": "Aplicaciones",
   "nav_models": "Modelos",

--- a/src/ui/src/locales/ja/common.json
+++ b/src/ui/src/locales/ja/common.json
@@ -17,5 +17,5 @@
   "retry": "再試行",
   "skip": "スキップ",
   "done": "完了",
-  "back_to_app": "← アプリに戻る"
+  "back_to_app": "アプリに戻る"
 }

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -1,4 +1,5 @@
 {
+  "settings_title": "設定",
   "nav_general": "一般",
   "nav_apps": "アプリ",
   "nav_models": "モデル",

--- a/src/ui/src/locales/pt-BR/common.json
+++ b/src/ui/src/locales/pt-BR/common.json
@@ -17,5 +17,5 @@
   "retry": "Tentar novamente",
   "skip": "Pular",
   "done": "Concluído",
-  "back_to_app": "← Voltar ao app"
+  "back_to_app": "Voltar ao app"
 }

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -1,4 +1,5 @@
 {
+  "settings_title": "Configurações",
   "nav_general": "Geral",
   "nav_apps": "Aplicativos",
   "nav_models": "Modelos",

--- a/src/ui/src/locales/zh-CN/common.json
+++ b/src/ui/src/locales/zh-CN/common.json
@@ -17,5 +17,5 @@
   "retry": "重试",
   "skip": "跳过",
   "done": "完成",
-  "back_to_app": "← 返回应用"
+  "back_to_app": "返回应用"
 }

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -1,4 +1,5 @@
 {
+  "settings_title": "设置",
   "nav_general": "通用",
   "nav_apps": "应用",
   "nav_models": "模型",


### PR DESCRIPTION
## Summary

- **Settings sidebar layout**: rebuilt the sidebar as a non-scrolling header + scrollable nav list. The header contains a subtle back-to-app button and a new "Settings" title; on macOS it gets `padding-top: 42px` to clear the overlay-titlebar traffic-light zone. The nav list lives in a `BoundedScrollPane` so it doesn't elastic-bounce on macOS WKWebView. The original `padding-top: 38px` (which scrolled away with the nav, letting items drift under the traffic lights) is gone.
- **Settings content pane**: also wrapped in `BoundedScrollPane` so the main settings content scrolls the same way as the chat pane and Dashboard.
- **Back link**: now uses a Lucide `ArrowLeft` icon instead of an embedded `←` glyph in the i18n string; the icon aligns cleanly across fonts and locales. The "Back to app" string is updated in all five locales to drop the arrow character.
- **i18n**: new `settings:settings_title` key in all five locales (en/es/ja/pt-BR/zh-CN).
- **Import Worktrees dialog**: Branch-name badges had `flex-shrink: 0` and no overflow handling, causing long names (e.g. `FEAT/BULK-OPERATIONS-OM-LL`) to overflow the card. Badge now uses `flex: 1; min-width: 0; text-overflow: ellipsis` to fill available space and truncate cleanly. Size badge keeps `flex: none` to stay at its natural width. Dialog card upgraded to `wide` (640 px) for more horizontal room.

## Why the approach changed mid-PR

The first commit used `position: sticky; top: 0` on a spacer child to cover the traffic-light zone. Two problems surfaced in follow-ups:
1. The spacer had `z-index: 2` and silently blocked the parent `dragRegion` (z-index: 1) from receiving drags. Adding `data-tauri-drag-region` to the spacer fixed that.
2. `position: sticky` is relative to the scroll container, so when macOS rubber-banded the sidebar during elastic bounce, the sticky element moved with it. The fix was to move the header *out* of the scroll container entirely (fixed header + scrollable nav), and lean on the existing `BoundedScrollPane` (which the codebase already uses for `ChatPanel` and `Dashboard`) to suppress elastic scroll via the `usePreventScrollBounce` hook + `overscroll-behavior-y: none`.

## Test Steps

1. Open Settings on macOS.
2. Confirm the sidebar header shows a small "← Back to app" button and a bold "Settings" title, both fully visible (not under traffic lights).
3. Scroll the sidebar nav down — header stays fixed; nav stops at edges with no elastic bounce.
4. Scroll the main settings content (right pane) — also no elastic bounce.
5. Drag the window from the top-left sidebar zone (above the back button) — window drags as expected.
6. Add a repository with many git worktrees (or trigger the "Existing worktrees found" dialog with long branch names, e.g. `feat/bulk-operations-om-ll`).
7. Confirm the branch-name badge truncates with `…` rather than overflowing the card.
8. Confirm the size badge (e.g. "66.4 MiB") still renders at its natural width.

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)