### PR TITLE
feat(files): reveal active editor file in tree

### DIFF
--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -130,6 +130,8 @@ curl -X POST "$SLACK_WEBHOOK_URL" \
 | Setting | Description | Default |
 |---------|-------------|---------|
 | Git gutter base | Which revision the editor's git gutter compares your buffer against. `Last commit (HEAD)` shows uncommitted changes only; `Workspace branch base` shows every change made on this workspace's branch since it diverged from the repository's base branch (matches the [Changes panel](/claudette/features/diff-viewer/)). | Last commit (HEAD) |
+| Show minimap | Displays Monaco's scaled-down file overview along the right edge of the editor. | Off |
+| Reveal active file in Files tree | Auto-expands ancestor folders, highlights the active editor file, and scrolls it into view in the Files tree. | On |
 
 ### Git Gutter Base
 

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -82,6 +82,9 @@ function App() {
   const setExtendedToolCallOutput = useAppStore((s) => s.setExtendedToolCallOutput);
   const setEditorGitGutterBase = useAppStore((s) => s.setEditorGitGutterBase);
   const setEditorMinimapEnabled = useAppStore((s) => s.setEditorMinimapEnabled);
+  const setRevealActiveFileInTree = useAppStore(
+    (s) => s.setRevealActiveFileInTree,
+  );
   const setEditorWordWrap = useAppStore((s) => s.setEditorWordWrap);
   const setEditorLineNumbersEnabled = useAppStore(
     (s) => s.setEditorLineNumbersEnabled,
@@ -489,6 +492,9 @@ function App() {
       .catch(() => {});
     getAppSetting("editor_minimap_enabled")
       .then((val) => { if (val === "true") setEditorMinimapEnabled(true); })
+      .catch(() => {});
+    getAppSetting("editor_reveal_active_file_in_tree")
+      .then((val) => { if (val === "false") setRevealActiveFileInTree(false); })
       .catch(() => {});
     // Editor view-state mirrors the minimap pattern: stored as strings
     // in app_settings, hydrated once at boot. Word wrap and line numbers
@@ -946,7 +952,7 @@ function App() {
       unlistenMissingCli.then((fn) => fn());
       unlistenMissingWorktree.then((fn) => fn());
     };
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultTerminalAppId, setWorkspaceAppsMenuShown, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setShowOpenRouterBalanceInUsageMeter, setOpenRouterBalanceSettingLoaded, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setToolDisplayMode, setExtendedToolCallOutput, setAlternativeBackendsAvailable, setPiSdkAvailable, setAlternativeBackendsEnabled, setCodexEnabled, setAgentBackends, setDefaultAgentBackendId, setClaudeAuthMethod, setEditorGitGutterBase, setEditorMinimapEnabled, setEditorWordWrap, setEditorLineNumbersEnabled, setEditorFontZoom, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings, setManualWorkspaceOrderByRepo]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultTerminalAppId, setWorkspaceAppsMenuShown, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setShowOpenRouterBalanceInUsageMeter, setOpenRouterBalanceSettingLoaded, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setToolDisplayMode, setExtendedToolCallOutput, setAlternativeBackendsAvailable, setPiSdkAvailable, setAlternativeBackendsEnabled, setCodexEnabled, setAgentBackends, setDefaultAgentBackendId, setClaudeAuthMethod, setEditorGitGutterBase, setEditorMinimapEnabled, setRevealActiveFileInTree, setEditorWordWrap, setEditorLineNumbersEnabled, setEditorFontZoom, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings, setManualWorkspaceOrderByRepo]);
 
   // Live freshness for LM Studio's `loaded_context_length`.
   //

