### PR TITLE
feat(pi): implement /compact on the Pi SDK harness via session.compact()

### DIFF
--- a/site/src/content/docs/features/slash-commands.mdx
+++ b/site/src/content/docs/features/slash-commands.mdx
@@ -14,7 +14,7 @@ Native commands ship with the app and always work. They split into two flavors:
 | Command | Effect |
 |---|---|
 | `/clear` | Clear the chat history (UI-only). |
-| `/compact` | Compact the conversation. On Claude Code the CLI handles it natively; on Codex Native Claudette issues the `thread/compact/start` JSON-RPC and the timeline renders a compaction divider when the `ContextCompaction` item arrives. Not supported on the Pi SDK harness — the Compact button is disabled and `/compact` prints a "not supported" notice. |
+| `/compact` | Compact the conversation. Works on every harness. On Claude Code the CLI handles it natively; on Codex Native Claudette issues the `thread/compact/start` JSON-RPC; on the Pi SDK harness Claudette calls Pi's native `AgentSession.compact()`. The timeline renders a compaction divider when the compaction completes. Pi also auto-compacts long sessions on its own — those land a divider too (labelled "automatic" or "context full"). A failed compaction surfaces a notice instead of a divider. |
 | `/plan` | Toggle plan mode on for the next turn. |
 | `/model` `[<model>]` | Show the active workspace model, or set it inline (`/model opus`, `/model claude-3-5-sonnet`, `/model pi/openai/gpt-5.4`, ...). |
 | `/permissions` `[readonly\|standard\|full]` | Show the current permission mode, or set it inline (`/permissions full`). Alias: `/allowed-tools`. |

