### PR TITLE
feat(project-view): persist issue/PR to workspace association from "Send to new workspace"

### DIFF
--- a/site/src/content/docs/features/project-view-issues-prs.mdx
+++ b/site/src/content/docs/features/project-view-issues-prs.mdx
@@ -24,6 +24,7 @@ Right-click any issue or PR row for:
 - **Open in browser** — opens the row's URL in your default browser.
 - **Copy URL** — copies the URL to the clipboard.
 - **Create workspace for this branch** (PR rows only) — creates a workspace on the repo's default base branch and surfaces the PR head branch in a toast.
+- **Go to workspace “&lt;name&gt;”** — shown only when a workspace has already been sent this issue/PR. Jumps straight to that workspace. It sits *above* "Send to new workspace", not in place of it, so spinning up a second workspace on the same item stays one deliberate click away.
 - **Send to new workspace ▶ &lt;model&gt;** — opens a submenu of available models. Pick one to (1) create a fresh workspace in the repo, (2) apply the chosen model to the new session so the toolbar reflects it and any cross-harness setup runs, and (3) auto-send a templated starter prompt as the first turn so the agent begins working immediately.
 
   The starter prompts link back to the source:
@@ -32,6 +33,17 @@ Right-click any issue or PR row for:
   - Pull requests: `Please review PR #<N> and continue or refactor as needed: <title>\n\nSource: <URL>\nBranch: <branch>`
 
   The submenu lists the same models the chat panel's model picker would show, with the same alternative-backends and OAuth gating. If you have no models available (alt-backends off and no Claude auth), the submenu shows a single disabled "No models available" row instead of silently swallowing the click.
+
+## Issue / PR ↔ workspace association
+
+When you send an issue or PR to a workspace, Claudette records the link — which workspace was spun up for which upstream item — and surfaces it on both sides:
+
+- **In the project view**, a row that already has a workspace shows an accent-tinted **"in progress" badge** carrying that workspace's name. Click the badge (or the right-click **Go to workspace** item) to jump straight to it. No more sending the same issue to two workspaces by accident.
+- **On the workspace**, the chat header breadcrumb gains a `#<N> — <title>` pill (click it to open the issue/PR in your browser), and the sidebar workspace row gains a small accent dot whose tooltip names the item. Both make it obvious what each workspace is for.
+
+The link is keyed on the workspace — one workspace owns at most one item. It survives an **archive → restore** round-trip: archiving a workspace only hides its badge, it doesn't drop the link. Hard-deleting the workspace drops the link for good.
+
+The association is part of this feature: with **Show open issues & PRs in project view** turned off, no links are written and none of the badges, breadcrumbs, or sidebar dots appear.
 
 Both sections poll every 60 seconds while the project view is visible. Polling pauses on `visibilitychange` to hidden — Claudette doesn't burn your `gh` / `glab` rate-limit budget for a tab you walked away from. The Refresh button in each section header forces an immediate fresh fetch.
 
@@ -60,6 +72,8 @@ User-authored SCM plugins can implement `list_issues` to participate. Plugins th
 All data is fetched on your machine using the credentials in your own `gh` / `glab` CLI. Claudette does not phone home, does not store an OAuth token, and does not proxy through any third-party server.
 
 A small SQLite cache (`repo_scm_lists_cache`) keeps the most recent response per `(repo_id, list_kind)` so the project view paints instantly on app launch instead of waiting for the first poll. Entries are anchored 60 seconds in the past on boot so the first visible visit always triggers a fresh fetch.
+
+Issue/PR ↔ workspace associations live in a separate local table (`workspace_scm_links`) — just the item number, URL, and title alongside the workspace id. Like everything else here it never leaves your machine.
 
 ## Limits
 

--- a/site/src/content/docs/features/project-view-issues-prs.mdx
+++ b/site/src/content/docs/features/project-view-issues-prs.mdx
@@ -23,7 +23,7 @@ Right-click any issue or PR row for:
 
 - **Open in browser** — opens the row's URL in your default browser.
 - **Copy URL** — copies the URL to the clipboard.
-- **Create workspace for this branch** (PR rows only) — creates a workspace on the repo's default base branch and surfaces the PR head branch in a toast.
+- **New workspace in this repo** (PR rows only) — creates a workspace on the repo's default base branch (**not** the PR head) and surfaces the PR head branch in a toast.
 - **Go to workspace “&lt;name&gt;”** — shown only when a workspace has already been sent this issue/PR. Jumps straight to that workspace. It sits *above* "Send to new workspace", not in place of it, so spinning up a second workspace on the same item stays one deliberate click away.
 - **Send to new workspace ▶ &lt;model&gt;** — opens a submenu of available models. Pick one to (1) create a fresh workspace in the repo, (2) apply the chosen model to the new session so the toolbar reflects it and any cross-harness setup runs, and (3) auto-send a templated starter prompt as the first turn so the agent begins working immediately.
 
@@ -80,7 +80,7 @@ Issue/PR ↔ workspace associations live in a separate local table (`workspace_s
 - Default 10 visible rows; click **Show all (N)** to expand to 50. Beyond 50, use the provider's web UI.
 - Sort: `updated_at DESC` (matches `gh` / `glab` defaults). No client-side resort.
 - Avatars are not rendered in v1 to keep the GitHub rate-limit footprint flat. A separate setting may add them later behind a per-plugin URL allowlist.
-- "Create workspace for this branch" (PR row right-click) creates a workspace on the repo's default base branch and surfaces the PR head branch in a toast. Threading the PR branch through the create flow lands as a follow-up — see the issue tracker.
+- "New workspace in this repo" (PR row right-click) creates a workspace on the repo's default base branch and surfaces the PR head branch in a toast. Threading the PR branch through the create flow lands as a follow-up — see the issue tracker.
 
 ## Troubleshooting
 

--- a/site/src/content/docs/features/project-view-issues-prs.mdx
+++ b/site/src/content/docs/features/project-view-issues-prs.mdx
@@ -38,7 +38,7 @@ Right-click any issue or PR row for:
 
 When you send an issue or PR to a workspace, Claudette records the link — which workspace was spun up for which upstream item — and surfaces it on both sides:
 
-- **In the project view**, a row that already has a workspace shows an accent-tinted **"in progress" badge** carrying that workspace's name. Click the badge (or the right-click **Go to workspace** item) to jump straight to it. No more sending the same issue to two workspaces by accident.
+- **In the project view**, dispatched issues/PRs are lifted into a collapsible **"In progress"** group at the top of the list, above the plain **"Open"** group — so they stay visible even if they'd otherwise sit past the row cap. Each dispatched row also carries an accent-tinted **badge** with its workspace's name; click the badge (or the right-click **Go to workspace** item) to jump straight to it. No more sending the same issue to two workspaces by accident.
 - **On the workspace**, the chat header breadcrumb gains a `#<N> — <title>` pill (click it to open the issue/PR in your browser), and the sidebar workspace row gains a small accent dot whose tooltip names the item. Both make it obvious what each workspace is for.
 
 The link is keyed on the workspace — one workspace owns at most one item. It survives an **archive → restore** round-trip: archiving a workspace only hides its badge, it doesn't drop the link. Hard-deleting the workspace drops the link for good.

--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -26,6 +26,9 @@ pub struct InitialData {
     /// Most recent chat message per workspace (for dashboard display).
     pub last_messages: Vec<ChatMessage>,
     pub scm_cache: Vec<claudette::db::ScmStatusCacheRow>,
+    /// Workspace -> SCM item (issue/PR) associations, for the project-view
+    /// "in progress" badge and the workspace-side breadcrumb.
+    pub workspace_scm_links: Vec<claudette::db::WorkspaceScmLinkRow>,
     /// Repository ids whose sidebar workspace order is user-defined.
     pub manual_workspace_order_repo_ids: Vec<String>,
 }
@@ -182,6 +185,9 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
 
     let last_messages = db.last_message_per_workspace().map_err(|e| e.to_string())?;
     let scm_cache = db.load_all_scm_status_cache().map_err(|e| e.to_string())?;
+    let workspace_scm_links = db
+        .load_all_workspace_scm_links()
+        .map_err(|e| e.to_string())?;
     let manual_workspace_order_repo_ids = db
         .list_app_settings_with_prefix(WORKSPACE_ORDER_MODE_PREFIX)
         .map_err(|e| e.to_string())?
@@ -203,6 +209,7 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
         default_branches,
         last_messages,
         scm_cache,
+        workspace_scm_links,
         manual_workspace_order_repo_ids,
     })
 }

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -6,7 +6,7 @@ use futures::stream::{self, StreamExt};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, State};
 
-use claudette::db::{Database, RepoScmListCacheRow};
+use claudette::db::{Database, RepoScmListCacheRow, WorkspaceScmLinkRow};
 use claudette::mcp_supervisor::McpSupervisor;
 use claudette::plugin_runtime::PluginError;
 use claudette::plugin_runtime::host_api::WorkspaceInfo;
@@ -842,6 +842,55 @@ pub async fn list_repo_open_pull_requests(
         .await
         .insert(cache_key, entry);
     Ok(resp)
+}
+
+/// Persist the association between a workspace and the SCM item (issue
+/// or PR) it was created for via the project-view "Send to new
+/// workspace" gesture. Keyed on `workspace_id` — one workspace owns at
+/// most one item, so a re-link replaces.
+///
+/// Returns the saved row (with the DB-assigned `created_at`). The caller
+/// treats failure as non-fatal: the workspace and its first turn already
+/// landed, so a missing link only costs the project-view badge.
+#[tauri::command]
+pub async fn create_workspace_scm_link(
+    workspace_id: String,
+    repo_id: String,
+    kind: String,
+    number: i64,
+    url: String,
+    title: String,
+    state: State<'_, AppState>,
+) -> Result<WorkspaceScmLinkRow, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    // Feature-gate short-circuit (defense in depth): the association is
+    // part of the project-view issues/PRs feature, and the only caller
+    // (`sendToNewWorkspace`) is reachable only from the gated sections.
+    // A stale frontend must not be able to write links with the flag off.
+    if !read_project_view_flag(&db) {
+        return Err("project-view issues/PRs feature is disabled".to_string());
+    }
+    let row = WorkspaceScmLinkRow {
+        workspace_id,
+        repo_id,
+        kind,
+        number,
+        url,
+        title,
+        created_at: String::new(),
+    };
+    db.upsert_workspace_scm_link(&row)
+        .map_err(|e| e.to_string())?;
+    // Re-load so the caller sees the DB-assigned `created_at`. `load_all`
+    // is fine here — this is a rare, user-triggered action and the table
+    // only ever holds one row per live workspace.
+    let saved = db
+        .load_all_workspace_scm_links()
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .find(|r| r.workspace_id == row.workspace_id)
+        .unwrap_or(row);
+    Ok(saved)
 }
 
 /// Drop the in-memory + on-disk cache for a repo's project-view lists so the

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -870,6 +870,16 @@ pub async fn create_workspace_scm_link(
     if !read_project_view_flag(&db) {
         return Err("project-view issues/PRs feature is disabled".to_string());
     }
+    // Validate `kind` server-side: the frontend resolver matches and
+    // filters on it, so an unexpected value would silently break badge
+    // resolution. The `workspace_scm_links.kind` CHECK constraint also
+    // rejects it at the DB layer — this guard just fails earlier with a
+    // clearer message than a raw SQLite constraint error.
+    if kind != "issue" && kind != "pr" {
+        return Err(format!(
+            "invalid SCM link kind {kind:?}: expected \"issue\" or \"pr\""
+        ));
+    }
     let row = WorkspaceScmLinkRow {
         workspace_id,
         repo_id,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1175,6 +1175,7 @@ fn main() {
             commands::scm::list_repo_open_issues,
             commands::scm::list_repo_open_pull_requests,
             commands::scm::refresh_repo_scm_lists,
+            commands::scm::create_workspace_scm_link,
             // Env-provider diagnostic UI
             commands::env::get_env_sources,
             commands::env::get_env_target_worktree,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -12,7 +12,7 @@ mod settings;
 pub use settings::RepositoryMcpServer;
 
 mod scm;
-pub use scm::{RepoScmListCacheRow, ScmStatusCacheRow};
+pub use scm::{RepoScmListCacheRow, ScmStatusCacheRow, WorkspaceScmLinkRow};
 
 mod scheduling;
 

--- a/src/db/scm.rs
+++ b/src/db/scm.rs
@@ -435,4 +435,26 @@ mod tests {
         let rows = db.load_all_workspace_scm_links().unwrap();
         assert!(rows.is_empty());
     }
+
+    #[test]
+    fn test_workspace_scm_link_kind_check_constraint() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
+            .unwrap();
+
+        // The migration's `CHECK (kind IN ('issue', 'pr'))` rejects any
+        // other value, so a bad `kind` can never reach link resolution.
+        let mut bad = make_scm_link("w1", "r1", 1);
+        bad.kind = "epic".into();
+        assert!(db.upsert_workspace_scm_link(&bad).is_err());
+
+        // The two valid values still insert.
+        for kind in ["issue", "pr"] {
+            let mut ok = make_scm_link("w1", "r1", 2);
+            ok.kind = kind.into();
+            db.upsert_workspace_scm_link(&ok).unwrap();
+        }
+    }
 }

--- a/src/db/scm.rs
+++ b/src/db/scm.rs
@@ -140,6 +140,57 @@ impl Database {
         )?;
         Ok(())
     }