--- a/src/ui/src/components/files/FileTree.active.test.tsx
+++ b/src/ui/src/components/files/FileTree.active.test.tsx
@@ -17,8 +17,32 @@ const entries: FileEntry[] = [
 const roots: Root[] = [];
 const containers: HTMLElement[] = [];
 const scrolledRows: string[] = [];
+const originalScrollIntoView = Element.prototype.scrollIntoView;
 
-async function renderTree(activeFilePath: string | null): Promise<HTMLElement> {
+function treeNode(activeFilePath: string | null, treeEntries = entries) {
+  return (
+    <FileTree
+      workspaceId={WS}
+      entries={treeEntries}
+      activeFilePath={activeFilePath}
+      onActivateFile={() => {}}
+      onActivateDiff={() => {}}
+      onContextMenu={() => {}}
+      creatingParentPath={null}
+      onCreateCommit={() => Promise.resolve(true)}
+      onCreateCancel={() => {}}
+      focusRequest={0}
+      renamingPath={null}
+      onRenameCommit={() => Promise.resolve(true)}
+      onRenameCancel={() => {}}
+    />
+  );
+}
+
+async function renderTree(activeFilePath: string | null): Promise<{
+  container: HTMLElement;
+  root: Root;
+}> {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -26,35 +50,19 @@ async function renderTree(activeFilePath: string | null): Promise<HTMLElement> {
   containers.push(container);
 
   await act(async () => {
-    root.render(
-      <FileTree
-        workspaceId={WS}
-        entries={entries}
-        activeFilePath={activeFilePath}
-        onActivateFile={() => {}}
-        onActivateDiff={() => {}}
-        onContextMenu={() => {}}
-        creatingParentPath={null}
-        onCreateCommit={() => Promise.resolve(true)}
-        onCreateCancel={() => {}}
-        focusRequest={0}
-        renamingPath={null}
-        onRenameCommit={() => Promise.resolve(true)}
-        onRenameCancel={() => {}}
-      />,
-    );
+    root.render(treeNode(activeFilePath));
   });
 
-  return container;
+  return { container, root };
 }
 
 beforeEach(() => {
   scrolledRows.length = 0;
-  Element.prototype.scrollIntoView = vi.fn(function (
-    this: Element,
-    _options?: ScrollIntoViewOptions,
-  ) {
-    scrolledRows.push(this.textContent ?? "");
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(function (this: Element, _options?: ScrollIntoViewOptions) {
+      scrolledRows.push(this.textContent ?? "");
+    }),
   });
   useAppStore.setState({
     allFilesExpandedDirsByWorkspace: {
@@ -69,11 +77,15 @@ afterEach(async () => {
     await act(async () => root.unmount());
   }
   for (const container of containers.splice(0)) container.remove();
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    configurable: true,
+    value: originalScrollIntoView,
+  });
 });
 
 describe("FileTree active file reveal", () => {
   it("marks the active file row and scrolls it into view", async () => {
-    const container = await renderTree("src/foo/bar.rs");
+    const { container } = await renderTree("src/foo/bar.rs");
 
     const activeRow = container.querySelector('[aria-current="true"]');
     expect(activeRow?.textContent).toContain("bar.rs");
@@ -84,5 +96,22 @@ describe("FileTree active file reveal", () => {
     ).map((row) => row.textContent ?? "");
     expect(expandedRows.some((row) => row.includes("src"))).toBe(true);
     expect(expandedRows.some((row) => row.includes("foo"))).toBe(true);
+  });
+
+  it("does not re-scroll the same active file on routine tree refreshes", async () => {
+    const { root } = await renderTree("src/foo/bar.rs");
+    expect(scrolledRows.some((row) => row.includes("bar.rs"))).toBe(true);
+    scrolledRows.length = 0;
+
+    await act(async () => {
+      root.render(
+        treeNode("src/foo/bar.rs", [
+          ...entries,
+          { path: "src/foo/qux.rs", is_directory: false },
+        ]),
+      );
+    });
+
+    expect(scrolledRows).toEqual([]);
   });
 });

--- a/src/ui/src/components/files/FileTree.active.test.tsx
+++ b/src/ui/src/components/files/FileTree.active.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "../../stores/useAppStore";
+import type { FileEntry } from "../../services/tauri";
+import { FileTree } from "./FileTree";
+
+const WS = "file-tree-active-ws";
+
+const entries: FileEntry[] = [
+  { path: "src/foo/bar.rs", is_directory: false },
+  { path: "src/foo/baz.rs", is_directory: false },
+];
+
+const roots: Root[] = [];
+const containers: HTMLElement[] = [];
+const scrolledRows: string[] = [];
+
+async function renderTree(activeFilePath: string | null): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  containers.push(container);
+
+  await act(async () => {
+    root.render(
+      <FileTree
+        workspaceId={WS}
+        entries={entries}
+        activeFilePath={activeFilePath}
+        onActivateFile={() => {}}
+        onActivateDiff={() => {}}
+        onContextMenu={() => {}}
+        creatingParentPath={null}
+        onCreateCommit={() => Promise.resolve(true)}
+        onCreateCancel={() => {}}
+        focusRequest={0}
+        renamingPath={null}
+        onRenameCommit={() => Promise.resolve(true)}
+        onRenameCancel={() => {}}
+      />,
+    );
+  });
+
+  return container;
+}
+
+beforeEach(() => {
+  scrolledRows.length = 0;
+  Element.prototype.scrollIntoView = vi.fn(function (
+    this: Element,
+    _options?: ScrollIntoViewOptions,
+  ) {
+    scrolledRows.push(this.textContent ?? "");
+  });
+  useAppStore.setState({
+    allFilesExpandedDirsByWorkspace: {
+      [WS]: { "src/": true, "src/foo/": true },
+    },
+    allFilesSelectedPathByWorkspace: {},
+  });
+});
+
+afterEach(async () => {
+  for (const root of roots.splice(0).reverse()) {
+    await act(async () => root.unmount());
+  }
+  for (const container of containers.splice(0)) container.remove();
+});
+
+describe("FileTree active file reveal", () => {
+  it("marks the active file row and scrolls it into view", async () => {
+    const container = await renderTree("src/foo/bar.rs");
+
+    const activeRow = container.querySelector('[aria-current="true"]');
+    expect(activeRow?.textContent).toContain("bar.rs");
+    expect(scrolledRows.some((row) => row.includes("bar.rs"))).toBe(true);
+
+    const expandedRows = Array.from(
+      container.querySelectorAll('[aria-expanded="true"]'),
+    ).map((row) => row.textContent ?? "");
+    expect(expandedRows.some((row) => row.includes("src"))).toBe(true);
+    expect(expandedRows.some((row) => row.includes("foo"))).toBe(true);
+  });
+});

--- a/src/ui/src/components/files/FileTree.module.css
+++ b/src/ui/src/components/files/FileTree.module.css
@@ -46,6 +46,12 @@
   color: var(--text-primary);
 }
 
+.rowActive {
+  background: var(--selected-bg);
+  box-shadow: inset 2px 0 0 var(--accent-primary);
+  color: var(--text-primary);
+}
+
 .rowDeleted .name {
   text-decoration: line-through;
   text-decoration-color: var(--diff-removed-text);
@@ -72,7 +78,9 @@
 }
 
 .rowSelected .icon,
-.rowSelected .chevron {
+.rowSelected .chevron,
+.rowActive .icon,
+.rowActive .chevron {
   color: var(--text-muted);
 }
 

--- a/src/ui/src/components/files/FileTree.tsx
+++ b/src/ui/src/components/files/FileTree.tsx
@@ -36,6 +36,7 @@ interface FileTreeProps {
    *  from one repo onto another. */
   workspaceId: string;
   entries: FileEntry[];
+  activeFilePath: string | null;
   /** Called when the user activates a file row (click / Enter / Space).
    *  The parent decides whether to actually open it (e.g. it may show a
    *  discard-changes modal first if there are unsaved changes). */
@@ -59,6 +60,7 @@ const EMPTY_EXPANDED: Record<string, boolean> = {};
 export const FileTree = memo(function FileTree({
   workspaceId,
   entries,
+  activeFilePath,
   onActivateFile,
   onActivateDiff,
   onContextMenu,
@@ -139,6 +141,13 @@ export const FileTree = memo(function FileTree({
       el.focus();
     }
   }, [focusedPath]);
+
+  useEffect(() => {
+    if (!activeFilePath) return;
+    const el = rowRefsRef.current.get(activeFilePath);
+    if (!el) return;
+    el.scrollIntoView({ block: "nearest" });
+  }, [activeFilePath, visible]);
 
   useEffect(() => {
     const previous = previousRenamingPathRef.current;
@@ -296,6 +305,8 @@ export const FileTree = memo(function FileTree({
       {visible.map(({ node, depth }, idx) => {
         const showCreateAfter =
           creatingParentPath !== null && createRowIndex === idx + 1;
+        const isActiveFile =
+          node.kind === "file" && activeFilePath === node.path;
         return (
           <Fragment key={node.path}>
             <Row
@@ -303,6 +314,7 @@ export const FileTree = memo(function FileTree({
               depth={depth}
               expanded={node.kind === "dir" ? !!expanded[node.path] : false}
               selected={selected === node.path}
+              active={isActiveFile}
               renaming={renamingPath === node.path}
               isLight={isLight}
               // Roving tabindex: exactly one row in the tree is in the tab
@@ -421,6 +433,7 @@ interface RowProps {
   depth: number;
   expanded: boolean;
   selected: boolean;
+  active: boolean;
   renaming: boolean;
   tabbable: boolean;
   isLight: boolean;
@@ -436,6 +449,7 @@ function Row({
   depth,
   expanded,
   selected,
+  active,
   renaming,
   tabbable,
   isLight,
@@ -467,6 +481,7 @@ function Row({
   const rowClassName = [
     styles.row,
     selected ? styles.rowSelected : "",
+    active ? styles.rowActive : "",
     status === "Deleted" ? styles.rowDeleted : "",
     tintStatus ? styles.rowStatusTinted : "",
   ]
@@ -491,6 +506,7 @@ function Row({
       role="treeitem"
       tabIndex={tabbable ? 0 : -1}
       aria-selected={selected}
+      aria-current={active ? "true" : undefined}
       // WAI-ARIA tree levels are 1-indexed; root rows are level 1.
       aria-level={depth + 1}
       // Per the spec, `aria-expanded` is meaningful only on rows that have

--- a/src/ui/src/components/files/FileTree.tsx
+++ b/src/ui/src/components/files/FileTree.tsx
@@ -112,6 +112,7 @@ export const FileTree = memo(function FileTree({
   // move focus on keyboard navigation — the WAI-ARIA tree pattern requires
   // focus to follow the selection so the screen reader announces the row.
   const rowRefsRef = useRef<Map<string, HTMLDivElement>>(new Map());
+  const scrolledActivePathRef = useRef<string | null>(null);
 
   /** The row that should currently be in the tab order (roving tabindex).
    *  Falls back to the first visible row when no row is selected, so the
@@ -144,9 +145,11 @@ export const FileTree = memo(function FileTree({
 
   useEffect(() => {
     if (!activeFilePath) return;
+    if (scrolledActivePathRef.current === activeFilePath) return;
     const el = rowRefsRef.current.get(activeFilePath);
     if (!el) return;
     el.scrollIntoView({ block: "nearest" });
+    scrolledActivePathRef.current = activeFilePath;
   }, [activeFilePath, visible]);
 
   useEffect(() => {

--- a/src/ui/src/components/files/FilesPanel.tsx
+++ b/src/ui/src/components/files/FilesPanel.tsx
@@ -60,6 +60,13 @@ export function FilesPanel() {
   const openDiffTab = useAppStore((s) => s.openDiffTab);
   const setDiffSelectedCommitHash = useAppStore((s) => s.setDiffSelectedCommitHash);
   const setAllFilesDirExpanded = useAppStore((s) => s.setAllFilesDirExpanded);
+  const revealFileInTree = useAppStore((s) => s.revealFileInTree);
+  const revealActiveFileInTree = useAppStore((s) => s.revealActiveFileInTree);
+  const activeFilePath = useAppStore((s) =>
+    selectedWorkspaceId
+      ? (s.activeFileTabByWorkspace[selectedWorkspaceId] ?? null)
+      : null,
+  );
   const keybindings = useAppStore((s) => s.keybindings);
 
   const [entries, setEntries] = useState<FileEntry[]>([]);
@@ -215,6 +222,16 @@ export function FilesPanel() {
     return () => clearInterval(interval);
   }, [isRunning, selectedWorkspaceId, refreshNonce, loadFiles, isPendingPlaceholder]);
 
+  useEffect(() => {
+    if (!selectedWorkspaceId || !activeFilePath || !revealActiveFileInTree) return;
+    revealFileInTree(selectedWorkspaceId, activeFilePath);
+  }, [
+    activeFilePath,
+    revealActiveFileInTree,
+    revealFileInTree,
+    selectedWorkspaceId,
+  ]);
+
   // React to the `requestNewFileAtRoot` nonce: open the inline create
   // editor at the workspace root.
   //
@@ -300,6 +317,7 @@ export function FilesPanel() {
           <FileTree
             workspaceId={selectedWorkspaceId}
             entries={entries}
+            activeFilePath={revealActiveFileInTree ? activeFilePath : null}
             onActivateFile={handleActivateFile}
             onActivateDiff={handleActivateDiff}
             onContextMenu={(target, x, y) => setContextMenu({ target, x, y })}

--- a/src/ui/src/components/settings/sections/EditorSettings.tsx
+++ b/src/ui/src/components/settings/sections/EditorSettings.tsx
@@ -12,6 +12,10 @@ export function EditorSettings() {
   const setEditorGitGutterBase = useAppStore((s) => s.setEditorGitGutterBase);
   const minimapEnabled = useAppStore((s) => s.editorMinimapEnabled);
   const setMinimapEnabled = useAppStore((s) => s.setEditorMinimapEnabled);
+  const revealActiveFileInTree = useAppStore((s) => s.revealActiveFileInTree);
+  const setRevealActiveFileInTree = useAppStore(
+    (s) => s.setRevealActiveFileInTree,
+  );
   const [error, setError] = useState<string | null>(null);
   // Lock controls while a persistence write is in flight. Without this,
   // a rapid sequence whose writes reject in interleaved order would have
@@ -47,6 +51,25 @@ export function EditorSettings() {
       await setAppSetting("editor_minimap_enabled", next ? "true" : "false");
     } catch (e) {
       setMinimapEnabled(!next);
+      setError(String(e));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const handleRevealActiveFileToggle = async () => {
+    if (pending) return;
+    const next = !revealActiveFileInTree;
+    setRevealActiveFileInTree(next);
+    setPending(true);
+    try {
+      setError(null);
+      await setAppSetting(
+        "editor_reveal_active_file_in_tree",
+        next ? "true" : "false",
+      );
+    } catch (e) {
+      setRevealActiveFileInTree(!next);
       setError(String(e));
     } finally {
       setPending(false);
@@ -115,6 +138,31 @@ export function EditorSettings() {
             data-checked={minimapEnabled}
             disabled={pending}
             onClick={handleMinimapToggle}
+          >
+            <div className={styles.toggleKnob} />
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>
+            {t("editor_reveal_active_file_label")}
+          </div>
+          <div className={styles.settingDescription}>
+            {t("editor_reveal_active_file_desc")}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.toggle}
+            role="switch"
+            aria-checked={revealActiveFileInTree}
+            aria-label={t("editor_reveal_active_file_label")}
+            aria-disabled={pending}
+            data-checked={revealActiveFileInTree}
+            disabled={pending}
+            onClick={handleRevealActiveFileToggle}
           >
             <div className={styles.toggleKnob} />
           </button>

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -288,6 +288,8 @@
   "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
   "editor_minimap_label": "Show minimap",
   "editor_minimap_desc": "Display Monaco's scaled-down overview of the file along the right edge of the editor.",
+  "editor_reveal_active_file_label": "Reveal active file in Files tree",
+  "editor_reveal_active_file_desc": "Auto-expand, highlight, and scroll to the active editor file in the Files tree.",
 
   "nav_diagnostics": "Diagnostics",
   "nav_storage": "Storage",

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -234,6 +234,8 @@
   "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
   "editor_minimap_label": "Show minimap",
   "editor_minimap_desc": "Display Monaco's scaled-down overview of the file along the right edge of the editor.",
+  "editor_reveal_active_file_label": "Reveal active file in Files tree",
+  "editor_reveal_active_file_desc": "Auto-expand, highlight, and scroll to the active editor file in the Files tree.",
   "git_title": "Git",
   "git_branch_prefix": "Prefijo del nombre de la rama",
   "git_branch_prefix_desc": "Prefijo para los nombres de las ramas de los nuevos espacios de trabajo.",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -234,6 +234,8 @@
   "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
   "editor_minimap_label": "Show minimap",
   "editor_minimap_desc": "Display Monaco's scaled-down overview of the file along the right edge of the editor.",
+  "editor_reveal_active_file_label": "Reveal active file in Files tree",
+  "editor_reveal_active_file_desc": "Auto-expand, highlight, and scroll to the active editor file in the Files tree.",
   "git_title": "Git",
   "git_branch_prefix": "ブランチ名のプレフィックス",
   "git_branch_prefix_desc": "新しいワークスペースのブランチ名に付けるプレフィックスです。",

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -234,6 +234,8 @@
   "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
   "editor_minimap_label": "Show minimap",
   "editor_minimap_desc": "Display Monaco's scaled-down overview of the file along the right edge of the editor.",
+  "editor_reveal_active_file_label": "Reveal active file in Files tree",
+  "editor_reveal_active_file_desc": "Auto-expand, highlight, and scroll to the active editor file in the Files tree.",
   "git_title": "Git",
   "git_branch_prefix": "Prefixo do nome da branch",
   "git_branch_prefix_desc": "Prefixo para nomes de branch de novos workspaces.",

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -234,6 +234,8 @@
   "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
   "editor_minimap_label": "Show minimap",
   "editor_minimap_desc": "Display Monaco's scaled-down overview of the file along the right edge of the editor.",
+  "editor_reveal_active_file_label": "Reveal active file in Files tree",
+  "editor_reveal_active_file_desc": "Auto-expand, highlight, and scroll to the active editor file in the Files tree.",
   "git_title": "Git",
   "git_branch_prefix": "分支名称前缀",
   "git_branch_prefix_desc": "新工作区分支名称的前缀。",

--- a/src/ui/src/stores/slices/fileTreeSlice.ts
+++ b/src/ui/src/stores/slices/fileTreeSlice.ts
@@ -141,6 +141,53 @@ export function pathMatchesTarget(
   return cleanPath === cleanTarget || cleanPath.startsWith(`${cleanTarget}/`);
 }
 
+export function getRevealAncestorDirs(path: string): string[] {
+  if (
+    path === "" ||
+    path.startsWith("/") ||
+    path.startsWith("~") ||
+    path.includes("\\")
+  ) {
+    return [];
+  }
+
+  const segments = path.split("/");
+  if (
+    segments.length < 2 ||
+    segments.some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    return [];
+  }
+
+  segments.pop();
+  const dirs: string[] = [];
+  let current = "";
+  for (const segment of segments) {
+    current = `${current}${segment}/`;
+    dirs.push(current);
+  }
+  return dirs;
+}
+
+function revealExpandedDirs(
+  expandedByWorkspace: Record<string, Record<string, boolean>>,
+  workspaceId: string,
+  path: string,
+): Record<string, Record<string, boolean>> {
+  const dirs = getRevealAncestorDirs(path);
+  if (dirs.length === 0) return expandedByWorkspace;
+
+  const current = expandedByWorkspace[workspaceId] ?? {};
+  if (dirs.every((dir) => current[dir])) return expandedByWorkspace;
+
+  const next = { ...current };
+  for (const dir of dirs) next[dir] = true;
+  return {
+    ...expandedByWorkspace,
+    [workspaceId]: next,
+  };
+}
+
 export interface FileTreeSlice {
   /** Per-workspace map of folder paths (with trailing "/") that are
    *  expanded in the All-Files tree. Scoped per workspace so two repos
@@ -192,6 +239,7 @@ export interface FileTreeSlice {
     workspaceId: string,
     path: string | null,
   ) => void;
+  revealFileInTree: (workspaceId: string, path: string) => void;
   requestFileTreeRefresh: (workspaceId: string) => void;
   /** Ask the FilesPanel for `workspaceId` to enter "create file at root"
    *  mode. The hotkey handler also flips the right sidebar to the Files
@@ -380,6 +428,17 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
         [workspaceId]: path,
       },
     })),
+  revealFileInTree: (workspaceId, path) =>
+    set((s) => {
+      if (!s.revealActiveFileInTree) return s;
+      const nextExpanded = revealExpandedDirs(
+        s.allFilesExpandedDirsByWorkspace,
+        workspaceId,
+        path,
+      );
+      if (nextExpanded === s.allFilesExpandedDirsByWorkspace) return s;
+      return { allFilesExpandedDirsByWorkspace: nextExpanded };
+    }),
   requestFileTreeRefresh: (workspaceId) =>
     set((s) => ({
       fileTreeRefreshNonceByWorkspace: {
@@ -428,6 +487,9 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
       const nextBuffers = s.fileBuffers[key]
         ? s.fileBuffers
         : { ...s.fileBuffers, [key]: makeUnloadedBuffer() };
+      const nextExpanded = s.revealActiveFileInTree
+        ? revealExpandedDirs(s.allFilesExpandedDirsByWorkspace, workspaceId, path)
+        : s.allFilesExpandedDirsByWorkspace;
       return {
         fileTabsByWorkspace: nextTabs,
         activeFileTabByWorkspace: {
@@ -446,6 +508,7 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
             }
           : s.fileRevealTargetByWorkspace,
         fileBuffers: nextBuffers,
+        allFilesExpandedDirsByWorkspace: nextExpanded,
       };
     }),
 
@@ -466,11 +529,15 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
       const tabs = s.fileTabsByWorkspace[workspaceId] ?? [];
       if (!tabs.includes(path)) return s;
       if (s.activeFileTabByWorkspace[workspaceId] === path) return s;
+      const nextExpanded = s.revealActiveFileInTree
+        ? revealExpandedDirs(s.allFilesExpandedDirsByWorkspace, workspaceId, path)
+        : s.allFilesExpandedDirsByWorkspace;
       return {
         activeFileTabByWorkspace: {
           ...s.activeFileTabByWorkspace,
           [workspaceId]: path,
         },
+        allFilesExpandedDirsByWorkspace: nextExpanded,
       };
     }),
 

--- a/src/ui/src/stores/slices/settingsSlice.ts
+++ b/src/ui/src/stores/slices/settingsSlice.ts
@@ -99,6 +99,8 @@ export interface SettingsSlice {
   setEditorGitGutterBase: (value: "head" | "merge_base") => void;
   editorMinimapEnabled: boolean;
   setEditorMinimapEnabled: (enabled: boolean) => void;
+  revealActiveFileInTree: boolean;
+  setRevealActiveFileInTree: (enabled: boolean) => void;
   /// File-viewer chrome: soft-wrap long lines in Monaco. Mirrors the
   /// `editorMinimapEnabled` persistence pattern — hydrated from
   /// `editor_word_wrap` in app_settings on app boot, written through
@@ -214,6 +216,9 @@ export const createSettingsSlice: StateCreator<
   setEditorGitGutterBase: (value) => set({ editorGitGutterBase: value }),
   editorMinimapEnabled: false,
   setEditorMinimapEnabled: (enabled) => set({ editorMinimapEnabled: enabled }),
+  revealActiveFileInTree: true,
+  setRevealActiveFileInTree: (enabled) =>
+    set({ revealActiveFileInTree: enabled }),
   editorWordWrap: true,
   setEditorWordWrap: (enabled) => set({ editorWordWrap: enabled }),
   editorLineNumbersEnabled: true,

--- a/src/ui/src/stores/useAppStore.editorViewState.test.ts
+++ b/src/ui/src/stores/useAppStore.editorViewState.test.ts
@@ -7,13 +7,15 @@ describe("editor view-state (word wrap, line numbers, font zoom)", () => {
       editorWordWrap: true,
       editorLineNumbersEnabled: true,
       editorFontZoom: 1,
+      revealActiveFileInTree: true,
     });
   });
 
-  it("defaults to wrap on, line numbers on, zoom 1.0", () => {
+  it("defaults to wrap on, line numbers on, active-file reveal on, zoom 1.0", () => {
     const state = useAppStore.getState();
     expect(state.editorWordWrap).toBe(true);
     expect(state.editorLineNumbersEnabled).toBe(true);
+    expect(state.revealActiveFileInTree).toBe(true);
     expect(state.editorFontZoom).toBe(1);
   });
 
@@ -27,6 +29,11 @@ describe("editor view-state (word wrap, line numbers, font zoom)", () => {
   it("setEditorLineNumbersEnabled toggles the flag", () => {
     useAppStore.getState().setEditorLineNumbersEnabled(false);
     expect(useAppStore.getState().editorLineNumbersEnabled).toBe(false);
+  });
+
+  it("setRevealActiveFileInTree toggles the flag", () => {
+    useAppStore.getState().setRevealActiveFileInTree(false);
+    expect(useAppStore.getState().revealActiveFileInTree).toBe(false);
   });
 
   it("setEditorFontZoom clamps to the [0.7, 2] range", () => {

--- a/src/ui/src/stores/useAppStore.fileTree.test.ts
+++ b/src/ui/src/stores/useAppStore.fileTree.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { useAppStore } from "./useAppStore";
-import { snapshotRemovedFilePath } from "./slices/fileTreeSlice";
+import {
+  getRevealAncestorDirs,
+  snapshotRemovedFilePath,
+} from "./slices/fileTreeSlice";
 
 const WS = "workspace-a";
 
@@ -14,6 +17,7 @@ function reset() {
     allFilesSelectedPathByWorkspace: {},
     tabOrderByWorkspace: {},
     filePathUndoStackByWorkspace: {},
+    revealActiveFileInTree: true,
   });
 }
 
@@ -31,6 +35,56 @@ function openLoadedFile(path: string, content = "saved") {
 
 describe("file path store updates", () => {
   beforeEach(reset);
+
+  it("computes ancestor directories for active-file tree reveal", () => {
+    expect(getRevealAncestorDirs("src/foo/bar.rs")).toEqual([
+      "src/",
+      "src/foo/",
+    ]);
+    expect(getRevealAncestorDirs("README.md")).toEqual([]);
+    expect(getRevealAncestorDirs("~/.claude/plans/plan.md")).toEqual([]);
+    expect(getRevealAncestorDirs("/tmp/memory.md")).toEqual([]);
+  });
+
+  it("reveals ancestor directories when opening a nested file tab", () => {
+    useAppStore.getState().openFileTab(WS, "src/foo/bar.rs");
+
+    expect(useAppStore.getState().allFilesExpandedDirsByWorkspace[WS]).toEqual({
+      "src/": true,
+      "src/foo/": true,
+    });
+  });
+
+  it("reveals ancestor directories when selecting an already-open file tab", () => {
+    useAppStore.getState().openFileTab(WS, "src/one.ts");
+    useAppStore.getState().openFileTab(WS, "tests/fixtures/two.ts");
+    useAppStore.setState({
+      allFilesExpandedDirsByWorkspace: { [WS]: {} },
+      activeFileTabByWorkspace: { [WS]: "src/one.ts" },
+    });
+
+    useAppStore.getState().selectFileTab(WS, "tests/fixtures/two.ts");
+
+    expect(useAppStore.getState().allFilesExpandedDirsByWorkspace[WS]).toEqual({
+      "tests/": true,
+      "tests/fixtures/": true,
+    });
+  });
+
+  it("does not reveal tree directories when the editor setting is disabled", () => {
+    useAppStore.setState({ revealActiveFileInTree: false });
+
+    useAppStore.getState().openFileTab(WS, "src/foo/bar.rs");
+
+    expect(useAppStore.getState().allFilesExpandedDirsByWorkspace[WS]).toBeUndefined();
+  });
+
+  it("does not reveal tree directories for non-worktree file paths", () => {
+    useAppStore.getState().openFileTab(WS, "~/.claude/plans/plan.md");
+    useAppStore.getState().openFileTab(WS, "/tmp/claudette-memory.md");
+
+    expect(useAppStore.getState().allFilesExpandedDirsByWorkspace[WS]).toBeUndefined();
+  });
 
   it("renames an open file tab and preserves its buffer", () => {
     openLoadedFile("src/app.ts");


### PR DESCRIPTION
## Summary
- reveal the active Monaco file in the Files tree by expanding ancestor directories when file tabs open or become active
- highlight the active file row and scroll it into view with nearest-block behavior
- add the Editor setting, locale strings, tests, and settings docs for the reveal behavior

Closes #885

## Validation
- bun run test src/stores/useAppStore.fileTree.test.ts src/components/files/FileTree.active.test.tsx src/stores/useAppStore.editorViewState.test.ts
- bunx tsc -b
- bun run lint:css
- bun run lint (passes with existing warnings)
- bun run build
- git diff --check