### PR TITLE
fix(metrics): preserve stats across workspace cleanup

### DIFF
--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -461,6 +461,37 @@ impl Database {
                 total_output_tokens,
             ],
         )?;
+        tx.execute(
+            "INSERT OR IGNORE INTO deleted_agent_sessions (
+                id, workspace_id, repository_id, started_at, last_message_at,
+                ended_at, turn_count, completed_ok
+             )
+             SELECT id, workspace_id, repository_id, started_at, last_message_at,
+                    ended_at, turn_count, completed_ok
+             FROM agent_sessions
+             WHERE workspace_id = ?1",
+            params![workspace_id],
+        )?;
+        tx.execute(
+            "INSERT OR IGNORE INTO deleted_agent_commits (
+                commit_hash, workspace_id, repository_id, session_id,
+                additions, deletions, files_changed, committed_at
+             )
+             SELECT commit_hash, workspace_id, repository_id, session_id,
+                    additions, deletions, files_changed, committed_at
+             FROM agent_commits
+             WHERE workspace_id = ?1",
+            params![workspace_id],
+        )?;
+        tx.execute(
+            "INSERT OR IGNORE INTO deleted_slash_command_usage (
+                workspace_id, repository_id, command_name, use_count, last_used_at
+             )
+             SELECT s.workspace_id, ?2, s.command_name, s.use_count, s.last_used_at
+             FROM slash_command_usage s
+             WHERE s.workspace_id = ?1",
+            params![workspace_id, repo_id],
+        )?;
         Ok(())
     }
 
@@ -1127,6 +1158,18 @@ mod tests {
             count_rows(&db, "SELECT COUNT(*) FROM deleted_workspace_summaries"),
             1
         );
