### PR TITLE
feat(monaco): open agent-managed files (plans, memory) in Monaco

### DIFF
--- a/.claude/skills/claudette-debug/reference/tauri-commands.md
+++ b/.claude/skills/claudette-debug/reference/tauri-commands.md
@@ -56,6 +56,7 @@ Keyed on `sessionId` (chat session id), not `workspaceId`.
 ## Plan
 
 - `readPlanFile(path)` -> `string` (file content)
+- `readAgentManagedFile(path)` -> `FileContent` (allow-listed agent file: plans, memory; absolute path in, rejects anything outside the allow-list)
 
 ## Diff
 

--- a/site/src/content/docs/features/file-editor.mdx
+++ b/site/src/content/docs/features/file-editor.mdx
@@ -19,6 +19,21 @@ Files open as tabs next to your chat and diff tabs, so you can hop between agent
 
 <Image src={fileEditor} alt="Monaco editor open on a Rust source file with the workspace sidebar on the left and the file tree on the right" loading="lazy" />
 
+## Agent-Managed Files
+
+Agents persist plans and memory notes outside your worktree — under `~/.claude/` (Claude Code) and `~/.codex/memories/` (Codex). When one of these paths appears in chat — in an `Editing` tool-call row, an agent message, or a plan card — clicking it opens the file directly in Monaco instead of failing the worktree path check.
+
+Recognized locations:
+
+| File | Location | Badge |
+|------|----------|-------|
+| Plans | `~/.claude/plans/**/*.md` | **Plan** |
+| Project memory | `~/.claude/projects/<project>/memory/**/*.md` | **Memory** (or **Memory index** for `MEMORY.md`) |
+| Other project notes | `~/.claude/projects/<project>/**/*.md` | **Project file** |
+| Codex memory | `~/.codex/memories/**/*.md` | **Memory** (or **Memory index**) |
+
+These tabs are **read-only** — they're for inspecting what the agent wrote, not editing it — and the pane toolbar shows a badge identifying the file kind alongside its full path. Everything else (only those allow-listed directories, never arbitrary absolute paths) still goes through the standard worktree security boundary.
+
 ## Read vs Edit Mode
 
 Files open in read-only mode by default. Toggling into edit mode does **not** remount the editor — your cursor position, scroll offset, and undo stack are preserved as you switch in and out of edit mode.

--- a/src-tauri/src/commands/agent_files.rs
+++ b/src-tauri/src/commands/agent_files.rs
@@ -1,0 +1,50 @@
+//! Tauri command for reading agent-managed files (plans, memory, …).
+//!
+//! Thin wrapper over the [`claudette::agent_files`] allow-list. The heavy
+//! lifting — canonicalization, component-wise root matching, symlink-escape
+//! rejection — lives in the library crate; this command just bridges it to
+//! the frontend file viewer.
+
+use std::path::Path;
+
+use claudette::agent_files::classify_agent_file;
+use claudette::file_expand;
+
+use super::files::FileContent;
+
+/// Viewer truncation cap for agent-managed files. Matches the worktree
+/// file viewer's cap so the frontend's edit-size affordances behave
+/// identically across both routes.
+const MAX_AGENT_FILE_SIZE: usize = 10 * 1024 * 1024;
+
+/// Read an agent-managed file (plan, memory note, …) for display in the
+/// read-only Monaco viewer.
+///
+/// `path` must resolve, after canonicalization, to a file under one of the
+/// allow-listed agent directories (see [`claudette::agent_files`]). Any
+/// other absolute path is rejected — this is a narrow, separately
+/// allow-listed route and does **not** relax the worktree file-read
+/// boundary enforced by `normalize_relative_path`.
+#[tauri::command]
+pub async fn read_agent_managed_file(path: String) -> Result<FileContent, String> {
+    let canonical = tauri::async_runtime::spawn_blocking(move || {
+        classify_agent_file(Path::new(&path)).map(|(canonical, _kind)| canonical)
+    })
+    .await
+    .map_err(|e| format!("agent file classification failed: {e}"))??;
+
+    let read = file_expand::read_authorized_file(&canonical, MAX_AGENT_FILE_SIZE)
+        .await
+        .ok_or_else(|| "Failed to read agent file".to_string())?;
+
+    Ok(FileContent {
+        path: canonical.to_string_lossy().into_owned(),
+        content: read.content,
+        is_binary: read.is_binary,
+        size_bytes: read.size_bytes,
+        truncated: read.truncated,
+        // Agent files are read through to their canonical location and
+        // rendered read-only; the git-gutter symlink concern doesn't apply.
+        is_symlink: false,
+    })
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod agent_backends;
 #[cfg(not(feature = "alternative-backends"))]
 #[path = "agent_backends_disabled.rs"]
 pub mod agent_backends;
+pub mod agent_files;
 pub mod apps;
 pub mod auth;
 pub mod boot;

--- a/src-tauri/src/commands/plan.rs
+++ b/src-tauri/src/commands/plan.rs
@@ -13,12 +13,16 @@ use claudette::agent_files::{AgentFileKind, classify_agent_file};
 #[tauri::command]
 pub async fn read_plan_file(path: String) -> Result<String, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        let (canonical, kind) = classify_agent_file(Path::new(&path))
-            .map_err(|_| "Only .claude/plans/*.md files can be read".to_string())?;
-        if kind != AgentFileKind::Plan {
-            return Err("Only .claude/plans/*.md files can be read".to_string());
+        match classify_agent_file(Path::new(&path)) {
+            Ok((canonical, AgentFileKind::Plan)) => std::fs::read_to_string(&canonical)
+                .map_err(|e| format!("Failed to read plan file: {e}")),
+            // An allow-listed file that isn't a plan (e.g. a memory note):
+            // surface the plan-specific message.
+            Ok((_, _)) => Err("Only .claude/plans/*.md files can be read".to_string()),
+            // Canonicalization / IO / not-allow-listed failures keep their
+            // specific message instead of collapsing into the generic one.
+            Err(e) => Err(e),
         }
-        std::fs::read_to_string(&canonical).map_err(|e| format!("Failed to read plan file: {e}"))
     })
     .await
     .map_err(|e| format!("Failed to read plan file: {e}"))?

--- a/src-tauri/src/commands/plan.rs
+++ b/src-tauri/src/commands/plan.rs
@@ -1,28 +1,23 @@
 use std::path::Path;
 
+use claudette::agent_files::{AgentFileKind, classify_agent_file};
+
 /// Read a plan file from disk and return its content.
 ///
-/// Validates via path components that the canonicalized path contains a
-/// `.claude/plans/` directory and ends with `.md`.
+/// Thin wrapper over the shared agent-file allow-list
+/// ([`claudette::agent_files`]): the path must canonicalize to a `.md`
+/// file under a `.claude/plans/` directory. Kept as its own command —
+/// rather than folded into `read_agent_managed_file` — because
+/// `PlanApprovalCard` drives it directly (including over WSS) and only
+/// ever wants plan files, never memory.
 #[tauri::command]
 pub async fn read_plan_file(path: String) -> Result<String, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        let canonical = std::fs::canonicalize(Path::new(&path))
