### PR TITLE
feat(composer): keep turn config editable during env prep

### DIFF
--- a/site/src/content/docs/features/per-repo-settings.mdx
+++ b/site/src/content/docs/features/per-repo-settings.mdx
@@ -73,7 +73,7 @@ The decision is per-repo, not global, so trusting one project's `.envrc` doesn't
 
 ### Loading state
 
-While an env-provider is resolving, Claudette surfaces the active plugin and elapsed time in three places: the workspace's row in the sidebar (spinner + tooltip), the chat composer placeholder, and an overlay above the integrated terminal. The terminal won't open a prompt and the agent won't spawn until the env layer is ready or fails.
+While an env-provider is resolving, Claudette surfaces the active plugin and elapsed time in three places: the workspace's row in the sidebar (spinner + tooltip), the chat composer placeholder, and an overlay above the integrated terminal. The terminal won't open a prompt and the agent won't spawn until the env layer is ready or fails. You can still prepare the next chat turn while this runs: pick a model, toggle Plan mode, adjust Thinking/effort, attach files, or open the composer overflow menu; only sending stays blocked until the environment is ready.
 
 ### Live provisioning output in the Claudette Terminal
 

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -367,10 +367,10 @@ export function ChatInputArea({
     : composerMode === "shell"
       ? t("run_shell_command")
       : t("send_message");
-  const sendButtonTooltip = workspaceEnvironmentPreparing
-    ? t("send_disabled_preparing_env")
-    : isRunning
-      ? tooltipWithHotkey(sendButtonLabel, "global.dismiss-or-stop", keybindings, isMac)
+  const sendButtonTooltip = isRunning
+    ? tooltipWithHotkey(sendButtonLabel, "global.dismiss-or-stop", keybindings, isMac)
+    : workspaceEnvironmentPreparing
+      ? t("send_disabled_preparing_env")
       : sendButtonLabel;
 
   // VU meter dynamic-vs-static decision lives in the parent because it

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -367,9 +367,11 @@ export function ChatInputArea({
     : composerMode === "shell"
       ? t("run_shell_command")
       : t("send_message");
-  const sendButtonTooltip = isRunning
-    ? tooltipWithHotkey(sendButtonLabel, "global.dismiss-or-stop", keybindings, isMac)
-    : sendButtonLabel;
+  const sendButtonTooltip = workspaceEnvironmentPreparing
+    ? t("send_disabled_preparing_env")
+    : isRunning
+      ? tooltipWithHotkey(sendButtonLabel, "global.dismiss-or-stop", keybindings, isMac)
+      : sendButtonLabel;
 
   // VU meter dynamic-vs-static decision lives in the parent because it
   // depends on the OS reduced-motion preference and the active provider's
@@ -1145,6 +1147,9 @@ export function ChatInputArea({
   };
 
   const showUltrathinkOverlay = composerMode === "prompt" && hasUltrathink(chatInput);
+  const sendDisabled = workspaceEnvironmentPreparing;
+  // Env warmup only blocks dispatch; composer configuration remains editable.
+  const configDisabled = false;
 
   return (
     <div
@@ -1302,7 +1307,7 @@ export function ChatInputArea({
               className={`${styles.attachBtn} ${attachMenuOpen ? styles.attachBtnActive : ""}`}
               onClick={() => setAttachMenuOpen((v) => !v)}
               title={t("add_files_connectors")}
-              disabled={workspaceEnvironmentPreparing}
+              disabled={configDisabled}
             >
               <Plus size={16} />
             </button>
@@ -1322,7 +1327,8 @@ export function ChatInputArea({
             sessionId={sessionId}
             workspaceId={selectedWorkspaceId}
             repoId={repoId ?? null}
-            disabled={workspaceEnvironmentPreparing}
+            configDisabled={configDisabled}
+            sendDisabled={sendDisabled}
             isRunning={isRunning}
             isRemote={isRemote}
           />

--- a/src/ui/src/components/chat/composer/ComposerToolbar.test.tsx
+++ b/src/ui/src/components/chat/composer/ComposerToolbar.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface MockState {
+  selectedModel: Record<string, string>;
+  selectedModelProvider: Record<string, string>;
+  disable1mContext: boolean;
+  planMode: Record<string, boolean>;
+  modelSelectorOpen: boolean;
+  keybindings: Record<string, unknown>;
+  claudeFlagsByWorkspace: Record<string, { resolved: string[] } | undefined>;
+  setSelectedModel: ReturnType<typeof vi.fn>;
+  setFastMode: ReturnType<typeof vi.fn>;
+  setThinkingEnabled: ReturnType<typeof vi.fn>;
+  setPlanMode: ReturnType<typeof vi.fn>;
+  setEffortLevel: ReturnType<typeof vi.fn>;
+  setChromeEnabled: ReturnType<typeof vi.fn>;
+  setShowThinkingBlocks: ReturnType<typeof vi.fn>;
+  setModelSelectorOpen: ReturnType<typeof vi.fn>;
+  loadWorkspaceClaudeFlags: ReturnType<typeof vi.fn>;
+}
+
+const appStore = vi.hoisted(
+  () =>
+    ({
+      selectedModel: { s1: "opus" },
+      selectedModelProvider: { s1: "anthropic" },
+      disable1mContext: false,
+      planMode: { s1: false },
+      modelSelectorOpen: false,
+      keybindings: {},
+      claudeFlagsByWorkspace: { w1: { resolved: [] } },
+      setSelectedModel: vi.fn(),
+      setFastMode: vi.fn(),
+      setThinkingEnabled: vi.fn(),
+      setPlanMode: vi.fn(),
+      setEffortLevel: vi.fn(),
+      setChromeEnabled: vi.fn(),
+      setShowThinkingBlocks: vi.fn(),
+      setModelSelectorOpen: vi.fn(),
+      loadWorkspaceClaudeFlags: vi.fn(),
+    }) satisfies MockState as MockState,
+);
+
+const serviceMocks = vi.hoisted(() => ({
+  getAppSetting: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("../../../stores/useAppStore", () => ({
+  useAppStore: <T,>(selector: (state: MockState) => T): T => selector(appStore),
+}));
+
+vi.mock("../../../services/tauri", () => ({
+  getAppSetting: serviceMocks.getAppSetting,
+}));
+
+vi.mock("../useModelRegistry", () => ({
+  useModelRegistry: () => [
+    {
+      id: "opus",
+      providerId: "anthropic",
+      label: "Opus",
+      supportsFastMode: false,
+      supportsEffort: true,
+    },
+  ],
+}));
+
+vi.mock("../ModelSelector", async () => {
+  const actual =
+    await vi.importActual<typeof import("../ModelSelector")>("../ModelSelector");
+  return {
+    ...actual,
+    ModelSelector: () => <div data-testid="model-selector" />,
+  };
+});
+
+vi.mock("../applySelectedModel", () => ({
+  applySelectedModel: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../applyPlanModeMountDefault", () => ({
+  applyPlanModeMountDefault: vi.fn(),
+}));
+
+vi.mock("./ReasoningPill", () => ({
+  ReasoningPill: ({ disabled }: { disabled: boolean }) => (
+    <button type="button" disabled={disabled} data-testid="reasoning-pill">
+      Thinking
+    </button>
+  ),
+}));
+
+vi.mock("./OverflowMenu", () => ({
+  OverflowMenu: ({
+    configDisabled,
+    sendDisabled,
+  }: {
+    configDisabled: boolean;
+    sendDisabled: boolean;
+  }) => (
+    <button
+      type="button"
+      disabled={configDisabled}
+      data-send-disabled={String(sendDisabled)}
+      data-testid="overflow-menu"
+    >
+      More options
+    </button>
+  ),
+}));
+
+import { ComposerToolbar } from "./ComposerToolbar";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function renderToolbar(props: {
+  configDisabled?: boolean;
+  sendDisabled?: boolean;
+  isRunning?: boolean;
+}): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+
+  await act(async () => {
+    root.render(
+      <ComposerToolbar
+        sessionId="s1"
+        workspaceId="w1"
+        repoId="r1"
+        configDisabled={props.configDisabled ?? false}
+        sendDisabled={props.sendDisabled ?? false}
+        isRunning={props.isRunning ?? false}
+        isRemote={false}
+      />,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  return { container, root };
+}
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll("button")).find((b) =>
+    b.textContent?.includes(text),
+  );
+  if (!button) throw new Error(`Button "${text}" not found`);
+  return button;
+}
+
+beforeEach(() => {
+  serviceMocks.getAppSetting.mockClear();
+  appStore.setSelectedModel.mockClear();
+  appStore.setPlanMode.mockClear();
+});
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
+describe("ComposerToolbar disable semantics", () => {
+  it("keeps config controls enabled when only sending is blocked", async () => {
+    const { container } = await renderToolbar({ sendDisabled: true });
+
+    expect(buttonByText(container, "Opus").disabled).toBe(false);
+    expect(buttonByText(container, "Plan").disabled).toBe(false);
+    expect(buttonByText(container, "Thinking").disabled).toBe(false);
+    expect(buttonByText(container, "More options").disabled).toBe(false);
+    expect(
+      buttonByText(container, "More options").dataset.sendDisabled,
+    ).toBe("true");
+  });
+
+  it("locks config controls when configuration changes are blocked", async () => {
+    const { container } = await renderToolbar({ configDisabled: true });
+
+    expect(buttonByText(container, "Opus").disabled).toBe(true);
+    expect(buttonByText(container, "Plan").disabled).toBe(true);
+    expect(buttonByText(container, "Thinking").disabled).toBe(true);
+    expect(buttonByText(container, "More options").disabled).toBe(true);
+  });
+
+  it("keeps running-turn session mutations locked", async () => {
+    const { container } = await renderToolbar({ isRunning: true });
+
+    expect(buttonByText(container, "Opus").disabled).toBe(true);
+    expect(buttonByText(container, "Plan").disabled).toBe(true);
+    expect(buttonByText(container, "Thinking").disabled).toBe(true);
+  });
+});

--- a/src/ui/src/components/chat/composer/ComposerToolbar.tsx
+++ b/src/ui/src/components/chat/composer/ComposerToolbar.tsx
@@ -24,8 +24,10 @@ interface ComposerToolbarProps {
   sessionId: string;
   workspaceId: string;
   repoId: string | null;
-  /** Blocks all toolbar interactions — set while the workspace environment is preparing. */
-  disabled: boolean;
+  /** Blocks controls that mutate turn configuration. Env preparation must not set this. */
+  configDisabled: boolean;
+  /** Blocks actions that require a ready workspace environment. */
+  sendDisabled: boolean;
   /** True while a turn is in flight. Pills that mutate session state stay locked;
    *  the overflow menu's Remote Control row uses this to queue mid-turn enables. */
   isRunning: boolean;
@@ -36,15 +38,18 @@ export function ComposerToolbar({
   sessionId,
   workspaceId,
   repoId,
-  disabled,
+  configDisabled,
+  sendDisabled,
   isRunning,
   isRemote,
 }: ComposerToolbarProps) {
   // Session-mutating pills (model, plan, reasoning) keep their pre-split
-  // behavior: locked whenever a turn is running OR the env is preparing.
+  // behavior: locked whenever a turn is running.
+  // Env preparation only blocks actions that need the resolved environment;
+  // users can still configure the first turn while that warmup runs.
   // The overflow menu deliberately opts out so users can queue Remote
   // Control mid-turn — see `OverflowMenu` for the per-item gating.
-  const mutationDisabled = disabled || isRunning;
+  const mutationDisabled = configDisabled || isRunning;
   const selectedModel = useAppStore((s) => s.selectedModel[sessionId] ?? "opus");
   const selectedProvider = useAppStore((s) => s.selectedModelProvider[sessionId] ?? "anthropic");
   const disable1mContext = useAppStore((s) => s.disable1mContext);
@@ -216,7 +221,8 @@ export function ComposerToolbar({
 
       <OverflowMenu
         sessionId={sessionId}
-        disabled={disabled}
+        configDisabled={configDisabled}
+        sendDisabled={sendDisabled}
         isRunning={isRunning}
         isRemote={isRemote}
       />

--- a/src/ui/src/components/chat/composer/OverflowMenu.test.tsx
+++ b/src/ui/src/components/chat/composer/OverflowMenu.test.tsx
@@ -122,7 +122,8 @@ const mountedContainers: HTMLElement[] = [];
 
 async function renderMenu(props: {
   sessionId?: string;
-  disabled?: boolean;
+  configDisabled?: boolean;
+  sendDisabled?: boolean;
   isRunning?: boolean;
   isRemote?: boolean;
 }): Promise<{ container: HTMLElement; root: Root }> {
@@ -135,7 +136,8 @@ async function renderMenu(props: {
     root.render(
       <OverflowMenu
         sessionId={props.sessionId ?? "s1"}
-        disabled={props.disabled ?? false}
+        configDisabled={props.configDisabled ?? false}
+        sendDisabled={props.sendDisabled ?? false}
         isRunning={props.isRunning ?? false}
         isRemote={props.isRemote ?? false}
       />,
@@ -151,7 +153,8 @@ async function rerenderMenu(
   root: Root,
   props: {
     sessionId?: string;
-    disabled?: boolean;
+    configDisabled?: boolean;
+    sendDisabled?: boolean;
     isRunning?: boolean;
     isRemote?: boolean;
   },
@@ -160,7 +163,8 @@ async function rerenderMenu(
     root.render(
       <OverflowMenu
         sessionId={props.sessionId ?? "s1"}
-        disabled={props.disabled ?? false}
+        configDisabled={props.configDisabled ?? false}
+        sendDisabled={props.sendDisabled ?? false}
         isRunning={props.isRunning ?? false}
         isRemote={props.isRemote ?? false}
       />,
@@ -237,8 +241,13 @@ describe("OverflowMenu — mid-turn reachability", () => {
     expect(triggerButton(container).disabled).toBe(false);
   });
 
-  it("disables the trigger button when the workspace is preparing", async () => {
-    const { container } = await renderMenu({ disabled: true });
+  it("does not disable the trigger button while the workspace is preparing", async () => {
+    const { container } = await renderMenu({ sendDisabled: true });
+    expect(triggerButton(container).disabled).toBe(false);
+  });
+
+  it("disables the trigger button when config changes are blocked", async () => {
+    const { container } = await renderMenu({ configDisabled: true });
     expect(triggerButton(container).disabled).toBe(true);
   });
 
@@ -253,6 +262,15 @@ describe("OverflowMenu — mid-turn reachability", () => {
 
   it("keeps Fast mode and Claude in Chrome enabled when idle", async () => {
     const { container } = await renderMenu({ isRunning: false });
+    await openDropdown(container);
+    expect(findMenuItemByLabel(container, "Fast mode").disabled).toBe(false);
+    expect(findMenuItemByLabel(container, "Claude in Chrome").disabled).toBe(
+      false,
+    );
+  });
+
+  it("keeps Fast mode and Claude in Chrome enabled while only send is blocked", async () => {
+    const { container } = await renderMenu({ sendDisabled: true });
     await openDropdown(container);
     expect(findMenuItemByLabel(container, "Fast mode").disabled).toBe(false);
     expect(findMenuItemByLabel(container, "Claude in Chrome").disabled).toBe(

--- a/src/ui/src/components/chat/composer/OverflowMenu.tsx
+++ b/src/ui/src/components/chat/composer/OverflowMenu.tsx
@@ -19,9 +19,10 @@ import styles from "./OverflowMenu.module.css";
 
 interface OverflowMenuProps {
   sessionId: string;
-  /** Blocks all menu interaction (trigger + every row). Set while the
-   *  workspace environment is preparing. */
-  disabled: boolean;
+  /** Blocks controls that mutate turn configuration. Env preparation must not set this. */
+  configDisabled: boolean;
+  /** Blocks actions that require a ready workspace environment. */
+  sendDisabled: boolean;
   /** True while a turn is in flight. Session-mutating rows (Fast Mode,
    *  Claude in Chrome) stay disabled. Remote Control deliberately stays
    *  clickable so the user can queue a mid-turn enable. */
@@ -38,7 +39,13 @@ const DISABLED_REMOTE_STATUS: ClaudeRemoteControlStatus = {
   lastError: null,
 };
 
-export function OverflowMenu({ sessionId, disabled, isRunning, isRemote }: OverflowMenuProps) {
+export function OverflowMenu({
+  sessionId,
+  configDisabled,
+  sendDisabled,
+  isRunning,
+  isRemote,
+}: OverflowMenuProps) {
   // Rows that would tear down or reconfigure the live persistent session
   // (Fast Mode is per-session; Claude in Chrome calls `resetAgentSession`)
   // stay locked mid-turn. Remote Control opts out: its row remains
@@ -47,7 +54,7 @@ export function OverflowMenu({ sessionId, disabled, isRunning, isRemote }: Overf
   // (not inside `RemoteControlMenuItem`) so they survive the dropdown
   // unmount that fires whenever the menu closes — clicking outside the
   // menu would otherwise discard the queued intent before the turn ends.
-  const mutationDisabled = disabled || isRunning;
+  const mutationDisabled = configDisabled || isRunning;
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const addToast = useAppStore((s) => s.addToast);
@@ -185,19 +192,19 @@ export function OverflowMenu({ sessionId, disabled, isRunning, isRemote }: Overf
     if (pendingEnableForSession !== sessionId) return;
     if (isRunning) return;
     // Don't fire if Remote Control is no longer available (experimental
-    // gate off, remote transport) or while the workspace environment is
-    // still preparing. The session-switch / showRemoteControl cleanup
-    // effects already clear the intent in those cases; this is the
+    // gate off or remote transport). The session-switch /
+    // showRemoteControl cleanup effects already clear the intent in those
+    // cases; this is the
     // belt-and-suspenders check at the fire site.
     if (!showRemoteControl) return;
-    if (disabled) return;
+    if (sendDisabled) return;
     setPendingEnableForSession(null);
     void runImmediate(true);
   }, [
-    disabled,
     isRunning,
     pendingEnableForSession,
     runImmediate,
+    sendDisabled,
     sessionId,
     showRemoteControl,
   ]);
@@ -292,7 +299,7 @@ export function OverflowMenu({ sessionId, disabled, isRunning, isRemote }: Overf
         type="button"
         className={styles.trigger}
         onClick={() => setOpen((v) => !v)}
-        disabled={disabled}
+        disabled={configDisabled}
         aria-label="More options"
         aria-expanded={open}
       >
@@ -324,7 +331,7 @@ export function OverflowMenu({ sessionId, disabled, isRunning, isRemote }: Overf
           />
           {showRemoteControl && (
             <RemoteControlMenuItem
-              disabled={disabled}
+              disabled={sendDisabled}
               isRunning={isRunning}
               status={remoteControlStatus}
               pendingEnable={pendingEnable}
@@ -348,8 +355,7 @@ function RemoteControlMenuItem({
   onQueuePending,
   onCancelPending,
 }: {
-  /** True while the workspace environment is preparing — hard-blocks
-   *  every interaction (firing OR queuing the toggle). */
+  /** True while send/env-dependent actions are unavailable. */
   disabled: boolean;
   /** True while a turn is in flight. Enable clicks during this window
    *  queue a pending enable; the deferred-fire effect (owned by the

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -17,6 +17,7 @@
   "steer_pending_attachment": "Sending attachment…",
   "stop_agent": "Stop agent",
   "send_message": "Send message",
+  "send_disabled_preparing_env": "Workspace environment is still preparing",
   "run_shell_command": "Run shell command",
   "add_files_connectors": "Add files or connectors",
   "attachments_not_supported": "Attachments not supported for remote workspaces",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -17,6 +17,7 @@
   "steer_pending_attachment": "Enviando archivo adjunto…",
   "stop_agent": "Detener agente",
   "send_message": "Enviar mensaje",
+  "send_disabled_preparing_env": "El entorno del espacio de trabajo aún se está preparando",
   "run_shell_command": "Ejecutar comando shell",
   "add_files_connectors": "Añadir archivos o conectores",
   "attachments_not_supported": "Adjuntos no soportados para espacios de trabajo remotos",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -17,6 +17,7 @@
   "steer_pending_attachment": "添付ファイルを送信中…",
   "stop_agent": "エージェントを停止",
   "send_message": "メッセージを送信",
+  "send_disabled_preparing_env": "ワークスペース環境をまだ準備中です",
   "run_shell_command": "シェルコマンドを実行",
   "add_files_connectors": "ファイルまたはコネクタを追加",
   "attachments_not_supported": "リモートワークスペースでは添付ファイルはサポートされていません",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -17,6 +17,7 @@
   "steer_pending_attachment": "Enviando anexo…",
   "stop_agent": "Parar agente",
   "send_message": "Enviar mensagem",
+  "send_disabled_preparing_env": "O ambiente do workspace ainda está sendo preparado",
   "run_shell_command": "Executar comando shell",
   "add_files_connectors": "Adicionar arquivos ou conectores",
   "attachments_not_supported": "Anexos não são suportados em workspaces remotos",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -17,6 +17,7 @@
   "steer_pending_attachment": "正在发送附件…",
   "stop_agent": "停止智能体",
   "send_message": "发送消息",
+  "send_disabled_preparing_env": "工作区环境仍在准备中",
   "run_shell_command": "运行 shell 命令",
   "add_files_connectors": "添加文件或连接器",
   "attachments_not_supported": "远程工作区不支持附件",


### PR DESCRIPTION
## Summary

Closes #886.

This splits the composer disable state into separate send/config semantics so workspace env-provider warmup only blocks actions that need a ready environment. While direnv/mise/dotenv/Nix devshell is still preparing, the user can now configure the first turn instead of waiting on the warmup wall.

## What Changed

- Kept model selection, Plan mode, Thinking/reasoning controls, attachments, and the composer overflow menu active while `workspaceEnvironmentPreparing` is true.
- Preserved the existing running-turn lock for session-mutating controls, so model/plan/reasoning/Fast/Chrome changes still stay disabled while an agent turn is in flight.
- Left send blocked during env warmup and added a warmup-specific tooltip so the disabled state explains itself.
- Kept Remote Control's env-dependent action gated by the send/env flag while still allowing the overflow menu to open.
- Documented the loading-state behavior in the per-repo settings docs and added localized tooltip strings.

## Validation

- `cd src/ui && bun run test src/components/chat/composer/ComposerToolbar.test.tsx src/components/chat/composer/OverflowMenu.test.tsx`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run lint` (passes with existing warnings only)
- `cd src/ui && bun run lint:css`
- `git diff --check`