+        assert_eq!(
+            count_rows(&db, "SELECT COUNT(*) FROM deleted_agent_sessions"),
+            1
+        );
+        assert_eq!(
+            count_rows(&db, "SELECT COUNT(*) FROM deleted_agent_commits"),
+            1
+        );
+        assert_eq!(
+            count_rows(&db, "SELECT COUNT(*) FROM deleted_slash_command_usage"),
+            1
+        );
 
         let (sessions, turns, commits, adds, dels, msgs_u, msgs_a, msgs_s, slash_used): (
             i64,
@@ -1182,6 +1225,39 @@ mod tests {
             .unwrap();
         assert_eq!(total_in, 12000);
         assert_eq!(total_out, 3000);
+
+        let (turns, completed_ok): (i64, i64) = db
+            .conn
+            .query_row(
+                "SELECT turn_count, completed_ok
+                 FROM deleted_agent_sessions WHERE workspace_id = 'w1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((turns, completed_ok), (5, 1));
+
+        let (adds, dels): (i64, i64) = db
+            .conn
+            .query_row(
+                "SELECT additions, deletions
+                 FROM deleted_agent_commits WHERE workspace_id = 'w1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((adds, dels), (50, 10));
+
+        let (command_name, use_count): (String, i64) = db
+            .conn
+            .query_row(
+                "SELECT command_name, use_count
+                 FROM deleted_slash_command_usage WHERE workspace_id = 'w1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((command_name, use_count), ("/foo".to_string(), 7));
     }
 
     #[test]
@@ -1196,6 +1272,13 @@ mod tests {
                 "SELECT COUNT(*) FROM deleted_workspace_summaries WHERE workspace_id = 'w1'"
             ),
             1
+        );
+        assert_eq!(
+            count_rows(
+                &db,
+                "SELECT COUNT(*) FROM deleted_agent_sessions WHERE workspace_id = 'w1'"
+            ),
+            0
         );
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -122,7 +122,20 @@ fn dashboard_metrics_with(conn: &Connection) -> Result<DashboardMetrics, rusqlit
     // `started_at` is stored as naive UTC (`datetime('now')` form), so comparing
     // it against UTC boundary timestamps is well-defined lexicographically.
     let sessions_today: u32 = conn.query_row(
-        "SELECT COUNT(*) FROM agent_sessions
+        "SELECT COALESCE(SUM(session_count), 0) FROM (
+             SELECT started_at, 1 AS session_count FROM agent_sessions
+             UNION ALL
+             SELECT started_at, 1 AS session_count FROM deleted_agent_sessions
+             UNION ALL
+             SELECT COALESCE(first_message_at, workspace_created_at) AS started_at,
+                    sessions_started AS session_count
+             FROM deleted_workspace_summaries s
+             WHERE sessions_started > 0
+               AND NOT EXISTS (
+                   SELECT 1 FROM deleted_agent_sessions ds
+                   WHERE ds.workspace_id = s.workspace_id
+               )
+         )
          WHERE started_at >= datetime('now', 'localtime', 'start of day', 'utc')
            AND started_at <  datetime('now', 'localtime', 'start of day', '+1 day', 'utc')",
         [],
@@ -130,14 +143,23 @@ fn dashboard_metrics_with(conn: &Connection) -> Result<DashboardMetrics, rusqlit
     )?;
 
     let commits_today: u32 = conn.query_row(
-        "SELECT COUNT(*) FROM agent_commits WHERE date(committed_at, 'localtime') = date('now', 'localtime')",
+        "SELECT COUNT(*) FROM (
+             SELECT committed_at FROM agent_commits
+             UNION ALL
+             SELECT committed_at FROM deleted_agent_commits
+         )
+         WHERE date(committed_at, 'localtime') = date('now', 'localtime')",
         [],
         |row| row.get::<_, i64>(0).map(|n| n as u32),
     )?;
 
     let (additions_7d, deletions_7d): (u64, u64) = conn.query_row(
         "SELECT COALESCE(SUM(additions), 0), COALESCE(SUM(deletions), 0)
-         FROM agent_commits
+         FROM (
+             SELECT additions, deletions, committed_at FROM agent_commits
+             UNION ALL
+             SELECT additions, deletions, committed_at FROM deleted_agent_commits
+         )
          WHERE date(committed_at, 'localtime') >= date('now', 'localtime', '-6 days')",
         [],
         |row| Ok((row.get::<_, i64>(0)? as u64, row.get::<_, i64>(1)? as u64)),
@@ -158,16 +180,40 @@ fn dashboard_metrics_with(conn: &Connection) -> Result<DashboardMetrics, rusqlit
     )?;
     let cost_30d_usd = live_cost_30d + deleted_cost_30d;
 
-    let success_rate_30d: f32 = conn
-        .query_row(
-            "SELECT AVG(CASE WHEN completed_ok THEN 1.0 ELSE 0.0 END)
+    let (successes_30d, completed_30d): (u64, u64) = conn.query_row(
+        "SELECT COALESCE(SUM(success_count), 0), COALESCE(SUM(session_count), 0)
+         FROM (
+             SELECT started_at, ended_at,
+                    CASE WHEN completed_ok THEN 1 ELSE 0 END AS success_count,
+                    1 AS session_count
              FROM agent_sessions
-             WHERE ended_at IS NOT NULL
-               AND started_at >= datetime('now', 'localtime', 'start of day', '-29 days', 'utc')",
-            [],
-            |row| row.get::<_, Option<f64>>(0),
-        )?
-        .unwrap_or(0.0) as f32;
+             UNION ALL
+             SELECT started_at, ended_at,
+                    CASE WHEN completed_ok THEN 1 ELSE 0 END AS success_count,
+                    1 AS session_count
+             FROM deleted_agent_sessions
+             UNION ALL
+             SELECT COALESCE(first_message_at, workspace_created_at) AS started_at,
+                    last_message_at AS ended_at,
+                    sessions_completed AS success_count,
+                    sessions_started AS session_count
+             FROM deleted_workspace_summaries s
+             WHERE sessions_started > 0
+               AND NOT EXISTS (
+                   SELECT 1 FROM deleted_agent_sessions ds
+                   WHERE ds.workspace_id = s.workspace_id
+               )
+         )
+         WHERE ended_at IS NOT NULL
+           AND started_at >= datetime('now', 'localtime', 'start of day', '-29 days', 'utc')",
+        [],
+        |row| Ok((row.get::<_, i64>(0)? as u64, row.get::<_, i64>(1)? as u64)),
+    )?;
+    let success_rate_30d = if completed_30d > 0 {
+        successes_30d as f32 / completed_30d as f32
+    } else {
+        0.0
+    };
 
     let (live_input_30d, live_output_30d): (u64, u64) = conn.query_row(
         "SELECT COALESCE(SUM(COALESCE(input_tokens, 0)), 0),
@@ -231,7 +277,12 @@ fn dashboard_metrics_with(conn: &Connection) -> Result<DashboardMetrics, rusqlit
 
 fn daily_counts_14d(conn: &Connection) -> Result<Vec<u32>, rusqlite::Error> {
     let mut stmt = conn.prepare(
-        "SELECT date(committed_at, 'localtime') AS d, COUNT(*) FROM agent_commits
+        "SELECT date(committed_at, 'localtime') AS d, COUNT(*)
+         FROM (
+             SELECT committed_at FROM agent_commits
+             UNION ALL
+             SELECT committed_at FROM deleted_agent_commits
+         )
          WHERE date(committed_at, 'localtime') >= date('now', 'localtime', '-13 days')
          GROUP BY d",
     )?;
@@ -245,7 +296,14 @@ fn daily_counts_14d(conn: &Connection) -> Result<Vec<u32>, rusqlite::Error> {
 
 fn daily_cost_30d(conn: &Connection) -> Result<Vec<f64>, rusqlite::Error> {
     let mut stmt = conn.prepare(
-        "SELECT date(created_at, 'localtime') AS d, COALESCE(SUM(cost_usd), 0) FROM chat_messages
+        "SELECT date(created_at, 'localtime') AS d, COALESCE(SUM(cost_usd), 0)
+         FROM (
+             SELECT created_at, cost_usd FROM chat_messages
+             UNION ALL
+             SELECT last_message_at AS created_at, total_cost_usd AS cost_usd
+             FROM deleted_workspace_summaries
+             WHERE last_message_at IS NOT NULL
+         )
          WHERE created_at >= datetime('now', 'localtime', 'start of day', '-29 days', 'utc')
          GROUP BY d",
     )?;
@@ -260,8 +318,17 @@ fn daily_cost_30d(conn: &Connection) -> Result<Vec<f64>, rusqlite::Error> {
 fn daily_tokens_30d(conn: &Connection) -> Result<Vec<u64>, rusqlite::Error> {
     let mut stmt = conn.prepare(
         "SELECT date(created_at, 'localtime') AS d,
-                COALESCE(SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)), 0)
-         FROM chat_messages
+                COALESCE(SUM(tokens), 0)
+         FROM (
+             SELECT created_at,
+                    COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0) AS tokens
+             FROM chat_messages
+             UNION ALL
+             SELECT last_message_at AS created_at,
+                    COALESCE(total_input_tokens, 0) + COALESCE(total_output_tokens, 0) AS tokens
+             FROM deleted_workspace_summaries
+             WHERE last_message_at IS NOT NULL
+         )
          WHERE created_at >= datetime('now', 'localtime', 'start of day', '-29 days', 'utc')
          GROUP BY d",
     )?;
@@ -475,8 +542,21 @@ fn heatmap(conn: &Connection) -> Result<Vec<HeatmapCell>, rusqlite::Error> {
     let mut stmt = conn.prepare(
         "SELECT CAST(strftime('%w', started_at, 'localtime') AS INTEGER) AS dow,
                 CAST((julianday(date('now', 'localtime')) - julianday(date(started_at, 'localtime'))) / 7 AS INTEGER) AS week,
-                COUNT(*) AS c
-         FROM agent_sessions
+                COALESCE(SUM(session_count), 0) AS c
+         FROM (
+             SELECT started_at, 1 AS session_count FROM agent_sessions
+             UNION ALL
+             SELECT started_at, 1 AS session_count FROM deleted_agent_sessions
+             UNION ALL
+             SELECT COALESCE(first_message_at, workspace_created_at) AS started_at,
+                    sessions_started AS session_count
+             FROM deleted_workspace_summaries s
+             WHERE sessions_started > 0
+               AND NOT EXISTS (
+                   SELECT 1 FROM deleted_agent_sessions ds
+                   WHERE ds.workspace_id = s.workspace_id
+               )
+         )
          WHERE started_at >= datetime('now', 'localtime', 'start of day', '-90 days', 'utc')
          GROUP BY dow, week",
     )?;
@@ -507,15 +587,35 @@ fn heatmap(conn: &Connection) -> Result<Vec<HeatmapCell>, rusqlite::Error> {
 }
 
 fn turn_histogram(conn: &Connection) -> Result<Vec<u32>, rusqlite::Error> {
-    let mut stmt = conn.prepare("SELECT turn_count FROM agent_sessions WHERE turn_count > 0")?;
+    let mut stmt = conn.prepare(
+        "SELECT turn_count, 1 AS session_count
+         FROM agent_sessions
+         WHERE turn_count > 0
+         UNION ALL
+         SELECT turn_count, 1 AS session_count
+         FROM deleted_agent_sessions
+         WHERE turn_count > 0
+         UNION ALL
+         SELECT CAST(ROUND(total_turns * 1.0 / sessions_started) AS INTEGER) AS turn_count,
+                sessions_started AS session_count
+         FROM deleted_workspace_summaries s
+         WHERE sessions_started > 0
+           AND total_turns > 0
+           AND NOT EXISTS (
+               SELECT 1 FROM deleted_agent_sessions ds
+               WHERE ds.workspace_id = s.workspace_id
+           )",
+    )?;
     let mut buckets = vec![0u32; 8];
-    for row in stmt.query_map([], |row| row.get::<_, i64>(0))? {
-        let count = row?;
+    for row in stmt.query_map([], |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)? as u32))
+    })? {
+        let (count, session_count) = row?;
         let idx = TURN_BUCKET_UPPER_BOUNDS
             .iter()
             .position(|&upper| count <= upper)
             .unwrap_or(7);
-        buckets[idx] += 1;
+        buckets[idx] += session_count;
     }
     Ok(buckets)
 }
@@ -523,7 +623,11 @@ fn turn_histogram(conn: &Connection) -> Result<Vec<u32>, rusqlite::Error> {
 fn top_slash_commands(conn: &Connection) -> Result<Vec<(String, u32)>, rusqlite::Error> {
     let mut stmt = conn.prepare(
         "SELECT command_name, CAST(SUM(use_count) AS INTEGER) AS total
-         FROM slash_command_usage
+         FROM (
+             SELECT command_name, use_count FROM slash_command_usage
+             UNION ALL
+             SELECT command_name, use_count FROM deleted_slash_command_usage
+         )
          GROUP BY command_name
          ORDER BY total DESC
          LIMIT 5",
@@ -547,7 +651,22 @@ fn recent_sessions_24h(conn: &Connection) -> Result<Vec<SessionDot>, rusqlite::E
     // SQLite timestamps elsewhere.
     let mut stmt = conn.prepare(
         "SELECT strftime('%Y-%m-%dT%H:%M:%SZ', ended_at), completed_ok, workspace_id
-         FROM agent_sessions
+         FROM (
+             SELECT ended_at, completed_ok, workspace_id FROM agent_sessions
+             UNION ALL
+             SELECT ended_at, completed_ok, workspace_id FROM deleted_agent_sessions
+             UNION ALL
+             SELECT last_message_at AS ended_at,
+                    CASE WHEN sessions_completed > 0 THEN 1 ELSE 0 END AS completed_ok,
+                    workspace_id
+             FROM deleted_workspace_summaries s
+             WHERE last_message_at IS NOT NULL
+               AND sessions_started > 0
+               AND NOT EXISTS (
+                   SELECT 1 FROM deleted_agent_sessions ds
+                   WHERE ds.workspace_id = s.workspace_id
+               )
+         )
          WHERE ended_at IS NOT NULL
            AND workspace_id IS NOT NULL
            AND ended_at >= datetime('now','-24 hours')
@@ -691,6 +810,28 @@ mod tests {
         );
         let m = dashboard_metrics(&path).unwrap();
         assert!((m.cost_30d_usd - 5.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn dashboard_time_series_merge_deleted_summary_totals() {
+        let (_dir, path) = setup_db();
+        let conn = Connection::open(&path).unwrap();
+        insert_repo(&conn, "r");
+        exec(
+            &conn,
+            "INSERT INTO deleted_workspace_summaries (
+                id, workspace_id, workspace_name, repository_id, workspace_created_at,
+                total_cost_usd, total_input_tokens, total_output_tokens, last_message_at
+             )
+             VALUES (
+                'd1', 'wsdel', 'dead', 'r', datetime('now','-10 days'),
+                7.25, 12000, 3000, datetime('now')
+             )",
+        );
+
+        let m = dashboard_metrics(&path).unwrap();
+        assert!((m.cost_daily_30d.last().unwrap() - 7.25).abs() < 1e-6);
+        assert_eq!(*m.tokens_daily_30d.last().unwrap(), 15000);
     }
 
     #[test]
@@ -902,6 +1043,86 @@ mod tests {
             a.top_slash_commands,
             vec![("commit".to_string(), 5), ("review".to_string(), 4)]
         );
+    }
+
+    #[test]
+    fn metrics_survive_workspace_hard_delete_detail_tables() {
+        let (_dir, path) = setup_db();
+        let conn = Connection::open(&path).unwrap();
+        insert_repo(&conn, "r");
+        insert_workspace(&conn, "w", "r");
+        exec(
+            &conn,
+            "INSERT INTO agent_sessions (
+                id, workspace_id, repository_id, started_at, last_message_at,
+                ended_at, completed_ok, turn_count
+             )
+             VALUES (
+                's1', 'w', 'r', datetime('now'), datetime('now'),
+                datetime('now'), 1, 5
+             )",
+        );
+        exec(
+            &conn,
+            "INSERT INTO agent_commits (
+                commit_hash, workspace_id, repository_id, additions, deletions,
+                files_changed, committed_at
+             )
+             VALUES ('c1', 'w', 'r', 10, 3, 2, datetime('now'))",
+        );
+        exec(
+            &conn,
+            "INSERT INTO slash_command_usage (workspace_id, command_name, use_count)
+             VALUES ('w', 'commit', 4)",
+        );
+
+        Database::open(&path)
+            .unwrap()
+            .delete_workspace_with_summary("w")
+            .unwrap();
+
+        let d = dashboard_metrics(&path).unwrap();
+        assert_eq!(d.sessions_today, 1);
+        assert_eq!(d.commits_today, 1);
+        assert_eq!(d.additions_7d, 10);
+        assert_eq!(d.deletions_7d, 3);
+        assert_eq!(*d.commits_daily_14d.last().unwrap(), 1);
+        assert!((d.success_rate_30d - 1.0).abs() < 1e-6);
+
+        let a = analytics_metrics(&path).unwrap();
+        assert_eq!(a.heatmap.iter().map(|c| c.count).sum::<u32>(), 1);
+        assert_eq!(a.turn_histogram, vec![0, 0, 1, 0, 0, 0, 0, 0]);
+        assert_eq!(a.top_slash_commands, vec![("commit".to_string(), 4)]);
+        assert_eq!(a.recent_sessions_24h.len(), 1);
+        assert_eq!(a.recent_sessions_24h[0].workspace_id, "w");
+    }
+
+    #[test]
+    fn metrics_use_deleted_summary_fallback_when_detail_rows_are_unavailable() {
+        let (_dir, path) = setup_db();
+        let conn = Connection::open(&path).unwrap();
+        insert_repo(&conn, "r");
+        exec(
+            &conn,
+            "INSERT INTO deleted_workspace_summaries (
+                id, workspace_id, workspace_name, repository_id, workspace_created_at,
+                sessions_started, sessions_completed, total_turns, last_message_at
+             )
+             VALUES (
+                'd1', 'w-gone', 'gone', 'r', datetime('now'),
+                2, 1, 6, datetime('now')
+             )",
+        );
+
+        let d = dashboard_metrics(&path).unwrap();
+        assert_eq!(d.sessions_today, 2);
+        assert!((d.success_rate_30d - 0.5).abs() < 1e-6);
+
+        let a = analytics_metrics(&path).unwrap();
+        assert_eq!(a.heatmap.iter().map(|c| c.count).sum::<u32>(), 2);
+        assert_eq!(a.turn_histogram, vec![0, 2, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(a.recent_sessions_24h.len(), 1);
+        assert_eq!(a.recent_sessions_24h[0].workspace_id, "w-gone");
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -17,6 +17,45 @@ use crate::model::{
 /// 8 turn-count buckets: [1,2], [3,4], [5,8], [9,16], [17,32], [33,64], [65,128], [129+].
 const TURN_BUCKET_UPPER_BOUNDS: [i64; 7] = [2, 4, 8, 16, 32, 64, 128];
 
+const MERGED_SESSIONS_CTE: &str = r#"
+WITH merged_sessions AS (
+    SELECT started_at,
+           ended_at,
+           completed_ok,
+           workspace_id,
+           turn_count,
+           1 AS session_count,
+           CASE WHEN completed_ok THEN 1 ELSE 0 END AS success_count
+    FROM agent_sessions
+    UNION ALL
+    SELECT started_at,
+           ended_at,
+           completed_ok,
+           workspace_id,
+           turn_count,
+           1 AS session_count,
+           CASE WHEN completed_ok THEN 1 ELSE 0 END AS success_count
+    FROM deleted_agent_sessions
+    UNION ALL
+    SELECT COALESCE(first_message_at, workspace_created_at) AS started_at,
+           last_message_at AS ended_at,
+           CASE WHEN sessions_completed > 0 THEN 1 ELSE 0 END AS completed_ok,
+           workspace_id,
+           CASE
+               WHEN total_turns > 0 THEN CAST(ROUND(total_turns * 1.0 / sessions_started) AS INTEGER)
+               ELSE 0
+           END AS turn_count,
+           sessions_started AS session_count,
+           sessions_completed AS success_count
+    FROM deleted_workspace_summaries s
+    WHERE sessions_started > 0
+      AND NOT EXISTS (
+          SELECT 1 FROM deleted_agent_sessions ds
+          WHERE ds.workspace_id = s.workspace_id
+      )
+)
+"#;
+
 pub fn dashboard_metrics(db_path: &Path) -> Result<DashboardMetrics, rusqlite::Error> {
     let conn = Connection::open(db_path)?;
     dashboard_metrics_with(&conn)
@@ -121,26 +160,16 @@ fn dashboard_metrics_with(conn: &Connection) -> Result<DashboardMetrics, rusqlit
     // Range form on raw `started_at` keeps `idx_agent_sessions_started` usable.
     // `started_at` is stored as naive UTC (`datetime('now')` form), so comparing
     // it against UTC boundary timestamps is well-defined lexicographically.
-    let sessions_today: u32 = conn.query_row(
-        "SELECT COALESCE(SUM(session_count), 0) FROM (
-             SELECT started_at, 1 AS session_count FROM agent_sessions
-             UNION ALL
-             SELECT started_at, 1 AS session_count FROM deleted_agent_sessions
-             UNION ALL
-             SELECT COALESCE(first_message_at, workspace_created_at) AS started_at,
-                    sessions_started AS session_count
-             FROM deleted_workspace_summaries s
-             WHERE sessions_started > 0
-               AND NOT EXISTS (
-                   SELECT 1 FROM deleted_agent_sessions ds
-                   WHERE ds.workspace_id = s.workspace_id
-               )
-         )
+    let sessions_today_sql = format!(
+        "{MERGED_SESSIONS_CTE}
+         SELECT COALESCE(SUM(session_count), 0)
+         FROM merged_sessions
          WHERE started_at >= datetime('now', 'localtime', 'start of day', 'utc')
-           AND started_at <  datetime('now', 'localtime', 'start of day', '+1 day', 'utc')",
-        [],
-        |row| row.get::<_, i64>(0).map(|n| n as u32),
-    )?;
+           AND started_at <  datetime('now', 'localtime', 'start of day', '+1 day', 'utc')"
+    );
+    let sessions_today: u32 = conn.query_row(&sessions_today_sql, [], |row| {
+        row.get::<_, i64>(0).map(|n| n as u32)
+    })?;
 
     let commits_today: u32 = conn.query_row(
         "SELECT COUNT(*) FROM (
@@ -180,35 +209,17 @@ fn dashboard_metrics_with(conn: &Connection) -> Result<DashboardMetrics, rusqlit
     )?;
     let cost_30d_usd = live_cost_30d + deleted_cost_30d;
 
-    let (successes_30d, completed_30d): (u64, u64) = conn.query_row(
-        "SELECT COALESCE(SUM(success_count), 0), COALESCE(SUM(session_count), 0)
-         FROM (
-             SELECT started_at, ended_at,
-                    CASE WHEN completed_ok THEN 1 ELSE 0 END AS success_count,
-                    1 AS session_count
-             FROM agent_sessions
-             UNION ALL
-             SELECT started_at, ended_at,
-                    CASE WHEN completed_ok THEN 1 ELSE 0 END AS success_count,
-                    1 AS session_count
-             FROM deleted_agent_sessions
-             UNION ALL
-             SELECT COALESCE(first_message_at, workspace_created_at) AS started_at,
-                    last_message_at AS ended_at,
-                    sessions_completed AS success_count,
-                    sessions_started AS session_count
-             FROM deleted_workspace_summaries s
-             WHERE sessions_started > 0
-               AND NOT EXISTS (
-                   SELECT 1 FROM deleted_agent_sessions ds
-                   WHERE ds.workspace_id = s.workspace_id
-               )
-         )
+    let success_rate_sql = format!(
+        "{MERGED_SESSIONS_CTE}
+         SELECT COALESCE(SUM(success_count), 0), COALESCE(SUM(session_count), 0)
+         FROM merged_sessions
          WHERE ended_at IS NOT NULL
-           AND started_at >= datetime('now', 'localtime', 'start of day', '-29 days', 'utc')",
-        [],
-        |row| Ok((row.get::<_, i64>(0)? as u64, row.get::<_, i64>(1)? as u64)),
-    )?;
+           AND started_at >= datetime('now', 'localtime', 'start of day', '-29 days', 'utc')"
+    );
+    let (successes_30d, completed_30d): (u64, u64) =
+        conn.query_row(&success_rate_sql, [], |row| {
+            Ok((row.get::<_, i64>(0)? as u64, row.get::<_, i64>(1)? as u64))
+        })?;
     let success_rate_30d = if completed_30d > 0 {
         successes_30d as f32 / completed_30d as f32
     } else {
@@ -539,27 +550,16 @@ fn repo_leaderboard(conn: &Connection) -> Result<Vec<RepoLeaderRow>, rusqlite::E
 
 fn heatmap(conn: &Connection) -> Result<Vec<HeatmapCell>, rusqlite::Error> {
     // 13 weeks × 7 days = 91 cells. Week index = days-ago / 7 (0 = most recent).
-    let mut stmt = conn.prepare(
-        "SELECT CAST(strftime('%w', started_at, 'localtime') AS INTEGER) AS dow,
+    let sql = format!(
+        "{MERGED_SESSIONS_CTE}
+         SELECT CAST(strftime('%w', started_at, 'localtime') AS INTEGER) AS dow,
                 CAST((julianday(date('now', 'localtime')) - julianday(date(started_at, 'localtime'))) / 7 AS INTEGER) AS week,
                 COALESCE(SUM(session_count), 0) AS c
-         FROM (
-             SELECT started_at, 1 AS session_count FROM agent_sessions
-             UNION ALL
-             SELECT started_at, 1 AS session_count FROM deleted_agent_sessions
-             UNION ALL
-             SELECT COALESCE(first_message_at, workspace_created_at) AS started_at,
-                    sessions_started AS session_count
-             FROM deleted_workspace_summaries s
-             WHERE sessions_started > 0
-               AND NOT EXISTS (
-                   SELECT 1 FROM deleted_agent_sessions ds
-                   WHERE ds.workspace_id = s.workspace_id
-               )
-         )
+         FROM merged_sessions
          WHERE started_at >= datetime('now', 'localtime', 'start of day', '-90 days', 'utc')
-         GROUP BY dow, week",
-    )?;
+         GROUP BY dow, week"
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let mut grid = [[0u32; 13]; 7];
     for row in stmt.query_map([], |row| {
         Ok((
@@ -587,25 +587,13 @@ fn heatmap(conn: &Connection) -> Result<Vec<HeatmapCell>, rusqlite::Error> {
 }
 
 fn turn_histogram(conn: &Connection) -> Result<Vec<u32>, rusqlite::Error> {
-    let mut stmt = conn.prepare(
-        "SELECT turn_count, 1 AS session_count
-         FROM agent_sessions
-         WHERE turn_count > 0
-         UNION ALL
-         SELECT turn_count, 1 AS session_count
-         FROM deleted_agent_sessions
-         WHERE turn_count > 0
-         UNION ALL
-         SELECT CAST(ROUND(total_turns * 1.0 / sessions_started) AS INTEGER) AS turn_count,
-                sessions_started AS session_count
-         FROM deleted_workspace_summaries s
-         WHERE sessions_started > 0
-           AND total_turns > 0
-           AND NOT EXISTS (
-               SELECT 1 FROM deleted_agent_sessions ds
-               WHERE ds.workspace_id = s.workspace_id
-           )",
-    )?;
+    let sql = format!(
+        "{MERGED_SESSIONS_CTE}
+         SELECT turn_count, session_count
+         FROM merged_sessions
+         WHERE turn_count > 0"
+    );
+    let mut stmt = conn.prepare(&sql)?;
     let mut buckets = vec![0u32; 8];
     for row in stmt.query_map([], |row| {
         Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)? as u32))
@@ -649,29 +637,16 @@ fn recent_sessions_24h(conn: &Connection) -> Result<Vec<SessionDot>, rusqlite::E
     // local time by V8, which would shift every dot by the user's UTC
     // offset — mirroring the backend's `ensure_utc_tz` treatment of
     // SQLite timestamps elsewhere.
-    let mut stmt = conn.prepare(
-        "SELECT strftime('%Y-%m-%dT%H:%M:%SZ', ended_at), completed_ok, workspace_id
-         FROM (
-             SELECT ended_at, completed_ok, workspace_id FROM agent_sessions
-             UNION ALL
-             SELECT ended_at, completed_ok, workspace_id FROM deleted_agent_sessions
-             UNION ALL
-             SELECT last_message_at AS ended_at,
-                    CASE WHEN sessions_completed > 0 THEN 1 ELSE 0 END AS completed_ok,
-                    workspace_id
-             FROM deleted_workspace_summaries s
-             WHERE last_message_at IS NOT NULL
-               AND sessions_started > 0
-               AND NOT EXISTS (
-                   SELECT 1 FROM deleted_agent_sessions ds
-                   WHERE ds.workspace_id = s.workspace_id
-               )
-         )
+    let sql = format!(
+        "{MERGED_SESSIONS_CTE}
+         SELECT strftime('%Y-%m-%dT%H:%M:%SZ', ended_at), completed_ok, workspace_id
+         FROM merged_sessions
          WHERE ended_at IS NOT NULL
            AND workspace_id IS NOT NULL
            AND ended_at >= datetime('now','-24 hours')
-         ORDER BY ended_at DESC",
-    )?;
+         ORDER BY ended_at DESC"
+    );
+    let mut stmt = conn.prepare(&sql)?;
     stmt.query_map([], |row| {
         Ok(SessionDot {
             ended_at: row.get(0)?,

--- a/src/migrations/20260519231159_deleted_workspace_metric_details.sql
+++ b/src/migrations/20260519231159_deleted_workspace_metric_details.sql
@@ -10,6 +10,7 @@ CREATE TABLE deleted_agent_sessions (
 );
 CREATE INDEX idx_deleted_agent_sessions_workspace ON deleted_agent_sessions(workspace_id);
 CREATE INDEX idx_deleted_agent_sessions_started   ON deleted_agent_sessions(started_at);
+CREATE INDEX idx_deleted_agent_sessions_ended     ON deleted_agent_sessions(ended_at);
 CREATE INDEX idx_deleted_agent_sessions_repo      ON deleted_agent_sessions(repository_id);
 
 CREATE TABLE deleted_agent_commits (

--- a/src/migrations/20260519231159_deleted_workspace_metric_details.sql
+++ b/src/migrations/20260519231159_deleted_workspace_metric_details.sql
@@ -1,0 +1,38 @@
+CREATE TABLE deleted_agent_sessions (
+    id              TEXT PRIMARY KEY,
+    workspace_id    TEXT,
+    repository_id   TEXT NOT NULL,
+    started_at      TEXT NOT NULL,
+    last_message_at TEXT NOT NULL,
+    ended_at        TEXT,
+    turn_count      INTEGER NOT NULL DEFAULT 0,
+    completed_ok    INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX idx_deleted_agent_sessions_workspace ON deleted_agent_sessions(workspace_id);
+CREATE INDEX idx_deleted_agent_sessions_started   ON deleted_agent_sessions(started_at);
+CREATE INDEX idx_deleted_agent_sessions_repo      ON deleted_agent_sessions(repository_id);
+
+CREATE TABLE deleted_agent_commits (
+    commit_hash     TEXT NOT NULL,
+    workspace_id    TEXT NOT NULL,
+    repository_id   TEXT NOT NULL,
+    session_id      TEXT,
+    additions       INTEGER NOT NULL DEFAULT 0,
+    deletions       INTEGER NOT NULL DEFAULT 0,
+    files_changed   INTEGER NOT NULL DEFAULT 0,
+    committed_at    TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, commit_hash)
+);
+CREATE INDEX idx_deleted_agent_commits_workspace ON deleted_agent_commits(workspace_id);
+CREATE INDEX idx_deleted_agent_commits_committed ON deleted_agent_commits(committed_at);
+CREATE INDEX idx_deleted_agent_commits_repo      ON deleted_agent_commits(repository_id);
+
+CREATE TABLE deleted_slash_command_usage (
+    workspace_id  TEXT NOT NULL,
+    repository_id TEXT NOT NULL,
+    command_name  TEXT NOT NULL,
+    use_count     INTEGER NOT NULL DEFAULT 1,
+    last_used_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (workspace_id, command_name)
+);
+CREATE INDEX idx_deleted_slash_command_usage_repo ON deleted_slash_command_usage(repository_id);

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -234,4 +234,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260517190000_agent_scheduled_tasks.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260519231159_deleted_workspace_metric_details",
+        sql: include_str!("20260519231159_deleted_workspace_metric_details.sql"),
+        legacy_version: None,
+    },
 ];


### PR DESCRIPTION
## Summary

This fixes the dashboard stats regression after archived workspace cleanup. Bulk cleanup was correctly routing deletes through the existing `delete_workspace_with_summary` materialization path, but that path only preserved coarse lifetime totals in `deleted_workspace_summaries`. Several dashboard widgets still read the raw `agent_sessions`, `agent_commits`, and `slash_command_usage` rows, which are cascaded away when a workspace is hard-deleted.

## Root Cause

Recent cleanup work (#841, with follow-up hardening in #857/#872) made it much easier to permanently delete archived workspaces in bulk. The cleanup path did not bypass metric preservation, but the preservation contract was incomplete:

- repo leaderboard, 30d cost, and token totals could survive from coarse summaries;
- activity heatmap, turns per session, slash command names, commit/churn time series, recent session dots, and success-rate detail depended on rows that were deleted by cascade.

That made the stats page look partially blank after cleanup even though the user expected archived cleanup to be storage-only, not analytics-destructive.

## Changes

- Adds a migration with non-cascading deleted metric detail tables:
  - `deleted_agent_sessions`
  - `deleted_agent_commits`
  - `deleted_slash_command_usage`
- Extends workspace hard-delete materialization to copy session, commit, and slash command detail rows before deleting the workspace.
- Updates dashboard and analytics queries to merge live rows with deleted-detail rows.
- Adds coarse fallback from `deleted_workspace_summaries` for workspaces already cleaned before this migration where exact detail rows cannot exist.
- Adds regression tests for both forward preservation and fallback behavior.

## Notes

For workspaces cleaned before this migration, exact slash command names cannot be reconstructed because the old summary only stored a total count. Going forward, names and counts are preserved in `deleted_slash_command_usage`.

## Validation

- `nix develop -c cargo test -p claudette metrics::tests`
- `nix develop -c cargo test -p claudette test_materialize_summary_on_hard_delete`
- `nix develop -c cargo test -p claudette test_delete_workspace_idempotent`
- `nix develop -c cargo fmt --all --check`
- `git diff --check`