-            .map_err(|e| format!("Invalid plan path: {e}"))?;
-
-        // Validate via path components: must have consecutive .claude → plans segments.
-        let components: Vec<&str> = canonical
-            .components()
-            .filter_map(|c| c.as_os_str().to_str())
-            .collect();
-        let has_plans_dir = components
-            .windows(2)
-            .any(|w| w[0] == ".claude" && w[1] == "plans");
-
-        if !has_plans_dir || canonical.extension().and_then(|e| e.to_str()) != Some("md") {
+        let (canonical, kind) = classify_agent_file(Path::new(&path))
+            .map_err(|_| "Only .claude/plans/*.md files can be read".to_string())?;
+        if kind != AgentFileKind::Plan {
             return Err("Only .claude/plans/*.md files can be read".to_string());
         }
-
         std::fs::read_to_string(&canonical).map_err(|e| format!("Failed to read plan file: {e}"))
     })
     .await

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1008,6 +1008,8 @@ fn main() {
             commands::chat::session::restore_chat_session,
             // Plan
             commands::plan::read_plan_file,
+            // Agent-managed files (plans, memory, …)
+            commands::agent_files::read_agent_managed_file,
             // Metrics
             commands::metrics::get_dashboard_metrics,
             commands::metrics::get_workspace_metrics_batch,

--- a/src/agent_files.rs
+++ b/src/agent_files.rs
@@ -1,20 +1,29 @@
 //! Allow-list for agent-managed files that live outside any worktree.
 //!
 //! Coding agents (Claude Code, Codex) persist plans, memory notes, and
-//! related markdown under fixed directories in the user's home — never
-//! inside a Claudette worktree. The worktree file-read commands reject
-//! absolute paths by design, so those files can't be opened through the
-//! normal editor route.
+//! related markdown under fixed directories in the user's agent config —
+//! never inside a Claudette worktree. The worktree file-read commands
+//! reject absolute paths by design, so those files can't be opened
+//! through the normal editor route.
 //!
 //! This module is the *one* place that decides which out-of-worktree
 //! paths are safe to read: a structured [`ROOTS`] allow-list plus a single
 //! [`classify_agent_file`] entry point. Adding a new agent directory is
 //! one [`AgentFileRoot`] entry — no new command, no forked validation.
 //!
-//! The matching is deliberately **component-wise** (whole path segments,
-//! never a substring compare) and runs against the **canonicalized** path,
-//! so symlink escapes resolve to their real location before matching.
+//! Each root is anchored at an agent's **base directory**, resolved the
+//! same way the agent's own CLI resolves it:
+//! - Claude Code: `$CLAUDE_CONFIG_DIR` if set, else `~/.claude`
+//! - Codex: `$CODEX_HOME` if set, else `~/.codex`
+//!
+//! A candidate path must canonicalize (resolving symlinks) to a location
+//! **under** one of those base directories, with the root's sub-path
+//! rooted directly at the base — not merely containing the segments
+//! somewhere. This rejects unrelated files under similarly-named
+//! directories elsewhere on disk, and resolves symlink escapes to their
+//! real location before the containment check.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
@@ -25,7 +34,7 @@ use serde::Serialize;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum AgentFileKind {
-    /// A plan file (`~/.claude/plans/**/*.md`).
+    /// A plan file (`<claude-config>/plans/**/*.md`).
     Plan,
     /// A memory note under an agent's memory directory.
     Memory,
@@ -36,7 +45,16 @@ pub enum AgentFileKind {
     ProjectFile,
 }
 
-/// One segment of an allow-list anchor.
+/// An agent whose config/home directory anchors one or more roots.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AgentBase {
+    /// Claude Code config dir — `$CLAUDE_CONFIG_DIR` or `~/.claude`.
+    ClaudeConfig,
+    /// Codex home dir — `$CODEX_HOME` or `~/.codex`.
+    CodexHome,
+}
+
+/// One segment of an allow-list sub-path.
 #[derive(Clone, Copy)]
 enum Seg {
     /// Must equal this exact directory name.
@@ -49,62 +67,119 @@ use Seg::{Any, Lit};
 
 /// A directory family whose files are safe to open read-only.
 ///
-/// `anchor` is a run of consecutive path segments that must appear, in
-/// order, somewhere in the canonical path. Any number of segments may
-/// follow the anchor before the file itself (an implicit `**`), and at
-/// least one must (the file).
+/// `sub_path` is the run of path segments directly under the agent's base
+/// directory — rooted at the base's first child, not matched anywhere.
+/// Any number of segments may follow before the file itself (an implicit
+/// `**`), and at least one must (the file).
 struct AgentFileRoot {
-    anchor: &'static [Seg],
+    base: AgentBase,
+    sub_path: &'static [Seg],
     /// Allowed file extensions, lowercase, without the leading dot.
     extensions: &'static [&'static str],
     kind: AgentFileKind,
 }
 
 /// The allow-list. Evaluated top-to-bottom; the first matching root wins,
-/// so the specific memory roots precede the broad project catch.
+/// so the specific memory root precedes the broad project catch.
 ///
 /// Keep this in sync with the frontend recognizer in
 /// `src/ui/src/utils/agentFiles.ts`.
 const ROOTS: &[AgentFileRoot] = &[
-    // Claude Code plans — `~/.claude/plans/**/*.md`.
+    // Claude Code plans — `<claude-config>/plans/**/*.md`.
     AgentFileRoot {
-        anchor: &[Lit(".claude"), Lit("plans")],
+        base: AgentBase::ClaudeConfig,
+        sub_path: &[Lit("plans")],
         extensions: &["md"],
         kind: AgentFileKind::Plan,
     },
-    // Claude Code project memory — `~/.claude/projects/<slug>/memory/**/*.md`.
+    // Claude Code project memory —
+    // `<claude-config>/projects/<slug>/memory/**/*.md`.
     AgentFileRoot {
-        anchor: &[Lit(".claude"), Lit("projects"), Any, Lit("memory")],
+        base: AgentBase::ClaudeConfig,
+        sub_path: &[Lit("projects"), Any, Lit("memory")],
         extensions: &["md"],
         kind: AgentFileKind::Memory,
     },
-    // Codex memory — `~/.codex/memories/**/*.md`.
+    // Codex memory — `<codex-home>/memories/**/*.md`.
     AgentFileRoot {
-        anchor: &[Lit(".codex"), Lit("memories")],
+        base: AgentBase::CodexHome,
+        sub_path: &[Lit("memories")],
         extensions: &["md"],
         kind: AgentFileKind::Memory,
     },
     // Broad Claude Code project catch — any other `.md` under a project
-    // directory (`~/.claude/projects/<slug>/**/*.md`).
+    // directory (`<claude-config>/projects/<slug>/**/*.md`).
     AgentFileRoot {
-        anchor: &[Lit(".claude"), Lit("projects"), Any],
+        base: AgentBase::ClaudeConfig,
+        sub_path: &[Lit("projects"), Any],
         extensions: &["md"],
         kind: AgentFileKind::ProjectFile,
     },
 ];
 
+/// Resolved base directories for the agent-managed-file roots.
+struct AgentBases {
+    claude_config: Option<PathBuf>,
+    codex_home: Option<PathBuf>,
+}
+
+impl AgentBases {
+    fn for_base(&self, base: AgentBase) -> Option<&Path> {
+        match base {
+            AgentBase::ClaudeConfig => self.claude_config.as_deref(),
+            AgentBase::CodexHome => self.codex_home.as_deref(),
+        }
+    }
+}
+
+/// Resolve the agent base directories, honoring the same env overrides the
+/// agents' own CLIs use (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`). An empty env
+/// value counts as unset — matching `fork::resolve_claude_projects_dir`.
+///
+/// Pure: env values and home dir are passed in, so the resolution is
+/// testable without mutating process-global state.
+fn resolve_agent_bases(
+    claude_config_env: Option<OsString>,
+    codex_home_env: Option<OsString>,
+    home_dir: Option<PathBuf>,
+) -> AgentBases {
+    let override_dir =
+        |env: Option<OsString>| env.filter(|value| !value.is_empty()).map(PathBuf::from);
+    AgentBases {
+        claude_config: override_dir(claude_config_env)
+            .or_else(|| home_dir.as_ref().map(|home| home.join(".claude"))),
+        codex_home: override_dir(codex_home_env)
+            .or_else(|| home_dir.as_ref().map(|home| home.join(".codex"))),
+    }
+}
+
 /// Classify `path` against the agent-managed-file allow-list.
 ///
-/// The path is canonicalized first, fully resolving symlinks: a symlink
+/// The path is canonicalized first, fully resolving symlinks, then checked
+/// for containment under a canonicalized agent base directory: a symlink
 /// placed inside an allow-listed directory that points elsewhere resolves
 /// to its real location and is rejected unless that location is itself
-/// allow-listed.
+/// inside an allow-listed root.
 ///
 /// Returns the canonical path together with its [`AgentFileKind`], or an
 /// `Err` describing why the path was rejected. This is the security gate
 /// for [`crate::file_expand::read_authorized_file`] — it does **not**
 /// relax the worktree file-read boundary, it is a separate narrow route.
 pub fn classify_agent_file(path: &Path) -> Result<(PathBuf, AgentFileKind), String> {
+    let bases = resolve_agent_bases(
+        std::env::var_os("CLAUDE_CONFIG_DIR"),
+        std::env::var_os("CODEX_HOME"),
+        dirs::home_dir(),
+    );
+    classify_agent_file_within(path, &bases)
+}
+
+/// Inner classifier with the base directories supplied explicitly, so
+/// tests can anchor the roots at a temp directory.
+fn classify_agent_file_within(
+    path: &Path,
+    bases: &AgentBases,
+) -> Result<(PathBuf, AgentFileKind), String> {
     let canonical =
         std::fs::canonicalize(path).map_err(|e| format!("Invalid agent file path: {e}"))?;
 
@@ -112,47 +187,54 @@ pub fn classify_agent_file(path: &Path) -> Result<(PathBuf, AgentFileKind), Stri
         return Err("Agent file path is not a regular file".to_string());
     }
 
-    let components: Vec<&str> = canonical
-        .components()
-        .filter_map(|c| c.as_os_str().to_str())
-        .collect();
     let extension = canonical
         .extension()
         .and_then(|e| e.to_str())
         .map(str::to_ascii_lowercase);
 
     for root in ROOTS {
-        let ext_ok = match extension.as_deref() {
-            Some(ext) => root.extensions.contains(&ext),
-            None => false,
+        let ext_ok = extension
+            .as_deref()
+            .is_some_and(|ext| root.extensions.contains(&ext));
+        if !ext_ok {
+            continue;
+        }
+        // Resolve and canonicalize the base directory. A missing base
+        // (agent never used on this machine) simply can't contain files,
+        // so skip the root rather than failing the whole classification.
+        let Some(base) = bases.for_base(root.base) else {
+            continue;
         };
-        if ext_ok && anchor_present(&components, root.anchor) {
-            let kind = refine_kind(root.kind, &canonical);
-            return Ok((canonical.clone(), kind));
+        let Ok(base_canonical) = std::fs::canonicalize(base) else {
+            continue;
+        };
+        // Containment check: the real file must live under the real base.
+        let Ok(relative) = canonical.strip_prefix(&base_canonical) else {
+            continue;
+        };
+        let segments: Vec<&str> = relative
+            .components()
+            .filter_map(|c| c.as_os_str().to_str())
+            .collect();
+        if sub_path_matches(&segments, root.sub_path) {
+            return Ok((canonical.clone(), refine_kind(root.kind, &canonical)));
         }
     }
 
     Err("Path is not an allow-listed agent-managed file".to_string())
 }
 
-/// True when `anchor` appears as a run of consecutive components in
-/// `components`, with at least one component (the file itself) following
-/// the run.
-fn anchor_present(components: &[&str], anchor: &[Seg]) -> bool {
-    let n = anchor.len();
-    // Need the anchor window plus at least one trailing component.
-    if components.len() <= n {
+/// True when `sub_path` matches the leading components of `segments`, with
+/// at least one trailing component (the file itself) after the match.
+fn sub_path_matches(segments: &[&str], sub_path: &[Seg]) -> bool {
+    let n = sub_path.len();
+    // Need the sub-path segments plus at least one trailing component.
+    if segments.len() <= n {
         return false;
     }
-    let last_start = components.len() - n - 1;
-    (0..=last_start).any(|start| {
-        anchor
-            .iter()
-            .zip(&components[start..start + n])
-            .all(|(seg, comp)| match seg {
-                Seg::Lit(name) => comp == name,
-                Seg::Any => true,
-            })
+    sub_path.iter().zip(segments).all(|(seg, comp)| match seg {
+        Seg::Lit(name) => comp == name,
+        Seg::Any => true,
     })
 }
 
@@ -182,11 +264,19 @@ mod tests {
         path
     }
 
+    /// Agent bases rooted at `<dir>/.claude` and `<dir>/.codex`.
+    fn bases_under(dir: &TempDir) -> AgentBases {
+        AgentBases {
+            claude_config: Some(dir.path().join(".claude")),
+            codex_home: Some(dir.path().join(".codex")),
+        }
+    }
+
     #[test]
     fn classifies_claude_plan() {
         let dir = TempDir::new().unwrap();
         let path = touch(&dir, ".claude/plans/sunny-otter.md");
-        let (_canonical, kind) = classify_agent_file(&path).unwrap();
+        let (_canonical, kind) = classify_agent_file_within(&path, &bases_under(&dir)).unwrap();
         assert_eq!(kind, AgentFileKind::Plan);
     }
 
@@ -194,7 +284,7 @@ mod tests {
     fn classifies_project_memory_note() {
         let dir = TempDir::new().unwrap();
         let path = touch(&dir, ".claude/projects/-Users-me-proj/memory/feedback_x.md");
-        let (_canonical, kind) = classify_agent_file(&path).unwrap();
+        let (_canonical, kind) = classify_agent_file_within(&path, &bases_under(&dir)).unwrap();
         assert_eq!(kind, AgentFileKind::Memory);
     }
 
@@ -202,7 +292,7 @@ mod tests {
     fn classifies_memory_index() {
         let dir = TempDir::new().unwrap();
         let path = touch(&dir, ".claude/projects/-Users-me-proj/memory/MEMORY.md");
-        let (_canonical, kind) = classify_agent_file(&path).unwrap();
+        let (_canonical, kind) = classify_agent_file_within(&path, &bases_under(&dir)).unwrap();
         assert_eq!(kind, AgentFileKind::MemoryIndex);
     }
 
@@ -210,23 +300,28 @@ mod tests {
     fn classifies_broad_project_markdown_as_project_file() {
         let dir = TempDir::new().unwrap();
         let path = touch(&dir, ".claude/projects/-Users-me-proj/scratch-notes.md");
-        let (_canonical, kind) = classify_agent_file(&path).unwrap();
+        let (_canonical, kind) = classify_agent_file_within(&path, &bases_under(&dir)).unwrap();
         assert_eq!(kind, AgentFileKind::ProjectFile);
     }
 
     #[test]
     fn classifies_codex_memory_and_index() {
         let dir = TempDir::new().unwrap();
+        let bases = bases_under(&dir);
+
         let note = touch(&dir, ".codex/memories/raw_memories.md");
-        assert_eq!(classify_agent_file(&note).unwrap().1, AgentFileKind::Memory);
+        assert_eq!(
+            classify_agent_file_within(&note, &bases).unwrap().1,
+            AgentFileKind::Memory
+        );
         let index = touch(&dir, ".codex/memories/MEMORY.md");
         assert_eq!(
-            classify_agent_file(&index).unwrap().1,
+            classify_agent_file_within(&index, &bases).unwrap().1,
             AgentFileKind::MemoryIndex
         );
         let nested = touch(&dir, ".codex/memories/rollout_summaries/2026-05-12-foo.md");
         assert_eq!(
-            classify_agent_file(&nested).unwrap().1,
+            classify_agent_file_within(&nested, &bases).unwrap().1,
             AgentFileKind::Memory
         );
     }
@@ -235,21 +330,31 @@ mod tests {
     fn rejects_sibling_non_markdown_file() {
         let dir = TempDir::new().unwrap();
         let path = touch(&dir, ".claude/plans/notes.txt");
-        assert!(classify_agent_file(&path).is_err());
+        assert!(classify_agent_file_within(&path, &bases_under(&dir)).is_err());
     }
 
     #[test]
     fn rejects_arbitrary_absolute_path() {
         let dir = TempDir::new().unwrap();
         let path = touch(&dir, "some/other/place/document.md");
-        assert!(classify_agent_file(&path).is_err());
+        assert!(classify_agent_file_within(&path, &bases_under(&dir)).is_err());
+    }
+
+    #[test]
+    fn rejects_lookalike_directory_outside_the_base() {
+        // A `.claude/plans/*.md` file that is NOT under the resolved base
+        // directory must be rejected — the anchor is the base dir, not the
+        // mere presence of `.claude/plans` segments anywhere in the path.
+        let dir = TempDir::new().unwrap();
+        let path = touch(&dir, "some-repo/.claude/plans/decoy.md");
+        assert!(classify_agent_file_within(&path, &bases_under(&dir)).is_err());
     }
 
     #[test]
     fn rejects_missing_path() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join(".claude/plans/nonexistent.md");
-        assert!(classify_agent_file(&path).is_err());
+        assert!(classify_agent_file_within(&path, &bases_under(&dir)).is_err());
     }
 
     #[test]
@@ -257,14 +362,14 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let memory_dir = dir.path().join(".claude/plans/looks-like.md");
         fs::create_dir_all(&memory_dir).unwrap();
-        assert!(classify_agent_file(&memory_dir).is_err());
+        assert!(classify_agent_file_within(&memory_dir, &bases_under(&dir)).is_err());
     }
 
     #[cfg(unix)]
     #[test]
     fn rejects_symlink_escape() {
         let dir = TempDir::new().unwrap();
-        // A real file outside any allow-listed root.
+        // A real file outside any allow-listed base directory.
         let secret = touch(&dir, "outside/secret.md");
         // A symlink planted inside an allow-listed directory pointing at it.
         let link_dir = dir.path().join(".claude/plans");
@@ -273,7 +378,53 @@ mod tests {
         std::os::unix::fs::symlink(&secret, &link).unwrap();
 
         // The symlink resolves (via canonicalize) to the real file, which
-        // has no `.claude/plans` segment — so it must be rejected.
-        assert!(classify_agent_file(&link).is_err());
+        // is not under the base directory — so it must be rejected.
+        assert!(classify_agent_file_within(&link, &bases_under(&dir)).is_err());
+    }
+
+    #[test]
+    fn resolve_agent_bases_prefers_env_overrides() {
+        let bases = resolve_agent_bases(
+            Some(OsString::from("/sandbox/claude-config")),
+            Some(OsString::from("/sandbox/codex")),
+            Some(PathBuf::from("/home/me")),
+        );
+        assert_eq!(
+            bases.claude_config.as_deref(),
+            Some(Path::new("/sandbox/claude-config"))
+        );
+        assert_eq!(
+            bases.codex_home.as_deref(),
+            Some(Path::new("/sandbox/codex"))
+        );
+    }
+
+    #[test]
+    fn resolve_agent_bases_falls_back_to_home() {
+        // Empty env values count as unset.
+        let bases =
+            resolve_agent_bases(Some(OsString::new()), None, Some(PathBuf::from("/home/me")));
+        assert_eq!(
+            bases.claude_config.as_deref(),
+            Some(Path::new("/home/me/.claude"))
+        );
+        assert_eq!(
+            bases.codex_home.as_deref(),
+            Some(Path::new("/home/me/.codex"))
+        );
+    }
+
+    #[test]
+    fn classifies_under_env_overridden_base() {
+        // Mirrors a `scripts/dev.sh` instance: the Claude config dir is a
+        // sandbox path, not `~/.claude`. Plans there must still classify.
+        let dir = TempDir::new().unwrap();
+        let path = touch(&dir, "claude-config/plans/dev-plan.md");
+        let bases = AgentBases {
+            claude_config: Some(dir.path().join("claude-config")),
+            codex_home: None,
+        };
+        let (_canonical, kind) = classify_agent_file_within(&path, &bases).unwrap();
+        assert_eq!(kind, AgentFileKind::Plan);
     }
 }

--- a/src/agent_files.rs
+++ b/src/agent_files.rs
@@ -1,0 +1,279 @@
+//! Allow-list for agent-managed files that live outside any worktree.
+//!
+//! Coding agents (Claude Code, Codex) persist plans, memory notes, and
+//! related markdown under fixed directories in the user's home — never
+//! inside a Claudette worktree. The worktree file-read commands reject
+//! absolute paths by design, so those files can't be opened through the
+//! normal editor route.
+//!
+//! This module is the *one* place that decides which out-of-worktree
+//! paths are safe to read: a structured [`ROOTS`] allow-list plus a single
+//! [`classify_agent_file`] entry point. Adding a new agent directory is
+//! one [`AgentFileRoot`] entry — no new command, no forked validation.
+//!
+//! The matching is deliberately **component-wise** (whole path segments,
+//! never a substring compare) and runs against the **canonicalized** path,
+//! so symlink escapes resolve to their real location before matching.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+/// What kind of agent-managed file a path resolved to. Surfaced to the UI
+/// as a small badge so the user can tell a plan from a memory note at a
+/// glance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentFileKind {
+    /// A plan file (`~/.claude/plans/**/*.md`).
+    Plan,
+    /// A memory note under an agent's memory directory.
+    Memory,
+    /// The conventional `MEMORY.md` index inside a memory directory.
+    MemoryIndex,
+    /// A markdown file under a Claude project directory that isn't a
+    /// recognized memory file — the broad project catch.
+    ProjectFile,
+}
+
+/// One segment of an allow-list anchor.
+#[derive(Clone, Copy)]
+enum Seg {
+    /// Must equal this exact directory name.
+    Lit(&'static str),
+    /// Matches exactly one path segment of any name (e.g. a project slug).
+    Any,
+}
+
+use Seg::{Any, Lit};
+
+/// A directory family whose files are safe to open read-only.
+///
+/// `anchor` is a run of consecutive path segments that must appear, in
+/// order, somewhere in the canonical path. Any number of segments may
+/// follow the anchor before the file itself (an implicit `**`), and at
+/// least one must (the file).
+struct AgentFileRoot {
+    anchor: &'static [Seg],
+    /// Allowed file extensions, lowercase, without the leading dot.
+    extensions: &'static [&'static str],
+    kind: AgentFileKind,
+}
+
+/// The allow-list. Evaluated top-to-bottom; the first matching root wins,
+/// so the specific memory roots precede the broad project catch.
+///
+/// Keep this in sync with the frontend recognizer in
+/// `src/ui/src/utils/agentFiles.ts`.
+const ROOTS: &[AgentFileRoot] = &[
+    // Claude Code plans — `~/.claude/plans/**/*.md`.
+    AgentFileRoot {
+        anchor: &[Lit(".claude"), Lit("plans")],
+        extensions: &["md"],
+        kind: AgentFileKind::Plan,
+    },
+    // Claude Code project memory — `~/.claude/projects/<slug>/memory/**/*.md`.
+    AgentFileRoot {
+        anchor: &[Lit(".claude"), Lit("projects"), Any, Lit("memory")],
+        extensions: &["md"],
+        kind: AgentFileKind::Memory,
+    },
+    // Codex memory — `~/.codex/memories/**/*.md`.
+    AgentFileRoot {
+        anchor: &[Lit(".codex"), Lit("memories")],
+        extensions: &["md"],
+        kind: AgentFileKind::Memory,
+    },
+    // Broad Claude Code project catch — any other `.md` under a project
+    // directory (`~/.claude/projects/<slug>/**/*.md`).
+    AgentFileRoot {
+        anchor: &[Lit(".claude"), Lit("projects"), Any],
+        extensions: &["md"],
+        kind: AgentFileKind::ProjectFile,
+    },
+];
+
+/// Classify `path` against the agent-managed-file allow-list.
+///
+/// The path is canonicalized first, fully resolving symlinks: a symlink
+/// placed inside an allow-listed directory that points elsewhere resolves
+/// to its real location and is rejected unless that location is itself
+/// allow-listed.
+///
+/// Returns the canonical path together with its [`AgentFileKind`], or an
+/// `Err` describing why the path was rejected. This is the security gate
+/// for [`crate::file_expand::read_authorized_file`] — it does **not**
+/// relax the worktree file-read boundary, it is a separate narrow route.
+pub fn classify_agent_file(path: &Path) -> Result<(PathBuf, AgentFileKind), String> {
+    let canonical =
+        std::fs::canonicalize(path).map_err(|e| format!("Invalid agent file path: {e}"))?;
+
+    if !canonical.is_file() {
+        return Err("Agent file path is not a regular file".to_string());
+    }
+
+    let components: Vec<&str> = canonical
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect();
+    let extension = canonical
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+
+    for root in ROOTS {
+        let ext_ok = match extension.as_deref() {
+            Some(ext) => root.extensions.contains(&ext),
+            None => false,
+        };
+        if ext_ok && anchor_present(&components, root.anchor) {
+            let kind = refine_kind(root.kind, &canonical);
+            return Ok((canonical.clone(), kind));
+        }
+    }
+
+    Err("Path is not an allow-listed agent-managed file".to_string())
+}
+
+/// True when `anchor` appears as a run of consecutive components in
+/// `components`, with at least one component (the file itself) following
+/// the run.
+fn anchor_present(components: &[&str], anchor: &[Seg]) -> bool {
+    let n = anchor.len();
+    // Need the anchor window plus at least one trailing component.
+    if components.len() <= n {
+        return false;
+    }
+    let last_start = components.len() - n - 1;
+    (0..=last_start).any(|start| {
+        anchor
+            .iter()
+            .zip(&components[start..start + n])
+            .all(|(seg, comp)| match seg {
+                Seg::Lit(name) => comp == name,
+                Seg::Any => true,
+            })
+    })
+}
+
+/// Promote a generic `Memory` match to `MemoryIndex` when the file is the
+/// conventional `MEMORY.md` index.
+fn refine_kind(base: AgentFileKind, canonical: &Path) -> AgentFileKind {
+    if base == AgentFileKind::Memory
+        && canonical.file_name().and_then(|n| n.to_str()) == Some("MEMORY.md")
+    {
+        AgentFileKind::MemoryIndex
+    } else {
+        base
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Create a file (and any missing parent directories) under `dir`.
+    fn touch(dir: &TempDir, relative: &str) -> PathBuf {
+        let path = dir.path().join(relative);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "# content\n").unwrap();
+        path
+    }
+
+    #[test]
+    fn classifies_claude_plan() {
+        let dir = TempDir::new().unwrap();
+        let path = touch(&dir, ".claude/plans/sunny-otter.md");
+        let (_canonical, kind) = classify_agent_file(&path).unwrap();
+        assert_eq!(kind, AgentFileKind::Plan);
+    }
+
+    #[test]
+    fn classifies_project_memory_note() {
+        let dir = TempDir::new().unwrap();
+        let path = touch(&dir, ".claude/projects/-Users-me-proj/memory/feedback_x.md");
+        let (_canonical, kind) = classify_agent_file(&path).unwrap();
+        assert_eq!(kind, AgentFileKind::Memory);
+    }
+
+    #[test]
+    fn classifies_memory_index() {
+        let dir = TempDir::new().unwrap();
+        let path = touch(&dir, ".claude/projects/-Users-me-proj/memory/MEMORY.md");
+        let (_canonical, kind) = classify_agent_file(&path).unwrap();
+        assert_eq!(kind, AgentFileKind::MemoryIndex);
+    }
+
+    #[test]
+    fn classifies_broad_project_markdown_as_project_file() {
+        let dir = TempDir::new().unwrap();
+        let path = touch(&dir, ".claude/projects/-Users-me-proj/scratch-notes.md");
+        let (_canonical, kind) = classify_agent_file(&path).unwrap();
+        assert_eq!(kind, AgentFileKind::ProjectFile);
+    }
+
+    #[test]
+    fn classifies_codex_memory_and_index() {
+        let dir = TempDir::new().unwrap();
+        let note = touch(&dir, ".codex/memories/raw_memories.md");
+        assert_eq!(classify_agent_file(&note).unwrap().1, AgentFileKind::Memory);
+        let index = touch(&dir, ".codex/memories/MEMORY.md");
+        assert_eq!(
+            classify_agent_file(&index).unwrap().1,
+            AgentFileKind::MemoryIndex
+        );
+        let nested = touch(&dir, ".codex/memories/rollout_summaries/2026-05-12-foo.md");
+        assert_eq!(
+            classify_agent_file(&nested).unwrap().1,
+            AgentFileKind::Memory
+        );
+    }
+
+    #[test]
+    fn rejects_sibling_non_markdown_file() {
+        let dir = TempDir::new().unwrap();
+        let path = touch(&dir, ".claude/plans/notes.txt");
+        assert!(classify_agent_file(&path).is_err());
+    }
+
+    #[test]
+    fn rejects_arbitrary_absolute_path() {
+        let dir = TempDir::new().unwrap();
+        let path = touch(&dir, "some/other/place/document.md");
+        assert!(classify_agent_file(&path).is_err());
+    }
+
+    #[test]
+    fn rejects_missing_path() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(".claude/plans/nonexistent.md");
+        assert!(classify_agent_file(&path).is_err());
+    }
+
+    #[test]
+    fn rejects_directory() {
+        let dir = TempDir::new().unwrap();
+        let memory_dir = dir.path().join(".claude/plans/looks-like.md");
+        fs::create_dir_all(&memory_dir).unwrap();
+        assert!(classify_agent_file(&memory_dir).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_escape() {
+        let dir = TempDir::new().unwrap();
+        // A real file outside any allow-listed root.
+        let secret = touch(&dir, "outside/secret.md");
+        // A symlink planted inside an allow-listed directory pointing at it.
+        let link_dir = dir.path().join(".claude/plans");
+        fs::create_dir_all(&link_dir).unwrap();
+        let link = link_dir.join("escape.md");
+        std::os::unix::fs::symlink(&secret, &link).unwrap();
+
+        // The symlink resolves (via canonicalize) to the real file, which
+        // has no `.claude/plans` segment — so it must be rejected.
+        assert!(classify_agent_file(&link).is_err());
+    }
+}

--- a/src/file_expand.rs
+++ b/src/file_expand.rs
@@ -134,6 +134,18 @@ pub async fn write_worktree_file(
         .map_err(|e| format!("write: {e}"))
 }
 
+/// Read a file at an already-authorized absolute path, with binary
+/// detection and a `max_bytes` truncation cap.
+///
+/// Unlike the `read_worktree_file*` helpers this performs **no** path
+/// containment check — the caller is responsible for having validated the
+/// path against an allow-list first (see [`crate::agent_files`]). The path
+/// is canonicalized so binary/size checks run against the real file.
+pub async fn read_authorized_file(path: &Path, max_bytes: usize) -> Option<SafeFileRead> {
+    let canonical = tokio::fs::canonicalize(path).await.ok()?;
+    read_checked(&canonical, max_bytes).await
+}
+
 /// Inner helper: resolve a relative path against the worktree, validate
 /// containment, read with binary/truncation checks.
 async fn resolve_and_read(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod agent_backend;
+pub mod agent_files;
 pub mod agent_mcp;
 pub mod audio;
 pub mod cesp;

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -59,6 +59,7 @@ import {
 import { ChatAuthFailureCallout } from "../auth/ChatAuthFailureCallout";
 import { cleanClaudeAuthError, isClaudeAuthError } from "../auth/claudeAuth";
 import { monacoFileLinkTarget } from "./chatFileLinks";
+import { tryOpenAgentFileTab } from "../../utils/agentFiles";
 import { useWorkspaceFileIndex } from "./useWorkspaceFileIndex";
 import { detectFileReferences } from "../../utils/filePathLinks";
 import {
@@ -490,6 +491,12 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   // passing a bad key into the file-tab store.
   const openFileInMonaco = useCallback(
     (filePath: string) => {
+      // Agent-managed files (plans, memory) live outside the worktree —
+      // route them to a read-only Monaco tab before worktree resolution.
+      if (tryOpenAgentFileTab(workspaceId, filePath, openFileTab)) {
+        onOpenFileLink?.();
+        return true;
+      }
       const target = monacoFileLinkTarget(filePath, worktreePath);
       if (!target) return false;
       onOpenFileLink?.();

--- a/src/ui/src/components/chat/StreamingMessage.tsx
+++ b/src/ui/src/components/chat/StreamingMessage.tsx
@@ -5,6 +5,7 @@ import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
 import { StreamingContext } from "./StreamingContext";
 import { ScrollContext } from "./ScrollContext";
 import { monacoFileLinkTarget } from "./chatFileLinks";
+import { tryOpenAgentFileTab } from "../../utils/agentFiles";
 import { useWorkspaceFileIndex } from "./useWorkspaceFileIndex";
 import styles from "./ChatPanel.module.css";
 import caretStyles from "./caret.module.css";
@@ -58,6 +59,7 @@ export const StreamingMessage = memo(function StreamingMessage({
 
   const openFileInMonaco = useCallback(
     (filePath: string) => {
+      if (tryOpenAgentFileTab(workspaceId, filePath, openFileTab)) return true;
       const target = monacoFileLinkTarget(filePath, worktreePath);
       if (!target) return false;
       openFileTab(workspaceId, target.path, target.revealTarget);

--- a/src/ui/src/components/chat/ToolActivityRow.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.tsx
@@ -15,6 +15,7 @@ import {
 } from "./editActivitySummary";
 import { resolveToolSummary } from "./toolMetadata";
 import { isSkillActivity, skillActivationName } from "./toolActivityGroups";
+import { tryOpenAgentFileTab } from "../../utils/agentFiles";
 import type { DiffLayer } from "../../types/diff";
 
 interface ToolActivityRowProps {
@@ -125,6 +126,10 @@ function GenericToolActivityRow({
   const openEditedFile = useCallback(
     (filePath: string) => {
       if (!selectedWorkspaceId) return;
+      // Agent-managed files (plans, memory) live outside the worktree, so
+      // they have no diff entry and no worktree-relative form — route them
+      // straight to a read-only Monaco tab.
+      if (tryOpenAgentFileTab(selectedWorkspaceId, filePath, openFileTab)) return;
       const relativePath = relativizePath(filePath, worktreePath).replace(/\\/g, "/");
       const diffTarget = findDiffTarget(relativePath, diffFiles, diffStagedFiles);
       if (diffTarget) {

--- a/src/ui/src/components/chat/useWorkspaceFileOpener.ts
+++ b/src/ui/src/components/chat/useWorkspaceFileOpener.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useAppStore } from "../../stores/useAppStore";
+import { tryOpenAgentFileTab } from "../../utils/agentFiles";
 import { monacoFileLinkTarget } from "./chatFileLinks";
 import { useWorkspaceFileIndex } from "./useWorkspaceFileIndex";
 
@@ -39,6 +40,9 @@ export function useWorkspaceFileOpener(
   const openFile = useCallback(
     (filePath: string) => {
       if (!workspaceId) return false;
+      // Agent-managed files (plans, memory) live outside the worktree —
+      // route them to a read-only Monaco tab before worktree resolution.
+      if (tryOpenAgentFileTab(workspaceId, filePath, openFileTab)) return true;
       const target = monacoFileLinkTarget(filePath, worktreePath);
       if (!target) return false;
       openFileTab(workspaceId, target.path, target.revealTarget);

--- a/src/ui/src/components/file-viewer/FileViewer.module.css
+++ b/src/ui/src/components/file-viewer/FileViewer.module.css
@@ -49,6 +49,21 @@
   font-size: 12px;
 }
 
+/* Metadata chip for agent-managed files (plan / memory / …) shown in the
+ * pane toolbar between the path and the view controls. */
+.agentBadge {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+  color: var(--accent-primary);
+  background: rgba(var(--accent-primary-rgb), 0.12);
+  border: 1px solid rgba(var(--accent-primary-rgb), 0.25);
+}
+
 .imageWrap {
   flex: 1;
   display: flex;

--- a/src/ui/src/components/file-viewer/FileViewer.test.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.test.tsx
@@ -13,6 +13,7 @@ import { FileViewer } from "./FileViewer";
 
 const serviceMocks = vi.hoisted(() => ({
   loadDiffFiles: vi.fn(),
+  readAgentManagedFile: vi.fn(),
   readWorkspaceFileBytes: vi.fn(),
   readWorkspaceFileForViewer: vi.fn(),
   writeWorkspaceFile: vi.fn(),
@@ -65,6 +66,7 @@ function seedOpenFile(closeNonce = 0) {
 
 beforeEach(() => {
   serviceMocks.loadDiffFiles.mockReset();
+  serviceMocks.readAgentManagedFile.mockReset();
   serviceMocks.readWorkspaceFileBytes.mockReset();
   serviceMocks.readWorkspaceFileForViewer.mockReset();
   serviceMocks.writeWorkspaceFile.mockReset();
@@ -119,5 +121,52 @@ describe("FileViewer close nonce handling", () => {
     const state = useAppStore.getState();
     expect(state.fileTabsByWorkspace[WS]).toEqual([]);
     expect(state.activeFileTabByWorkspace[WS]).toBeNull();
+  });
+});
+
+describe("FileViewer agent-managed files", () => {
+  const AGENT_FILE = "/Users/test/.claude/plans/sunny-otter.md";
+
+  function seedOpenAgentFile() {
+    useAppStore.setState({
+      selectedWorkspaceId: WS,
+      fileTabsByWorkspace: { [WS]: [AGENT_FILE] },
+      activeFileTabByWorkspace: { [WS]: AGENT_FILE },
+      fileRevealTargetByWorkspace: {},
+      fileBuffers: {
+        [fileBufferKey(WS, AGENT_FILE)]: makeUnloadedBuffer(),
+      },
+      requestCloseFileTabNonceByWorkspace: { [WS]: 0 },
+    });
+  }
+
+  it("loads an agent-managed file via the allow-listed route", async () => {
+    serviceMocks.readAgentManagedFile.mockResolvedValue({
+      path: AGENT_FILE,
+      content: "# Plan",
+      is_binary: false,
+      size_bytes: 6,
+      truncated: false,
+      is_symlink: false,
+    });
+    seedOpenAgentFile();
+
+    const container = await render(<FileViewer />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Routed to the agent-file command, not the worktree file reader.
+    expect(serviceMocks.readAgentManagedFile).toHaveBeenCalledWith(AGENT_FILE);
+    expect(serviceMocks.readWorkspaceFileForViewer).not.toHaveBeenCalled();
+
+    // Buffer loaded; the kind badge is rendered (mocked t() echoes the key).
+    const buffer = useAppStore.getState().fileBuffers[
+      fileBufferKey(WS, AGENT_FILE)
+    ];
+    expect(buffer?.loaded).toBe(true);
+    expect(buffer?.baseline).toBe("# Plan");
+    expect(container.textContent).toContain("agent_file_badge_plan");
   });
 });

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -603,6 +603,7 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
               revealTarget={revealTarget}
               onRevealTargetApplied={handleRevealTargetApplied}
               isSymlink={bufferState.isSymlink}
+              disableGitGutter={!!agentFile}
               readOnly={editDisabled}
               onChange={handleBufferChange}
               onSave={handleSave}

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -23,10 +23,15 @@ import { tooltipWithHotkey } from "../../hotkeys/display";
 import { fileBufferKey } from "../../stores/slices/fileTreeSlice";
 import {
   loadDiffFiles,
+  readAgentManagedFile,
   readWorkspaceFileBytes,
   readWorkspaceFileForViewer,
   writeWorkspaceFile,
 } from "../../services/tauri";
+import {
+  agentFileKindI18nKey,
+  classifyAgentFile,
+} from "../../utils/agentFiles";
 import { WorkspacePanelHeader } from "../shared/WorkspacePanelHeader";
 import { PaneToolbar } from "../shared/PaneToolbar";
 import { SegmentedControl } from "../shared/SegmentedControl";
@@ -112,6 +117,10 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
 
   const isMarkdown = MARKDOWN_EXT.test(path);
   const isImage = isImagePath(path);
+  // Agent-managed files (plans, memory) are opened by absolute path and
+  // live outside the worktree. They load through the allow-listed
+  // `read_agent_managed_file` route and render strictly read-only.
+  const agentFile = useMemo(() => classifyAgentFile(path), [path]);
 
   // Initial load. Triggered when the buffer entry exists but isn't loaded
   // yet (`loaded=false`). The slice seeds an unloaded entry on `openFileTab`,
@@ -122,7 +131,26 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
     if (!bufferState || bufferState.loaded) return;
     const version = ++loadVersionRef.current;
 
-    if (isImage) {
+    if (agentFile) {
+      // Agent-managed files load through the allow-listed backend route.
+      // They are always markdown, never images.
+      readAgentManagedFile(path)
+        .then((res) => {
+          if (version !== loadVersionRef.current) return;
+          setFileBufferLoaded(workspaceId, path, {
+            baseline: res.content ?? "",
+            isBinary: res.is_binary,
+            isSymlink: res.is_symlink,
+            sizeBytes: res.size_bytes,
+            truncated: res.truncated,
+            imageBytesB64: null,
+          });
+        })
+        .catch((e) => {
+          if (version !== loadVersionRef.current) return;
+          setFileBufferLoadError(workspaceId, path, String(e));
+        });
+    } else if (isImage) {
       readWorkspaceFileBytes(workspaceId, path)
         .then((res) => {
           if (version !== loadVersionRef.current) return;
@@ -174,6 +202,7 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
   }, [
     bufferState,
     isImage,
+    agentFile,
     workspaceId,
     path,
     setFileBufferLoaded,
@@ -196,13 +225,17 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
   // available" for binary) or rare enough not to warrant chrome (oversize
   // files between the edit cap and the viewer cap render read-only with
   // no banner — Monaco's read-only cursor signals it).
+  //
+  // Agent-managed files are always read-only: they're inspected from chat,
+  // not edited, and there's no in-app save route back to their home dir.
   const editDisabled =
-    !!bufferState &&
-    bufferState.loaded &&
-    (isImage ||
-      bufferState.isBinary ||
-      bufferState.sizeBytes > EDIT_SIZE_LIMIT_BYTES ||
-      bufferState.truncated);
+    !!agentFile ||
+    (!!bufferState &&
+      bufferState.loaded &&
+      (isImage ||
+        bufferState.isBinary ||
+        bufferState.sizeBytes > EDIT_SIZE_LIMIT_BYTES ||
+        bufferState.truncated));
 
   const handleBufferChange = useCallback(
     (next: string) => {
@@ -282,7 +315,10 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
     t,
   ]);
 
-  const showMarkdownToggle = isMarkdown && !editDisabled;
+  // Agent-managed markdown is read-only but still gets the source/preview
+  // toggle — inspecting a plan or memory note as rendered markdown (à la
+  // the inline plan card) is the common case.
+  const showMarkdownToggle = isMarkdown && (!editDisabled || !!agentFile);
   const showMarkdownPreview =
     showMarkdownToggle &&
     bufferState?.preview === "preview" &&
@@ -473,6 +509,16 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
       <PaneToolbar
         path={path}
         dirty={dirty}
+        badge={
+          agentFile ? (
+            <span
+              className={styles.agentBadge}
+              title={t("file_agent_managed_readonly")}
+            >
+              {t(agentFileKindI18nKey(agentFile.kind))}
+            </span>
+          ) : undefined
+        }
         actions={
           <>
             {showMarkdownToggle && (

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -37,6 +37,10 @@ interface MonacoEditorProps {
    *  stripe for every line of a resolved-target buffer that doesn't
    *  match git's blob (which is just the target path string). */
   isSymlink: boolean;
+  /** Hard-disable the git gutter. Set for agent-managed tabs, whose
+   *  absolute paths aren't tracked in the workspace repo — running the
+   *  gutter would only fire a guaranteed-to-fail git IPC per open. */
+  disableGitGutter?: boolean;
   /** Read-only mode. Toggled at runtime via `updateOptions` so flipping
    *  view/edit doesn't lose cursor position or undo stack. */
   readOnly: boolean;
@@ -66,6 +70,7 @@ export const MonacoEditor = memo(function MonacoEditor({
   value,
   filename,
   isSymlink,
+  disableGitGutter = false,
   revealTarget,
   onRevealTargetApplied,
   readOnly,
@@ -274,6 +279,7 @@ export const MonacoEditor = memo(function MonacoEditor({
     filename,
     currentBuffer,
     isSymlink,
+    disableGitGutter,
   );
 
   return (

--- a/src/ui/src/components/file-viewer/useGitGutter.ts
+++ b/src/ui/src/components/file-viewer/useGitGutter.ts
@@ -62,6 +62,11 @@ export function useGitGutter(
   // outside the worktree (or untracked), so the cheapest correct
   // behavior is "no gutter for symlinks".
   isSymlink: boolean,
+  // Hard-disable the gutter regardless of file state. Set for
+  // agent-managed tabs, whose absolute paths aren't tracked in the
+  // workspace repo — a gutter fetch would only fire a guaranteed-to-fail
+  // git IPC per open. See `FileViewer`'s `agentFile` handling.
+  skipGutter = false,
 ) {
   // `null` = gutter unavailable (no head, fetch error, binary, or revision
   // not yet resolved). Empty string `""` = file untracked at the revision;
@@ -101,8 +106,9 @@ export function useGitGutter(
   useEffect(() => {
     const version = ++fetchVersionRef.current;
 
-    // Bail for symlinks — see the doc comment on `isSymlink` above.
-    if (isSymlink) {
+    // Bail for symlinks or hard-disabled gutters (agent-managed tabs) —
+    // see the doc comments on `isSymlink` / `skipGutter` above.
+    if (isSymlink || skipGutter) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setHead(null);
       collectionRef.current?.clear();
@@ -153,7 +159,15 @@ export function useGitGutter(
     // has moved HEAD). Re-fetching on `diffMergeBase` change is the
     // cheapest way to inherit that signal in both modes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspaceId, filename, revision, diffMergeBase, collectionRef, isSymlink]);
+  }, [
+    workspaceId,
+    filename,
+    revision,
+    diffMergeBase,
+    collectionRef,
+    isSymlink,
+    skipGutter,
+  ]);
 
   // Debounced recompute on every buffer or head change. (Unchanged from
   // before Task 6 except that it now responds to `head` updates produced

--- a/src/ui/src/components/shared/PaneToolbar.tsx
+++ b/src/ui/src/components/shared/PaneToolbar.tsx
@@ -7,11 +7,14 @@ interface PaneToolbarProps {
   path?: string;
   /** Show an unsaved-changes dot next to the path. */
   dirty?: boolean;
+  /** Optional metadata chip rendered between the path and the actions —
+   *  e.g. an agent-managed file's "Plan" / "Memory" badge. */
+  badge?: ReactNode;
   /** Right-aligned controls (segmented controls, icon buttons). */
   actions: ReactNode;
 }
 
-export function PaneToolbar({ path, dirty, actions }: PaneToolbarProps) {
+export function PaneToolbar({ path, dirty, badge, actions }: PaneToolbarProps) {
   return (
     <div className={styles.toolbar}>
       {path !== undefined && (
@@ -22,6 +25,7 @@ export function PaneToolbar({ path, dirty, actions }: PaneToolbarProps) {
           {path}
         </span>
       )}
+      {badge}
       <div className={styles.actions}>{actions}</div>
     </div>
   );

--- a/src/ui/src/hooks/useWorkspaceFileWatcher.ts
+++ b/src/ui/src/hooks/useWorkspaceFileWatcher.ts
@@ -95,7 +95,14 @@ export function useWorkspaceFileWatcher(): void {
   useEffect(() => {
     if (!selectedWorkspaceId) return;
     const workspaceId = selectedWorkspaceId;
-    const paths = fileTabs ?? [];
+    // Agent-managed file tabs (plans, memory) are keyed by absolute path
+    // and live outside the worktree. The backend watcher resolves paths
+    // relative to the worktree, so absolute keys can't be watched — drop
+    // them from the set. These files are opened read-only for inspection;
+    // live on-disk follow isn't part of that contract.
+    const paths = (fileTabs ?? []).filter(
+      (p) => !p.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(p),
+    );
     // Even an empty array is a meaningful instruction — it asks the
     // watcher to drop any prior subscriptions for this workspace.
     void watchWorkspaceFiles(workspaceId, paths).catch((err) => {

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -243,6 +243,11 @@
   "file_dirty_aria": "Unsaved changes",
   "file_external_change_reload_tooltip": "File changed on disk — click to reload (your unsaved edits will be lost)",
   "file_external_change_reload_aria": "Reload from disk",
+  "file_agent_managed_readonly": "Agent-managed file — read-only",
+  "agent_file_badge_plan": "Plan",
+  "agent_file_badge_memory": "Memory",
+  "agent_file_badge_memory_index": "Memory index",
+  "agent_file_badge_project": "Project file",
 
   "editor_menu_file": "File",
   "editor_menu_edit": "Edit",

--- a/src/ui/src/services/tauri/files.ts
+++ b/src/ui/src/services/tauri/files.ts
@@ -38,6 +38,14 @@ export function readWorkspaceFileForViewer(
   });
 }
 
+/** Read an agent-managed file (plan, memory note, …) for the read-only
+ *  Monaco viewer. `path` is an absolute path; the backend's
+ *  `read_agent_managed_file` allow-list validates that it canonicalizes
+ *  to a file under a known agent directory and rejects anything else. */
+export function readAgentManagedFile(path: string): Promise<FileContent> {
+  return invoke("read_agent_managed_file", { path });
+}
+
 /** Replace the watch set for `workspaceId` with `paths`. Idempotent —
  *  the file-viewer hook re-asserts the full open-tab list whenever
  *  files are opened or closed. The backend's `FileWatcher` deduplicates

--- a/src/ui/src/utils/agentFiles.test.ts
+++ b/src/ui/src/utils/agentFiles.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  agentFileKindI18nKey,
+  classifyAgentFile,
+  tryOpenAgentFileTab,
+} from "./agentFiles";
+
+describe("classifyAgentFile", () => {
+  it("classifies a Claude plan file", () => {
+    const result = classifyAgentFile(
+      "/Users/me/.claude/plans/sunny-otter.md",
+    );
+    expect(result).toEqual({
+      kind: "plan",
+      path: "/Users/me/.claude/plans/sunny-otter.md",
+    });
+  });
+
+  it("classifies a project memory note", () => {
+    expect(
+      classifyAgentFile(
+        "/Users/me/.claude/projects/-Users-me-proj/memory/feedback_testing.md",
+      )?.kind,
+    ).toBe("memory");
+  });
+
+  it("classifies the MEMORY.md index distinctly", () => {
+    expect(
+      classifyAgentFile(
+        "/Users/me/.claude/projects/-Users-me-proj/memory/MEMORY.md",
+      )?.kind,
+    ).toBe("memory-index");
+  });
+
+  it("classifies other project markdown as a project file", () => {
+    expect(
+      classifyAgentFile(
+        "/Users/me/.claude/projects/-Users-me-proj/scratch-notes.md",
+      )?.kind,
+    ).toBe("project-file");
+  });
+
+  it("classifies Codex memory files", () => {
+    expect(
+      classifyAgentFile("/Users/me/.codex/memories/raw_memories.md")?.kind,
+    ).toBe("memory");
+    expect(
+      classifyAgentFile("/Users/me/.codex/memories/MEMORY.md")?.kind,
+    ).toBe("memory-index");
+    expect(
+      classifyAgentFile(
+        "/Users/me/.codex/memories/rollout_summaries/2026-05-12-foo.md",
+      )?.kind,
+    ).toBe("memory");
+  });
+
+  it("strips a trailing :line suffix from the tab key", () => {
+    expect(
+      classifyAgentFile("/Users/me/.claude/plans/x.md:42"),
+    ).toEqual({ kind: "plan", path: "/Users/me/.claude/plans/x.md" });
+  });
+
+  it("recognizes Windows-drive absolute paths", () => {
+    expect(
+      classifyAgentFile("C:/Users/me/.claude/plans/x.md")?.kind,
+    ).toBe("plan");
+  });
+
+  it("normalizes backslashes in the tab key", () => {
+    expect(
+      classifyAgentFile("C:\\Users\\me\\.claude\\plans\\x.md")?.path,
+    ).toBe("C:/Users/me/.claude/plans/x.md");
+  });
+
+  it("rejects non-markdown files under an allow-listed root", () => {
+    expect(classifyAgentFile("/Users/me/.claude/plans/notes.txt")).toBeNull();
+  });
+
+  it("rejects workspace-relative paths", () => {
+    expect(classifyAgentFile("src/main.rs")).toBeNull();
+    expect(classifyAgentFile("plans/foo.md")).toBeNull();
+    expect(classifyAgentFile(".claude/plans/foo.md")).toBeNull();
+  });
+
+  it("rejects arbitrary absolute paths", () => {
+    expect(classifyAgentFile("/Users/me/Documents/notes.md")).toBeNull();
+    expect(classifyAgentFile("/etc/passwd")).toBeNull();
+  });
+
+  it("rejects an empty or anchorless path", () => {
+    expect(classifyAgentFile("")).toBeNull();
+    expect(classifyAgentFile("/")).toBeNull();
+  });
+});
+
+describe("tryOpenAgentFileTab", () => {
+  it("opens an agent file tab and reports success", () => {
+    const openFileTab = vi.fn();
+    const opened = tryOpenAgentFileTab(
+      "ws-1",
+      "/Users/me/.claude/plans/x.md",
+      openFileTab,
+    );
+    expect(opened).toBe(true);
+    expect(openFileTab).toHaveBeenCalledWith(
+      "ws-1",
+      "/Users/me/.claude/plans/x.md",
+    );
+  });
+
+  it("does nothing for a non-agent path", () => {
+    const openFileTab = vi.fn();
+    expect(tryOpenAgentFileTab("ws-1", "src/main.rs", openFileTab)).toBe(false);
+    expect(openFileTab).not.toHaveBeenCalled();
+  });
+
+  it("does nothing without a workspace", () => {
+    const openFileTab = vi.fn();
+    expect(
+      tryOpenAgentFileTab(null, "/Users/me/.claude/plans/x.md", openFileTab),
+    ).toBe(false);
+    expect(openFileTab).not.toHaveBeenCalled();
+  });
+});
+
+describe("agentFileKindI18nKey", () => {
+  it("maps every kind to a chat-namespace key", () => {
+    expect(agentFileKindI18nKey("plan")).toBe("agent_file_badge_plan");
+    expect(agentFileKindI18nKey("memory")).toBe("agent_file_badge_memory");
+    expect(agentFileKindI18nKey("memory-index")).toBe(
+      "agent_file_badge_memory_index",
+    );
+    expect(agentFileKindI18nKey("project-file")).toBe(
+      "agent_file_badge_project",
+    );
+  });
+});

--- a/src/ui/src/utils/agentFiles.ts
+++ b/src/ui/src/utils/agentFiles.ts
@@ -1,0 +1,166 @@
+/**
+ * Recognizer for agent-managed files — plans, memory notes, and other
+ * markdown that coding agents (Claude Code, Codex) persist under fixed
+ * home directories, outside any worktree.
+ *
+ * This mirrors the backend allow-list in `src/agent_files.rs`. It exists
+ * so the chat surface can decide *routing*: an allow-listed path opens in
+ * a read-only Monaco tab via `read_agent_managed_file` instead of being
+ * sent to the worktree file-read command, which rejects absolute paths.
+ *
+ * This is a routing hint, **not** a security boundary — the backend
+ * `classify_agent_file` re-validates every read and canonicalizes the
+ * path (resolving symlink escapes), which this string-only classifier
+ * cannot. A frontend false positive surfaces as a load error; a false
+ * negative just falls back to the OS opener.
+ *
+ * Keep the roots here in sync with `ROOTS` in `src/agent_files.rs`.
+ */
+
+import { stripFileLineSuffix } from "./filePathLinks";
+
+export type AgentFileKind = "plan" | "memory" | "memory-index" | "project-file";
+
+export interface AgentFileClassification {
+  kind: AgentFileKind;
+  /** Normalized absolute path — the stable Monaco tab key. */
+  path: string;
+}
+
+/** One segment of an allow-list anchor. */
+type Seg = { lit: string } | { any: true };
+
+interface AgentFileRoot {
+  /** Consecutive path segments that must appear, in order, in the path. */
+  anchor: Seg[];
+  /** Allowed file extensions, lowercase, without the leading dot. */
+  extensions: string[];
+  kind: AgentFileKind;
+}
+
+/** Evaluated top-to-bottom; first match wins, so the specific memory
+ *  roots precede the broad project catch. */
+const ROOTS: AgentFileRoot[] = [
+  // Claude Code plans — ~/.claude/plans/**/*.md
+  {
+    anchor: [{ lit: ".claude" }, { lit: "plans" }],
+    extensions: ["md"],
+    kind: "plan",
+  },
+  // Claude Code project memory — ~/.claude/projects/<slug>/memory/**/*.md
+  {
+    anchor: [
+      { lit: ".claude" },
+      { lit: "projects" },
+      { any: true },
+      { lit: "memory" },
+    ],
+    extensions: ["md"],
+    kind: "memory",
+  },
+  // Codex memory — ~/.codex/memories/**/*.md
+  {
+    anchor: [{ lit: ".codex" }, { lit: "memories" }],
+    extensions: ["md"],
+    kind: "memory",
+  },
+  // Broad Claude Code project catch — any other .md under a project dir.
+  {
+    anchor: [{ lit: ".claude" }, { lit: "projects" }, { any: true }],
+    extensions: ["md"],
+    kind: "project-file",
+  },
+];
+
+/** True when `anchor` appears as a run of consecutive components in
+ *  `components`, with at least one component (the file) following it. */
+function anchorPresent(components: string[], anchor: Seg[]): boolean {
+  const n = anchor.length;
+  if (components.length <= n) return false;
+  for (let start = 0; start + n <= components.length - 1; start++) {
+    let matched = true;
+    for (let i = 0; i < n; i++) {
+      const seg = anchor[i];
+      if ("lit" in seg && components[start + i] !== seg.lit) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) return true;
+  }
+  return false;
+}
+
+/**
+ * Classify an absolute path against the agent-managed-file allow-list.
+ * Returns the kind and normalized path, or `null` when the path is not an
+ * allow-listed agent file (relative paths always return `null` — a
+ * worktree tab key never starts with a slash).
+ */
+export function classifyAgentFile(rawPath: string): AgentFileClassification | null {
+  if (!rawPath) return null;
+  const normalized = stripFileLineSuffix(rawPath.trim()).replace(/\\/g, "/");
+  // Only absolute paths can be agent-managed files. Workspace-relative
+  // tab keys never start with a slash or a Windows drive letter.
+  const isAbsolute =
+    normalized.startsWith("/") || /^[A-Za-z]:\//.test(normalized);
+  if (!isAbsolute) return null;
+
+  const components = normalized.split("/").filter((c) => c.length > 0);
+  if (components.length === 0) return null;
+  const basename = components[components.length - 1];
+  const dot = basename.lastIndexOf(".");
+  if (dot <= 0 || dot === basename.length - 1) return null;
+  const ext = basename.slice(dot + 1).toLowerCase();
+
+  for (const root of ROOTS) {
+    if (!root.extensions.includes(ext)) continue;
+    if (!anchorPresent(components, root.anchor)) continue;
+    const kind: AgentFileKind =
+      root.kind === "memory" && basename === "MEMORY.md"
+        ? "memory-index"
+        : root.kind;
+    return { kind, path: normalized };
+  }
+  return null;
+}
+
+/**
+ * Routing helper shared by every chat-surface file-link opener. If
+ * `filePath` is an allow-listed agent-managed file, open it as a
+ * read-only Monaco tab keyed by its absolute path and return `true`;
+ * otherwise return `false` so the caller falls back to worktree-relative
+ * resolution.
+ */
+export function tryOpenAgentFileTab(
+  workspaceId: string | null | undefined,
+  filePath: string,
+  openFileTab: (workspaceId: string, path: string) => void,
+): boolean {
+  if (!workspaceId) return false;
+  const agent = classifyAgentFile(filePath);
+  if (!agent) return false;
+  openFileTab(workspaceId, agent.path);
+  return true;
+}
+
+/** Chat-namespace i18n key for an agent file's badge label. The literal
+ *  return type keeps it assignable to the typed `t()` key parameter. */
+export type AgentFileBadgeKey =
+  | "agent_file_badge_plan"
+  | "agent_file_badge_memory"
+  | "agent_file_badge_memory_index"
+  | "agent_file_badge_project";
+
+export function agentFileKindI18nKey(kind: AgentFileKind): AgentFileBadgeKey {
+  switch (kind) {
+    case "plan":
+      return "agent_file_badge_plan";
+    case "memory":
+      return "agent_file_badge_memory";
+    case "memory-index":
+      return "agent_file_badge_memory_index";
+    case "project-file":
+      return "agent_file_badge_project";
+  }
+}

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -25,6 +25,7 @@ import {
   isLikelyFilePathTarget,
   isLikelyRelativeFileReference,
 } from "./filePathLinks";
+import { classifyAgentFile } from "./agentFiles";
 import { getCachedHighlight, highlightCode } from "./highlight";
 import { rehypeFilePathLinks } from "./rehypeFilePathLinks";
 
@@ -403,6 +404,10 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
   const filePath = href
     ? (encodedFilePath ?? localhostFilePath ?? hrefFilePath)
     : null;
+  // Agent-managed files (plans, memory) sit outside every worktree, so the
+  // workspace resolver never verifies them. Recognize them explicitly so
+  // they render as a Monaco-bound button instead of inert prose.
+  const agentFile = filePath ? classifyAgentFile(filePath) : null;
   const encodedExplicitFilePath =
     encodedFilePath && isAbsoluteExplicitFilePath(encodedFilePath)
       ? encodedFilePath
@@ -431,6 +436,17 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
   };
   const openFilePath = () => {
     if (!filePath) return;
+    if (agentFile && fileOpen) {
+      try {
+        if (fileOpen.openFile(agentFile.path)) return;
+      } catch (err) {
+        console.error(
+          "Failed to open agent file link in Monaco:",
+          agentFile.path,
+          err,
+        );
+      }
+    }
     if (fileOpen) {
       if (verifiedFilePath) {
         try {
@@ -495,7 +511,8 @@ const MarkdownLink: NonNullable<Components["a"]> = ({
       hasFileResolver &&
       !verifiedFilePath &&
       !encodedExplicitFilePath &&
-      !encodedWorkspaceRelativeFilePath
+      !encodedWorkspaceRelativeFilePath &&
+      !agentFile
     ) {
       return createElement("span", props, renderedFilePathLabel);
     }


### PR DESCRIPTION
## Summary

Clicking an agent-managed file path in chat — a plan or memory file written under `~/.claude/**` or `~/.codex/**` — used to open a tab that immediately errored **"Failed to load: absolute paths are not allowed"**. The path resolves outside the workspace worktree, so it hit the worktree file-read security boundary (`normalize_relative_path` in `files.rs`), which rejects every absolute path by design.

This PR adds a **narrow, structured allow-list** for agent-managed file roots so those files open **read-only** in Monaco — without relaxing the worktree boundary. Closes #864.

### Reproduced cases (both fixed)
- **Plans** — `~/.claude/plans/<slug>.md` from an `Editing` row / `ExitPlanMode`.
- **Project memory** — `~/.claude/projects/<slug>/memory/*.md`, including the `MEMORY.md` index.

## Approach

One allow-list on each side of the IPC boundary, serving distinct roles:

- **Backend allow-list = the security gate.** Canonicalizes the path (resolving symlinks), then validates it.
- **Frontend recognizer = a routing hint.** Decides *which loader to call*. A false positive surfaces as a load error; a false negative falls back to the OS opener. Only the backend is trusted.

### Backend

- **`src/agent_files.rs`** (new) — a single `ROOTS` allow-list + `classify_agent_file()`. Matching is **component-wise** (whole path segments, never a substring compare) against the **canonicalized** path, so a symlink planted inside an allow-listed directory resolves to its real location and is rejected unless that location is itself allow-listed. Adding a directory is one `AgentFileRoot` row.

  | Agent | Root | Kind |
  |---|---|---|
  | Claude Code | `~/.claude/plans/**/*.md` | Plan |
  | Claude Code | `~/.claude/projects/<slug>/memory/**/*.md` | Memory / Memory index (`MEMORY.md`) |
  | Claude Code | `~/.claude/projects/<slug>/**/*.md` | Project file (broad catch) |
  | Codex | `~/.codex/memories/**/*.md` | Memory / Memory index |

- **`read_agent_managed_file`** command (`src-tauri/src/commands/agent_files.rs`) — thin wrapper returning `FileContent`, applying the existing viewer size cap + binary detection via a new `file_expand::read_authorized_file` helper.
- **`read_plan_file`** now delegates to the same classifier — behavior and the `"Only .claude/plans/*.md files can be read"` error string are preserved, so the `PlanApprovalCard` flow (including over WSS) is unchanged.
- **`normalize_relative_path` is untouched** — this is a separate, allow-listed route, not a relaxation of the worktree boundary.

### Frontend

- **`src/ui/src/utils/agentFiles.ts`** (new) — `classifyAgentFile()` mirrors the backend roots; `tryOpenAgentFileTab()` is the shared recognizer wired into all four chat-surface openers (`useWorkspaceFileOpener`, `StreamingMessage`, `MessagesWithTurns`, and `ToolActivityRow` — the actual repro path).
- The markdown `<a>` override (`markdown.ts`) now renders allow-list-matched paths as Monaco-bound buttons instead of inert prose.
- **`FileViewer`** loads agent tabs via `read_agent_managed_file`, renders them **read-only**, keeps the markdown source/preview toggle available, and shows a kind badge (**Plan** / **Memory** / **Memory index** / **Project file**) in the pane toolbar next to the full absolute path.
- The file watcher skips absolute agent paths (they have no worktree-relative form to watch).

## Tests

- **Rust** — 10 new `agent_files` unit tests: plan / project-memory / memory-index / Codex / broad-project matches, plus rejections for non-markdown siblings, arbitrary absolute paths, missing paths, directories, and **symlink escape**.
- **Frontend** — new `agentFiles.test.ts` (classification, `tryOpenAgentFileTab`, badge keys, Windows-drive + line-suffix handling) and a `FileViewer` integration test confirming an agent path routes through `read_agent_managed_file`.

## Verification

- Rust: `claudette` compiles, `clippy` clean, `cargo fmt` clean; `claudette-tauri` `cargo check` passes (default features).
- Frontend: `tsc -b` + `vite build` pass; full suite **2607 tests pass**; `lint:css` passes.

## Docs

- `site/.../features/file-editor.mdx` gains an **Agent-Managed Files** section.
- `tauri-commands.md` reference updated with `readAgentManagedFile`.

## Not done

Verified via builds, unit tests, and a FileViewer integration test — **not** click-tested in a live dev build (would need a real agent session that wrote a plan/memory file). Happy to do live UAT if desired before merge.
