### PR TITLE
fix(updater): raise boot probation timeout to 20s

### DIFF
--- a/site/src/content/docs/features/diagnostics.mdx
+++ b/site/src/content/docs/features/diagnostics.mdx
@@ -129,7 +129,7 @@ On startup, Claudette also scans `${TMPDIR}/claudette-dev/*.json` (the discovery
 
 ## Update boot-health rollback
 
-After an in-app update, Claudette starts the new build on a short probation window (10 s by default). The React app sends a boot heartbeat after the first commit past the loader (`viewStateHydrated` is true and `loadInitialData` resolved). If that heartbeat never arrives, Claudette treats the update as failed to start and tries to restore the previous self-contained install.
+After an in-app update, Claudette starts the new build on a short probation window (20 s by default). The React app sends a boot heartbeat after the first commit past the loader (`viewStateHydrated` is true and `loadInitialData` resolved). If that heartbeat never arrives, Claudette treats the update as failed to start and tries to restore the previous self-contained install.
 
 When rollback succeeds, the next launch shows a native dialog saying which version failed and which version was restored. When rollback cannot be applied (for example, there was no usable previous-install backup or the install location could not be replaced), Claudette writes a no-loop failure report and shows a dialog with the failed version plus the release URL to download manually.
 
@@ -150,7 +150,7 @@ The OS data dir is `~/Library/Application Support/claudette/` on macOS, `$XDG_DA
 
 ### Tuning the probation window
 
-`CLAUDETTE_BOOT_PROBATION_SECS` overrides the default 10 s probation. Useful for slow first-launch scenarios (e.g. cold-cache Linux builds where libwebkit2gtk dynamic loading dominates startup time) and for shrinking the window while testing the rollback path locally. Values are clamped to the range 1–120 s; non-numeric values fall back to the default. Setting `CLAUDETTE_BOOT_PROBATION_SECS=2` plus an artificial pre-render hang in the React tree is the recommended way to exercise the rollback dialog from a dev build.
+`CLAUDETTE_BOOT_PROBATION_SECS` overrides the default 20 s probation. Useful for slow first-launch scenarios (e.g. cold-cache Linux builds where libwebkit2gtk dynamic loading dominates startup time) and for shrinking the window while testing the rollback path locally. Values are clamped to the range 1–120 s; non-numeric values fall back to the default. Setting `CLAUDETTE_BOOT_PROBATION_SECS=2` plus an artificial pre-render hang in the React tree is the recommended way to exercise the rollback dialog from a dev build.
 
 ## Sandboxed (fresh-user) sessions
 

--- a/src-tauri/src/boot_probation.rs
+++ b/src-tauri/src/boot_probation.rs
@@ -11,7 +11,7 @@ use tokio::sync::Notify;
 
 const SENTINEL_FILE: &str = "boot-probation.json";
 const REPORT_FILE: &str = "boot-rollback-report.json";
-const DEFAULT_PROBATION_SECS: u64 = 10;
+const DEFAULT_PROBATION_SECS: u64 = 20;
 /// Hard floor / ceiling for the env-var override. A 0-second probation
 /// would never let `boot_ok` race the timer; a 10-minute probation makes
 /// the rollback feel broken to users on the unhappy path.

--- a/src-tauri/src/boot_probation.rs
+++ b/src-tauri/src/boot_probation.rs
@@ -13,7 +13,7 @@ const SENTINEL_FILE: &str = "boot-probation.json";
 const REPORT_FILE: &str = "boot-rollback-report.json";
 const DEFAULT_PROBATION_SECS: u64 = 20;
 /// Hard floor / ceiling for the env-var override. A 0-second probation
-/// would never let `boot_ok` race the timer; a 10-minute probation makes
+/// would never let `boot_ok` race the timer; a 2-minute probation makes
 /// the rollback feel broken to users on the unhappy path.
 const MIN_PROBATION_SECS: u64 = 1;
 const MAX_PROBATION_SECS: u64 = 120;


### PR DESCRIPTION
## Summary

- raise the updater boot-probation default from 10 seconds to 20 seconds
- keep the `CLAUDETTE_BOOT_PROBATION_SECS` override and `[1, 120]` clamp unchanged
- update the diagnostics docs so the documented default matches the runtime behavior

## Why

Closes #889. The previous 10 second default could expire during the macOS first-launch path after an auto-update, before React finished initial data loading and sent `boot_ok`. That made healthy nightly builds look failed and triggered a spurious rollback dialog. A 20 second default gives cold first launches more room while preserving the rollback signal for genuinely broken builds.

## Validation

- `nix develop -c ./scripts/stage-cli-sidecar.sh`
- `nix develop -c cargo test -p claudette-tauri boot_probation`
- `nix develop -c cargo fmt --all --check`
- `git diff --check`
- searched for stale 10 second boot-probation references in the touched runtime/docs surfaces

## Notes

Manual auto-update smoke on macOS is still the release-path confirmation step, since this change only adjusts the default timer and does not change the update installation flow.