+
+    // --- Workspace <-> SCM item links ---
+
+    /// Record (or replace) the association between a workspace and the SCM
+    /// item it was created for. `row.created_at` is ignored; the database
+    /// sets it to `datetime('now')`. A workspace is created fresh before
+    /// this is called, so the `OR REPLACE` only ever inserts in practice —
+    /// it stays for idempotency under retry.
+    pub fn upsert_workspace_scm_link(
+        &self,
+        row: &WorkspaceScmLinkRow,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO workspace_scm_links
+                (workspace_id, repo_id, kind, number, url, title, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))",
+            params![
+                row.workspace_id,
+                row.repo_id,
+                row.kind,
+                row.number,
+                row.url,
+                row.title,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Load every workspace -> SCM item link. Consumed at boot by
+    /// `load_initial_data` to hydrate the project-view badges. Rows for
+    /// hard-deleted workspaces are already gone via the FK cascade.
+    pub fn load_all_workspace_scm_links(
+        &self,
+    ) -> Result<Vec<WorkspaceScmLinkRow>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT workspace_id, repo_id, kind, number, url, title, created_at
+             FROM workspace_scm_links",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(WorkspaceScmLinkRow {
+                workspace_id: row.get(0)?,
+                repo_id: row.get(1)?,
+                kind: row.get(2)?,
+                number: row.get(3)?,
+                url: row.get(4)?,
+                title: row.get(5)?,
+                created_at: row.get(6)?,
+            })
+        })?;
+        rows.collect()
+    }
 }
 
 /// Persisted repo-wide SCM list (issues or PRs by scope).
@@ -154,6 +205,21 @@ pub struct RepoScmListCacheRow {
     pub payload: String,
     pub error: Option<String>,
     pub fetched_at: String,
+}
+
+/// Persisted association between a workspace and the SCM item (issue or
+/// PR) it was spun up for. Powers the project-view "in progress" badge
+/// and the workspace-side "what is this for" breadcrumb. `kind` is one of
+/// `"issue"` or `"pr"`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceScmLinkRow {
+    pub workspace_id: String,
+    pub repo_id: String,
+    pub kind: String,
+    pub number: i64,
+    pub url: String,
+    pub title: String,
+    pub created_at: String,
 }
 
 #[cfg(test)]
@@ -313,5 +379,60 @@ mod tests {
         let rows = db.load_all_scm_status_cache().unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].pr_json, Some("null".into()));
+    }
+
+    fn make_scm_link(workspace_id: &str, repo_id: &str, number: i64) -> WorkspaceScmLinkRow {
+        WorkspaceScmLinkRow {
+            workspace_id: workspace_id.into(),
+            repo_id: repo_id.into(),
+            kind: "issue".into(),
+            number,
+            url: format!("https://example.com/issues/{number}"),
+            title: format!("Issue {number}"),
+            created_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_workspace_scm_link_upsert_and_load() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
+            .unwrap();
+
+        db.upsert_workspace_scm_link(&make_scm_link("w1", "r1", 898))
+            .unwrap();
+        let rows = db.load_all_workspace_scm_links().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].workspace_id, "w1");
+        assert_eq!(rows[0].number, 898);
+        assert_eq!(rows[0].kind, "issue");
+        assert!(!rows[0].created_at.is_empty(), "created_at is DB-set");
+
+        // Re-linking the same workspace replaces, never duplicates.
+        let mut updated = make_scm_link("w1", "r1", 900);
+        updated.kind = "pr".into();
+        db.upsert_workspace_scm_link(&updated).unwrap();
+        let rows = db.load_all_workspace_scm_links().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].number, 900);
+        assert_eq!(rows[0].kind, "pr");
+    }
+
+    #[test]
+    fn test_workspace_scm_link_cascade_delete() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
+            .unwrap();
+        db.upsert_workspace_scm_link(&make_scm_link("w1", "r1", 898))
+            .unwrap();
+
+        // Hard-deleting the workspace drops its link via the FK cascade.
+        db.delete_workspace("w1").unwrap();
+        let rows = db.load_all_workspace_scm_links().unwrap();
+        assert!(rows.is_empty());
     }
 }

--- a/src/migrations/20260520153000_workspace_scm_links.sql
+++ b/src/migrations/20260520153000_workspace_scm_links.sql
@@ -18,7 +18,7 @@
 CREATE TABLE IF NOT EXISTS workspace_scm_links (
     workspace_id  TEXT PRIMARY KEY REFERENCES workspaces(id) ON DELETE CASCADE,
     repo_id       TEXT NOT NULL,
-    kind          TEXT NOT NULL,
+    kind          TEXT NOT NULL CHECK (kind IN ('issue', 'pr')),
     number        INTEGER NOT NULL,
     url           TEXT NOT NULL,
     title         TEXT NOT NULL,

--- a/src/migrations/20260520153000_workspace_scm_links.sql
+++ b/src/migrations/20260520153000_workspace_scm_links.sql
@@ -1,0 +1,29 @@
+-- Persisted association between an SCM item (issue / PR) and the
+-- workspace created for it via the project-view "Send to new workspace"
+-- gesture. Keyed on `workspace_id` — one workspace owns at most one item.
+--
+-- Distinct from `scm_status_cache` (per-workspace PR badge, keyed on
+-- workspace_id) and `repo_scm_lists_cache` (repo-wide issue/PR lists):
+-- this table records *which local workspace was spun up for which
+-- upstream item*, so the project view can show an "in progress" badge
+-- and the workspace can show what it is for.
+--
+-- `kind` is one of "issue" or "pr". The (repo_id, kind, number) index
+-- powers the project-view lookup that decorates each issue / PR row.
+--
+-- The `workspace_id` FK cascades on hard-delete so a deleted workspace
+-- drops its link automatically. Archived workspaces keep their row; the
+-- project-view badge filters them out client-side (see issue #898) so
+-- an archive -> restore round-trip does not lose the association.
+CREATE TABLE IF NOT EXISTS workspace_scm_links (
+    workspace_id  TEXT PRIMARY KEY REFERENCES workspaces(id) ON DELETE CASCADE,
+    repo_id       TEXT NOT NULL,
+    kind          TEXT NOT NULL,
+    number        INTEGER NOT NULL,
+    url           TEXT NOT NULL,
+    title         TEXT NOT NULL,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_scm_links_item
+    ON workspace_scm_links (repo_id, kind, number);

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -244,4 +244,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260519231159_deleted_workspace_metric_details.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260520153000_workspace_scm_links",
+        sql: include_str!("20260520153000_workspace_scm_links.sql"),
+        legacy_version: None,
+    },
 ];

--- a/src/ui/scripts/smoke-built-bundle.mjs
+++ b/src/ui/scripts/smoke-built-bundle.mjs
@@ -119,6 +119,7 @@ try {
             default_branches: {},
             last_messages: [],
             scm_cache: [],
+            workspace_scm_links: [],
             manual_workspace_order_repo_ids: [],
           };
         case "get_diagnostics_settings":

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -183,8 +183,11 @@ function App() {
         }
         setLastMessages(msgMap);
         // Issue/PR -> workspace associations for the project-view "in
-        // progress" badge and the workspace breadcrumb.
-        hydrateWorkspaceScmLinks(data.workspace_scm_links);
+        // progress" badge and the workspace breadcrumb. Tolerate a
+        // payload without the field — an older headless server reached
+        // over WSS predates it, and the bundle smoke test's mock omits
+        // it; either way an absent list just means "no links yet".
+        hydrateWorkspaceScmLinks(data.workspace_scm_links ?? []);
         await hydratePersistedViewState(localWorkspaces);
         setViewStateHydrated(true);
         // Boot-health gate: only ack on the success path. The

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -56,6 +56,9 @@ function App() {
   const setDefaultBranches = useAppStore((s) => s.setDefaultBranches);
   const setTerminalFontSize = useAppStore((s) => s.setTerminalFontSize);
   const setLastMessages = useAppStore((s) => s.setLastMessages);
+  const hydrateWorkspaceScmLinks = useAppStore(
+    (s) => s.hydrateWorkspaceScmLinks,
+  );
   const setRemoteConnections = useAppStore((s) => s.setRemoteConnections);
   const setDiscoveredServers = useAppStore((s) => s.setDiscoveredServers);
   const setLocalServerRunning = useAppStore((s) => s.setLocalServerRunning);
@@ -179,6 +182,9 @@ function App() {
           msgMap[msg.workspace_id] = msg;
         }
         setLastMessages(msgMap);
+        // Issue/PR -> workspace associations for the project-view "in
+        // progress" badge and the workspace breadcrumb.
+        hydrateWorkspaceScmLinks(data.workspace_scm_links);
         await hydratePersistedViewState(localWorkspaces);
         setViewStateHydrated(true);
         // Boot-health gate: only ack on the success path. The
@@ -936,7 +942,7 @@ function App() {
       unlistenMissingCli.then((fn) => fn());
       unlistenMissingWorktree.then((fn) => fn());
     };
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultTerminalAppId, setWorkspaceAppsMenuShown, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setProjectViewIssuesPrsEnabled, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setToolDisplayMode, setExtendedToolCallOutput, setAlternativeBackendsAvailable, setPiSdkAvailable, setAlternativeBackendsEnabled, setCodexEnabled, setAgentBackends, setDefaultAgentBackendId, setClaudeAuthMethod, setEditorGitGutterBase, setEditorMinimapEnabled, setRevealActiveFileInTree, setEditorWordWrap, setEditorLineNumbersEnabled, setEditorFontZoom, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings, setManualWorkspaceOrderByRepo]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultTerminalAppId, setWorkspaceAppsMenuShown, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setProjectViewIssuesPrsEnabled, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setToolDisplayMode, setExtendedToolCallOutput, setAlternativeBackendsAvailable, setPiSdkAvailable, setAlternativeBackendsEnabled, setCodexEnabled, setAgentBackends, setDefaultAgentBackendId, setClaudeAuthMethod, setEditorGitGutterBase, setEditorMinimapEnabled, setRevealActiveFileInTree, setEditorWordWrap, setEditorLineNumbersEnabled, setEditorFontZoom, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings, setManualWorkspaceOrderByRepo, hydrateWorkspaceScmLinks]);
 
   // Live freshness for LM Studio's `loaded_context_length`.
   //

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -184,9 +184,9 @@ function App() {
         setLastMessages(msgMap);
         // Issue/PR -> workspace associations for the project-view "in
         // progress" badge and the workspace breadcrumb. Tolerate a
-        // payload without the field — an older headless server reached
-        // over WSS predates it, and the bundle smoke test's mock omits
-        // it; either way an absent list just means "no links yet".
+        // payload without the field — a headless server reached over
+        // WSS may predate it — so an absent list just means "no links
+        // yet" instead of crashing the initial-data load.
         hydrateWorkspaceScmLinks(data.workspace_scm_links ?? []);
         await hydratePersistedViewState(localWorkspaces);
         setViewStateHydrated(true);

--- a/src/ui/src/components/project/RepoIssuesSection.test.tsx
+++ b/src/ui/src/components/project/RepoIssuesSection.test.tsx
@@ -6,7 +6,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RepoIssuesSection } from "./RepoIssuesSection";
 import { useRepoOpenIssues } from "../../hooks/useRepoOpenIssues";
 import { openUrl } from "../../services/tauri";
