### PR TITLE
fix(tasks): kill elastic scroll bounce + auto-scroll to active task in Tasks sidebar

### DIFF
--- a/site/src/content/docs/features/task-history.mdx
+++ b/site/src/content/docs/features/task-history.mdx
@@ -11,6 +11,14 @@ Open the right sidebar and choose **Tasks**. The **Current** section shows the s
 
 The tab badge counts every task the panel would surface — the active checklist plus any subagent buckets plus every task across archived history runs — so a workspace with older task lists still signals that there is task context to review.
 
+## Following the Active Task
+
+As an agent works through a long checklist, Claudette keeps the **currently-active task** scrolled into view — the task that is `in_progress`, or the next `pending` one if none is in progress. When the agent moves on, the list follows the new active task with a smooth scroll so you never have to chase active work down a long list.
+
+Auto-follow yields the moment you scroll the list yourself — wheel, trackpad, scrollbar, or keyboard. The list then stays exactly where you put it even as new task transitions arrive, so you can read **History** without being pulled away. A **Jump to current** pill appears at the bottom of the list whenever the active task is off-screen; click it to scroll back to the active task and re-enable auto-follow.
+
+Like every other scroll surface in Claudette, the Tasks list does not elastic-bounce at its top and bottom edges.
+
 ## Subagent Tasks
 
 When the main agent spawns subagents (via Claude Code's `TaskCreate` / agent-teams flow), each subagent's own task list renders in its own section above **History**, labeled with the subagent's name. The main agent's checklist stays in **Current**; subagent buckets are kept separate so the two never collide. Once a subagent finishes (status leaves `running`), its bucket is archived into **History** under the owning session.

--- a/src/ui/src/components/right-sidebar/TaskList.module.css
+++ b/src/ui/src/components/right-sidebar/TaskList.module.css
@@ -1,7 +1,53 @@
+/* Positioning context for the absolutely-placed "Jump to current" pill,
+ * and the flex column that lets `.list` own the scroll surface. */
+.container {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 .list {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 4px;
+  /* Belt-and-suspenders with usePreventScrollBounce (via BoundedScrollPane):
+   * the CSS property handles the trackpad-flick edge case before the wheel
+   * listener can intercept; the JS hook handles WKWebView's elastic gesture
+   * that the CSS property doesn't reliably suppress. */
+  overscroll-behavior-y: none;
+}
+
+/* "Jump to current" pill — mirrors the chat panel's scroll-to-bottom pill
+ * (ScrollToBottomPill.module.css). Floats over the bottom of the list when
+ * the active task has scrolled out of view and auto-follow is paused. */
+.jumpToCurrent {
+  position: absolute;
+  left: 50%;
+  bottom: 12px;
+  transform: translateX(-50%);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: var(--chat-input-bg);
+  border: 1px solid var(--divider);
+  border-radius: 20px;
+  color: var(--accent-primary);
+  font-size: var(--caption-size);
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: var(--shadow-md);
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.jumpToCurrent:hover {
+  background: var(--hover-bg);
+  border-color: var(--accent-primary);
 }
 
 .empty {

--- a/src/ui/src/components/right-sidebar/TaskList.test.tsx
+++ b/src/ui/src/components/right-sidebar/TaskList.test.tsx
@@ -2,12 +2,43 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TaskStatus, TrackedTask } from "../../hooks/useTaskTracker";
 import type { WorkspaceTaskHistoryResult } from "../../hooks/useWorkspaceTaskHistory";
 import { TaskList } from "./TaskList";
 
 const mountedRoots: Root[] = [];
 const mountedContainers: HTMLElement[] = [];
+
+// `useActiveTaskScroll` reaches for browser APIs happy-dom doesn't fully
+// implement. Stub them deterministically: a `scrollIntoView` spy lets the
+// auto-scroll tests assert on calls, and the observers are no-ops so DOM
+// churn never drives the pill on its own during a test.
+let scrollIntoView: ReturnType<typeof vi.fn>;
+
+/** A constructable no-op standing in for ResizeObserver / MutationObserver. */
+class NoopObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+function installDomStubs() {
+  scrollIntoView = vi.fn();
+  Element.prototype.scrollIntoView =
+    scrollIntoView as unknown as Element["scrollIntoView"];
+  globalThis.ResizeObserver =
+    NoopObserver as unknown as typeof globalThis.ResizeObserver;
+  globalThis.MutationObserver =
+    NoopObserver as unknown as typeof globalThis.MutationObserver;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  }) as typeof globalThis.requestAnimationFrame;
+}
 
 async function render(node: React.ReactNode): Promise<HTMLElement> {
   const container = document.createElement("div");
@@ -21,6 +52,28 @@ async function render(node: React.ReactNode): Promise<HTMLElement> {
   return container;
 }
 
+/** Mount a `TaskList` and return its container plus a `rerender` that swaps
+ *  the `taskHistory` prop on the same root — used to drive task transitions. */
+async function renderTaskList(history: WorkspaceTaskHistoryResult) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(<TaskList taskHistory={history} />);
+  });
+  const rerender = (next: WorkspaceTaskHistoryResult) =>
+    act(async () => {
+      root.render(<TaskList taskHistory={next} />);
+    });
+  return { container, rerender };
+}
+
+beforeEach(() => {
+  installDomStubs();
+});
+
 afterEach(async () => {
   for (const root of mountedRoots.splice(0).reverse()) {
     await act(async () => {
@@ -30,7 +83,50 @@ afterEach(async () => {
   for (const container of mountedContainers.splice(0)) {
     container.remove();
   }
+  vi.restoreAllMocks();
 });
+
+function makeTask(
+  id: string,
+  status: TaskStatus,
+  description = `Task ${id}`,
+): TrackedTask {
+  return { id, description, status, source: "task" };
+}
+
+/** A history result with only a Current section — enough to exercise the
+ *  active-task auto-scroll without the History / subagent machinery. */
+function historyWith(tasks: TrackedTask[]): WorkspaceTaskHistoryResult {
+  return {
+    current: {
+      tasks,
+      completedCount: tasks.filter((t) => t.status === "completed").length,
+      totalCount: tasks.length,
+    },
+    sessions: [],
+    siblings: [],
+    subagents: [],
+    historyRunCount: 0,
+    totalBadgeCount: tasks.length,
+    loading: false,
+  };
+}
+
+/** Dispatch a manual scroll gesture inside the list. A `keydown` bubbles to
+ *  the scroll container's listener and is never produced by `scrollIntoView`,
+ *  so it is the cleanest way to simulate the user taking scroll control. */
+function dispatchManualScroll(container: HTMLElement) {
+  const surface = container.querySelector("[aria-label='Current tasks']");
+  surface?.dispatchEvent(
+    new KeyboardEvent("keydown", { bubbles: true, key: "ArrowDown" }),
+  );
+}
+
+function jumpToCurrentPill(container: HTMLElement): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>(
+    "button[aria-label='Jump to current task']",
+  );
+}
 
 function taskHistory(): WorkspaceTaskHistoryResult {
   return {
@@ -234,5 +330,77 @@ describe("TaskList", () => {
     });
 
     expect(container.textContent).toContain("Initial plan snapshot.");
+  });
+
+  it("scrolls the active task into view when the active task changes", async () => {
+    const { rerender } = await renderTaskList(
+      historyWith([
+        makeTask("t1", "in_progress"),
+        makeTask("t2", "pending"),
+      ]),
+    );
+    // Isolate the transition from the initial mount auto-scroll.
+    scrollIntoView.mockClear();
+
+    // t1 completes, t2 becomes in_progress → the active task changes.
+    await rerender(
+      historyWith([
+        makeTask("t1", "completed"),
+        makeTask("t2", "in_progress"),
+      ]),
+    );
+
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("stops auto-scrolling once the user scrolls the list manually", async () => {
+    const { container, rerender } = await renderTaskList(
+      historyWith([
+        makeTask("t1", "in_progress"),
+        makeTask("t2", "pending"),
+      ]),
+    );
+    scrollIntoView.mockClear();
+
+    // The user takes scroll control.
+    await act(async () => {
+      dispatchManualScroll(container);
+    });
+
+    // A task transition arrives — auto-follow must stay yielded.
+    await rerender(
+      historyWith([
+        makeTask("t1", "completed"),
+        makeTask("t2", "in_progress"),
+      ]),
+    );
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("shows a 'Jump to current' pill after a manual scroll and hides it on click", async () => {
+    const { container } = await renderTaskList(
+      historyWith([
+        makeTask("t1", "in_progress"),
+        makeTask("t2", "pending"),
+      ]),
+    );
+    // While auto-follow is armed the active row is kept in view — no pill.
+    expect(jumpToCurrentPill(container)).toBeNull();
+
+    // User scrolls away → active row off-screen → pill appears.
+    await act(async () => {
+      dispatchManualScroll(container);
+    });
+    const pill = jumpToCurrentPill(container);
+    expect(pill).not.toBeNull();
+
+    // Clicking it re-arms auto-follow, scrolls back, and dismisses the pill.
+    scrollIntoView.mockClear();
+    await act(async () => {
+      pill!.click();
+    });
+    expect(scrollIntoView).toHaveBeenCalled();
+    expect(jumpToCurrentPill(container)).toBeNull();
   });
 });

--- a/src/ui/src/components/right-sidebar/TaskList.tsx
+++ b/src/ui/src/components/right-sidebar/TaskList.tsx
@@ -1,5 +1,5 @@
-import { memo, useState } from "react";
-import { ChevronRight } from "lucide-react";
+import { memo, useRef, useState, type RefObject } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import type {
   SubagentTaskRun,
   TaskRun,
@@ -7,6 +7,8 @@ import type {
   TrackedTask,
 } from "../../hooks/useTaskTracker";
 import type { WorkspaceTaskHistoryResult } from "../../hooks/useWorkspaceTaskHistory";
+import { useActiveTaskScroll } from "../../hooks/useActiveTaskScroll";
+import { BoundedScrollPane } from "../shared/BoundedScrollPane";
 import styles from "./TaskList.module.css";
 
 function statusIcon(status: TaskStatus): string {
@@ -39,12 +41,35 @@ function statusColor(status: TaskStatus): string {
   }
 }
 
-function TaskItem({ task }: { task: TrackedTask }) {
+/**
+ * Pick the task the Tasks panel should keep in view — the agent's current
+ * focus. Preference order: the in-progress task, then the next pending
+ * task, then the last task in the list as a backstop. `blocked`,
+ * `completed`, and `cancelled` tasks are never treated as active; a list
+ * stalled entirely on blocked work falls through to the last-row backstop.
+ */
+function findActiveTask(tasks: TrackedTask[]): TrackedTask | null {
+  if (tasks.length === 0) return null;
+  return (
+    tasks.find((t) => t.status === "in_progress") ??
+    tasks.find((t) => t.status === "pending") ??
+    tasks[tasks.length - 1] ??
+    null
+  );
+}
+
+function TaskItem({
+  task,
+  rowRef,
+}: {
+  task: TrackedTask;
+  rowRef?: RefObject<HTMLDivElement | null>;
+}) {
   const isCompleted = task.status === "completed";
   const isCancelled = task.status === "cancelled";
 
   return (
-    <div className={styles.task}>
+    <div className={styles.task} ref={rowRef}>
       <span
         className={styles.statusIcon}
         style={{ color: statusColor(task.status) }}
@@ -72,13 +97,24 @@ function TaskItem({ task }: { task: TrackedTask }) {
   );
 }
 
-function TaskRows({ tasks }: { tasks: TrackedTask[] }) {
+function TaskRows({
+  tasks,
+  activeTask,
+  activeRef,
+}: {
+  tasks: TrackedTask[];
+  /** When set, the matching row receives `activeRef` so the auto-scroll
+   *  hook can find it. Only the Current section passes these. */
+  activeTask?: TrackedTask | null;
+  activeRef?: RefObject<HTMLDivElement | null>;
+}) {
   return (
     <>
       {tasks.map((task) => (
         <TaskItem
           key={`${task.source}-${task.id}-${task.description}`}
           task={task}
+          rowRef={activeRef && task === activeTask ? activeRef : undefined}
         />
       ))}
     </>
@@ -151,106 +187,131 @@ export const TaskList = memo(function TaskList({
   taskHistory: WorkspaceTaskHistoryResult;
 }) {
   const [expandedRuns, setExpandedRuns] = useState<Record<string, boolean>>({});
+  const listRef = useRef<HTMLDivElement>(null);
   const { current, sessions, siblings, subagents, loading } = taskHistory;
+
+  // The active task drives auto-scroll: when its id changes the hook brings
+  // the matching row into view (unless the user has scrolled away).
+  const activeTask = findActiveTask(current.tasks);
+  const { activeTaskRef, showPill, jumpToActive } = useActiveTaskScroll(
+    listRef,
+    activeTask?.id ?? null,
+  );
+
   const hasCurrent = current.tasks.length > 0;
   const hasHistory = sessions.length > 0;
   const hasSubagents = subagents.length > 0;
   const hasSiblings = siblings.length > 0;
-
-  if (!hasCurrent && !hasHistory && !hasSubagents && !hasSiblings) {
-    return (
-      <div className={styles.list}>
-        <div className={styles.empty}>
-          {loading ? "Loading tasks..." : "No tasks"}
-        </div>
-      </div>
-    );
-  }
+  const isEmpty = !hasCurrent && !hasHistory && !hasSubagents && !hasSiblings;
 
   return (
-    <div className={styles.list}>
-      {hasCurrent && (
-        <section className={styles.section} aria-label="Current tasks">
-          <div className={styles.sectionHeader}>
-            <span>Current</span>
-            <span className={styles.sectionMeta}>
-              {current.completedCount}/{current.totalCount}
-            </span>
+    <div className={styles.container}>
+      <BoundedScrollPane ref={listRef} className={styles.list}>
+        {isEmpty && (
+          <div className={styles.empty}>
+            {loading ? "Loading tasks..." : "No tasks"}
           </div>
-          {current.explanation && (
-            <div className={styles.explanation}>{current.explanation}</div>
-          )}
-          <TaskRows tasks={current.tasks} />
-        </section>
-      )}
+        )}
 
-      {hasSubagents &&
-        subagents.map((run) => <SubagentSection key={run.id} run={run} />)}
-
-      {hasSiblings &&
-        siblings.map((sibling) => (
-          <section
-            key={`sibling-${sibling.session.id}`}
-            className={styles.section}
-            aria-label={`Sibling session: ${sibling.session.name}`}
-          >
+        {hasCurrent && (
+          <section className={styles.section} aria-label="Current tasks">
             <div className={styles.sectionHeader}>
-              <span
-                className={styles.subagentLabel}
-                title={sibling.session.name}
-              >
-                {sibling.session.name}
-                <span className={styles.liveDot} aria-hidden="true" />
-              </span>
+              <span>Current</span>
               <span className={styles.sectionMeta}>
-                {sibling.current.completedCount}/{sibling.current.totalCount}
+                {current.completedCount}/{current.totalCount}
               </span>
             </div>
-            {sibling.current.tasks.length > 0 && (
-              <TaskRows tasks={sibling.current.tasks} />
+            {current.explanation && (
+              <div className={styles.explanation}>{current.explanation}</div>
             )}
-            {sibling.subagents.map((run) => (
-              <SubagentSection key={run.id} run={run} />
+            <TaskRows
+              tasks={current.tasks}
+              activeTask={activeTask}
+              activeRef={activeTaskRef}
+            />
+          </section>
+        )}
+
+        {hasSubagents &&
+          subagents.map((run) => <SubagentSection key={run.id} run={run} />)}
+
+        {hasSiblings &&
+          siblings.map((sibling) => (
+            <section
+              key={`sibling-${sibling.session.id}`}
+              className={styles.section}
+              aria-label={`Sibling session: ${sibling.session.name}`}
+            >
+              <div className={styles.sectionHeader}>
+                <span
+                  className={styles.subagentLabel}
+                  title={sibling.session.name}
+                >
+                  {sibling.session.name}
+                  <span className={styles.liveDot} aria-hidden="true" />
+                </span>
+                <span className={styles.sectionMeta}>
+                  {sibling.current.completedCount}/{sibling.current.totalCount}
+                </span>
+              </div>
+              {sibling.current.tasks.length > 0 && (
+                <TaskRows tasks={sibling.current.tasks} />
+              )}
+              {sibling.subagents.map((run) => (
+                <SubagentSection key={run.id} run={run} />
+              ))}
+            </section>
+          ))}
+
+        {hasHistory && (
+          <section className={styles.section} aria-label="Task history">
+            <div className={styles.sectionHeader}>
+              <span>History</span>
+              <span className={styles.sectionMeta}>
+                {taskHistory.historyRunCount}
+              </span>
+            </div>
+            {sessions.map(({ session, runs }) => (
+              <div key={session.id} className={styles.sessionGroup}>
+                <div className={styles.sessionHeader}>
+                  <span className={styles.sessionName}>{session.name}</span>
+                  {session.status === "Archived" && (
+                    <span className={styles.archivedBadge}>Archived</span>
+                  )}
+                </div>
+                {runs.map((run) => {
+                  const key = `${session.id}:${run.id}`;
+                  const expanded = expandedRuns[key] === true;
+                  return (
+                    <RunSummary
+                      key={key}
+                      run={run}
+                      expanded={expanded}
+                      onToggle={() =>
+                        setExpandedRuns((prev) => ({
+                          ...prev,
+                          [key]: !(prev[key] === true),
+                        }))
+                      }
+                    />
+                  );
+                })}
+              </div>
             ))}
           </section>
-        ))}
+        )}
+      </BoundedScrollPane>
 
-      {hasHistory && (
-        <section className={styles.section} aria-label="Task history">
-          <div className={styles.sectionHeader}>
-            <span>History</span>
-            <span className={styles.sectionMeta}>
-              {taskHistory.historyRunCount}
-            </span>
-          </div>
-          {sessions.map(({ session, runs }) => (
-            <div key={session.id} className={styles.sessionGroup}>
-              <div className={styles.sessionHeader}>
-                <span className={styles.sessionName}>{session.name}</span>
-                {session.status === "Archived" && (
-                  <span className={styles.archivedBadge}>Archived</span>
-                )}
-              </div>
-              {runs.map((run) => {
-                const key = `${session.id}:${run.id}`;
-                const expanded = expandedRuns[key] === true;
-                return (
-                  <RunSummary
-                    key={key}
-                    run={run}
-                    expanded={expanded}
-                    onToggle={() =>
-                      setExpandedRuns((prev) => ({
-                        ...prev,
-                        [key]: !(prev[key] === true),
-                      }))
-                    }
-                  />
-                );
-              })}
-            </div>
-          ))}
-        </section>
+      {showPill && (
+        <button
+          type="button"
+          className={styles.jumpToCurrent}
+          onClick={jumpToActive}
+          aria-label="Jump to current task"
+        >
+          <ChevronDown size={14} aria-hidden="true" />
+          <span>Jump to current</span>
+        </button>
       )}
     </div>
   );

--- a/src/ui/src/components/right-sidebar/TaskList.tsx
+++ b/src/ui/src/components/right-sidebar/TaskList.tsx
@@ -43,18 +43,22 @@ function statusColor(status: TaskStatus): string {
 
 /**
  * Pick the task the Tasks panel should keep in view — the agent's current
- * focus. Preference order: the in-progress task, then the next pending
- * task, then the last task in the list as a backstop. `blocked`,
- * `completed`, and `cancelled` tasks are never treated as active; a list
- * stalled entirely on blocked work falls through to the last-row backstop.
+ * focus. Preference order:
+ *   1. the task that is `in_progress`,
+ *   2. otherwise the first `pending` task,
+ *   3. otherwise the last task in the list, as a backstop.
+ *
+ * The backstop is intentionally status-agnostic: when nothing is actively
+ * progressing (every task completed, or the list stalled entirely on
+ * blocked work) the panel anchors on the end of the list rather than
+ * scrolling nowhere.
  */
 function findActiveTask(tasks: TrackedTask[]): TrackedTask | null {
   if (tasks.length === 0) return null;
   return (
     tasks.find((t) => t.status === "in_progress") ??
     tasks.find((t) => t.status === "pending") ??
-    tasks[tasks.length - 1] ??
-    null
+    tasks[tasks.length - 1]
   );
 }
 

--- a/src/ui/src/hooks/useActiveTaskScroll.ts
+++ b/src/ui/src/hooks/useActiveTaskScroll.ts
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+
+/**
+ * How long after a programmatic `scrollIntoView` we keep attributing
+ * `scroll` events to that animation rather than to the user. A smooth
+ * scroll emits a burst of `scroll` events over its duration; without this
+ * window each one would look like manual intent and cancel auto-follow the
+ * instant it was armed.
+ */
+const PROGRAMMATIC_SCROLL_WINDOW_MS = 600;
+
+/**
+ * Keeps the currently-active task row visible in the Tasks sidebar as the
+ * agent works through its list — and yields the moment the user scrolls.
+ *
+ * This is deliberately *not* `useStickyScroll`. Chat appends new items at
+ * the bottom, so it pins `scrollTop = scrollHeight`. The Tasks list renders
+ * top-down (Current → Subagents → Siblings → History): new work lands
+ * inside the Current section near the top while History can be hundreds of
+ * rows tall. Pinning the literal bottom would scroll *away* from active
+ * work, so this hook scrolls the active row into view with
+ * `scrollIntoView({ block: "nearest" })` instead.
+ *
+ * Re-follow model (chosen in issue 878): a manual scroll latches
+ * auto-follow OFF and only the "Jump to current" pill (`jumpToActive`)
+ * re-arms it. Task transitions alone never move the list once the user has
+ * taken control — so the list stays exactly where the user left it.
+ *
+ * Reuses the user-intent-version pattern from `useStickyScroll`: a manual
+ * gesture bumps `userScrollVersionRef`; auto-follow is armed iff that
+ * counter still equals `followVersionRef` (the snapshot taken when follow
+ * was last armed).
+ *
+ * @param containerRef the scroll surface (a `BoundedScrollPane`).
+ * @param activeTaskId id of the active task, or `null` when there is none.
+ *        Changing it is the sole trigger for an auto-scroll.
+ */
+export function useActiveTaskScroll(
+  containerRef: RefObject<HTMLElement | null>,
+  activeTaskId: string | null,
+) {
+  // DOM node of the active task row. The caller attaches this to whichever
+  // row it considers active; React keeps `.current` in lockstep as that
+  // row changes.
+  const activeTaskRef = useRef<HTMLDivElement>(null);
+  // Bumped on every gesture that signals manual scroll intent.
+  const userScrollVersionRef = useRef(0);
+  // Snapshot of `userScrollVersionRef` taken the last time auto-follow was
+  // armed (initial mount + every "Jump to current" click). Auto-follow is
+  // active iff the live counter still equals this snapshot.
+  const followVersionRef = useRef(0);
+  // Timestamp until which `scroll` events are treated as our own
+  // `scrollIntoView` animation rather than as manual intent.
+  const programmaticUntilRef = useRef(0);
+  // Latest `activeTaskId`, read by listener closures without re-binding.
+  const activeTaskIdRef = useRef(activeTaskId);
+  activeTaskIdRef.current = activeTaskId;
+
+  const [showPill, setShowPill] = useState(false);
+
+  const isFollowing = useCallback(
+    () => userScrollVersionRef.current === followVersionRef.current,
+    [],
+  );
+
+  const isActiveTaskOffScreen = useCallback(() => {
+    const container = containerRef.current;
+    const row = activeTaskRef.current;
+    if (!container || !row) return false;
+    const c = container.getBoundingClientRect();
+    const r = row.getBoundingClientRect();
+    // Fully above the viewport or fully below it.
+    return r.bottom <= c.top || r.top >= c.bottom;
+  }, [containerRef]);
+
+  const recomputePill = useCallback(() => {
+    // The pill is the "you scrolled away — click to come back" affordance.
+    // While auto-follow is still armed the active row is being kept in view
+    // for the user, so there is nothing to jump to.
+    if (activeTaskIdRef.current == null || isFollowing()) {
+      setShowPill(false);
+      return;
+    }
+    setShowPill(isActiveTaskOffScreen());
+  }, [isFollowing, isActiveTaskOffScreen]);
+
+  const scrollActiveIntoView = useCallback(() => {
+    const row = activeTaskRef.current;
+    if (!row) return;
+    programmaticUntilRef.current = Date.now() + PROGRAMMATIC_SCROLL_WINDOW_MS;
+    row.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, []);
+
+  /**
+   * Re-arm auto-follow and bring the active row back into view. Wired to
+   * the "Jump to current" pill — the only thing that re-arms following once
+   * the user has scrolled away (issue 878 re-follow model).
+   */
+  const jumpToActive = useCallback(() => {
+    followVersionRef.current = userScrollVersionRef.current;
+    scrollActiveIntoView();
+    setShowPill(false);
+  }, [scrollActiveIntoView]);
+
+  // The sole auto-scroll trigger: the active task changed (e.g. the agent
+  // flipped task 30 from pending → in_progress). A container or sidebar
+  // resize deliberately never moves the list on its own.
+  useEffect(() => {
+    if (activeTaskId == null) {
+      setShowPill(false);
+      return;
+    }
+    if (isFollowing()) {
+      scrollActiveIntoView();
+      setShowPill(false);
+    } else {
+      recomputePill();
+    }
+  }, [activeTaskId, isFollowing, scrollActiveIntoView, recomputePill]);
+
+  // Bind scroll-intent + pill-visibility listeners once the container is
+  // mounted. The container is stable for the lifetime of the panel, so this
+  // effect runs once.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const markIntent = () => {
+      userScrollVersionRef.current += 1;
+    };
+
+    // wheel / touch / keyboard are unambiguous user gestures — never
+    // synthesised by `scrollIntoView` — so they latch auto-follow off
+    // unconditionally and refresh the pill straight away.
+    const onGesture = () => {
+      markIntent();
+      recomputePill();
+    };
+    // `scroll` additionally covers scrollbar-drag, but our own smooth scroll
+    // emits `scroll` too — ignore those within the programmatic window so
+    // auto-follow can't cancel itself.
+    const onScroll = () => {
+      if (Date.now() >= programmaticUntilRef.current) markIntent();
+      recomputePill();
+    };
+
+    let rafScheduled = false;
+    let disposed = false;
+    const scheduleRecompute = () => {
+      if (rafScheduled || disposed) return;
+      rafScheduled = true;
+      requestAnimationFrame(() => {
+        rafScheduled = false;
+        if (!disposed) recomputePill();
+      });
+    };
+
+    el.addEventListener("scroll", onScroll, { passive: true });
+    el.addEventListener("wheel", onGesture, { passive: true });
+    el.addEventListener("touchmove", onGesture, { passive: true });
+    el.addEventListener("keydown", onGesture);
+
+    // A height change (sidebar/window resize) can push the active row out
+    // of view — refresh the pill, but never auto-scroll.
+    const resizeObserver = new ResizeObserver(scheduleRecompute);
+    resizeObserver.observe(el);
+    // Content churn (new tasks, RunSummary expand/collapse) shifts the
+    // active row without an id transition — keep the pill honest.
+    const mutationObserver = new MutationObserver(scheduleRecompute);
+    mutationObserver.observe(el, { childList: true, subtree: true });
+
+    return () => {
+      disposed = true;
+      el.removeEventListener("scroll", onScroll);
+      el.removeEventListener("wheel", onGesture);
+      el.removeEventListener("touchmove", onGesture);
+      el.removeEventListener("keydown", onGesture);
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+    };
+  }, [containerRef, recomputePill]);
+
+  return { activeTaskRef, showPill, jumpToActive } as const;
+}


### PR DESCRIPTION
## Summary

Fixes two scroll ergonomics issues with the **Tasks** tab in the right sidebar (issue #878).

### 1. Elastic bounce
The Tasks list was the only major scroll surface bypassing the app's bounce-prevention primitive — it used a raw `overflow-y: auto` div. It now uses the shared `BoundedScrollPane` component plus `overscroll-behavior-y: none`, the exact belt-and-suspenders recipe `BoundedScrollPane`'s doc comment prescribes (the JS hook handles WKWebView's elastic gesture; the CSS property handles the trackpad-flick edge case). Visual parity with chat / Dashboard / settings.

### 2. Auto-scroll to the active task
New `useActiveTaskScroll` hook keeps the **currently-active task** scrolled into view as the agent works through a long list.

This is deliberately **not** modeled on chat's `useStickyScroll`. Chat appends at the bottom and pins `scrollTop = scrollHeight`. The Tasks list renders top-down (Current → Subagents → Siblings → History) and new work lands inside the Current section near the top — pinning the literal bottom would scroll *away* from active work. Instead the hook resolves the active row (first `in_progress`, then first `pending`, then last row as a backstop) and calls `scrollIntoView({ block: "nearest", behavior: "smooth" })`.

**Re-follow model:** a manual scroll latches auto-follow OFF; task transitions never move the list again until the user clicks a **Jump to current** pill (mirrors chat's scroll-to-bottom pill). This was confirmed with @jamesbrink as the preferred UX over silent re-arming.

**Key design points:**
- Auto-scroll triggers **solely** on active-task-id change. The `ResizeObserver` / `MutationObserver` only recompute pill visibility — they never scroll. This is what makes "expanding a history run" and "resizing the sidebar width" not steal scroll position, by construction.
- Manual-intent detection reuses `useStickyScroll`'s `userScrollVersionRef` pattern. `wheel` / `touchmove` / `keydown` are unambiguous gestures and latch follow off unconditionally; `scroll` additionally covers scrollbar-drag but is gated by a 600ms window so a programmatic smooth-scroll's own burst of `scroll` events can't cancel auto-follow.

## Acceptance criteria

- [x] Wheel-flick / two-finger swipe at the top or bottom edge does not elastic-bounce.
- [x] Task transitions past the viewport smooth-scroll the active task into view.
- [x] Manual scroll (wheel, touch, scrollbar drag, keyboard) makes auto-scroll yield.
- [x] **Jump to current** pill appears when the active task is off-screen; click scrolls to it and hides the pill.
- [x] Expanding a history `RunSummary` does not steal scroll position.
- [x] Resizing the sidebar width does not re-trigger auto-scroll.
- [x] No regression to chat / Dashboard / settings scroll surfaces (only Tasks touched).

## Files

| File | Change |
|---|---|
| `src/ui/src/hooks/useActiveTaskScroll.ts` | **New** — auto-scroll hook + pill state |
| `src/ui/src/components/right-sidebar/TaskList.tsx` | `BoundedScrollPane`, `findActiveTask`, active-row ref, pill |
| `src/ui/src/components/right-sidebar/TaskList.module.css` | `.container`, bounce guard, `.jumpToCurrent` pill |
| `src/ui/src/components/right-sidebar/TaskList.test.tsx` | 3 new cases (transition, manual-yield, pill) |
| `site/src/content/docs/features/task-history.mdx` | New "Following the Active Task" section |

## Testing

- `bunx tsc -b` — clean
- `bun run lint` — 0 errors · `bun run lint:css` — clean
- `bunx vitest run` — **2593 passed, 0 failed** (no regressions)
- `TaskList.test.tsx` — 8/8 (5 existing + 3 new)

## Notes

`findActiveTask` follows the issue spec exactly and skips `blocked` tasks — a list stalled entirely on blocked work falls through to the last-row backstop rather than anchoring on the blocked task. Trivially adjustable if the blocked task should be the anchor instead.

Closes #878