--- a/src-pi-harness/src/main.ts
+++ b/src-pi-harness/src/main.ts
@@ -11,6 +11,7 @@ import {
   SettingsManager,
   createAgentSession,
   defineTool,
+  estimateTokens,
   getAgentDir,
   type AgentSession,
   type AgentSessionEvent,
@@ -54,6 +55,10 @@ type HarnessState = {
   // tracks `/permissions` toggles that trigger a sidecar respawn via
   // the `allowed_tools_changed` drift path.
   bypassPermissions: boolean;
+  // Wall-clock start of the in-flight compaction, set on
+  // `compaction_start` and consumed by `compaction_end` to report a
+  // `durationMs`. Cleared once the end event is emitted.
+  compactionStartedAt?: number;
 };
 
 const state: HarnessState = {
@@ -1105,15 +1110,54 @@ function routeSessionEvent(event: AgentSessionEvent): void {
       }
       break;
     }
+    case "compaction_start": {
+      // Record the start so `compaction_end` can report a duration.
+      // The Rust side flips the UI to "Compacting" for a manual
+      // /compact; auto-compaction (threshold/overflow) rides an active
+      // turn that already owns the status indicator.
+      state.compactionStartedAt = Date.now();
+      send({ type: "compaction_start", reason: event.reason });
+      break;
+    }
     case "compaction_end": {
-      // Compaction failure is surfaced in passing — it doesn't abort
-      // the turn on its own, but the next prompt may behave oddly,
-      // so the user should know. Same shape as auto_retry_end.
-      const errorMessage = (event as { errorMessage?: string }).errorMessage?.trim();
-      const aborted = (event as { aborted?: boolean }).aborted;
-      if (aborted && errorMessage) {
-        send({ type: "thinking_delta", delta: `[Pi compaction failed] ${errorMessage}\n` });
+      // Translate Pi's native compaction completion into a structured
+      // event the Rust harness maps onto Claudette's compact_boundary
+      // divider. Flatten `result` so the deserializer needs no nested
+      // struct. A run that produced no `result` — explicit abort OR a
+      // generic failure carrying `errorMessage` — freed no context, so
+      // flag it `aborted` and let the Rust side surface a notice rather
+      // than a misleading divider.
+      const startedAt = state.compactionStartedAt;
+      state.compactionStartedAt = undefined;
+      const succeeded =
+        !event.aborted && event.result != null && !event.errorMessage;
+      const payload: Record<string, unknown> = {
+        type: "compaction_end",
+        reason: event.reason,
+        aborted: !succeeded,
+        willRetry: event.willRetry === true,
+      };
+      if (startedAt !== undefined) {
+        payload.durationMs = Date.now() - startedAt;
       }
+      if (succeeded && event.result) {
+        payload.tokensBefore = event.result.tokensBefore;
+        // CompactionResult carries no post-compaction count. Pi's
+        // internal `estimateContextTokens` isn't in the package's
+        // public exports, so reconstruct its spirit: sum the exported
+        // chars/4 `estimateTokens` heuristic over the reloaded message
+        // list (`messages` already holds the post-compaction context
+        // by the time `compaction_end` fires on the success path).
+        if (state.session) {
+          payload.tokensAfter = state.session.messages.reduce(
+            (sum, message) => sum + estimateTokens(message),
+            0,
+          );
+        }
+      } else if (event.errorMessage) {
+        payload.errorMessage = event.errorMessage.trim();
+      }
+      send(payload);
       break;
     }
     // Per-LLM-turn boundaries fire N times inside the agent loop —
@@ -1124,7 +1168,6 @@ function routeSessionEvent(event: AgentSessionEvent): void {
     // the double-Result bug.
     case "turn_start":
     case "turn_end":
-    case "compaction_start":
     case "queue_update":
     case "session_info_changed":
     case "thinking_level_changed":
@@ -1161,6 +1204,30 @@ async function handle(message: RequestMessage): Promise<void> {
       runTurn(state.session.steer(asPromptString(message.prompt) ?? ""));
       respond(message.id, message.type, true);
       break;
+    case "compact": {
+      if (!state.session) throw new Error("Pi session has not started");
+      // Pi's `compact()` aborts any current operation, runs the
+      // summarization, and reports its lifecycle via the
+      // `compaction_start` / `compaction_end` events on the session
+      // subscription. Don't await — the response here is just the
+      // action-accepted ack, mirroring `prompt` / `steer`.
+      // `customInstructions` biases the summary (Pi's CLI `/compact
+      // <focus>`); Claudette rejects `/compact` arguments today, so
+      // this is always undefined for now but the slot is wired.
+      const customInstructions =
+        typeof message.customInstructions === "string"
+          ? message.customInstructions
+          : undefined;
+      void state.session.compact(customInstructions).catch((error) => {
+        // `compact()` emits `compaction_end` before it re-throws, so the
+        // structured event the Rust per-turn pump terminates on has
+        // already been sent. Swallow the rejection (surfaced via `error`
+        // for the logs) to avoid an unhandled-promise crash.
+        send({ type: "error", error: `Pi compaction failed: ${String(error)}` });
+      });
+      respond(message.id, message.type, true);
+      break;
+    }
     case "abort":
       // Resolve any pending approval prompts so the corresponding
       // tool `execute()` calls don't keep awaiting after Pi has been

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -777,16 +777,26 @@ pub(super) fn ensure_harness_accepts_attachments(
 }
 
 /// True when this turn should be intercepted as a native compaction
-/// instead of a normal user turn. Only the Codex app-server path needs
-/// the intercept: Claude Code handles `/compact` natively as user input,
-/// and the Pi SDK harness is short-circuited at the UI layer.
+/// instead of a normal user turn. The Codex app-server and Pi SDK
+/// harnesses both need the intercept — each exposes a `start_compact()`
+/// that swaps in for `send_turn`. Claude Code is excluded: its CLI
+/// handles the literal `/compact` user input natively, so routing it
+/// through `start_compact()` would be wrong.
 ///
 /// Routing /compact through `send_chat_message` (and only swapping
 /// `send_turn` for `start_compact` at the very last step) lets us reuse
 /// the full spawn-or-reuse machinery, so /compact works whether or not
-/// a Codex process is currently alive — matching the Claude UX.
-pub(super) fn is_codex_compact_intent(harness: AgentBackendRuntimeHarness, prompt: &str) -> bool {
-    harness == AgentBackendRuntimeHarness::CodexAppServer && prompt.trim() == "/compact"
+/// an agent process is currently alive — matching the Claude UX.
+pub(super) fn is_native_compact_intent(harness: AgentBackendRuntimeHarness, prompt: &str) -> bool {
+    if prompt.trim() != "/compact" {
+        return false;
+    }
+    match harness {
+        AgentBackendRuntimeHarness::CodexAppServer => true,
+        #[cfg(feature = "pi-sdk")]
+        AgentBackendRuntimeHarness::PiSdk => true,
+        _ => false,
+    }
 }
 
 fn cleanup_failed_steer_persistence(
@@ -1040,13 +1050,13 @@ pub async fn send_chat_message(
         resolved_model = Some(rewritten);
     }
     ensure_harness_accepts_attachments(backend_runtime.harness, &prepared_user_send.cli_atts)?;
-    // Codex `/compact` doesn't take attachments — `start_compact()` ignores
-    // them. Reject up-front so attachments never get persisted as orphan
-    // rows under the synthesized `/compact` user message (the body
+    // Native `/compact` doesn't take attachments — `start_compact()`
+    // ignores them. Reject up-front so attachments never get persisted as
+    // orphan rows under the synthesized `/compact` user message (the body
     // wouldn't reference them and the compaction RPC has no slot for
     // them either). The check runs after attachment validation so the
     // generic shape rules still apply first.
-    if is_codex_compact_intent(backend_runtime.harness, &content)
+    if is_native_compact_intent(backend_runtime.harness, &content)
         && !prepared_user_send.cli_atts.is_empty()
     {
         return Err(
@@ -1581,16 +1591,16 @@ pub async fn send_chat_message(
     // migration: after this turn the new harness has the full prior
     // context in its native turn-1 input and subsequent turns flow
     // through unchanged.
-    // Detect `/compact` against the Codex app-server harness from the
+    // Detect `/compact` against a native-compaction harness from the
     // raw `content` (the slash command the user typed) — **before** the
     // cross-harness migration prelude is merged below. A queued prelude
     // would make `prompt` look like `"{prelude…}\n/compact"`, defeating
-    // the literal-string check in `is_codex_compact_intent` and routing
+    // the literal-string check in `is_native_compact_intent` and routing
     // the compact intent as a regular user turn (reintroducing the
-    // original Codex-narrates-/compact bug).
-    let is_codex_compact = is_codex_compact_intent(backend_runtime.harness, &content);
+    // original agent-narrates-/compact bug).
+    let is_native_compact = is_native_compact_intent(backend_runtime.harness, &content);
 
-    let prompt = if is_codex_compact {
+    let prompt = if is_native_compact {
         // Don't consume a pending cross-harness migration prelude for a
         // compaction action — there's no model-visible prompt for
         // `start_compact()` to attach the prelude to. Leave the prelude
@@ -1972,7 +1982,7 @@ pub async fn send_chat_message(
         let local_user_message_uuid = uuid::Uuid::new_v4().to_string();
         session.active_pid = Some(reuse_pid);
         session.remember_local_user_message_uuid(local_user_message_uuid.clone());
-        let turn_result = if is_codex_compact {
+        let turn_result = if is_native_compact {
             ps.start_compact().await
         } else {
             ps.send_turn_with_uuid(&prompt, &image_attachments, &local_user_message_uuid)
@@ -2140,7 +2150,7 @@ pub async fn send_chat_message(
                     let session = agents.get_mut(&chat_session_id).ok_or("Session lost")?;
                     session.remember_local_user_message_uuid(local_user_message_uuid.clone());
                 }
-                let handle = if is_codex_compact {
+                let handle = if is_native_compact {
                     ps.start_compact().await?
                 } else {
                     ps.send_turn_with_uuid(&prompt, &image_attachments, &local_user_message_uuid)
@@ -2301,7 +2311,7 @@ pub async fn send_chat_message(
             let session = agents.get_mut(&chat_session_id).ok_or("Session lost")?;
             session.remember_local_user_message_uuid(local_user_message_uuid.clone());
         }
-        let handle = if is_codex_compact {
+        let handle = if is_native_compact {
             ps.start_compact().await?
         } else {
             ps.send_turn_with_uuid(&prompt, &image_attachments, &local_user_message_uuid)
@@ -3922,42 +3932,51 @@ mod tests {
     }
 
     #[test]
-    fn codex_compact_intent_detects_literal_slash_compact() {
-        // The send pipeline checks this exactly: harness == Codex AND
-        // the prompt (post @-mention expansion) is literally "/compact".
-        // Anything else — whitespace around it is fine, but adding an
-        // argument like "/compact foo" is NOT a compact intent and must
-        // continue down the normal send_turn path.
-        assert!(super::is_codex_compact_intent(
+    fn native_compact_intent_detects_literal_slash_compact() {
+        // The send pipeline checks this exactly: a native-compaction
+        // harness AND the prompt (post @-mention expansion) is literally
+        // "/compact". Anything else — whitespace around it is fine, but
+        // adding an argument like "/compact foo" is NOT a compact intent
+        // and must continue down the normal send_turn path.
+        assert!(super::is_native_compact_intent(
             AgentBackendRuntimeHarness::CodexAppServer,
             "/compact",
         ));
-        assert!(super::is_codex_compact_intent(
+        assert!(super::is_native_compact_intent(
             AgentBackendRuntimeHarness::CodexAppServer,
             "  /compact  \n",
         ));
-        assert!(!super::is_codex_compact_intent(
+        assert!(!super::is_native_compact_intent(
             AgentBackendRuntimeHarness::CodexAppServer,
             "/compact please",
         ));
-        assert!(!super::is_codex_compact_intent(
+        assert!(!super::is_native_compact_intent(
             AgentBackendRuntimeHarness::CodexAppServer,
             "tell me about compaction",
         ));
     }
 
+    /// Pi exposes a native `start_compact()` too, so `/compact` against
+    /// the Pi SDK harness must be intercepted exactly like Codex.
+    #[cfg(feature = "pi-sdk")]
     #[test]
-    fn codex_compact_intent_excludes_other_harnesses() {
-        // Claude Code interprets the literal `/compact` natively; we
-        // must NOT swap in start_compact for it. Same for Pi (which
-        // wouldn't have a start_compact to call anyway).
-        assert!(!super::is_codex_compact_intent(
-            AgentBackendRuntimeHarness::ClaudeCode,
+    fn native_compact_intent_detects_pi_harness() {
+        assert!(super::is_native_compact_intent(
+            AgentBackendRuntimeHarness::PiSdk,
             "/compact",
         ));
-        #[cfg(feature = "pi-sdk")]
-        assert!(!super::is_codex_compact_intent(
+        assert!(!super::is_native_compact_intent(
             AgentBackendRuntimeHarness::PiSdk,
+            "/compact focus on the bug",
+        ));
+    }
+
+    #[test]
+    fn native_compact_intent_excludes_claude_code() {
+        // Claude Code interprets the literal `/compact` natively; we
+        // must NOT swap in start_compact for it.
+        assert!(!super::is_native_compact_intent(
+            AgentBackendRuntimeHarness::ClaudeCode,
             "/compact",
         ));
     }

--- a/src/agent/harness.rs
+++ b/src/agent/harness.rs
@@ -247,8 +247,9 @@ impl AgentSession {
     ///   synthetic `compacting` status event; the `ContextCompaction` item
     ///   later flows through the stream as a `compact_boundary` + `Result`
     ///   pair.
-    /// - Pi SDK: no native compaction protocol exists, so callers should
-    ///   surface "not supported" in the UI rather than invoking this method.
+    /// - Pi SDK: issues the sidecar `compact` request, which calls Pi's
+    ///   native `AgentSession.compact()`; the `compaction_end` event flows
+    ///   back through the stream as a `compact_boundary` + `Result` pair.
     pub async fn start_compact(&self) -> Result<TurnHandle, String> {
         match self {
             Self::ClaudeCode(_) => Err(
@@ -258,7 +259,7 @@ impl AgentSession {
             ),
             Self::CodexAppServer(session) => session.start_compact().await,
             #[cfg(feature = "pi-sdk")]
-            Self::PiSdk(_) => Err("Compaction is not supported on the Pi SDK harness.".to_string()),
+            Self::PiSdk(session) => session.start_compact().await,
         }
     }
 

--- a/src/agent/pi_sdk.rs
+++ b/src/agent/pi_sdk.rs
@@ -466,9 +466,29 @@ impl PiSdkSession {
         // event and the eventual boundary can't slip past before the
         // per-turn pump exists.
         let mut broadcast_rx = self.event_tx.subscribe();
+        let cached = self.init_cache.lock().await.clone();
         self.send_request(json!({ "type": "compact" })).await?;
 
         let (mpsc_tx, mpsc_rx) = mpsc::channel::<AgentEvent>(128);
+        // Replay the cached command-line + init events first, exactly as
+        // `send_turn` does. The chat bridge's `got_init` flag is set when
+        // it sees the `System { subtype: "init" }` event; the live init
+        // is emitted once during `start_session`, before this per-turn
+        // receiver subscribed. Without the replay `got_init` stays false
+        // for the compaction turn, and a Pi process crash during/after
+        // compaction would hit `send_chat_message`'s `!got_init` branch —
+        // misclassified as an init failure, wrongly clearing session
+        // state and DB rows instead of the gentler mid-turn-crash path.
+        if let Some(event) = cached.command_line
+            && mpsc_tx.send(event).await.is_err()
+        {
+            return Err("Pi SDK harness compact receiver closed".to_string());
+        }
+        if let Some(event) = cached.init
+            && mpsc_tx.send(event).await.is_err()
+        {
+            return Err("Pi SDK harness compact receiver closed".to_string());
+        }
         tokio::spawn(async move {
             loop {
                 match broadcast_rx.recv().await {

--- a/src/agent/pi_sdk.rs
+++ b/src/agent/pi_sdk.rs
@@ -448,6 +448,60 @@ impl PiSdkSession {
         Ok(())
     }
 
+    /// Trigger Pi's native context compaction via the sidecar's
+    /// `compact` request. Returns a [`TurnHandle`] shaped exactly like
+    /// [`Self::send_turn`]'s so `send_chat_message` can plug it into the
+    /// same per-turn event pump without branching.
+    ///
+    /// Pi's `AgentSession.compact()` aborts any current operation,
+    /// summarizes the conversation, and reports its lifecycle via
+    /// `compaction_start` / `compaction_end` events on the session
+    /// subscription. [`route_pi_message`] translates a successful
+    /// `compaction_end` into a `compact_boundary` System event plus a
+    /// synthetic `Result`: the boundary persists the `COMPACTION:...`
+    /// sentinel, and the `Result` terminates this pump so the chat
+    /// session's status flips back to Idle.
+    pub async fn start_compact(&self) -> Result<TurnHandle, String> {
+        // Subscribe BEFORE the request so the `compaction_start` status
+        // event and the eventual boundary can't slip past before the
+        // per-turn pump exists.
+        let mut broadcast_rx = self.event_tx.subscribe();
+        self.send_request(json!({ "type": "compact" })).await?;
+
+        let (mpsc_tx, mpsc_rx) = mpsc::channel::<AgentEvent>(128);
+        tokio::spawn(async move {
+            loop {
+                match broadcast_rx.recv().await {
+                    Ok(event) => {
+                        let is_turn_end =
+                            matches!(&event, AgentEvent::Stream(StreamEvent::Result { .. }));
+                        let is_process_exit = matches!(&event, AgentEvent::ProcessExited(_));
+                        if mpsc_tx.send(event).await.is_err() {
+                            break;
+                        }
+                        if is_turn_end || is_process_exit {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(
+                            target: "claudette::agent",
+                            subsystem = "pi-sdk",
+                            dropped_events = n,
+                            "broadcast lag — pi compact pump missed events"
+                        );
+                    }
+                }
+            }
+        });
+
+        Ok(TurnHandle {
+            event_rx: mpsc_rx,
+            pid: self.pid,
+        })
+    }
+
     pub async fn send_control_response(
         &self,
         request_id: &str,
@@ -705,6 +759,38 @@ enum PiHarnessMessage {
     TurnError {
         #[serde(default)]
         error: Option<String>,
+    },
+    /// Pi began native context compaction. `reason` is `"manual"` (a
+    /// user `/compact`), `"threshold"` (auto-compaction crossed the
+    /// keep-recent budget), or `"overflow"` (context window exhausted).
+    /// Arrives on the same session subscription as turn events.
+    #[serde(rename = "compaction_start")]
+    CompactionStart {
+        #[serde(default)]
+        reason: Option<String>,
+    },
+    /// Pi finished native context compaction. The sidecar flattens Pi's
+    /// `CompactionResult` and collapses "explicit abort" and "generic
+    /// failure" into a single `aborted` flag meaning "did NOT free
+    /// context". On the success path `tokens_before` / `tokens_after` /
+    /// `duration_ms` feed the compaction divider; on the failure path
+    /// `error_message` carries the reason.
+    #[serde(rename = "compaction_end")]
+    CompactionEnd {
+        #[serde(default)]
+        reason: Option<String>,
+        #[serde(default)]
+        aborted: bool,
+        #[serde(default, rename = "willRetry")]
+        will_retry: bool,
+        #[serde(default, rename = "errorMessage")]
+        error_message: Option<String>,
+        #[serde(default, rename = "tokensBefore")]
+        tokens_before: Option<u64>,
+        #[serde(default, rename = "tokensAfter")]
+        tokens_after: Option<u64>,
+        #[serde(default, rename = "durationMs")]
+        duration_ms: Option<u64>,
     },
     #[serde(rename = "error")]
     Error {
@@ -1128,6 +1214,83 @@ async fn route_pi_message(
             output.text.clear();
             output.thinking.clear();
         }
+        PiHarnessMessage::CompactionStart { reason } => {
+            // A manual /compact runs through `start_compact`'s dedicated
+            // per-turn pump; flip the UI to "Compacting" so the user
+            // sees progress, mirroring the Codex compacting affordance.
+            // Auto-compaction (threshold/overflow) fires inside a live
+            // turn that already owns the status indicator — leave it.
+            if reason.as_deref() == Some("manual") {
+                let _ = event_tx.send(pi_compacting_status_event());
+            }
+        }
+        PiHarnessMessage::CompactionEnd {
+            reason,
+            aborted,
+            will_retry,
+            error_message,
+            tokens_before,
+            tokens_after,
+            duration_ms,
+        } => {
+            let is_manual = reason.as_deref() == Some("manual");
+            if aborted {
+                // No context was freed. For a manual /compact surface a
+                // visible notice as an assistant text block (Pi's
+                // harness already routes operational errors this way).
+                // Auto-compaction failures stay quiet: the turn
+                // continues and a `will_retry` run may still succeed, so
+                // a mid-turn notice would just be noise.
+                if is_manual {
+                    let detail = error_message
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|m| !m.is_empty())
+                        .unwrap_or("Pi could not compact the conversation.");
+                    let _ = event_tx.send(AgentEvent::Stream(StreamEvent::Assistant {
+                        message: AssistantMessage {
+                            content: vec![ContentBlock::Text {
+                                text: format!("Compaction did not complete: {detail}"),
+                            }],
+                        },
+                    }));
+                } else if !will_retry {
+                    tracing::warn!(
+                        target: "claudette::agent",
+                        subsystem = "pi-sdk",
+                        reason = reason.as_deref().unwrap_or("unknown"),
+                        error = error_message.as_deref().unwrap_or(""),
+                        "pi auto-compaction failed"
+                    );
+                }
+            } else {
+                // Success → compact_boundary System event. `send.rs`'s
+                // sentinel writer persists the COMPACTION:... row and the
+                // CompactionDivider renders. `trigger` keeps Pi's wire
+                // vocabulary (`manual` / `threshold` / `overflow`); the
+                // divider's label table maps each to a friendly string.
+                let trigger = reason
+                    .clone()
+                    .filter(|r| !r.is_empty())
+                    .unwrap_or_else(|| "manual".to_string());
+                let _ = event_tx.send(pi_compact_boundary_event(
+                    crate::agent::types::CompactMetadata {
+                        trigger,
+                        pre_tokens: tokens_before.unwrap_or(0),
+                        post_tokens: tokens_after.unwrap_or(0),
+                        duration_ms: duration_ms.unwrap_or(0),
+                    },
+                ));
+            }
+            // The manual /compact pump (set up by `start_compact`)
+            // terminates on a Result; emit one so `session.agent_status`
+            // flips back to Idle. Auto-compaction rides an active turn
+            // whose own `turn_end` produces the Result — emitting one
+            // here would cut that turn short.
+            if is_manual {
+                let _ = event_tx.send(pi_compaction_finish_event());
+            }
+        }
         PiHarnessMessage::Error { error } => {
             let _ = event_tx.send(AgentEvent::Stderr(
                 error.unwrap_or_else(|| "Pi SDK harness error".to_string()),
@@ -1251,6 +1414,72 @@ fn pi_command_line_event(path: &Path) -> AgentEvent {
         "{}",
         path.display()
     )))
+}
+
+/// In-flight indicator for a manual Pi compaction. The frontend
+/// `useAgentStream` listener flips `workspace.agent_status` to
+/// `"Compacting"` on this exact shape (`subtype: "status"` +
+/// `status: "compacting"`), matching the Codex affordance.
+fn pi_compacting_status_event() -> AgentEvent {
+    AgentEvent::Stream(StreamEvent::System {
+        subtype: "status".to_string(),
+        session_id: None,
+        state: None,
+        detail: None,
+        task_id: None,
+        tool_use_id: None,
+        output_file: None,
+        summary: None,
+        description: None,
+        last_tool_name: None,
+        usage: None,
+        status: Some("compacting".to_string()),
+        compact_result: None,
+        compact_metadata: None,
+        command_line: None,
+    })
+}
+
+/// `compact_boundary` System event for a successful Pi compaction.
+/// `send_chat_message`'s sentinel writer persists the `COMPACTION:...`
+/// row from `compact_metadata`, and the `CompactionDivider` renders.
+/// `compact_result` stays `None`: the `StreamEvent::System` contract
+/// reserves it for the end-of-compaction *status* event (Claude CLI's
+/// pattern); the boundary carries its payload in `compact_metadata`.
+fn pi_compact_boundary_event(meta: crate::agent::types::CompactMetadata) -> AgentEvent {
+    AgentEvent::Stream(StreamEvent::System {
+        subtype: "compact_boundary".to_string(),
+        session_id: None,
+        state: None,
+        detail: None,
+        task_id: None,
+        tool_use_id: None,
+        output_file: None,
+        summary: None,
+        description: None,
+        last_tool_name: None,
+        usage: None,
+        status: None,
+        compact_result: None,
+        compact_metadata: Some(meta),
+        command_line: None,
+    })
+}
+
+/// Synthetic terminal event that ends the per-turn pump `start_compact`
+/// set up, so the chat session's status flips back to `"Idle"`. Mirrors
+/// the `subtype: "success"` Result Claude's CLI emits at the end of its
+/// `/compact` turn. Always `success`: the compaction *operation*
+/// completed even when it freed nothing — a failure, if any, is already
+/// surfaced as an assistant notice.
+fn pi_compaction_finish_event() -> AgentEvent {
+    AgentEvent::Stream(StreamEvent::Result {
+        subtype: "success".to_string(),
+        result: None,
+        total_cost_usd: None,
+        duration_ms: None,
+        usage: None,
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2268,6 +2497,291 @@ mod tests {
             AgentEvent::Stderr(line) => assert!(!line.is_empty()),
             other => panic!("expected Stderr, got {other:?}"),
         }
+    }
+
+    /// Drain every event currently buffered on the receiver.
+    fn drain_events(rx: &mut broadcast::Receiver<AgentEvent>) -> Vec<AgentEvent> {
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+        }
+        events
+    }
+
+    /// The sidecar emits camelCase keys; pin the rename mapping so a
+    /// wire-shaped success `compaction_end` deserializes with every
+    /// field populated.
+    #[test]
+    fn parses_compaction_end_success() {
+        let line = r#"{"type":"compaction_end","reason":"manual","aborted":false,"willRetry":false,"tokensBefore":120000,"tokensAfter":30000,"durationMs":4200}"#;
+        match serde_json::from_str::<PiHarnessMessage>(line).unwrap() {
+            PiHarnessMessage::CompactionEnd {
+                reason,
+                aborted,
+                will_retry,
+                error_message,
+                tokens_before,
+                tokens_after,
+                duration_ms,
+            } => {
+                assert_eq!(reason.as_deref(), Some("manual"));
+                assert!(!aborted);
+                assert!(!will_retry);
+                assert!(error_message.is_none());
+                assert_eq!(tokens_before, Some(120000));
+                assert_eq!(tokens_after, Some(30000));
+                assert_eq!(duration_ms, Some(4200));
+            }
+            other => panic!("expected CompactionEnd, got {other:?}"),
+        }
+    }
+
+    /// The aborted/failed variant carries no token counts — make sure
+    /// the absent fields default cleanly and `errorMessage` decodes.
+    #[test]
+    fn parses_compaction_end_aborted_without_tokens() {
+        let line = r#"{"type":"compaction_end","reason":"manual","aborted":true,"willRetry":false,"errorMessage":"context provider 500"}"#;
+        match serde_json::from_str::<PiHarnessMessage>(line).unwrap() {
+            PiHarnessMessage::CompactionEnd {
+                aborted,
+                error_message,
+                tokens_before,
+                tokens_after,
+                duration_ms,
+                ..
+            } => {
+                assert!(aborted);
+                assert_eq!(error_message.as_deref(), Some("context provider 500"));
+                assert!(tokens_before.is_none());
+                assert!(tokens_after.is_none());
+                assert!(duration_ms.is_none());
+            }
+            other => panic!("expected CompactionEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_compaction_start() {
+        let msg: PiHarnessMessage =
+            serde_json::from_str(r#"{"type":"compaction_start","reason":"threshold"}"#).unwrap();
+        match msg {
+            PiHarnessMessage::CompactionStart { reason } => {
+                assert_eq!(reason.as_deref(), Some("threshold"));
+            }
+            other => panic!("expected CompactionStart, got {other:?}"),
+        }
+    }
+
+    /// A manual /compact runs a dedicated per-turn pump, so its
+    /// `compaction_start` flips the UI to "Compacting" via a
+    /// `status` System event.
+    #[tokio::test]
+    async fn route_compaction_start_manual_emits_compacting_status() {
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::CompactionStart {
+                reason: Some("manual".to_string()),
+            },
+        )
+        .await;
+        match next_event(&mut rx).await {
+            AgentEvent::Stream(StreamEvent::System {
+                subtype, status, ..
+            }) => {
+                assert_eq!(subtype, "status");
+                assert_eq!(status.as_deref(), Some("compacting"));
+            }
+            other => panic!("expected status System event, got {other:?}"),
+        }
+        assert!(try_recv_now(&mut rx).is_none());
+    }
+
+    /// Auto-compaction (threshold/overflow) fires inside a live turn
+    /// that already owns the status indicator — its `compaction_start`
+    /// must not stomp it with a stray status event.
+    #[tokio::test]
+    async fn route_compaction_start_threshold_emits_nothing() {
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::CompactionStart {
+                reason: Some("threshold".to_string()),
+            },
+        )
+        .await;
+        assert!(try_recv_now(&mut rx).is_none());
+    }
+
+    /// A successful manual `compaction_end` produces exactly the
+    /// compact_boundary System event (carrying Pi's token counts) plus
+    /// the synthetic Result that terminates `start_compact`'s pump.
+    #[tokio::test]
+    async fn route_compaction_end_manual_success_emits_boundary_and_finish() {
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::CompactionEnd {
+                reason: Some("manual".to_string()),
+                aborted: false,
+                will_retry: false,
+                error_message: None,
+                tokens_before: Some(120000),
+                tokens_after: Some(30000),
+                duration_ms: Some(4200),
+            },
+        )
+        .await;
+        let events = drain_events(&mut rx);
+        assert_eq!(events.len(), 2, "boundary + finish, nothing else");
+        match &events[0] {
+            AgentEvent::Stream(StreamEvent::System {
+                subtype,
+                compact_metadata,
+                compact_result,
+                ..
+            }) => {
+                assert_eq!(subtype, "compact_boundary");
+                assert!(compact_result.is_none());
+                let meta = compact_metadata.as_ref().expect("compact_metadata set");
+                assert_eq!(meta.trigger, "manual");
+                assert_eq!(meta.pre_tokens, 120000);
+                assert_eq!(meta.post_tokens, 30000);
+                assert_eq!(meta.duration_ms, 4200);
+            }
+            other => panic!("expected compact_boundary System event, got {other:?}"),
+        }
+        match &events[1] {
+            AgentEvent::Stream(StreamEvent::Result { subtype, .. }) => {
+                assert_eq!(subtype, "success");
+            }
+            other => panic!("expected synthetic Result, got {other:?}"),
+        }
+    }
+
+    /// Auto-compaction rides an active turn whose own `turn_end`
+    /// produces the Result — a threshold `compaction_end` emits only the
+    /// divider boundary, never a Result that would cut the turn short.
+    #[tokio::test]
+    async fn route_compaction_end_threshold_success_emits_boundary_only() {
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::CompactionEnd {
+                reason: Some("threshold".to_string()),
+                aborted: false,
+                will_retry: false,
+                error_message: None,
+                tokens_before: Some(150000),
+                tokens_after: Some(40000),
+                duration_ms: Some(3100),
+            },
+        )
+        .await;
+        let events = drain_events(&mut rx);
+        assert_eq!(events.len(), 1, "boundary only — no terminating Result");
+        match &events[0] {
+            AgentEvent::Stream(StreamEvent::System {
+                subtype,
+                compact_metadata,
+                ..
+            }) => {
+                assert_eq!(subtype, "compact_boundary");
+                assert_eq!(
+                    compact_metadata.as_ref().expect("metadata set").trigger,
+                    "threshold",
+                );
+            }
+            other => panic!("expected compact_boundary System event, got {other:?}"),
+        }
+    }
+
+    /// A failed manual compaction freed no context: surface a visible
+    /// assistant notice (never a divider) plus the Result that ends the
+    /// pump. The error text rides the notice.
+    #[tokio::test]
+    async fn route_compaction_end_manual_aborted_emits_notice_and_finish() {
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::CompactionEnd {
+                reason: Some("manual".to_string()),
+                aborted: true,
+                will_retry: false,
+                error_message: Some("context provider 500".to_string()),
+                tokens_before: None,
+                tokens_after: None,
+                duration_ms: None,
+            },
+        )
+        .await;
+        let events = drain_events(&mut rx);
+        assert_eq!(events.len(), 2, "notice + finish, no boundary");
+        match &events[0] {
+            AgentEvent::Stream(StreamEvent::Assistant { message }) => {
+                let text = match message.content.first() {
+                    Some(ContentBlock::Text { text }) => text.as_str(),
+                    other => panic!("expected text content, got {other:?}"),
+                };
+                assert!(
+                    text.contains("context provider 500"),
+                    "carries the error: {text}"
+                );
+            }
+            other => panic!("expected assistant notice, got {other:?}"),
+        }
+        assert!(
+            matches!(
+                &events[1],
+                AgentEvent::Stream(StreamEvent::Result { subtype, .. }) if subtype == "success"
+            ),
+            "manual pump must still terminate on a Result",
+        );
+    }
+
+    /// An auto-compaction failure must not inject a stray mid-turn
+    /// notice or Result — the turn it rides owns those.
+    #[tokio::test]
+    async fn route_compaction_end_threshold_aborted_is_quiet() {
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::CompactionEnd {
+                reason: Some("threshold".to_string()),
+                aborted: true,
+                will_retry: false,
+                error_message: Some("boom".to_string()),
+                tokens_before: None,
+                tokens_after: None,
+                duration_ms: None,
+            },
+        )
+        .await;
+        assert!(try_recv_now(&mut rx).is_none());
     }
 
     /// Unknown variants (e.g. a future-protocol message Claudette

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1389,15 +1389,15 @@ export function ChatPanel() {
           } else {
             // Resolve the active backend's effective harness via the same
             // fallback chain the send pipeline uses
-            // (per-session provider → default backend → first available).
-            // Claude Code and Codex both fall through to the normal send
-            // path with the literal `/compact`: Claude's CLI interprets it
-            // natively, and `send_chat_message` (Rust side) intercepts the
-            // same string when the harness is Codex and swaps `send_turn`
-            // for `start_compact` at the last possible step. Pi has no
-            // native compaction protocol — short-circuit with a local
-            // message. If we can't resolve a harness yet (agentBackends
-            // hasn't loaded), surface a local error rather than guess.
+            // (per-session provider → default backend → first available)
+            // purely as a readiness guard: if we can't resolve a harness
+            // yet (agentBackends hasn't loaded), surface a local error
+            // rather than fire `/compact` against an unknown backend.
+            // Every supported harness handles the literal `/compact`:
+            // Claude's CLI interprets it natively, while `send_chat_message`
+            // (Rust side) intercepts the same string for Codex and Pi and
+            // swaps `send_turn` for `start_compact` at the last possible
+            // step.
             const harness = resolveSessionHarness({
               sessionId,
               selectedModelProvider: state.selectedModelProvider,
@@ -1410,17 +1410,10 @@ export function ChatPanel() {
               );
               return;
             }
-            if (harness === "pi_sdk") {
-              addLocalMessage("/compact: not supported on this backend.");
-              return;
-            }
-            // claude_code or codex_app_server — fall through with the
-            // literal `/compact`. The send pipeline (frontend
-            // dispatchChatMessage + backend send_chat_message) handles
-            // session spawn-or-reuse, user-message persistence, and turn
-            // setup uniformly. For Codex, send_chat_message branches at
-            // the very last step to issue `start_compact` instead of
-            // `send_turn`.
+            // Fall through with the literal `/compact`. The send pipeline
+            // (frontend dispatchChatMessage + backend send_chat_message)
+            // handles session spawn-or-reuse, user-message persistence,
+            // and turn setup uniformly.
             trimmed = "/compact";
           }
         }

--- a/src/ui/src/components/chat/CompactionDivider.tsx
+++ b/src/ui/src/components/chat/CompactionDivider.tsx
@@ -17,7 +17,12 @@ function formatDurationSeconds(ms: number): string {
 
 function triggerLabel(trigger: string): string {
   if (trigger === "manual") return "manual";
-  if (trigger === "auto") return "automatic";
+  // "auto" is Claude CLI's auto-trigger; "threshold" is Pi's
+  // equivalent (auto-compaction crossed the keep-recent budget).
+  if (trigger === "auto" || trigger === "threshold") return "automatic";
+  // "overflow" is Pi forcing a compaction because the context window
+  // is exhausted.
+  if (trigger === "overflow") return "context full";
   if (trigger === "codex") return "Codex";
   return "compaction"; // friendly fallback for unknown triggers
 }

--- a/src/ui/src/components/chat/composer/ContextPopover.module.css
+++ b/src/ui/src/components/chat/composer/ContextPopover.module.css
@@ -153,22 +153,8 @@
   transition: background var(--transition-fast);
 }
 
-.actionBtn:hover:not(:disabled) {
+.actionBtn:hover {
   background: var(--hover-bg);
-}
-
-.actionBtn:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-/* Wrapper for tooltip-on-disabled-button.  The disabled <button> swallows
- * hover/title events, so the AppTooltip system reads `data-tooltip` from
- * this wrapper span instead.  Matches `.actionBtn` flex behavior so the
- * button still expands to fill its row. */
-.actionBtnWrap {
-  flex: 1;
-  display: flex;
 }
 
 @keyframes fadeUp {

--- a/src/ui/src/components/chat/composer/ContextPopover.tsx
+++ b/src/ui/src/components/chat/composer/ContextPopover.tsx
@@ -1,11 +1,10 @@
-import { type RefObject, useEffect, useMemo, useRef } from "react";
+import { type RefObject, useEffect, useRef } from "react";
 import { useAppStore } from "../../../stores/useAppStore";
 import { computeMeterState } from "../contextMeterLogic";
 import { formatTokens } from "../formatTokens";
 import { useSelectedModelEntry } from "../useSelectedModelEntry";
 import { segmentedBand, segmentedColor, stateLabel } from "./segmentedMeterLogic";
 import { estimateCost, formatCost } from "./formatCost";
-import { resolveSessionHarness } from "../resolveSessionHarness";
 import styles from "./ContextPopover.module.css";
 
 interface ContextPopoverProps {
@@ -31,32 +30,9 @@ const SEGMENT_COLORS = [
 export function ContextPopover({ sessionId, onClose, onCompact, onClear, triggerRef }: ContextPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const usage = useAppStore((s) => s.latestTurnUsage[sessionId]);
-  const agentBackends = useAppStore((s) => s.agentBackends);
-  const selectedModelProvider = useAppStore((s) => s.selectedModelProvider);
-  const defaultAgentBackendId = useAppStore((s) => s.defaultAgentBackendId);
 
   const model = useSelectedModelEntry(sessionId);
   const state = computeMeterState(usage, model?.contextWindowTokens);
-
-  // The Pi SDK harness has no native compaction protocol. Disable the
-  // button so clicking can't produce a confusing no-op. Resolution
-  // matches the send pipeline's fallback (per-session provider →
-  // default backend → first available), so a fresh session with no
-  // explicit provider still gates correctly when the default backend
-  // is Pi. Fail-open on `null` (agent_backends not loaded yet): keep
-  // the button enabled rather than block the much more common
-  // Claude/Codex case on a transient empty state. ChatPanel's
-  // `/compact` dispatch surfaces a "backend not ready" local message
-  // if the click actually races the backend load.
-  const compactSupported = useMemo(() => {
-    const harness = resolveSessionHarness({
-      sessionId,
-      selectedModelProvider,
-      agentBackends,
-      defaultAgentBackendId,
-    });
-    return harness !== "pi_sdk";
-  }, [agentBackends, defaultAgentBackendId, selectedModelProvider, sessionId]);
 
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
@@ -154,31 +130,13 @@ export function ContextPopover({ sessionId, onClose, onCompact, onClear, trigger
       </div>
 
       <div className={styles.actions}>
-        {/* Wrap the disabled-state button in a tooltip-bearing span:
-            Chromium swallows `title`/hover events on disabled <button>
-            elements, so users would get no explanation. The shared
-            AppTooltip pattern reads `data-tooltip` via document-level
-            pointerover, which still fires over the wrapper span. The
-            wrapper has zero visual effect when the button is enabled
-            (no data-tooltip attribute, no styles). */}
-        <span
-          className={styles.actionBtnWrap}
-          data-tooltip={
-            compactSupported
-              ? undefined
-              : "Compaction is not supported on this backend."
-          }
-        >
         <button
           type="button"
           className={styles.actionBtn}
           onClick={() => { onCompact(); onClose(); }}
-          disabled={!compactSupported}
-          aria-disabled={!compactSupported || undefined}
         >
           Compact
         </button>
-        </span>
         <button
           type="button"
           className={styles.actionBtn}

--- a/src/ui/src/components/chat/resolveSessionHarness.ts
+++ b/src/ui/src/components/chat/resolveSessionHarness.ts
@@ -20,16 +20,14 @@ import {
  * Mirrors `resolve_dispatch_harness` for the Pi downgrade case: a non-Pi
  * backend (Ollama, LM Studio, OpenAI, …) configured to dispatch through
  * Pi gets downgraded to the first non-Pi allowed harness when no enabled
- * Pi card exists. Without this the Compact button is incorrectly disabled
- * and `/compact` is rejected with "not supported on this backend" even
- * though the actual send path routes through Claude CLI and supports it.
+ * Pi card exists, so the resolved harness matches the harness the Rust
+ * send pipeline will actually run.
  *
- * Used by both `ChatPanel`'s `/compact` dispatch and `ContextPopover`'s
- * "Compact" button gate so the two surfaces stay in sync — if either
- * silently assumed `claude_code` while the session was actually running
- * on Pi (a real `selectedModelProvider[sessionId] === undefined` case
- * after first launch), Pi compact text would either misroute through the
- * Codex intercept or hit the wrong "not supported" path.
+ * Used by `ChatPanel`'s `/compact` dispatch purely as a readiness guard:
+ * a `null` result means `agent_backends` hasn't loaded yet, so `/compact`
+ * should surface a "backend not ready" notice rather than fire blind.
+ * Every harness (Claude Code, Codex Native, Pi SDK) supports `/compact`,
+ * so the resolved harness value itself no longer gates the command.
  */
 export function resolveSessionHarness(args: {
   sessionId: string;


### PR DESCRIPTION
## Summary

Finishes the `harness_action` triangle started in #881: `/compact` now
works on the **Pi SDK harness** by calling Pi's native
`AgentSession.compact()`. Pi auto-compaction (threshold/overflow) also
renders a timeline divider for free, since it flows through the same new
plumbing.

Before this, Pi was short-circuited with a "not supported" stub at three
layers (the `ContextPopover` Compact button, the `/compact` slash
dispatch, and `AgentSession::start_compact`). That was a Codex-PR-era
placeholder, not a real platform limitation — `@earendil-works/pi-coding-agent@0.74.0`
exposes a first-class `compact()` API and the sidecar already received
(but swallowed) the lifecycle events.

Closes #884.

## What changed

**Sidecar — `src-pi-harness/src/main.ts`**
- Tracks `compactionStartedAt`; emits structured `compaction_start` /
  `compaction_end` messages in place of the old swallow-on-success
  behavior. `compaction_end` flattens Pi's `CompactionResult` so the
  Rust deserializer needs no nested struct.
- `tokensAfter` is computed by summing the exported `estimateTokens()`
  (chars/4 heuristic) over the post-compaction message list. Pi's
  internal `estimateContextTokens` is **not** in the package's public
  `exports` map, so its intent is reconstructed from the exported
  primitive.
- New `compact` request handler invokes `AgentSession.compact()`
  (fire-and-forget, mirroring `prompt` / `steer`).

**Rust — `src/agent/pi_sdk.rs`, `src/agent/harness.rs`**
- New `PiHarnessMessage::{CompactionStart, CompactionEnd}` variants.
- `route_pi_message` translates a **successful** `compaction_end` into a
  `compact_boundary` System event (the existing sentinel-writer in
  `send.rs` persists `COMPACTION:...` and the `CompactionDivider`
  renders). A **failed/aborted** one becomes an assistant text notice
  (manual `/compact` only — auto-compaction failures stay quiet so they
  don't inject mid-turn noise).
- Manual `/compact` additionally gets a synthetic terminating `Result`
  so its dedicated per-turn pump ends and the status flips back to Idle.
  Auto-compaction emits **only** the boundary — the live turn it rides
  produces its own `Result`.
- `PiSdkSession::start_compact()` returns a `TurnHandle`, matching the
  Codex path so `send_chat_message` reuses the same per-turn event pump.
- `AgentSession::start_compact()` Pi arm now dispatches instead of
  returning the "not supported" error.

**Send pipeline — `src-tauri/src/commands/chat/send.rs`**
- `is_codex_compact_intent` → `is_native_compact_intent`, now also
  intercepting the Pi harness. Without this, Pi's `/compact` would reach
  the model as a literal prompt string (the exact #881 bug shape).

**Frontend**
- `ChatPanel.tsx` — dropped the `harness === "pi_sdk"` short-circuit in
  the `harness_action` branch; Pi now flows through the normal send path.
- `ContextPopover.tsx` — dropped the `compactSupported` gate; the Compact
  button is always enabled (and its unused store selectors / disabled-
  tooltip wrapper removed).
- `CompactionDivider.tsx` — `triggerLabel` extended: `threshold` →
  "automatic", `overflow` → "context full".
- `resolveSessionHarness.ts` — doc comment refreshed (it no longer gates
  `/compact`; it's now purely a backend-readiness guard).

**Docs** — `slash-commands.mdx` `/compact` row rewritten for Pi.

## Deviations from the issue spec

1. **Failed-compaction notice.** The issue proposed a `task_notification`
   event. Investigation found the frontend handler hard-requires a
   matching `tool_use_id` (`useAgentStream.ts:321`) and silently drops a
   notification without one — so it would render nothing. Failed manual
   compactions surface as an **assistant text notice** instead, matching
   how the Pi harness already routes operational errors.
2. **`send.rs` was edited** though not in the issue's file list — the
   `is_codex_compact_intent` predicate hard-coded `== CodexAppServer`.
3. **`start_compact()` returns `TurnHandle`**, not the `Result<(), _>`
   the issue sketched — the harness-enum signature requires it, and it's
   what lets the per-turn pump work.

## Testing

- `cargo fmt --all --check` ✅
- `cargo clippy -p claudette --all-features --all-targets` — clean ✅
- `cargo clippy -p claudette-tauri --all-targets` — no warnings from
  changed code ✅
- Rust unit tests: 8 new `pi_sdk` tests (parse + `route_pi_message`
  success/abort/threshold paths) + 3 `send.rs` `native_compact` tests ✅
- Sidecar `tsc --noEmit` + `bun build` ✅
- Frontend `tsc -b`, `eslint` (no new findings), `lint:css`, `vitest`
  (2590 pass) ✅

**Not covered: runtime UAT.** Exercising `/compact` against a live
Pi-authed workspace with a long session was not performed; verification
is compilation + unit-level. Worth a manual pass before merge.

## Acceptance criteria

- [x] Pi `/compact` triggers `AgentSession.compact()`, not a model reply
- [x] Timeline renders a `CompactionDivider` with trigger + token counts
- [x] `ContextPopover` Compact button enabled on Pi
- [x] Pi auto-compaction emits a divider (`automatic` / `context full`)
- [x] No regression on Claude Code / Codex Native
- [x] Aborted compactions surface a notice, not a misleading divider
- [x] `/compact <args>` still rejected on all backends