+import { useAppStore } from "../../stores/useAppStore";
 import type { Issue, RepoIssuesPayload } from "../../types/plugin";
+import type { Workspace } from "../../types/workspace";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
   .IS_REACT_ACT_ENVIRONMENT = true;
@@ -66,8 +68,32 @@ function expand(container: HTMLElement) {
   });
 }
 
+function makeWorkspace(over: Partial<Workspace> = {}): Workspace {
+  return {
+    id: "ws-1",
+    repository_id: "repo-1",
+    name: "fix-the-thing",
+    branch_name: "james/fix-the-thing",
+    worktree_path: "/tmp/ws",
+    status: "Active",
+    agent_status: "Idle",
+    status_line: "",
+    created_at: "1700000000",
+    sort_order: 0,
+    remote_connection_id: null,
+    ...over,
+  };
+}
+
 beforeEach(() => {
   mockedHook.mockReset();
+  // Reset the link/workspace slices so a test that seeds them can't
+  // leak grouping state into the others.
+  useAppStore.setState({
+    workspaceScmLinks: {},
+    workspaces: [],
+    projectViewIssuesPrsEnabled: false,
+  });
 });
 
 afterEach(() => {
@@ -171,5 +197,51 @@ describe("RepoIssuesSection error/cache handling", () => {
     const container = render();
     // Header badge is visible without expanding.
     expect(container.textContent).toContain("3");
+  });
+
+  it("splits dispatched issues into an 'In progress' group", () => {
+    // Issue #2 has a live workspace; #1 and #3 do not. The section
+    // only mounts with the project-view feature on, so mirror that.
+    useAppStore.setState({
+      projectViewIssuesPrsEnabled: true,
+      workspaces: [makeWorkspace({ id: "ws-1", name: "fixer" })],
+      workspaceScmLinks: {
+        "ws-1": {
+          workspace_id: "ws-1",
+          repo_id: "repo-1",
+          kind: "issue",
+          number: 2,
+          url: "https://example.com/issues/2",
+          title: "Issue 2",
+          created_at: "2026-05-20 10:00:00",
+        },
+      },
+    });
+    mockedHook.mockReturnValue({
+      payload: makePayload({
+        issues: [makeIssue(1), makeIssue(2), makeIssue(3)],
+      }),
+      loading: false,
+      refresh: vi.fn(),
+    });
+    const container = render();
+    expand(container);
+
+    // Both group headers appear, and the dispatched issue's workspace
+    // badge is rendered.
+    expect(container.textContent).toContain("In progress");
+    expect(container.textContent).toContain("Open");
+    expect(container.textContent).toContain("fixer");
+  });
+
+  it("renders a flat list (no group headers) when nothing is dispatched", () => {
+    mockedHook.mockReturnValue({
+      payload: makePayload({ issues: [makeIssue(1), makeIssue(2)] }),
+      loading: false,
+      refresh: vi.fn(),
+    });
+    const container = render();
+    expand(container);
+    expect(container.textContent).not.toContain("In progress");
   });
 });

--- a/src/ui/src/components/project/RepoIssuesSection.tsx
+++ b/src/ui/src/components/project/RepoIssuesSection.tsx
@@ -11,10 +11,12 @@ import { useAppStore } from "../../stores/useAppStore";
 import { useRepoOpenIssues } from "../../hooks/useRepoOpenIssues";
 import { ContextMenu, type ContextMenuItem } from "../shared/ContextMenu";
 import { useModelRegistry } from "../chat/useModelRegistry";
+import { useWorkspaceScmLink } from "../../hooks/useWorkspaceScmLink";
 import type { Issue, IssueLabel } from "../../types/plugin";
 import dashStyles from "../layout/Dashboard.module.css";
 import styles from "./RepoListsSection.module.css";
 import { formatTimeAgo } from "./timeAgo";
