### PR TITLE
fix(workspace): prevent duplicate workspace creation on app reload

### DIFF
--- a/src-cli/src/commands/workspace.rs
+++ b/src-cli/src/commands/workspace.rs
@@ -63,7 +63,14 @@ pub async fn run(action: Action, json: bool) -> Result<(), Box<dyn Error>> {
     let info = discovery::read_app_info()?;
     match action {
         Action::List => {
+            // `list_workspaces` returns every row regardless of status,
+            // but `workspace list` is documented as listing *active*
+            // workspaces — filter here so the command matches its
+            // contract. The shared IPC method is intentionally left
+            // untouched: `purge` (below) and `pr` resolution both rely
+            // on seeing archived / all rows. See issue #896.
             let value = ipc::call(&info, "list_workspaces", serde_json::json!({})).await?;
+            let value = active_workspaces(value);
             if json {
                 output::print_json(&value)?;
             } else {
@@ -315,6 +322,30 @@ fn parse_created_at(value: &str) -> Option<u64> {
     u64::try_from(secs).ok()
 }
 
+/// Keep only `Active` rows from a `list_workspaces` response.
+///
+/// `claudette workspace list` is documented as listing *active*
+/// workspaces, but the underlying `list_workspaces` IPC method has no
+/// `WHERE status` clause and returns archived rows too. Filtering in the
+/// CLI keeps the command faithful to its contract without changing the
+/// shared IPC method — `workspace purge` and `pr` resolution both depend
+/// on it returning every row. `WorkspaceStatus` serializes capitalized
+/// (`"Active"` / `"Archived"`), matching `resolve_purge_ids` above.
+/// See issue #896.
+///
+/// A non-array value (unexpected shape) is returned untouched so the
+/// caller's existing "unexpected response shape" handling still fires.
+fn active_workspaces(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(rows) => serde_json::Value::Array(
+            rows.into_iter()
+                .filter(|row| row.get("status").and_then(|v| v.as_str()) == Some("Active"))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
 /// Minimal table renderer for `workspace list`. Format is intentionally
 /// simple — we'll switch to a real table crate (`tabled`?) when more
 /// commands need column-aware rendering.
@@ -342,7 +373,7 @@ fn render_workspace_table(value: &serde_json::Value) {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_created_at;
+    use super::{active_workspaces, parse_created_at};
 
     #[test]
     fn parses_unix_seconds_string() {
@@ -368,5 +399,42 @@ mod tests {
         assert_eq!(parse_created_at(""), None);
         assert_eq!(parse_created_at("nope"), None);
         assert_eq!(parse_created_at("2023-13-01 00:00:00"), None);
+    }
+
+    #[test]
+    fn active_workspaces_drops_archived_rows() {
+        // `workspace list` is documented active-only; the IPC method is
+        // not — this filter is what bridges the gap (issue #896).
+        let input = serde_json::json!([
+            { "id": "w1", "status": "Active" },
+            { "id": "w2", "status": "Archived" },
+            { "id": "w3", "status": "Active" },
+        ]);
+        let out = active_workspaces(input);
+        let ids: Vec<&str> = out
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|r| r.get("id").and_then(|v| v.as_str()))
+            .collect();
+        assert_eq!(ids, ["w1", "w3"]);
+    }
+
+    #[test]
+    fn active_workspaces_empty_when_all_archived() {
+        let input = serde_json::json!([
+            { "id": "w1", "status": "Archived" },
+            { "id": "w2", "status": "Archived" },
+        ]);
+        let out = active_workspaces(input);
+        assert!(out.as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn active_workspaces_passes_through_non_array() {
+        // An unexpected (non-array) shape is returned untouched so the
+        // caller's "unexpected response shape" handling still triggers.
+        let input = serde_json::json!({ "error": "boom" });
+        assert_eq!(active_workspaces(input.clone()), input);
     }
 }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -35,6 +35,32 @@ pub struct CreateWorkspaceResult {
     pub setup_result: Option<SetupResult>,
 }
 
+/// Error returned by [`create_workspace`] when a create for the same
+/// repository is already running. The frontend (`useCreateWorkspace.ts`)
+/// matches on the `"already being created for this repository"` substring
+/// to surface a calm toast instead of a failure alert — keep the wording
+/// in sync if you touch this. See issue #896.
+const WORKSPACE_CREATE_IN_FLIGHT_ERR: &str =
+    "A workspace is already being created for this repository. Please wait for it to finish.";
+
+/// RAII release for the per-repo workspace-creation slot claimed via
+/// [`AppState::try_begin_workspace_create`].
+///
+/// Holding this for the lifetime of [`create_workspace`] frees the slot
+/// on every exit path — the normal return, an error bubbled up from
+/// `create_workspace_inner`, or an unwind — so a failed or panicking
+/// create can never wedge a repo into a permanently un-creatable state.
+struct WorkspaceCreateGuard<'a> {
+    state: &'a AppState,
+    repo_id: String,
+}
+
+impl Drop for WorkspaceCreateGuard<'_> {
+    fn drop(&mut self) {
+        self.state.end_workspace_create(&self.repo_id);
+    }
+}
+
 #[tauri::command]
 #[tracing::instrument(
     target = "claudette::workspace",
@@ -48,6 +74,22 @@ pub async fn create_workspace(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<CreateWorkspaceResult, String> {
+    // Single-flight guard against duplicate workspace creation. The
+    // frontend's `creationInFlight` latch (useCreateWorkspace.ts) is a
+    // module-level JS variable that a webview reload resets to `false`,
+    // while the Rust command spawned by the first create keeps running
+    // across that reload. Without this process-side guard a reload — or
+    // any re-click while a slow create is in flight — issues a second
+    // `create_workspace` that mints a duplicate `-N` row. The slot is
+    // keyed per repo so creates in *different* repos still run
+    // concurrently. See issue #896.
+    if !state.try_begin_workspace_create(&repo_id) {
+        return Err(WORKSPACE_CREATE_IN_FLIGHT_ERR.to_string());
+    }
+    let _create_guard = WorkspaceCreateGuard {
+        state: state.inner(),
+        repo_id: repo_id.clone(),
+    };
     create_workspace_inner(
         &repo_id,
         &name,

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -35,13 +35,15 @@ pub struct CreateWorkspaceResult {
     pub setup_result: Option<SetupResult>,
 }
 
-/// Error returned by [`create_workspace`] when a create for the same
-/// repository is already running. The frontend (`useCreateWorkspace.ts`)
-/// matches on the `"already being created for this repository"` substring
-/// to surface a calm toast instead of a failure alert — keep the wording
-/// in sync if you touch this. See issue #896.
-const WORKSPACE_CREATE_IN_FLIGHT_ERR: &str =
-    "A workspace is already being created for this repository. Please wait for it to finish.";
+/// Stable error code returned by [`create_workspace`] when a create for
+/// the same repository is already running. Returned as a bare token (not
+/// a human-readable sentence) so the cross-process contract with the
+/// frontend is a fixed identifier rather than prose — immune to wording
+/// tweaks and future localization. `useCreateWorkspace.ts` matches this
+/// exact string and owns the user-facing copy. Mirrors the
+/// `WORKSPACE_FILE_NOT_FOUND` error-code convention in
+/// `src-tauri/src/commands/files.rs`. See issue #896.
+const WORKSPACE_CREATE_IN_FLIGHT_ERR: &str = "WORKSPACE_CREATE_IN_FLIGHT";
 
 /// RAII release for the per-repo workspace-creation slot claimed via
 /// [`AppState::try_begin_workspace_create`].

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -686,6 +686,16 @@ pub struct AppState {
     /// the post-DB worktree/branch cleanup loop check the same flag, so
     /// the user's Cancel click really does stop further work.
     pub bulk_cleanup_cancels: RwLock<HashMap<String, Arc<AtomicBool>>>,
+    /// Repository IDs with a GUI-initiated `create_workspace` currently in
+    /// flight. A create runs for several seconds (git worktree add + setup
+    /// script + env resolve). The frontend's `creationInFlight` latch is a
+    /// webview-scoped JS variable that a reload resets to `false`, so on its
+    /// own it can't stop a reload-then-reclick from minting a duplicate `-N`
+    /// workspace. This set lives in the Rust process — unaffected by webview
+    /// reloads — and `create_workspace` consults it before each create.
+    /// Keyed per repo so unrelated repos still create concurrently. See
+    /// issue #896.
+    pub workspace_creates_in_flight: Mutex<HashSet<String>>,
     /// Nudges the native agent scheduler after a wakeup/routine is created,
     /// deleted, or manually fired so the polling loop can recompute its next
     /// deadline immediately instead of waiting for the fallback tick.
@@ -742,12 +752,36 @@ impl AppState {
             auth_login_cancel: tokio::sync::Mutex::new(None),
             auth_login_stdin: tokio::sync::Mutex::new(None),
             bulk_cleanup_cancels: RwLock::new(HashMap::new()),
+            workspace_creates_in_flight: Mutex::new(HashSet::new()),
             scheduler_notify: Arc::new(tokio::sync::Notify::new()),
         }
     }
 
     pub fn next_pty_id(&self) -> u64 {
         self.next_pty_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Try to claim the workspace-creation slot for `repo_id`.
+    ///
+    /// Returns `true` if the slot was free (the caller may proceed with the
+    /// create) and `false` if a create for this repo is already in flight.
+    /// The matching release is [`AppState::end_workspace_create`], normally
+    /// run from a `Drop` guard so it fires on every exit path. See the
+    /// `workspace_creates_in_flight` field and issue #896.
+    pub fn try_begin_workspace_create(&self, repo_id: &str) -> bool {
+        self.workspace_creates_in_flight
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(repo_id.to_string())
+    }
+
+    /// Release the workspace-creation slot for `repo_id`. Idempotent —
+    /// releasing a repo that holds no slot is a harmless no-op.
+    pub fn end_workspace_create(&self, repo_id: &str) {
+        self.workspace_creates_in_flight
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(repo_id);
     }
 
     /// Snapshot the plugin registry for use across `await` points.
@@ -963,5 +997,51 @@ mod tests {
         // Cleanup.
         finish_tx.send(()).unwrap();
         holder.await.unwrap();
+    }
+}
+
+// ---- Regression: duplicate workspace creation (issue #896) --------------
+//
+// Cross-platform (not `#[cfg(unix)]`) because the in-flight slot logic has
+// no OS-specific code. Pins the per-repo single-flight contract that stops
+// a webview reload + re-click from minting a duplicate `-N` workspace.
+#[cfg(test)]
+mod create_slot_tests {
+    use super::AppState;
+    use claudette::plugin_runtime::PluginRegistry;
+
+    /// Build a throwaway `AppState`. The temp dir is returned so the caller
+    /// keeps it alive — `AppState::new` opens a SQLite DB under it during
+    /// construction, but the slot methods under test never touch disk.
+    fn test_state() -> (AppState, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = PluginRegistry::discover(dir.path());
+        let state = AppState::new(
+            dir.path().join("claudette.db"),
+            dir.path().join("worktrees"),
+            registry,
+        );
+        (state, dir)
+    }
+
+    #[test]
+    fn workspace_create_slot_is_single_flight_per_repo() {
+        let (state, _dir) = test_state();
+
+        // First claim for a repo wins.
+        assert!(state.try_begin_workspace_create("repo-a"));
+        // A second claim while the first is in flight is rejected — this is
+        // the guard that survives a webview reload.
+        assert!(!state.try_begin_workspace_create("repo-a"));
+        // A different repo is unaffected: concurrent creates across repos
+        // are still allowed.
+        assert!(state.try_begin_workspace_create("repo-b"));
+
+        // Releasing repo-a's slot makes it claimable again.
+        state.end_workspace_create("repo-a");
+        assert!(state.try_begin_workspace_create("repo-a"));
+
+        // Releasing a repo that holds no slot is a harmless no-op.
+        state.end_workspace_create("never-claimed");
     }
 }

--- a/src/ui/scripts/check-css-tokens.mjs
+++ b/src/ui/scripts/check-css-tokens.mjs
@@ -61,6 +61,8 @@ const HEX_EXCLUSIONS = [
   /getPropertyValue\(.*\)\.trim\(\)\s*\|\| \(.*\?.*"#/,
   // `accentPreview: "#..."` / `accent_preview: "#..."`
   /(accentPreview|accent_preview):\s*"#/,
+  // GitHub issue / PR number reference: `issue #896`, `PR #905`, `fix #123`, etc.
+  /(issue|pull request|PR|fix|fixes|close|closes|ref|refs|see)\s+#[0-9a-fA-F]+\b/i,
 ];
 
 // Hex file-level exclusions (entire file is exempt from Rule 1).

--- a/src/ui/scripts/check-css-tokens.mjs
+++ b/src/ui/scripts/check-css-tokens.mjs
@@ -61,8 +61,11 @@ const HEX_EXCLUSIONS = [
   /getPropertyValue\(.*\)\.trim\(\)\s*\|\| \(.*\?.*"#/,
   // `accentPreview: "#..."` / `accent_preview: "#..."`
   /(accentPreview|accent_preview):\s*"#/,
-  // GitHub issue / PR number reference: `issue #896`, `PR #905`, `fix #123`, etc.
-  /(issue|pull request|PR|fix|fixes|close|closes|ref|refs|see)\s+#[0-9a-fA-F]+\b/i,
+  // GitHub issue / PR number reference: `issue #896`, `PR #905`,
+  // `fix #123`, etc. Decimal digits only — issue / PR numbers are never
+  // hex, and a `[0-9a-fA-F]+` class would wrongly exempt genuine hex
+  // colors written after one of these keywords (e.g. `fix #fff`).
+  /(issue|pull request|PR|fix|fixes|close|closes|ref|refs|see)\s+#[0-9]+\b/i,
 ];
 
 // Hex file-level exclusions (entire file is exempt from Rule 1).

--- a/src/ui/src/hooks/useCreateWorkspace.test.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.test.ts
@@ -314,4 +314,36 @@ describe("createWorkspaceOrchestrated", () => {
 
     errSpy.mockRestore();
   });
+
+  it("treats the backend in-flight rejection as benign: toast + null, no throw", async () => {
+    // The backend's `create_workspace` refuses a second create for a repo
+    // that already has one running (issue #896). That guard survives a
+    // webview reload — unlike the module-level latch — so the orchestrator
+    // must surface the rejection calmly (toast) and return null, the same
+    // shape as the in-process single-flight early-return, rather than
+    // throwing a "Failed to create workspace" error at the caller.
+    const addToast = vi.fn();
+    useAppStore.setState({ addToast });
+    mockGenerateWorkspaceName.mockResolvedValue({
+      slug: "calm-protea",
+      display: "calm protea",
+      message: null,
+    });
+    mockCreateWorkspace.mockRejectedValue(
+      new Error(
+        "A workspace is already being created for this repository. Please wait for it to finish.",
+      ),
+    );
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const out = await createWorkspaceOrchestrated("repo-1");
+    expect(out).toBeNull();
+
+    // A toast was surfaced and the latch released so a retry can proceed.
+    expect(addToast).toHaveBeenCalledTimes(1);
+    expect(addToast.mock.calls[0][0]).toMatch(/already being created/i);
+    expect(useAppStore.getState().creatingWorkspaceRepoId).toBeNull();
+
+    errSpy.mockRestore();
+  });
 });

--- a/src/ui/src/hooks/useCreateWorkspace.test.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.test.ts
@@ -338,10 +338,11 @@ describe("createWorkspaceOrchestrated", () => {
       display: "calm protea",
       message: null,
     });
+    // The backend returns the bare error code (not a sentence) so the
+    // cross-process contract is a fixed token — see
+    // `WORKSPACE_CREATE_IN_FLIGHT_ERR` in `commands/workspace.rs`.
     mockCreateWorkspace.mockRejectedValue(
-      new Error(
-        "A workspace is already being created for this repository. Please wait for it to finish.",
-      ),
+      new Error("WORKSPACE_CREATE_IN_FLIGHT"),
     );
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 

--- a/src/ui/src/hooks/useCreateWorkspace.test.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.test.ts
@@ -315,15 +315,24 @@ describe("createWorkspaceOrchestrated", () => {
     errSpy.mockRestore();
   });
 
-  it("treats the backend in-flight rejection as benign: toast + null, no throw", async () => {
+  it("treats the backend in-flight rejection as benign: toast, null, restored selection, no error log", async () => {
     // The backend's `create_workspace` refuses a second create for a repo
     // that already has one running (issue #896). That guard survives a
     // webview reload — unlike the module-level latch — so the orchestrator
-    // must surface the rejection calmly (toast) and return null, the same
-    // shape as the in-process single-flight early-return, rather than
-    // throwing a "Failed to create workspace" error at the caller.
+    // must treat the rejection as benign: surface a calm toast, return
+    // null (the same shape as the in-process single-flight early-return),
+    // restore the pre-create selection rather than yanking the user to
+    // the dashboard, and not log it at error level (nothing failed).
     const addToast = vi.fn();
-    useAppStore.setState({ addToast });
+    // A workspace the user was viewing before clicking New — the
+    // optimistic placeholder briefly steals selection, so the benign
+    // rejection must restore selection to this row, not null it.
+    const prior = makeWorkspace("prior");
+    useAppStore.setState({
+      addToast,
+      workspaces: [prior],
+      selectedWorkspaceId: prior.id,
+    });
     mockGenerateWorkspaceName.mockResolvedValue({
       slug: "calm-protea",
       display: "calm protea",
@@ -343,6 +352,10 @@ describe("createWorkspaceOrchestrated", () => {
     expect(addToast).toHaveBeenCalledTimes(1);
     expect(addToast.mock.calls[0][0]).toMatch(/already being created/i);
     expect(useAppStore.getState().creatingWorkspaceRepoId).toBeNull();
+    // Selection is restored to where the user was — not nulled to the
+    // dashboard — and the benign rejection is never logged as a failure.
+    expect(useAppStore.getState().selectedWorkspaceId).toBe(prior.id);
+    expect(errSpy).not.toHaveBeenCalled();
 
     errSpy.mockRestore();
   });

--- a/src/ui/src/hooks/useCreateWorkspace.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.ts
@@ -38,16 +38,18 @@ function buildPlaceholderWorkspace(repoId: string, slug: string): Workspace {
 }
 
 /** Detect the backend's "a create is already running for this repo"
- *  rejection (issue #896). `create_workspace` returns it as a plain
- *  string across the Tauri IPC boundary, so message text is the only
- *  signal available — the error reaching the catch block is typically a
- *  `string`, occasionally an `Error`. Matching on a stable, distinctive
- *  substring keeps this resilient to minor wording tweaks on the Rust
- *  side (`WORKSPACE_CREATE_IN_FLIGHT_ERR` in
- *  `src-tauri/src/commands/workspace.rs` — keep the two in sync). */
+ *  rejection (issue #896). `create_workspace` returns the bare error
+ *  code `WORKSPACE_CREATE_IN_FLIGHT` across the Tauri IPC boundary — a
+ *  fixed token rather than a human sentence, so this match can't
+ *  silently break on a Rust-side wording tweak or future localization
+ *  (mirrors the `WORKSPACE_FILE_NOT_FOUND` convention in
+ *  `FileViewer.tsx`). The error reaching the catch block is typically a
+ *  `string`, occasionally an `Error`, so normalize before comparing.
+ *  Keep this code in sync with `WORKSPACE_CREATE_IN_FLIGHT_ERR` in
+ *  `src-tauri/src/commands/workspace.rs`. */
 function isCreateInFlightRejection(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return message.includes("already being created for this repository");
+  return message === "WORKSPACE_CREATE_IN_FLIGHT";
 }
 
 /** Outcome surfaced to callers so they can show toasts or chain follow-up work

--- a/src/ui/src/hooks/useCreateWorkspace.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.ts
@@ -37,6 +37,19 @@ function buildPlaceholderWorkspace(repoId: string, slug: string): Workspace {
   };
 }
 
+/** Detect the backend's "a create is already running for this repo"
+ *  rejection (issue #896). `create_workspace` returns it as a plain
+ *  string across the Tauri IPC boundary, so message text is the only
+ *  signal available — the error reaching the catch block is typically a
+ *  `string`, occasionally an `Error`. Matching on a stable, distinctive
+ *  substring keeps this resilient to minor wording tweaks on the Rust
+ *  side (`WORKSPACE_CREATE_IN_FLIGHT_ERR` in
+ *  `src-tauri/src/commands/workspace.rs` — keep the two in sync). */
+function isCreateInFlightRejection(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("already being created for this repository");
+}
+
 /** Outcome surfaced to callers so they can show toasts or chain follow-up work
  *  without prying into the store. The orchestration still performs the core
  *  side-effects (addWorkspace, selectWorkspace, addChatMessage, openModal)
@@ -222,6 +235,20 @@ export async function createWorkspaceOrchestrated(
     // recovery surface).
     if (placeholderId) {
       useAppStore.getState().cancelPendingCreate(placeholderId, null);
+    }
+    // A backend in-flight rejection is not a failure: the user (or a
+    // webview reload) re-triggered a create that is already running for
+    // this repo, and the backend correctly refused to mint a duplicate.
+    // Surface it as a calm toast and return null — the same shape as the
+    // module-level `creationInFlight` early-return — so the caller does
+    // not pop a scary "Failed to create workspace" alert. See issue #896.
+    if (isCreateInFlightRejection(e)) {
+      useAppStore
+        .getState()
+        .addToast(
+          "A workspace is already being created for this repository. Please wait for it to finish.",
+        );
+      return null;
     }
     // Re-throw so the caller decides whether to alert / toast.
     throw e;

--- a/src/ui/src/hooks/useCreateWorkspace.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.ts
@@ -98,6 +98,12 @@ export async function createWorkspaceOrchestrated(
   creationInFlight = true;
   const { selectOnCreate = true } = options;
   const store = useAppStore.getState();
+  // Selection in effect before this create runs. If a benign backend
+  // in-flight rejection tears the optimistic placeholder back down
+  // (issue #896), selection is restored to this rather than nulled —
+  // nothing actually failed, so the user should land where they were
+  // instead of being yanked to the dashboard.
+  const priorSelectedWorkspaceId = store.selectedWorkspaceId;
   // Publish to the store so the sidebar's optimistic "preparing
   // workspace…" indicator row appears immediately, regardless of
   // which UI surface (sidebar +, welcome card, project view, hotkey)
@@ -226,6 +232,29 @@ export async function createWorkspaceOrchestrated(
 
     return { workspaceId: result.workspace.id, sessionId };
   } catch (e) {
+    // A backend in-flight rejection is not a failure: the user (or a
+    // webview reload) re-triggered a create that is already running for
+    // this repo, and the backend correctly refused to mint a duplicate.
+    // Handle it ahead of the error-level log and null-selection teardown
+    // below — it is a benign outcome, so it must not surface in
+    // logs/telemetry as a failure, and it should leave the user where
+    // they were rather than yanking them to the dashboard. Tear the
+    // placeholder down restoring the pre-create selection, surface a
+    // calm toast, and return null — the same shape as the module-level
+    // `creationInFlight` early-return. See issue #896.
+    if (isCreateInFlightRejection(e)) {
+      if (placeholderId) {
+        useAppStore
+          .getState()
+          .cancelPendingCreate(placeholderId, priorSelectedWorkspaceId);
+      }
+      useAppStore
+        .getState()
+        .addToast(
+          "A workspace is already being created for this repository. Please wait for it to finish.",
+        );
+      return null;
+    }
     console.error("Failed to create workspace:", e);
     // Tear down the optimistic placeholder so the user isn't stranded
     // on a selected row that will never resolve. Restore selection to
@@ -235,20 +264,6 @@ export async function createWorkspaceOrchestrated(
     // recovery surface).
     if (placeholderId) {
       useAppStore.getState().cancelPendingCreate(placeholderId, null);
-    }
-    // A backend in-flight rejection is not a failure: the user (or a
-    // webview reload) re-triggered a create that is already running for
-    // this repo, and the backend correctly refused to mint a duplicate.
-    // Surface it as a calm toast and return null — the same shape as the
-    // module-level `creationInFlight` early-return — so the caller does
-    // not pop a scary "Failed to create workspace" alert. See issue #896.
-    if (isCreateInFlightRejection(e)) {
-      useAppStore
-        .getState()
-        .addToast(
-          "A workspace is already being created for this repository. Please wait for it to finish.",
-        );
-      return null;
     }
     // Re-throw so the caller decides whether to alert / toast.
     throw e;


### PR DESCRIPTION
## Summary

Fixes a duplicate-workspace bug: a workspace create runs for several seconds (git worktree add + setup script + env resolve), and the only guard against a double-fire was `creationInFlight`, a module-level JS variable in the webview. A webview reload resets that variable to `false`, while the Rust `create_workspace` command spawned by the first create keeps running across the reload — so a reload (or any re-click while a slow create is in flight) issued a second `create_workspace` and minted a duplicate `-N` workspace row.

## Changes

- **Process-side single-flight guard.** Added `workspace_creates_in_flight` (a per-repo `HashSet`) to `AppState`. `create_workspace` claims the repo's slot before each create and rejects a concurrent create for the same repo. An RAII `WorkspaceCreateGuard` releases the slot on every exit path — normal return, error, or unwind — so a failed/panicking create can never wedge a repo into a permanently un-creatable state. The set lives in the Rust process, so it survives webview reloads. Creates in *different* repos still run concurrently.
- **Calm frontend handling.** `useCreateWorkspace.ts` detects the backend rejection (substring match on the in-flight error) and surfaces it as a toast returning `null` — the same shape as the in-process early-return — instead of throwing a scary "Failed to create workspace" alert.
- **`claudette workspace list` fix.** The command is documented as listing *active* workspaces but returned archived rows too, because the shared `list_workspaces` IPC method has no status filter. Filtered to active rows in the CLI's `List` arm; the IPC method itself is left untouched since `workspace purge` and `pr` resolution both depend on seeing every row.

## Tests

- `state.rs` — `workspace_create_slot_is_single_flight_per_repo` pins the per-repo claim/reject/release contract.
- `useCreateWorkspace.test.ts` — verifies the backend in-flight rejection is treated as benign (toast + `null`, no throw).
- `workspace.rs` (CLI) — `active_workspaces` filtering: drops archived rows, empty when all archived, passes non-array shapes through untouched.

Refs #896