+import { WorkspaceLinkBadge } from "./WorkspaceLinkBadge";
 import {
   buildModelSubmenuItems,
   sendToNewWorkspace,
@@ -224,6 +226,8 @@ function IssueRow({ repoId, issue, onOpen, onCopyUrl }: IssueRowProps) {
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const registry = useModelRegistry();
   const addToast = useAppStore((s) => s.addToast);
+  const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+  const linked = useWorkspaceScmLink(repoId, "issue", issue.number);
   const visibleLabels = issue.labels.slice(0, MAX_LABELS_VISIBLE);
   const overflow = Math.max(0, issue.labels.length - visibleLabels.length);
 
@@ -231,6 +235,17 @@ function IssueRow({ repoId, issue, onOpen, onCopyUrl }: IssueRowProps) {
     { label: "Open in browser", onSelect: () => onOpen(issue.url) },
     { label: "Copy URL", onSelect: () => onCopyUrl(issue.url) },
     { type: "separator" },
+    // When a workspace is already on this issue, offer a jump to it
+    // *above* — not instead of — "Send to new workspace": a second
+    // workspace on the same issue is still one deliberate click away.
+    ...(linked
+      ? ([
+          {
+            label: `Go to workspace “${linked.workspaceName}”`,
+            onSelect: () => selectWorkspace(linked.workspaceId),
+          },
+        ] satisfies ContextMenuItem[])
+      : []),
     {
       type: "submenu",
       label: "Send to new workspace",
@@ -290,6 +305,7 @@ function IssueRow({ repoId, issue, onOpen, onCopyUrl }: IssueRowProps) {
             )}
           </span>
         )}
+        {linked && <WorkspaceLinkBadge link={linked} />}
         <span className={styles.rowMeta}>
           {issue.comment_count > 0 && (
             <span className={styles.rowCommentCount}>

--- a/src/ui/src/components/project/RepoIssuesSection.tsx
+++ b/src/ui/src/components/project/RepoIssuesSection.tsx
@@ -17,6 +17,8 @@ import dashStyles from "../layout/Dashboard.module.css";
 import styles from "./RepoListsSection.module.css";
 import { formatTimeAgo } from "./timeAgo";
 import { WorkspaceLinkBadge } from "./WorkspaceLinkBadge";
+import { RepoListGroup } from "./RepoListGroup";
+import { partitionByWorkspaceLink } from "./workspaceScmLink";
 import {
   buildModelSubmenuItems,
   sendToNewWorkspace,
@@ -49,10 +51,26 @@ export const RepoIssuesSection = memo(function RepoIssuesSection({
   const addToast = useAppStore((s) => s.addToast);
 
   const issues = useMemo(() => payload?.issues ?? [], [payload?.issues]);
-  const visible = useMemo(() => {
-    if (showAll) return issues.slice(0, ALL_VISIBLE_LIMIT);
-    return issues.slice(0, DEFAULT_VISIBLE);
-  }, [issues, showAll]);
+  // Split out the issues a workspace is already on so they get their
+  // own "In progress" group above the rest (issue #898). The row cap
+  // applies only to `rest` — every dispatched issue stays visible,
+  // even one that would otherwise sit past the cap.
+  const workspaceScmLinks = useAppStore((s) => s.workspaceScmLinks);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const { inProgress, rest } = useMemo(
+    () =>
+      partitionByWorkspaceLink(
+        issues,
+        { repoId, kind: "issue" },
+        workspaceScmLinks,
+        workspaces,
+      ),
+    [issues, repoId, workspaceScmLinks, workspaces],
+  );
+  const visibleRest = useMemo(() => {
+    if (showAll) return rest.slice(0, ALL_VISIBLE_LIMIT);
+    return rest.slice(0, DEFAULT_VISIBLE);
+  }, [rest, showAll]);
 
   const handleCopyUrl = async (url: string) => {
     try {
@@ -101,7 +119,9 @@ export const RepoIssuesSection = memo(function RepoIssuesSection({
           repoId={repoId}
           payload={payload}
           loading={loading}
-          visible={visible}
+          inProgress={inProgress}
+          visibleRest={visibleRest}
+          restTotal={rest.length}
           totalCount={issues.length}
           showAll={showAll}
           onShowAll={() => setShowAll(true)}
@@ -120,7 +140,13 @@ interface RepoIssuesBodyProps {
   repoId: string;
   payload: ReturnType<typeof useRepoOpenIssues>["payload"];
   loading: boolean;
-  visible: Issue[];
+  /// Issues that already have a workspace — rendered in their own group.
+  inProgress: Issue[];
+  /// The remaining issues, already capped to the visible-row limit.
+  visibleRest: Issue[];
+  /// Total count of `rest` before the cap — drives the "Show all" row.
+  restTotal: number;
+  /// Total count of all open issues — drives the empty/error branches.
   totalCount: number;
   showAll: boolean;
   onShowAll: () => void;
@@ -133,7 +159,9 @@ function RepoIssuesBody({
   repoId,
   payload,
   loading,
-  visible,
+  inProgress,
+  visibleRest,
+  restTotal,
   totalCount,
   showAll,
   onShowAll,
@@ -175,6 +203,23 @@ function RepoIssuesBody({
     return <div className={styles.muted}>No open issues.</div>;
   }
 
+  const renderRow = (issue: Issue) => (
+    <IssueRow
+      key={issue.number}
+      repoId={repoId}
+      issue={issue}
+      onOpen={onOpen}
+      onCopyUrl={onCopyUrl}
+    />
+  );
+  const showAllRow = !showAll && restTotal > visibleRest.length && (
+    <li>
+      <button type="button" className={styles.retryButton} onClick={onShowAll}>
+        Show all ({restTotal})
+      </button>
+    </li>
+  );
+
   return (
     <>
       {payload?.error && (
@@ -189,28 +234,27 @@ function RepoIssuesBody({
           </button>
         </div>
       )}
-      <ul className={styles.list}>
-        {visible.map((issue) => (
-          <IssueRow
-            key={issue.number}
-            repoId={repoId}
-            issue={issue}
-            onOpen={onOpen}
-            onCopyUrl={onCopyUrl}
-          />
-        ))}
-        {!showAll && totalCount > visible.length && (
-          <li>
-            <button
-              type="button"
-              className={styles.retryButton}
-              onClick={onShowAll}
-            >
-              Show all ({totalCount})
-            </button>
-          </li>
-        )}
-      </ul>
+      {inProgress.length > 0 ? (
+        // Dispatched issues get their own group above the rest. When
+        // nothing is dispatched the list renders flat (the `else`
+        // branch), so the common case is visually unchanged.
+        <>
+          <RepoListGroup label="In progress" count={inProgress.length} accent>
+            <ul className={styles.list}>{inProgress.map(renderRow)}</ul>
+          </RepoListGroup>
+          <RepoListGroup label="Open" count={restTotal}>
+            <ul className={styles.list}>
+              {visibleRest.map(renderRow)}
+              {showAllRow}
+            </ul>
+          </RepoListGroup>
+        </>
+      ) : (
+        <ul className={styles.list}>
+          {visibleRest.map(renderRow)}
+          {showAllRow}
+        </ul>
+      )}
     </>
   );
 }

--- a/src/ui/src/components/project/RepoListGroup.tsx
+++ b/src/ui/src/components/project/RepoListGroup.tsx
@@ -1,0 +1,46 @@
+import { useState, type ReactNode } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import styles from "./RepoListsSection.module.css";
+
+export interface RepoListGroupProps {
+  /// Group label, e.g. "In progress" or "Open".
+  label: string;
+  /// Count shown next to the label.
+  count: number;
+  /// Accent the header — used to make the "In progress" group stand
+  /// apart from the plain "Open" group.
+  accent?: boolean;
+  /// Whether the group starts expanded. Defaults to expanded.
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+/// A collapsible labelled group inside a project-view list. Used to
+/// split dispatched ("In progress") issues/PRs — ones that already
+/// have a workspace — from the rest (issue #898). Collapse state is
+/// local UI state, intentionally not persisted (matches the rest of
+/// the project view's section chrome).
+export function RepoListGroup({
+  label,
+  count,
+  accent = false,
+  defaultOpen = true,
+  children,
+}: RepoListGroupProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className={styles.group}>
+      <button
+        type="button"
+        className={`${styles.groupHeader}${accent ? ` ${styles.groupHeaderAccent}` : ""}`}
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        {open ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+        <span className={styles.groupLabel}>{label}</span>
+        <span className={styles.groupCount}>{count}</span>
+      </button>
+      {open && children}
+    </div>
+  );
+}

--- a/src/ui/src/components/project/RepoListsSection.module.css
+++ b/src/ui/src/components/project/RepoListsSection.module.css
@@ -93,6 +93,62 @@
   gap: 4px;
 }
 
+/* Collapsible "In progress" / "Open" group inside a project-view list
+   (issue #898). Groups stack with a small gap; each gets a faint
+   uppercase sub-header. */
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.group + .group {
+  margin-top: 8px;
+}
+
+.groupHeader {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  align-self: flex-start;
+  padding: 2px 4px;
+  margin: 0;
+  font-family: inherit;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.groupHeader:hover {
+  color: var(--text-muted);
+}
+
+/* The "In progress" group reads in the accent color so dispatched
+   work is obvious at a glance. */
+.groupHeaderAccent {
+  color: var(--accent-primary);
+}
+
+.groupHeaderAccent:hover {
+  color: var(--accent-primary);
+}
+
+.groupLabel {
+  line-height: 1;
+}
+
+.groupCount {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  opacity: 0.8;
+}
+
 .row {
   display: flex;
   align-items: center;

--- a/src/ui/src/components/project/RepoListsSection.module.css
+++ b/src/ui/src/components/project/RepoListsSection.module.css
@@ -207,6 +207,42 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* "In progress" badge: an issue/PR row whose work is already underway in
+   a Claudette workspace (issue #898). Accent-tinted pill, clickable to
+   jump straight to that workspace. The alpha tints reuse the same
+   color-mix idiom as `.labelColored` so the badge sits on hover
+   backgrounds without a hard fill. */
+.workspaceBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  max-width: 150px;
+  font-family: inherit;
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--accent-primary);
+  background: color-mix(in srgb, var(--accent-primary) 13%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-primary) 38%, transparent);
+  border-radius: 999px;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.workspaceBadge:hover {
+  background: color-mix(in srgb, var(--accent-primary) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent-primary) 55%, transparent);
+}
+
+.workspaceBadgeName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .muted {
   font-size: 12px;
   color: var(--text-faint);

--- a/src/ui/src/components/project/RepoPullRequestsSection.tsx
+++ b/src/ui/src/components/project/RepoPullRequestsSection.tsx
@@ -14,9 +14,11 @@ import { useRepoOpenPullRequests } from "../../hooks/useRepoOpenPullRequests";
 import { createWorkspaceOrchestrated } from "../../hooks/useCreateWorkspace";
 import { ContextMenu, type ContextMenuItem } from "../shared/ContextMenu";
 import { useModelRegistry } from "../chat/useModelRegistry";
+import { useWorkspaceScmLink } from "../../hooks/useWorkspaceScmLink";
 import type { PullRequest, PullRequestScope } from "../../types/plugin";
 import dashStyles from "../layout/Dashboard.module.css";
 import styles from "./RepoListsSection.module.css";
+import { WorkspaceLinkBadge } from "./WorkspaceLinkBadge";
 import {
   buildModelSubmenuItems,
   sendToNewWorkspace,
@@ -275,6 +277,8 @@ function PullRequestRow({
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const registry = useModelRegistry();
   const addToast = useAppStore((s) => s.addToast);
+  const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+  const linked = useWorkspaceScmLink(repoId, "pr", pr.number);
 
   const items: ContextMenuItem[] = [
     { label: "Open in browser", onSelect: () => onOpen(pr.url) },
@@ -287,6 +291,16 @@ function PullRequestRow({
       onSelect: () => onCreateWorkspaceForBranch(pr),
     },
     { type: "separator" },
+    // Jump to an existing workspace for this PR, kept *alongside* the
+    // "Send to new workspace" submenu rather than replacing it.
+    ...(linked
+      ? ([
+          {
+            label: `Go to workspace “${linked.workspaceName}”`,
+            onSelect: () => selectWorkspace(linked.workspaceId),
+          },
+        ] satisfies ContextMenuItem[])
+      : []),
     {
       type: "submenu",
       label: "Send to new workspace",
@@ -343,6 +357,7 @@ function PullRequestRow({
         <span className={styles.rowBranch} title={`${pr.base} ← ${pr.branch}`}>
           {pr.base} ← {pr.branch}
         </span>
+        {linked && <WorkspaceLinkBadge link={linked} />}
         <span className={styles.rowMeta}>
           {pr.author && <span>{pr.author}</span>}
         </span>

--- a/src/ui/src/components/project/RepoPullRequestsSection.tsx
+++ b/src/ui/src/components/project/RepoPullRequestsSection.tsx
@@ -19,6 +19,8 @@ import type { PullRequest, PullRequestScope } from "../../types/plugin";
 import dashStyles from "../layout/Dashboard.module.css";
 import styles from "./RepoListsSection.module.css";
 import { WorkspaceLinkBadge } from "./WorkspaceLinkBadge";
+import { RepoListGroup } from "./RepoListGroup";
+import { partitionByWorkspaceLink } from "./workspaceScmLink";
 import {
   buildModelSubmenuItems,
   sendToNewWorkspace,
@@ -52,10 +54,25 @@ export const RepoPullRequestsSection = memo(function RepoPullRequestsSection({
     () => payload?.pull_requests ?? [],
     [payload?.pull_requests],
   );
-  const visible = useMemo(() => {
-    if (showAll) return prs.slice(0, ALL_VISIBLE_LIMIT);
-    return prs.slice(0, DEFAULT_VISIBLE);
-  }, [prs, showAll]);
+  // Dispatched PRs (ones that already have a workspace) get their own
+  // "In progress" group above the rest (issue #898). The row cap
+  // applies only to `rest`.
+  const workspaceScmLinks = useAppStore((s) => s.workspaceScmLinks);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const { inProgress, rest } = useMemo(
+    () =>
+      partitionByWorkspaceLink(
+        prs,
+        { repoId, kind: "pr" },
+        workspaceScmLinks,
+        workspaces,
+      ),
+    [prs, repoId, workspaceScmLinks, workspaces],
+  );
+  const visibleRest = useMemo(() => {
+    if (showAll) return rest.slice(0, ALL_VISIBLE_LIMIT);
+    return rest.slice(0, DEFAULT_VISIBLE);
+  }, [rest, showAll]);
 
   const handleCopyUrl = async (url: string) => {
     try {
@@ -141,7 +158,9 @@ export const RepoPullRequestsSection = memo(function RepoPullRequestsSection({
           repoId={repoId}
           payload={payload}
           loading={loading}
-          visible={visible}
+          inProgress={inProgress}
+          visibleRest={visibleRest}
+          restTotal={rest.length}
           totalCount={prs.length}
           showAll={showAll}
           onShowAll={() => setShowAll(true)}
@@ -163,7 +182,13 @@ interface RepoPullRequestsBodyProps {
   repoId: string;
   payload: ReturnType<typeof useRepoOpenPullRequests>["payload"];
   loading: boolean;
-  visible: PullRequest[];
+  /// PRs that already have a workspace — rendered in their own group.
+  inProgress: PullRequest[];
+  /// The remaining PRs, already capped to the visible-row limit.
+  visibleRest: PullRequest[];
+  /// Total count of `rest` before the cap — drives the "Show all" row.
+  restTotal: number;
+  /// Total count of all open PRs — drives the empty/error branches.
   totalCount: number;
   showAll: boolean;
   onShowAll: () => void;
@@ -177,7 +202,9 @@ function RepoPullRequestsBody({
   repoId,
   payload,
   loading,
-  visible,
+  inProgress,
+  visibleRest,
+  restTotal,
   totalCount,
   showAll,
   onShowAll,
@@ -218,6 +245,24 @@ function RepoPullRequestsBody({
     return <div className={styles.muted}>No open pull requests.</div>;
   }
 
+  const renderRow = (pr: PullRequest) => (
+    <PullRequestRow
+      key={pr.number}
+      repoId={repoId}
+      pr={pr}
+      onOpen={onOpen}
+      onCopyUrl={onCopyUrl}
+      onCreateWorkspaceForBranch={onCreateWorkspaceForBranch}
+    />
+  );
+  const showAllRow = !showAll && restTotal > visibleRest.length && (
+    <li>
+      <button type="button" className={styles.retryButton} onClick={onShowAll}>
+        Show all ({restTotal})
+      </button>
+    </li>
+  );
+
   return (
     <>
       {payload?.error && (
@@ -232,29 +277,26 @@ function RepoPullRequestsBody({
           </button>
         </div>
       )}
-      <ul className={styles.list}>
-        {visible.map((pr) => (
-          <PullRequestRow
-            key={pr.number}
-            repoId={repoId}
-            pr={pr}
-            onOpen={onOpen}
-            onCopyUrl={onCopyUrl}
-            onCreateWorkspaceForBranch={onCreateWorkspaceForBranch}
-          />
-        ))}
-        {!showAll && totalCount > visible.length && (
-          <li>
-            <button
-              type="button"
-              className={styles.retryButton}
-              onClick={onShowAll}
-            >
-              Show all ({totalCount})
-            </button>
-          </li>
-        )}
-      </ul>
+      {inProgress.length > 0 ? (
+        // Dispatched PRs get their own group above the rest; flat list
+        // when nothing is dispatched keeps the common case unchanged.
+        <>
+          <RepoListGroup label="In progress" count={inProgress.length} accent>
+            <ul className={styles.list}>{inProgress.map(renderRow)}</ul>
+          </RepoListGroup>
+          <RepoListGroup label="Open" count={restTotal}>
+            <ul className={styles.list}>
+              {visibleRest.map(renderRow)}
+              {showAllRow}
+            </ul>
+          </RepoListGroup>
+        </>
+      ) : (
+        <ul className={styles.list}>
+          {visibleRest.map(renderRow)}
+          {showAllRow}
+        </ul>
+      )}
     </>
   );
 }

--- a/src/ui/src/components/project/WorkspaceLinkBadge.tsx
+++ b/src/ui/src/components/project/WorkspaceLinkBadge.tsx
@@ -1,0 +1,31 @@
+import { CircleDot } from "lucide-react";
+import { useAppStore } from "../../stores/useAppStore";
+import type { ResolvedWorkspaceLink } from "./workspaceScmLink";
+import styles from "./RepoListsSection.module.css";
+
+export interface WorkspaceLinkBadgeProps {
+  link: ResolvedWorkspaceLink;
+}
+
+/// "In progress" indicator shown on a project-view issue/PR row that
+/// already has a workspace working on it. Clicking jumps straight to
+/// that workspace. `stopPropagation` keeps the click off the row's
+/// open-in-browser handler.
+export function WorkspaceLinkBadge({ link }: WorkspaceLinkBadgeProps) {
+  const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+  return (
+    <button
+      type="button"
+      className={styles.workspaceBadge}
+      title={`In progress in workspace “${link.workspaceName}” — click to open`}
+      aria-label={`Go to workspace ${link.workspaceName}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        selectWorkspace(link.workspaceId);
+      }}
+    >
+      <CircleDot size={10} aria-hidden />
+      <span className={styles.workspaceBadgeName}>{link.workspaceName}</span>
+    </button>
+  );
+}

--- a/src/ui/src/components/project/WorkspaceLinkBadge.tsx
+++ b/src/ui/src/components/project/WorkspaceLinkBadge.tsx
@@ -23,6 +23,14 @@ export function WorkspaceLinkBadge({ link }: WorkspaceLinkBadgeProps) {
         e.stopPropagation();
         selectWorkspace(link.workspaceId);
       }}
+      onKeyDown={(e) => {
+        // The enclosing row is a `role="button"` that opens the
+        // issue/PR URL on Enter/Space. Keep the badge's own keyboard
+        // activation from also bubbling up and firing that handler.
+        if (e.key === "Enter" || e.key === " ") {
+          e.stopPropagation();
+        }
+      }}
     >
       <CircleDot size={10} aria-hidden />
       <span className={styles.workspaceBadgeName}>{link.workspaceName}</span>

--- a/src/ui/src/components/project/sendToNewWorkspace.test.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.test.ts
@@ -10,8 +10,9 @@ import {
 } from "./sendToNewWorkspace";
 import { createWorkspaceOrchestrated } from "../../hooks/useCreateWorkspace";
 import { applySelectedModel } from "../chat/applySelectedModel";
-import { sendChatMessage } from "../../services/tauri";
+import { createWorkspaceScmLink, sendChatMessage } from "../../services/tauri";
 import type { Model } from "../chat/modelRegistry";
+import type { WorkspaceScmLink } from "../../types/plugin";
 
 vi.mock("../../hooks/useCreateWorkspace", () => ({
   createWorkspaceOrchestrated: vi.fn(),
@@ -21,11 +22,13 @@ vi.mock("../chat/applySelectedModel", () => ({
 }));
 vi.mock("../../services/tauri", () => ({
   sendChatMessage: vi.fn().mockResolvedValue(undefined),
+  createWorkspaceScmLink: vi.fn(),
 }));
 
 const mockedCreate = vi.mocked(createWorkspaceOrchestrated);
 const mockedApplyModel = vi.mocked(applySelectedModel);
 const mockedSend = vi.mocked(sendChatMessage);
+const mockedCreateLink = vi.mocked(createWorkspaceScmLink);
 
 function makeModel(overrides: Partial<Model> & { id: string }): Model {
   return {
@@ -56,11 +59,31 @@ const PR_ARGS: SendToNewWorkspaceArgs = {
   modelId: "sonnet",
 };
 
+/// Echo a `createWorkspaceScmLink` call back as a persisted row — mirrors
+/// what the Rust command returns (DB-assigned `created_at`).
+function makeLinkFromArgs(
+  callArgs: Parameters<typeof createWorkspaceScmLink>[0],
+): WorkspaceScmLink {
+  return {
+    workspace_id: callArgs.workspaceId,
+    repo_id: callArgs.repoId,
+    kind: callArgs.kind,
+    number: callArgs.number,
+    url: callArgs.url,
+    title: callArgs.title,
+    created_at: "2026-05-20 15:30:00",
+  };
+}
+
 beforeEach(() => {
   mockedCreate.mockReset();
   mockedApplyModel.mockClear();
   mockedSend.mockClear();
-  useAppStore.setState({ chatMessages: {}, toasts: [] });
+  mockedCreateLink.mockReset();
+  mockedCreateLink.mockImplementation((a) =>
+    Promise.resolve(makeLinkFromArgs(a)),
+  );
+  useAppStore.setState({ chatMessages: {}, toasts: [], workspaceScmLinks: {} });
 });
 
 afterEach(() => {
@@ -257,5 +280,43 @@ describe("sendToNewWorkspace", () => {
     mockedCreate.mockRejectedValue(new Error("disk full"));
     await expect(sendToNewWorkspace(ISSUE_ARGS)).rejects.toThrow("disk full");
     expect(mockedSend).not.toHaveBeenCalled();
+  });
+
+  it("persists the issue/PR -> workspace link into the store", async () => {
+    mockedCreate.mockResolvedValue({
+      workspaceId: "ws-4",
+      sessionId: "sess-4",
+    });
+
+    await sendToNewWorkspace(ISSUE_ARGS);
+
+    expect(mockedCreateLink).toHaveBeenCalledWith({
+      workspaceId: "ws-4",
+      repoId: "repo-1",
+      kind: "issue",
+      number: ISSUE_ARGS.number,
+      url: ISSUE_ARGS.url,
+      title: ISSUE_ARGS.title,
+    });
+    const link = useAppStore.getState().workspaceScmLinks["ws-4"];
+    expect(link).toMatchObject({
+      workspace_id: "ws-4",
+      kind: "issue",
+      number: ISSUE_ARGS.number,
+    });
+  });
+
+  it("still completes the send when link persistence fails", async () => {
+    mockedCreate.mockResolvedValue({
+      workspaceId: "ws-5",
+      sessionId: "sess-5",
+    });
+    mockedCreateLink.mockRejectedValueOnce(new Error("db locked"));
+
+    await sendToNewWorkspace(ISSUE_ARGS);
+
+    // The send is non-negotiable; only the badge is lost.
+    expect(mockedSend).toHaveBeenCalled();
+    expect(useAppStore.getState().workspaceScmLinks["ws-5"]).toBeUndefined();
   });
 });

--- a/src/ui/src/components/project/sendToNewWorkspace.test.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.test.ts
@@ -320,20 +320,25 @@ describe("sendToNewWorkspace", () => {
     expect(useAppStore.getState().workspaceScmLinks["ws-5"]).toBeUndefined();
   });
 
-  it("does not persist the link when the send itself fails", async () => {
+  it("records the link before the send so the badge is instant", async () => {
     mockedCreate.mockResolvedValue({
       workspaceId: "ws-6",
       sessionId: "sess-6",
     });
     mockedSend.mockRejectedValueOnce(new Error("network down"));
 
-    // The gesture failed — the error propagates to the caller and the
-    // association must NOT be recorded, or the project view would show
-    // a misleading "in progress" badge for a send that never landed.
+    // `sendChatMessage` blocks on the new workspace's env prep (direnv
+    // / nix, ~20-30s) and can fail outright. The association is keyed
+    // on workspace *creation*, so it is recorded before the send — the
+    // badge appears immediately, and a later send failure still leaves
+    // a valid link (the workspace exists; the user can retry from it).
     await expect(sendToNewWorkspace(ISSUE_ARGS)).rejects.toThrow(
       "network down",
     );
-    expect(mockedCreateLink).not.toHaveBeenCalled();
-    expect(useAppStore.getState().workspaceScmLinks["ws-6"]).toBeUndefined();
+    expect(mockedCreateLink).toHaveBeenCalled();
+    expect(useAppStore.getState().workspaceScmLinks["ws-6"]).toMatchObject({
+      workspace_id: "ws-6",
+      number: ISSUE_ARGS.number,
+    });
   });
 });

--- a/src/ui/src/components/project/sendToNewWorkspace.test.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.test.ts
@@ -319,4 +319,21 @@ describe("sendToNewWorkspace", () => {
     expect(mockedSend).toHaveBeenCalled();
     expect(useAppStore.getState().workspaceScmLinks["ws-5"]).toBeUndefined();
   });
+
+  it("does not persist the link when the send itself fails", async () => {
+    mockedCreate.mockResolvedValue({
+      workspaceId: "ws-6",
+      sessionId: "sess-6",
+    });
+    mockedSend.mockRejectedValueOnce(new Error("network down"));
+
+    // The gesture failed — the error propagates to the caller and the
+    // association must NOT be recorded, or the project view would show
+    // a misleading "in progress" badge for a send that never landed.
+    await expect(sendToNewWorkspace(ISSUE_ARGS)).rejects.toThrow(
+      "network down",
+    );
+    expect(mockedCreateLink).not.toHaveBeenCalled();
+    expect(useAppStore.getState().workspaceScmLinks["ws-6"]).toBeUndefined();
+  });
 });

--- a/src/ui/src/components/project/sendToNewWorkspace.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.ts
@@ -1,7 +1,7 @@
 import { useAppStore } from "../../stores/useAppStore";
 import { createWorkspaceOrchestrated } from "../../hooks/useCreateWorkspace";
 import { applySelectedModel } from "../chat/applySelectedModel";
-import { sendChatMessage } from "../../services/tauri";
+import { createWorkspaceScmLink, sendChatMessage } from "../../services/tauri";
 import type { Model } from "../chat/modelRegistry";
 import type { ContextMenuItem } from "../shared/ContextMenu";
 
@@ -54,6 +54,23 @@ export async function sendToNewWorkspace(
   const { workspaceId, sessionId } = outcome;
   const provider = args.providerId ?? "anthropic";
   await applySelectedModel(sessionId, args.modelId, provider);
+  // Persist the issue/PR -> workspace association so the project view can
+  // show an "in progress" badge and the workspace knows what it is for.
+  // Best-effort: the workspace and its first turn already succeeded, so a
+  // failure here only costs the badge — never abort the send for it.
+  try {
+    const link = await createWorkspaceScmLink({
+      workspaceId,
+      repoId: args.repoId,
+      kind: args.kind,
+      number: args.number,
+      url: args.url,
+      title: args.title,
+    });
+    useAppStore.getState().setWorkspaceScmLink(link);
+  } catch (e) {
+    console.error("[sendToNewWorkspace] failed to persist SCM link:", e);
+  }
   const prompt = renderStarterPrompt(args);
   // Optimistically insert the user's prompt into the chat store BEFORE
   // firing the send. Without this the new workspace opens straight to

--- a/src/ui/src/components/project/sendToNewWorkspace.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.ts
@@ -54,23 +54,6 @@ export async function sendToNewWorkspace(
   const { workspaceId, sessionId } = outcome;
   const provider = args.providerId ?? "anthropic";
   await applySelectedModel(sessionId, args.modelId, provider);
-  // Persist the issue/PR -> workspace association so the project view can
-  // show an "in progress" badge and the workspace knows what it is for.
-  // Best-effort: the workspace and its first turn already succeeded, so a
-  // failure here only costs the badge — never abort the send for it.
-  try {
-    const link = await createWorkspaceScmLink({
-      workspaceId,
-      repoId: args.repoId,
-      kind: args.kind,
-      number: args.number,
-      url: args.url,
-      title: args.title,
-    });
-    useAppStore.getState().setWorkspaceScmLink(link);
-  } catch (e) {
-    console.error("[sendToNewWorkspace] failed to persist SCM link:", e);
-  }
   const prompt = renderStarterPrompt(args);
   // Optimistically insert the user's prompt into the chat store BEFORE
   // firing the send. Without this the new workspace opens straight to
@@ -117,6 +100,25 @@ export async function sendToNewWorkspace(
     /* attachments */ undefined,
     messageId,
   );
+  // Persist the issue/PR -> workspace association only once the send has
+  // actually landed — `sendChatMessage` throwing above propagates out of
+  // this function and skips this block, so a failed gesture never leaves
+  // a misleading "in progress" badge. Best-effort past this point: the
+  // workspace and its first turn already succeeded, so a link-write
+  // failure only costs the badge — never surface it as a send failure.
+  try {
+    const link = await createWorkspaceScmLink({
+      workspaceId,
+      repoId: args.repoId,
+      kind: args.kind,
+      number: args.number,
+      url: args.url,
+      title: args.title,
+    });
+    useAppStore.getState().setWorkspaceScmLink(link);
+  } catch (e) {
+    console.error("[sendToNewWorkspace] failed to persist SCM link:", e);
+  }
   store.addToast(`Sent #${args.number} to a new workspace`);
 }
 

--- a/src/ui/src/components/project/sendToNewWorkspace.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.ts
@@ -54,6 +54,30 @@ export async function sendToNewWorkspace(
   const { workspaceId, sessionId } = outcome;
   const provider = args.providerId ?? "anthropic";
   await applySelectedModel(sessionId, args.modelId, provider);
+  // Persist the issue/PR -> workspace association the moment the
+  // workspace exists. The link records "a workspace was created for
+  // this item" — true as soon as creation succeeds — so recording it
+  // here keeps the project-view "in progress" badge instant. The
+  // alternative (after `sendChatMessage`) would delay the badge by the
+  // new workspace's env-prep time: direnv / nix can block the first
+  // turn for 20-30s, and the dispatch should read as done immediately.
+  // Best-effort: a link-write failure only costs the badge, never the
+  // send. The FK cascade still drops the row if the workspace is later
+  // deleted, so a failed first turn leaves nothing orphaned — the
+  // workspace is real and the user can retry the turn from it.
+  try {
+    const link = await createWorkspaceScmLink({
+      workspaceId,
+      repoId: args.repoId,
+      kind: args.kind,
+      number: args.number,
+      url: args.url,
+      title: args.title,
+    });
+    useAppStore.getState().setWorkspaceScmLink(link);
+  } catch (e) {
+    console.error("[sendToNewWorkspace] failed to persist SCM link:", e);
+  }
   const prompt = renderStarterPrompt(args);
   // Optimistically insert the user's prompt into the chat store BEFORE
   // firing the send. Without this the new workspace opens straight to
@@ -100,25 +124,6 @@ export async function sendToNewWorkspace(
     /* attachments */ undefined,
     messageId,
   );
-  // Persist the issue/PR -> workspace association only once the send has
-  // actually landed — `sendChatMessage` throwing above propagates out of
-  // this function and skips this block, so a failed gesture never leaves
-  // a misleading "in progress" badge. Best-effort past this point: the
-  // workspace and its first turn already succeeded, so a link-write
-  // failure only costs the badge — never surface it as a send failure.
-  try {
-    const link = await createWorkspaceScmLink({
-      workspaceId,
-      repoId: args.repoId,
-      kind: args.kind,
-      number: args.number,
-      url: args.url,
-      title: args.title,
-    });
-    useAppStore.getState().setWorkspaceScmLink(link);
-  } catch (e) {
-    console.error("[sendToNewWorkspace] failed to persist SCM link:", e);
-  }
   store.addToast(`Sent #${args.number} to a new workspace`);
 }
 

--- a/src/ui/src/components/project/workspaceScmLink.test.ts
+++ b/src/ui/src/components/project/workspaceScmLink.test.ts
@@ -76,4 +76,49 @@ describe("resolveWorkspaceLink", () => {
     const workspaces = [makeWorkspace({ status: "Archived" })];
     expect(resolveWorkspaceLink(links, workspaces, TARGET)).toBeNull();
   });
+
+  it("does not let a stale link shadow a newer active one for the same item", () => {
+    // The right-click menu keeps "Send to new workspace" available even
+    // when a link exists, so an item can carry several links. An older
+    // archived/deleted one must not hide the active workspace.
+    const links = {
+      "ws-old": makeLink({
+        workspace_id: "ws-old",
+        created_at: "2026-05-19 09:00:00",
+      }),
+      "ws-new": makeLink({
+        workspace_id: "ws-new",
+        created_at: "2026-05-20 15:30:00",
+      }),
+    };
+    const workspaces = [
+      makeWorkspace({ id: "ws-old", status: "Archived" }),
+      makeWorkspace({ id: "ws-new", name: "fresh-start", status: "Active" }),
+    ];
+    expect(resolveWorkspaceLink(links, workspaces, TARGET)).toEqual({
+      workspaceId: "ws-new",
+      workspaceName: "fresh-start",
+      link: links["ws-new"],
+    });
+  });
+
+  it("prefers the most recently created link when several are active", () => {
+    const links = {
+      "ws-old": makeLink({
+        workspace_id: "ws-old",
+        created_at: "2026-05-19 09:00:00",
+      }),
+      "ws-new": makeLink({
+        workspace_id: "ws-new",
+        created_at: "2026-05-20 15:30:00",
+      }),
+    };
+    const workspaces = [
+      makeWorkspace({ id: "ws-old", name: "first-try", status: "Active" }),
+      makeWorkspace({ id: "ws-new", name: "second-try", status: "Active" }),
+    ];
+    expect(resolveWorkspaceLink(links, workspaces, TARGET)?.workspaceId).toBe(
+      "ws-new",
+    );
+  });
 });

--- a/src/ui/src/components/project/workspaceScmLink.test.ts
+++ b/src/ui/src/components/project/workspaceScmLink.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { resolveWorkspaceLink } from "./workspaceScmLink";
+import type { Workspace } from "../../types/workspace";
+import type { WorkspaceScmLink } from "../../types/plugin";
+
+function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    id: "ws-1",
+    repository_id: "repo-1",
+    name: "slender-mint",
+    branch_name: "james/slender-mint",
+    worktree_path: "/tmp/slender-mint",
+    status: "Active",
+    agent_status: "Idle",
+    status_line: "",
+    created_at: "1700000000",
+    sort_order: 0,
+    remote_connection_id: null,
+    ...overrides,
+  };
+}
+
+function makeLink(overrides: Partial<WorkspaceScmLink> = {}): WorkspaceScmLink {
+  return {
+    workspace_id: "ws-1",
+    repo_id: "repo-1",
+    kind: "issue",
+    number: 898,
+    url: "https://github.com/utensils/claudette/issues/898",
+    title: "persist issue/PR -> workspace association",
+    created_at: "2026-05-20 15:30:00",
+    ...overrides,
+  };
+}
+
+const TARGET = { repoId: "repo-1", kind: "issue", number: 898 } as const;
+
+describe("resolveWorkspaceLink", () => {
+  it("resolves to an active linked workspace", () => {
+    const links = { "ws-1": makeLink() };
+    const workspaces = [makeWorkspace()];
+    expect(resolveWorkspaceLink(links, workspaces, TARGET)).toEqual({
+      workspaceId: "ws-1",
+      workspaceName: "slender-mint",
+      link: links["ws-1"],
+    });
+  });
+
+  it("returns null when no link matches the target item", () => {
+    const links = { "ws-1": makeLink({ number: 1 }) };
+    const workspaces = [makeWorkspace()];
+    expect(resolveWorkspaceLink(links, workspaces, TARGET)).toBeNull();
+  });
+
+  it("distinguishes issue #N from PR #N with the same number", () => {
+    const links = { "ws-1": makeLink({ kind: "pr" }) };
+    const workspaces = [makeWorkspace()];
+    expect(resolveWorkspaceLink(links, workspaces, TARGET)).toBeNull();
+  });
+
+  it("scopes the match to the target repo", () => {
+    const links = { "ws-1": makeLink({ repo_id: "repo-other" }) };
+    const workspaces = [makeWorkspace()];
+    expect(resolveWorkspaceLink(links, workspaces, TARGET)).toBeNull();
+  });
+
+  it("returns null when the linked workspace was hard-deleted", () => {
+    // The link row outlives the workspace only in-session — the FK
+    // cascade drops it on next boot. The read-side filter must cover it.
+    const links = { "ws-1": makeLink() };
+    expect(resolveWorkspaceLink(links, [], TARGET)).toBeNull();
+  });
+
+  it("hides the badge when the linked workspace is archived", () => {
+    const links = { "ws-1": makeLink() };
+    const workspaces = [makeWorkspace({ status: "Archived" })];
+    expect(resolveWorkspaceLink(links, workspaces, TARGET)).toBeNull();
+  });
+});

--- a/src/ui/src/components/project/workspaceScmLink.test.ts
+++ b/src/ui/src/components/project/workspaceScmLink.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { resolveWorkspaceLink } from "./workspaceScmLink";
+import {
+  partitionByWorkspaceLink,
+  resolveWorkspaceLink,
+} from "./workspaceScmLink";
 import type { Workspace } from "../../types/workspace";
 import type { WorkspaceScmLink } from "../../types/plugin";
 
@@ -120,5 +123,50 @@ describe("resolveWorkspaceLink", () => {
     expect(resolveWorkspaceLink(links, workspaces, TARGET)?.workspaceId).toBe(
       "ws-new",
     );
+  });
+});
+
+describe("partitionByWorkspaceLink", () => {
+  const items = [{ number: 1 }, { number: 898 }, { number: 3 }];
+
+  it("splits dispatched items from the rest, preserving order", () => {
+    const links = {
+      "ws-1": makeLink({ workspace_id: "ws-1", number: 898 }),
+    };
+    const workspaces = [makeWorkspace({ id: "ws-1" })];
+    const { inProgress, rest } = partitionByWorkspaceLink(
+      items,
+      { repoId: "repo-1", kind: "issue" },
+      links,
+      workspaces,
+    );
+    expect(inProgress.map((i) => i.number)).toEqual([898]);
+    expect(rest.map((i) => i.number)).toEqual([1, 3]);
+  });
+
+  it("treats an item whose workspace is archived as not in progress", () => {
+    const links = {
+      "ws-1": makeLink({ workspace_id: "ws-1", number: 898 }),
+    };
+    const workspaces = [makeWorkspace({ id: "ws-1", status: "Archived" })];
+    const { inProgress, rest } = partitionByWorkspaceLink(
+      items,
+      { repoId: "repo-1", kind: "issue" },
+      links,
+      workspaces,
+    );
+    expect(inProgress).toEqual([]);
+    expect(rest.map((i) => i.number)).toEqual([1, 898, 3]);
+  });
+
+  it("puts everything in `rest` when no links exist", () => {
+    const { inProgress, rest } = partitionByWorkspaceLink(
+      items,
+      { repoId: "repo-1", kind: "issue" },
+      {},
+      [],
+    );
+    expect(inProgress).toEqual([]);
+    expect(rest).toEqual(items);
   });
 });

--- a/src/ui/src/components/project/workspaceScmLink.ts
+++ b/src/ui/src/components/project/workspaceScmLink.ts
@@ -76,3 +76,28 @@ export function resolveWorkspaceLink(
   }
   return null;
 }
+
+/// Split SCM items into the ones a workspace is already working on
+/// ("in progress") and the rest, preserving input order within each
+/// group. Powers the project-view "In progress" group (issue #898) —
+/// dispatched items surface in their own section regardless of where
+/// they fall in the provider's `updated_at`-sorted list, so one that
+/// would otherwise sit past the row cap stays visible.
+export function partitionByWorkspaceLink<T extends { number: number }>(
+  items: readonly T[],
+  target: { repoId: string; kind: "issue" | "pr" },
+  links: Record<string, WorkspaceScmLink>,
+  workspaces: Workspace[],
+): { inProgress: T[]; rest: T[] } {
+  const inProgress: T[] = [];
+  const rest: T[] = [];
+  for (const item of items) {
+    const linked = resolveWorkspaceLink(links, workspaces, {
+      repoId: target.repoId,
+      kind: target.kind,
+      number: item.number,
+    });
+    (linked ? inProgress : rest).push(item);
+  }
+  return { inProgress, rest };
+}

--- a/src/ui/src/components/project/workspaceScmLink.ts
+++ b/src/ui/src/components/project/workspaceScmLink.ts
@@ -27,11 +27,18 @@ export interface ScmItemTarget {
 /// a hard-delete), so the freshness filter lives here on the read side.
 /// That keeps an archive -> restore round-trip from losing the link.
 ///
-/// Returns `null` — i.e. the project view shows no badge — when:
-///   - no link matches the target item, OR
-///   - the linked workspace has been hard-deleted (absent from
-///     `workspaces`), OR
-///   - the linked workspace exists but is archived.
+/// An item can have *several* links — the right-click menu deliberately
+/// keeps "Send to new workspace" available even when a link already
+/// exists, so a user can spin up a second workspace on the same issue.
+/// The freshness filter is therefore applied across *every* candidate:
+/// a stale (archived / hard-deleted) link must never shadow a newer
+/// active one. When more than one active link exists, the most recently
+/// created wins so the badge tracks the latest workspace.
+///
+/// Returns `null` — i.e. the project view shows no badge — when no link
+/// matches the target item, or when every matching link points at a
+/// workspace that has been hard-deleted (absent from `workspaces`) or
+/// archived.
 ///
 /// `links` is keyed by `workspace_id` (see `ScmSlice.workspaceScmLinks`),
 /// so this scans its values; the map is workspace-count-sized (a handful
@@ -43,22 +50,29 @@ export function resolveWorkspaceLink(
 ): ResolvedWorkspaceLink | null {
   // Match on all three of repo / kind / number: an issue #N and a PR #N
   // can share a number, so the number alone is not a unique key.
-  const link = Object.values(links).find(
+  const candidates = Object.values(links).filter(
     (l) =>
       l.repo_id === target.repoId &&
       l.kind === target.kind &&
       l.number === target.number,
   );
-  if (!link) return null;
-  // The freshness filter — "keep row, hide badge". A link can outlive
-  // its workspace in-session (hard-deleted, absent here until the next
-  // boot drops the row via the FK cascade), or point at an archived
-  // workspace whose row we intentionally keep. Both hide the badge.
-  const workspace = workspaces.find((w) => w.id === link.workspace_id);
-  if (!workspace || workspace.status === "Archived") return null;
-  return {
-    workspaceId: workspace.id,
-    workspaceName: workspace.name,
-    link,
-  };
+  // Newest first — `created_at` is the SQLite `datetime('now')` string
+  // (`YYYY-MM-DD HH:MM:SS`), which sorts lexically.
+  candidates.sort((a, b) => b.created_at.localeCompare(a.created_at));
+  // Apply the freshness filter to every candidate, not just the first:
+  // a link can outlive its workspace in-session (hard-deleted, absent
+  // here until the next boot drops the row via the FK cascade) or point
+  // at an archived workspace whose row we intentionally keep. Either
+  // way it must not shadow a newer active link for the same item.
+  for (const link of candidates) {
+    const workspace = workspaces.find((w) => w.id === link.workspace_id);
+    if (workspace && workspace.status !== "Archived") {
+      return {
+        workspaceId: workspace.id,
+        workspaceName: workspace.name,
+        link,
+      };
+    }
+  }
+  return null;
 }

--- a/src/ui/src/components/project/workspaceScmLink.ts
+++ b/src/ui/src/components/project/workspaceScmLink.ts
@@ -1,0 +1,64 @@
+import type { Workspace } from "../../types/workspace";
+import type { WorkspaceScmLink } from "../../types/plugin";
+
+/// A resolved issue/PR -> workspace association, already narrowed to a
+/// workspace that is safe to surface in the project view: it still
+/// exists and is not archived. The "in progress" badge renders only
+/// when `resolveWorkspaceLink` returns one of these.
+export interface ResolvedWorkspaceLink {
+  workspaceId: string;
+  workspaceName: string;
+  /// The raw persisted link — carries `url` / `title` / `kind` for the
+  /// workspace-side breadcrumb and tooltip.
+  link: WorkspaceScmLink;
+}
+
+/// The SCM item a project-view row represents.
+export interface ScmItemTarget {
+  repoId: string;
+  kind: "issue" | "pr";
+  number: number;
+}
+
+/// Find the workspace currently working on a given SCM item.
+///
+/// Issue #898 chose "keep row, hide badge": the backend never deletes a
+/// link when its workspace is archived (only the FK cascade drops it on
+/// a hard-delete), so the freshness filter lives here on the read side.
+/// That keeps an archive -> restore round-trip from losing the link.
+///
+/// Returns `null` — i.e. the project view shows no badge — when:
+///   - no link matches the target item, OR
+///   - the linked workspace has been hard-deleted (absent from
+///     `workspaces`), OR
+///   - the linked workspace exists but is archived.
+///
+/// `links` is keyed by `workspace_id` (see `ScmSlice.workspaceScmLinks`),
+/// so this scans its values; the map is workspace-count-sized (a handful
+/// in practice), and the project view memoizes per row.
+export function resolveWorkspaceLink(
+  links: Record<string, WorkspaceScmLink>,
+  workspaces: Workspace[],
+  target: ScmItemTarget,
+): ResolvedWorkspaceLink | null {
+  // Match on all three of repo / kind / number: an issue #N and a PR #N
+  // can share a number, so the number alone is not a unique key.
+  const link = Object.values(links).find(
+    (l) =>
+      l.repo_id === target.repoId &&
+      l.kind === target.kind &&
+      l.number === target.number,
+  );
+  if (!link) return null;
+  // The freshness filter — "keep row, hide badge". A link can outlive
+  // its workspace in-session (hard-deleted, absent here until the next
+  // boot drops the row via the FK cascade), or point at an archived
+  // workspace whose row we intentionally keep. Both hide the badge.
+  const workspace = workspaces.find((w) => w.id === link.workspace_id);
+  if (!workspace || workspace.status === "Archived") return null;
+  return {
+    workspaceId: workspace.id,
+    workspaceName: workspace.name,
+    link,
+  };
+}

--- a/src/ui/src/components/shared/WorkspacePanelHeader.module.css
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.module.css
@@ -46,3 +46,53 @@
   color: var(--text-dim);
   white-space: nowrap;
 }
+
+/* Breadcrumb wrapper: branch info + the optional issue/PR link pill. */
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+/* "What is this workspace for" pill — the issue/PR it was created
+   against (issue #898). Accent-tinted, clickable to open the source. */
+.scmLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  max-width: 320px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--accent-primary);
+  background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-primary) 34%, transparent);
+  border-radius: 999px;
+  padding: 1px 8px;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.scmLink:hover {
+  background: color-mix(in srgb, var(--accent-primary) 20%, transparent);
+  border-color: color-mix(in srgb, var(--accent-primary) 50%, transparent);
+}
+
+.scmLinkIcon {
+  flex-shrink: 0;
+}
+
+.scmLinkNumber {
+  flex-shrink: 0;
+  font-weight: 600;
+}
+
+.scmLinkTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+}

--- a/src/ui/src/components/shared/WorkspacePanelHeader.tsx
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.tsx
@@ -1,5 +1,6 @@
-import { GitBranch } from "lucide-react";
+import { CircleDot, GitBranch } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
+import { openUrl } from "../../services/tauri";
 import { WorkspaceActions } from "../chat/WorkspaceActions";
 import { PanelToggles } from "./PanelToggles";
 import { PanelHeader } from "./PanelHeader";
@@ -15,30 +16,56 @@ export function WorkspacePanelHeader() {
   const workspaces = useAppStore((s) => s.workspaces);
   const repositories = useAppStore((s) => s.repositories);
   const defaultBranchesMap = useAppStore((s) => s.defaultBranches);
+  // The issue/PR breadcrumb is part of the project-view issues/PRs
+  // feature, so it stays gated behind the same flag.
+  const projectViewEnabled = useAppStore((s) => s.projectViewIssuesPrsEnabled);
+  const scmLink = useAppStore((s) =>
+    selectedWorkspaceId ? s.workspaceScmLinks[selectedWorkspaceId] : undefined,
+  );
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const repo = repositories.find((r) => r.id === ws?.repository_id);
   const defaultBranch = repo ? defaultBranchesMap[repo.id] : undefined;
 
-  const left =
-    ws && (repo ? (
-      <span className={styles.branchInfo}>
-        <span className={styles.repoName}>{repo.name}</span>
-        <span className={styles.branchSep}>/</span>
-        <GitBranch size={12} className={styles.branchIcon} />
-        <span className={styles.branchName}>{ws.branch_name}</span>
-        {defaultBranch && (
-          <>
-            <span className={styles.branchArrow}>{">"}</span>
-            <span className={styles.baseBranch}>
-              {defaultBranch.replace(/^origin\//, "")}
-            </span>
-          </>
-        )}
-      </span>
-    ) : (
-      <span className={styles.repoName}>{ws.name}</span>
-    ));
+  // "What is this workspace for" — the issue/PR it was spun up against.
+  // Clicking opens the source in the browser.
+  const scmLinkEl =
+    projectViewEnabled && scmLink ? (
+      <button
+        type="button"
+        className={styles.scmLink}
+        title={`${scmLink.kind === "pr" ? "PR" : "Issue"} #${scmLink.number}: ${scmLink.title} — open in browser`}
+        onClick={() => void openUrl(scmLink.url)}
+      >
+        <CircleDot size={11} className={styles.scmLinkIcon} aria-hidden />
+        <span className={styles.scmLinkNumber}>#{scmLink.number}</span>
+        <span className={styles.scmLinkTitle}>{scmLink.title}</span>
+      </button>
+    ) : null;
+
+  const left = ws ? (
+    <span className={styles.headerLeft}>
+      {repo ? (
+        <span className={styles.branchInfo}>
+          <span className={styles.repoName}>{repo.name}</span>
+          <span className={styles.branchSep}>/</span>
+          <GitBranch size={12} className={styles.branchIcon} />
+          <span className={styles.branchName}>{ws.branch_name}</span>
+          {defaultBranch && (
+            <>
+              <span className={styles.branchArrow}>{">"}</span>
+              <span className={styles.baseBranch}>
+                {defaultBranch.replace(/^origin\//, "")}
+              </span>
+            </>
+          )}
+        </span>
+      ) : (
+        <span className={styles.repoName}>{ws.name}</span>
+      )}
+      {scmLinkEl}
+    </span>
+  ) : null;
 
   return (
     <PanelHeader

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -482,6 +482,18 @@
   gap: 2px;
 }
 
+/* Issue/PR -> workspace link indicator (issue #898). Sits between the
+   workspace info column and the hover action buttons; accent-tinted so
+   it reads as "this workspace has an upstream item" at a glance. */
+.wsScmLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
 .wsInfo {
   display: flex;
   flex-direction: column;

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -29,6 +29,7 @@ import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, CircleCheck, C
 import { resolveScmPrIcon } from "../shared/workspaceStatusIcon";
 import { RepoIcon } from "../shared/RepoIcon";
 import { WorkspaceEnvSpinner } from "./WorkspaceEnvSpinner";
+import { WorkspaceScmLinkIcon } from "./WorkspaceScmLinkIcon";
 import { extractRemoteWorkspace } from "./remoteWorkspaceResponse";
 import { HelpMenu } from "./HelpMenu";
 import { UpdateBanner } from "../layout/UpdateBanner";
@@ -785,6 +786,7 @@ export const Sidebar = memo(function Sidebar() {
             );
           })()}
         </div>
+        <WorkspaceScmLinkIcon workspaceId={ws.id} />
         <div className={styles.wsActions}>
           {ws.status === "Active" ? (
             <button

--- a/src/ui/src/components/sidebar/WorkspaceScmLinkIcon.tsx
+++ b/src/ui/src/components/sidebar/WorkspaceScmLinkIcon.tsx
@@ -1,0 +1,32 @@
+import { CircleDot } from "lucide-react";
+import { useAppStore } from "../../stores/useAppStore";
+import styles from "./Sidebar.module.css";
+
+export interface WorkspaceScmLinkIconProps {
+  workspaceId: string;
+}
+
+/// Small indicator on a sidebar workspace row when that workspace was
+/// spun up for a specific issue/PR via the project-view "Send to new
+/// workspace" gesture. Informational — the tooltip names the item;
+/// clicking the row already selects the workspace.
+///
+/// Gated behind `projectViewIssuesPrsEnabled`: the association is part
+/// of the project-view issues/PRs feature, so it stays invisible
+/// whenever that feature is turned off.
+export function WorkspaceScmLinkIcon({ workspaceId }: WorkspaceScmLinkIconProps) {
+  const enabled = useAppStore((s) => s.projectViewIssuesPrsEnabled);
+  const link = useAppStore((s) => s.workspaceScmLinks[workspaceId]);
+  if (!enabled || !link) return null;
+  const prefix = link.kind === "pr" ? "PR" : "Issue";
+  return (
+    <span
+      className={styles.wsScmLink}
+      title={`${prefix} #${link.number} — ${link.title}`}
+      aria-label={`${prefix} #${link.number}: ${link.title}`}
+      role="img"
+    >
+      <CircleDot size={11} />
+    </span>
+  );
+}

--- a/src/ui/src/hooks/useWorkspaceScmLink.ts
+++ b/src/ui/src/hooks/useWorkspaceScmLink.ts
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+import { useAppStore } from "../stores/useAppStore";
+import {
+  resolveWorkspaceLink,
+  type ResolvedWorkspaceLink,
+} from "../components/project/workspaceScmLink";
+
+/// Resolve the workspace (if any) currently working on a given issue/PR,
+/// for the project-view "in progress" badge and the right-click "Go to
+/// workspace" menu item.
+///
+/// Returns `null` when no workspace is linked, or when the linked
+/// workspace has been archived / hard-deleted — see `resolveWorkspaceLink`
+/// for the "keep row, hide badge" rationale (issue #898).
+///
+/// Also returns `null` whenever `projectViewIssuesPrsEnabled` is off:
+/// the association is part of the project-view issues/PRs feature and
+/// stays gated behind the same flag, so toggling the feature off hides
+/// every badge live.
+export function useWorkspaceScmLink(
+  repoId: string,
+  kind: "issue" | "pr",
+  number: number,
+): ResolvedWorkspaceLink | null {
+  const enabled = useAppStore((s) => s.projectViewIssuesPrsEnabled);
+  const links = useAppStore((s) => s.workspaceScmLinks);
+  const workspaces = useAppStore((s) => s.workspaces);
+  return useMemo(
+    () =>
+      enabled
+        ? resolveWorkspaceLink(links, workspaces, { repoId, kind, number })
+        : null,
+    [enabled, links, workspaces, repoId, kind, number],
+  );
+}

--- a/src/ui/src/services/tauri/initialData.ts
+++ b/src/ui/src/services/tauri/initialData.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { ChatMessage, Repository, Workspace } from "../../types";
-import type { ScmStatusCacheRow } from "../../types/plugin";
+import type { ScmStatusCacheRow, WorkspaceScmLink } from "../../types/plugin";
 
 export interface InitialData {
   repositories: Repository[];
@@ -9,6 +9,7 @@ export interface InitialData {
   default_branches: Record<string, string>;
   last_messages: ChatMessage[];
   scm_cache: ScmStatusCacheRow[];
+  workspace_scm_links: WorkspaceScmLink[];
   manual_workspace_order_repo_ids: string[];
 }
 

--- a/src/ui/src/services/tauri/initialData.ts
+++ b/src/ui/src/services/tauri/initialData.ts
@@ -9,7 +9,9 @@ export interface InitialData {
   default_branches: Record<string, string>;
   last_messages: ChatMessage[];
   scm_cache: ScmStatusCacheRow[];
-  workspace_scm_links: WorkspaceScmLink[];
+  /** Optional: a headless server older than this field omits it over
+   *  WSS, and the bundle smoke-test mock does not synthesize it. */
+  workspace_scm_links?: WorkspaceScmLink[];
   manual_workspace_order_repo_ids: string[];
 }
 

--- a/src/ui/src/services/tauri/initialData.ts
+++ b/src/ui/src/services/tauri/initialData.ts
@@ -10,7 +10,7 @@ export interface InitialData {
   last_messages: ChatMessage[];
   scm_cache: ScmStatusCacheRow[];
   /** Optional: a headless server older than this field omits it over
-   *  WSS, and the bundle smoke-test mock does not synthesize it. */
+   *  WSS. The desktop backend always sends it. */
   workspace_scm_links?: WorkspaceScmLink[];
   manual_workspace_order_repo_ids: string[];
 }

--- a/src/ui/src/services/tauri/scm.ts
+++ b/src/ui/src/services/tauri/scm.ts
@@ -6,6 +6,7 @@ import type {
   RepoIssuesPayload,
   RepoPullRequestsPayload,
   ScmDetail,
+  WorkspaceScmLink,
 } from "../../types/plugin";
 
 export function listScmProviders(): Promise<PluginInfo[]> {
@@ -58,4 +59,25 @@ export function listRepoOpenPullRequests(
 
 export function refreshRepoScmLists(repoId: string): Promise<void> {
   return invoke("refresh_repo_scm_lists", { repoId });
+}
+
+/// Persist the association between a freshly-created workspace and the
+/// issue/PR it was spun up for. Returns the saved row (with the
+/// DB-assigned `created_at`). Used by `sendToNewWorkspace`.
+export function createWorkspaceScmLink(args: {
+  workspaceId: string;
+  repoId: string;
+  kind: "issue" | "pr";
+  number: number;
+  url: string;
+  title: string;
+}): Promise<WorkspaceScmLink> {
+  return invoke("create_workspace_scm_link", {
+    workspaceId: args.workspaceId,
+    repoId: args.repoId,
+    kind: args.kind,
+    number: args.number,
+    url: args.url,
+    title: args.title,
+  });
 }

--- a/src/ui/src/stores/slices/scmSlice.ts
+++ b/src/ui/src/stores/slices/scmSlice.ts
@@ -5,6 +5,7 @@ import type {
   RepoPullRequestsPayload,
   ScmDetail,
   ScmSummary,
+  WorkspaceScmLink,
 } from "../../types/plugin";
 import type { AppState } from "../useAppStore";
 
@@ -41,6 +42,20 @@ export interface ScmSlice {
    *  refresh clears the backend cache so a stale frontend store doesn't
    *  beat the next fetch. */
   clearRepoScmLists: (repoId: string) => void;
+
+  // --- Workspace <-> SCM item links ---
+
+  /** Issue/PR associations keyed by `workspace_id`. Hydrated at boot from
+   *  `load_initial_data` and appended to when `sendToNewWorkspace`
+   *  succeeds. Powers the project-view "in progress" badge and the
+   *  workspace-side breadcrumb. Rows for archived/deleted workspaces are
+   *  filtered out at read time (see `resolveWorkspaceLink`) rather than
+   *  evicted here, so an archive -> restore round-trip keeps the link. */
+  workspaceScmLinks: Record<string, WorkspaceScmLink>;
+  /** Replace the boot snapshot of workspace -> SCM links. */
+  hydrateWorkspaceScmLinks: (links: WorkspaceScmLink[]) => void;
+  /** Record a single workspace -> SCM link (after `sendToNewWorkspace`). */
+  setWorkspaceScmLink: (link: WorkspaceScmLink) => void;
 }
 
 export const createScmSlice: StateCreator<AppState, [], [], ScmSlice> = (
@@ -86,4 +101,19 @@ export const createScmSlice: StateCreator<AppState, [], [], ScmSlice> = (
         repoPullRequestsByRepoId: nextPrs,
       };
     }),
+
+  workspaceScmLinks: {},
+  hydrateWorkspaceScmLinks: (links) =>
+    set(() => ({
+      workspaceScmLinks: Object.fromEntries(
+        links.map((l) => [l.workspace_id, l]),
+      ),
+    })),
+  setWorkspaceScmLink: (link) =>
+    set((s) => ({
+      workspaceScmLinks: {
+        ...s.workspaceScmLinks,
+        [link.workspace_id]: link,
+      },
+    })),
 });

--- a/src/ui/src/types/plugin.ts
+++ b/src/ui/src/types/plugin.ts
@@ -59,6 +59,21 @@ export interface ScmStatusCacheRow {
   fetched_at: string;
 }
 
+/** A persisted association between an SCM item (issue or PR) and the
+ *  workspace created for it via the project-view "Send to new
+ *  workspace" gesture. Keyed on `workspace_id` server-side — one
+ *  workspace owns at most one item. Mirrors `WorkspaceScmLinkRow` in
+ *  `src/db/scm.rs`. */
+export interface WorkspaceScmLink {
+  workspace_id: string;
+  repo_id: string;
+  kind: "issue" | "pr";
+  number: number;
+  url: string;
+  title: string;
+  created_at: string;
+}
+
 export interface IssueLabel {
   name: string;
   /** Hex color without leading '#'. May be empty when the provider


### PR DESCRIPTION
## Linked Issue

Closes #898

## Summary

PR #895 added the project-view Issues/PRs lists and the right-click **Send to new workspace** gesture — but nothing about that link was persisted. The issue number only lived as free text in the starter prompt, so the project view couldn't tell which issues already had an agent on them, and sending the same issue twice silently raced two workspaces.

This persists a structured **issue/PR ↔ workspace association** and surfaces it on both sides.

**Persistence**
- New `workspace_scm_links` table (migration `20260520153000`), keyed on `workspace_id` — one workspace owns at most one item. `workspace_id` is a FK with `ON DELETE CASCADE`, so a hard-deleted workspace drops its link automatically. `kind` is constrained by a `CHECK (kind IN ('issue','pr'))`.
- `sendToNewWorkspace()` writes the row via the new `create_workspace_scm_link` Tauri command **the moment the workspace is created** — *not* gated behind the first turn's send. The send blocks 20–30s on the new workspace's env prep (direnv/nix); the link records "a workspace was created for this item", which is true at creation, so the badge is instant. Best-effort: a write failure only costs the badge, never the send.
- Links hydrate at boot through `load_initial_data` (new optional `workspace_scm_links` field — tolerated absent for older headless servers over WSS).

**Project view** (`RepoIssuesSection` / `RepoPullRequestsSection`)
- Dispatched issues/PRs are partitioned into a collapsible **"In progress"** group above the plain **"Open"** group, so they stay visible even past the 10-row cap (the cap applies only to "Open"). Lists with nothing dispatched render flat — the common case is visually unchanged.
- Each dispatched row carries an accent **badge** with the workspace name — click it (or the right-click **"Go to workspace"** item) to jump to that workspace.
- **"Go to workspace"** sits *above* — not replacing — "Send to new workspace", so a deliberate second workspace stays one click away.

**Workspace side**
- A `#N — title` pill in the chat-header breadcrumb (`WorkspacePanelHeader`), click to open the source URL.
- An accent dot on the sidebar workspace row, tooltip naming the item.

**Archive semantics** — "keep row, hide badge": archived workspaces keep their link row; a read-side filter (`resolveWorkspaceLink`) hides the badge instead, so an archive → restore round-trip never loses the association. The filter scans *every* link for an item (an item can carry several) and breaks ties by most-recent `created_at`, so a stale link can't shadow a newer active workspace.

**Feature gating** — every new surface and the backend write command are gated behind the existing `projectViewIssuesPrsEnabled` flag; with the project-view feature off, no links are written and nothing renders.

**Review** — Codex (gpt-5.5) flagged 2 issues, fixed in `af9a4eb4` (resolver filter ordering; badge keydown bubbling). Copilot flagged 6 across three passes, all addressed: `kind` validation (command + DB CHECK), persistence timing, and several comment/doc accuracy nits.

## Screenshots

_Pending — UI changes are: the "In progress" / "Open" groups + accent badge on project-view issue/PR rows, the "Go to workspace" context-menu item, the `#N — title` pill in the workspace chat header, and the accent dot on sidebar workspace rows. All gated behind `projectViewIssuesPrsEnabled`. Happy to attach a dev-build capture on request._

## UAT Plan

- [ ] Enable **Settings → Git → Show open issues & PRs in project view**.
- [ ] In a repo with a GitHub/GitLab remote, expand the project-view **Issues** section, right-click an issue → **Send to new workspace ▶ <model>**.
- [ ] The dispatch is instant: the issue immediately moves into an **"In progress"** group at the top of the list with an accent badge naming the new workspace — it does not wait for env prep / the first turn.
- [ ] Click the badge → jumps to that workspace. Right-click the issue → a **"Go to workspace"** item appears above "Send to new workspace".
- [ ] Open the linked workspace: the chat header shows a `#N — title` pill (click opens the issue URL); the sidebar row shows an accent dot with a tooltip.
- [ ] Archive the workspace → the issue drops out of "In progress" back to "Open"; restore it → it returns (link survived).
- [ ] Hard-delete the workspace → badge gone; relaunch the app → still gone (FK cascade).
- [ ] Turn the feature flag back off → groups collapse to a flat list, badges/pill/sidebar dot all disappear.

## Checklist

- [x] CI passes (tests, clippy, fmt, tsc -b) — green on the latest commit; verified locally: `cargo test -p claudette`, `cargo clippy -p claudette`, `cargo fmt --check`, `cargo check -p claudette-tauri`, `bunx tsc -b`, `bun run test` (2632 pass), `bun run lint:css`, `bun run smoke:bundle`
- [x] New or updated tests cover the changed behaviour — `db::scm` cascade/upsert/CHECK tests, `workspaceScmLink.test.ts` (resolver + `partitionByWorkspaceLink`), `sendToNewWorkspace.test.ts` link-persistence cases, `RepoIssuesSection.test.tsx` grouping
- [x] Documentation updated if public behaviour changed — `site/.../project-view-issues-prs.mdx`
- [x] PR title follows conventional commit format
