### PR TITLE
fix(db): reclaim SQLite free pages

### DIFF
--- a/site/src/content/docs/features/diagnostics.mdx
+++ b/site/src/content/docs/features/diagnostics.mdx
@@ -70,6 +70,7 @@ Established domains:
 |--------|--------|
 | `claudette::startup` | process boot, paths, multi-instance warning |
 | `claudette::panic` | Rust panic hook output (with backtrace) |
+| `claudette::db` | database open, migrations, and compaction |
 | `claudette::chat` | turn lifecycle, persistent session reuse / respawn |
 | `claudette::agent` | Claude CLI subprocess events |
 | `claudette::backend` | alternative-provider gateway |
@@ -118,6 +119,14 @@ CLAUDETTE_LOG_FORMAT=json cargo tauri dev
 jq 'select(.target=="claudette::chat" and .level=="ERROR")' \
   ~/.claudette/logs/claudette.2026-05-08.log
 ```
+
+## Database compaction on upgrade
+
+Claudette stores app state in `claudette.db` under the OS data directory (`~/Library/Application Support/claudette/` on macOS, `$XDG_DATA_HOME/claudette/` on Linux, and `%APPDATA%/claudette/` on Windows unless `CLAUDETTE_DATA_DIR` overrides it).
+
+Older builds left SQLite auto-vacuum disabled, so deleting checkpoint snapshots could free pages inside SQLite without shrinking the database file on disk. The first launch of a build with database compaction may run a one-time SQLite `VACUUM` to apply incremental auto-vacuum and reclaim those stranded pages. For very large databases, startup can pause while that rewrite finishes. Other database connections wait up to 30 seconds for the maintenance lock before retrying on a later open.
+
+After conversion, routine database opens only check that the compaction mode is in place. High-churn delete paths, such as checkpoint and workspace cleanup, run bounded incremental vacuum work after the delete commits. To inspect this lifecycle, filter logs for the `claudette::db` target.
 
 ## Multiple dev instances
 

--- a/src/db/chat.rs
+++ b/src/db/chat.rs
@@ -338,10 +338,11 @@ impl Database {
         &self,
         workspace_id: &str,
     ) -> Result<(), rusqlite::Error> {
-        self.conn.execute(
+        let deleted = self.conn.execute(
             "DELETE FROM chat_messages WHERE workspace_id = ?1",
             params![workspace_id],
         )?;
+        self.best_effort_incremental_vacuum_after_delete(deleted);
         Ok(())
     }
 
@@ -350,18 +351,20 @@ impl Database {
         &self,
         chat_session_id: &str,
     ) -> Result<(), rusqlite::Error> {
-        self.conn.execute(
+        let deleted = self.conn.execute(
             "DELETE FROM chat_messages WHERE chat_session_id = ?1",
             params![chat_session_id],
         )?;
+        self.best_effort_incremental_vacuum_after_delete(deleted);
         Ok(())
     }
 
     pub fn delete_chat_message(&self, message_id: &str) -> Result<(), rusqlite::Error> {
-        self.conn.execute(
+        let deleted = self.conn.execute(
             "DELETE FROM chat_messages WHERE id = ?1",
             params![message_id],
         )?;
+        self.best_effort_incremental_vacuum_after_delete(deleted);
         Ok(())
     }
 

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -782,42 +782,48 @@ mod tests {
 
     #[test]
     fn test_delete_checkpoint_reclaims_checkpoint_file_pages() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = Database::open(&dir.path().join("claudette.db")).unwrap();
-        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+        fn setup_checkpoint_file_db() -> (tempfile::TempDir, Database) {
+            let dir = tempfile::tempdir().unwrap();
+            let db = Database::open(&dir.path().join("claudette.db")).unwrap();
+            db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+                .unwrap();
+            db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
+                .unwrap();
+            db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+                .unwrap();
+            db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+                .unwrap();
+            db.insert_checkpoint_files(&[CheckpointFile {
+                id: "cf1".into(),
+                checkpoint_id: "cp1".into(),
+                file_path: "large.bin".into(),
+                content: Some(vec![7; 1024 * 1024]),
+                file_mode: 0o100644,
+            }])
             .unwrap();
-        db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
-            .unwrap();
-        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
-            .unwrap();
-        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
-            .unwrap();
-        db.insert_checkpoint_files(&[CheckpointFile {
-            id: "cf1".into(),
-            checkpoint_id: "cp1".into(),
-            file_path: "large.bin".into(),
-            content: Some(vec![7; 1024 * 1024]),
-            file_mode: 0o100644,
-        }])
-        .unwrap();
+            (dir, db)
+        }
 
-        db.conn()
-            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
-            .unwrap();
-        let page_count_after_insert: i64 = db
+        let (_raw_dir, raw_db) = setup_checkpoint_file_db();
+        raw_db
             .conn()
-            .query_row("PRAGMA page_count", [], |row| row.get(0))
+            .execute("DELETE FROM conversation_checkpoints WHERE id = 'cp1'", [])
             .unwrap();
-
-        db.delete_checkpoint("cp1").unwrap();
-
-        let page_count_after_delete: i64 = db
+        let freelist_after_raw_delete: i64 = raw_db
             .conn()
-            .query_row("PRAGMA page_count", [], |row| row.get(0))
+            .query_row("PRAGMA freelist_count", [], |row| row.get(0))
             .unwrap();
+
+        let (_vacuum_dir, vacuum_db) = setup_checkpoint_file_db();
+        vacuum_db.delete_checkpoint("cp1").unwrap();
+        let freelist_after_vacuuming_delete: i64 = vacuum_db
+            .conn()
+            .query_row("PRAGMA freelist_count", [], |row| row.get(0))
+            .unwrap();
+
         assert!(
-            page_count_after_delete < page_count_after_insert,
-            "checkpoint file delete should reclaim pages; before={page_count_after_insert} after={page_count_after_delete}"
+            freelist_after_vacuuming_delete < freelist_after_raw_delete,
+            "checkpoint file delete should drain some free pages; raw={freelist_after_raw_delete} vacuumed={freelist_after_vacuuming_delete}"
         );
     }
 

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -90,14 +90,16 @@ impl Database {
             "DELETE FROM conversation_checkpoints WHERE chat_session_id = ?1 AND turn_index > ?2",
             params![chat_session_id, turn_index],
         )?;
+        self.best_effort_incremental_vacuum_after_delete(deleted);
         Ok(deleted)
     }
 
     pub fn delete_checkpoint(&self, checkpoint_id: &str) -> Result<(), rusqlite::Error> {
-        self.conn.execute(
+        let deleted = self.conn.execute(
             "DELETE FROM conversation_checkpoints WHERE id = ?1",
             params![checkpoint_id],
         )?;
+        self.best_effort_incremental_vacuum_after_delete(deleted);
         Ok(())
     }
 
@@ -137,6 +139,7 @@ impl Database {
             "DELETE FROM conversation_checkpoints WHERE workspace_id = ?1 AND turn_index > ?2",
             params![workspace_id, turn_index],
         )?;
+        self.best_effort_incremental_vacuum_after_delete(deleted);
         Ok(deleted)
     }
 
@@ -445,6 +448,7 @@ impl Database {
                AND rowid > (SELECT rowid FROM chat_messages WHERE id = ?2)",
             params![workspace_id, after_message_id],
         )?;
+        self.best_effort_incremental_vacuum_after_delete(deleted);
         Ok(deleted)
     }
 
@@ -462,6 +466,7 @@ impl Database {
                AND rowid > (SELECT rowid FROM chat_messages WHERE id = ?2)",
             params![chat_session_id, after_message_id],
         )?;
+        self.best_effort_incremental_vacuum_after_delete(deleted);
         Ok(deleted)
     }
 
@@ -541,7 +546,7 @@ impl Database {
 mod tests {
     use super::*;
     use crate::db::test_support::*;
-    use crate::model::ChatRole;
+    use crate::model::{ChatRole, CheckpointFile};
 
     /// Build a `ConversationCheckpoint` anchored to the workspace's default
     /// active session.
@@ -773,6 +778,47 @@ mod tests {
         assert_eq!(turns[0].checkpoint_id, "cp2");
         assert_eq!(turns[0].activities.len(), 1);
         assert_eq!(turns[0].activities[0].id, "a2");
+    }
+
+    #[test]
+    fn test_delete_checkpoint_reclaims_checkpoint_file_pages() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("claudette.db")).unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        db.insert_checkpoint_files(&[CheckpointFile {
+            id: "cf1".into(),
+            checkpoint_id: "cp1".into(),
+            file_path: "large.bin".into(),
+            content: Some(vec![7; 1024 * 1024]),
+            file_mode: 0o100644,
+        }])
+        .unwrap();
+
+        db.conn()
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+            .unwrap();
+        let page_count_after_insert: i64 = db
+            .conn()
+            .query_row("PRAGMA page_count", [], |row| row.get(0))
+            .unwrap();
+
+        db.delete_checkpoint("cp1").unwrap();
+
+        let page_count_after_delete: i64 = db
+            .conn()
+            .query_row("PRAGMA page_count", [], |row| row.get(0))
+            .unwrap();
+        assert!(
+            page_count_after_delete < page_count_after_insert,
+            "checkpoint file delete should reclaim pages; before={page_count_after_insert} after={page_count_after_delete}"
+        );
     }
 
     #[test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::path::Path;
+use std::time::Duration;
 
 use rusqlite::{Connection, params};
 
@@ -7,6 +8,7 @@ use crate::migrations::{MIGRATIONS, Migration};
 
 const SQLITE_AUTO_VACUUM_FULL: i64 = 1;
 const SQLITE_AUTO_VACUUM_INCREMENTAL: i64 = 2;
+const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 const INCREMENTAL_VACUUM_PAGES_AFTER_DELETE: i64 = 4096;
 
 mod repository;
@@ -81,6 +83,7 @@ impl Database {
         conn: &Connection,
         enable_incremental_auto_vacuum_before_schema: bool,
     ) -> Result<(), rusqlite::Error> {
+        conn.busy_timeout(SQLITE_BUSY_TIMEOUT)?;
         if enable_incremental_auto_vacuum_before_schema {
             conn.execute_batch("PRAGMA auto_vacuum=INCREMENTAL;")?;
         }
@@ -138,12 +141,13 @@ impl Database {
         if mode == SQLITE_AUTO_VACUUM_INCREMENTAL {
             return Ok(false);
         }
-
-        self.conn.execute_batch("PRAGMA auto_vacuum=INCREMENTAL;")?;
         if mode == SQLITE_AUTO_VACUUM_FULL {
+            // FULL already returns freed pages to the OS on each commit. Avoid
+            // rewriting a user/dev DB just to change to incremental mode.
             return Ok(false);
         }
 
+        self.conn.execute_batch("PRAGMA auto_vacuum=INCREMENTAL;")?;
         tracing::info!(
             target: "claudette::db",
             "converting database to incremental auto-vacuum; running one-time VACUUM"
@@ -175,6 +179,9 @@ impl Database {
     }
 
     fn incremental_vacuum(&self, max_pages: i64) -> Result<(), rusqlite::Error> {
+        if max_pages <= 0 {
+            return Ok(());
+        }
         if self.auto_vacuum_mode()? != SQLITE_AUTO_VACUUM_INCREMENTAL {
             return Ok(());
         }
@@ -184,7 +191,7 @@ impl Database {
         if freelist_count <= 0 {
             return Ok(());
         }
-        let pages = freelist_count.min(max_pages).max(1);
+        let pages = freelist_count.min(max_pages);
         self.conn
             .execute_batch(&format!("PRAGMA incremental_vacuum({pages});"))
     }
@@ -446,6 +453,12 @@ mod tests {
             .unwrap()
     }
 
+    fn busy_timeout_ms(db: &Database) -> i64 {
+        db.conn()
+            .query_row("PRAGMA busy_timeout", [], |r| r.get(0))
+            .unwrap()
+    }
+
     /// Apply the SQL bodies of the first N pre-redesign migrations directly,
     /// then set `PRAGMA user_version = N`, producing a DB that looks exactly
     /// like one from before the redesign at that version.
@@ -513,6 +526,12 @@ mod tests {
     }
 
     #[test]
+    fn test_database_connections_wait_on_busy_locks() {
+        let db = Database::open_in_memory().unwrap();
+        assert_eq!(busy_timeout_ms(&db), SQLITE_BUSY_TIMEOUT.as_millis() as i64);
+    }
+
+    #[test]
     fn test_existing_file_db_converts_to_incremental_auto_vacuum() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("claudette.db");
@@ -534,6 +553,35 @@ mod tests {
         let db = Database::open(&path).unwrap();
 
         assert_eq!(auto_vacuum_mode(&db), SQLITE_AUTO_VACUUM_INCREMENTAL);
+        let preserved: i64 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM preexisting_table", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(preserved, 1);
+    }
+
+    #[test]
+    fn test_full_auto_vacuum_db_is_left_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("claudette.db");
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "PRAGMA auto_vacuum=FULL;
+                 CREATE TABLE preexisting_table (id INTEGER PRIMARY KEY, payload BLOB);
+                 INSERT INTO preexisting_table (payload) VALUES (zeroblob(65536));",
+            )
+            .unwrap();
+            assert_eq!(
+                conn.query_row("PRAGMA auto_vacuum", [], |r| r.get::<_, i64>(0))
+                    .unwrap(),
+                SQLITE_AUTO_VACUUM_FULL
+            );
+        }
+
+        let db = Database::open(&path).unwrap();
+
+        assert_eq!(auto_vacuum_mode(&db), SQLITE_AUTO_VACUUM_FULL);
         let preserved: i64 = db
             .conn()
             .query_row("SELECT COUNT(*) FROM preexisting_table", [], |r| r.get(0))

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -5,6 +5,10 @@ use rusqlite::{Connection, params};
 
 use crate::migrations::{MIGRATIONS, Migration};
 
+const SQLITE_AUTO_VACUUM_FULL: i64 = 1;
+const SQLITE_AUTO_VACUUM_INCREMENTAL: i64 = 2;
+const INCREMENTAL_VACUUM_PAGES_AFTER_DELETE: i64 = 4096;
+
 mod repository;
 pub use repository::is_duplicate_repository_path_error;
 
@@ -55,20 +59,32 @@ impl Database {
                 )
             })?;
         }
+        let is_fresh_file = is_fresh_database_file(path);
         let conn = Connection::open(path)?;
-        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        Self::configure_connection(&conn, is_fresh_file)?;
         let db = Self { conn };
         db.migrate()?;
+        db.run_space_maintenance();
         Ok(db)
     }
 
     #[allow(dead_code)]
     pub fn open_in_memory() -> Result<Self, rusqlite::Error> {
         let conn = Connection::open_in_memory()?;
-        conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+        Self::configure_connection(&conn, true)?;
         let db = Self { conn };
         db.migrate()?;
         Ok(db)
+    }
+
+    fn configure_connection(
+        conn: &Connection,
+        enable_incremental_auto_vacuum_before_schema: bool,
+    ) -> Result<(), rusqlite::Error> {
+        if enable_incremental_auto_vacuum_before_schema {
+            conn.execute_batch("PRAGMA auto_vacuum=INCREMENTAL;")?;
+        }
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
     }
 
     /// Execute raw SQL. Intended for test setup only.
@@ -94,6 +110,83 @@ impl Database {
         self.bootstrap_and_backfill(MIGRATIONS)?;
         Self::run_migrations(&self.conn, MIGRATIONS)?;
         self.heal_orphaned_sessions()
+    }
+
+    fn run_space_maintenance(&self) {
+        match self.ensure_incremental_auto_vacuum() {
+            Ok(true) => {}
+            Ok(false) => self.best_effort_incremental_vacuum(INCREMENTAL_VACUUM_PAGES_AFTER_DELETE),
+            Err(e) => {
+                tracing::warn!(
+                    target: "claudette::db",
+                    error = %e,
+                    "database space maintenance skipped"
+                );
+            }
+        }
+    }
+
+    /// Ensure freed pages can be returned to the OS.
+    ///
+    /// SQLite only honors `PRAGMA auto_vacuum` immediately before any tables
+    /// exist. Existing field databases therefore need a one-time `VACUUM`
+    /// after flipping the pragma; this must live outside the SQL migration
+    /// runner because migrations execute inside transactions and `VACUUM`
+    /// is prohibited there.
+    fn ensure_incremental_auto_vacuum(&self) -> Result<bool, rusqlite::Error> {
+        let mode = self.auto_vacuum_mode()?;
+        if mode == SQLITE_AUTO_VACUUM_INCREMENTAL {
+            return Ok(false);
+        }
+
+        self.conn.execute_batch("PRAGMA auto_vacuum=INCREMENTAL;")?;
+        if mode == SQLITE_AUTO_VACUUM_FULL {
+            return Ok(false);
+        }
+
+        tracing::info!(
+            target: "claudette::db",
+            "converting database to incremental auto-vacuum; running one-time VACUUM"
+        );
+        self.conn.execute_batch("VACUUM;")?;
+        Ok(true)
+    }
+
+    fn auto_vacuum_mode(&self) -> Result<i64, rusqlite::Error> {
+        self.conn
+            .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
+    }
+
+    fn best_effort_incremental_vacuum_after_delete(&self, rows_deleted: usize) {
+        if rows_deleted > 0 {
+            self.best_effort_incremental_vacuum(INCREMENTAL_VACUUM_PAGES_AFTER_DELETE);
+        }
+    }
+
+    fn best_effort_incremental_vacuum(&self, max_pages: i64) {
+        if let Err(e) = self.incremental_vacuum(max_pages) {
+            tracing::warn!(
+                target: "claudette::db",
+                max_pages,
+                error = %e,
+                "incremental vacuum skipped"
+            );
+        }
+    }
+
+    fn incremental_vacuum(&self, max_pages: i64) -> Result<(), rusqlite::Error> {
+        if self.auto_vacuum_mode()? != SQLITE_AUTO_VACUUM_INCREMENTAL {
+            return Ok(());
+        }
+        let freelist_count: i64 = self
+            .conn
+            .query_row("PRAGMA freelist_count", [], |row| row.get(0))?;
+        if freelist_count <= 0 {
+            return Ok(());
+        }
+        let pages = freelist_count.min(max_pages).max(1);
+        self.conn
+            .execute_batch(&format!("PRAGMA incremental_vacuum({pages});"))
     }
 
     /// Ensure `schema_migrations` exists; seed it from `PRAGMA user_version`
@@ -315,6 +408,14 @@ fn is_already_exists_error(err: &rusqlite::Error) -> bool {
     msg.contains("already exists") || msg.contains("duplicate column name")
 }
 
+fn is_fresh_database_file(path: &Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(metadata) => metadata.len() == 0,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(_) => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -336,6 +437,12 @@ mod tests {
         stmt.query_map([], |r| r.get::<_, String>(0))
             .unwrap()
             .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    fn auto_vacuum_mode(db: &Database) -> i64 {
+        db.conn()
+            .query_row("PRAGMA auto_vacuum", [], |r| r.get(0))
             .unwrap()
     }
 
@@ -393,6 +500,45 @@ mod tests {
     fn test_fresh_db_applies_all_migrations() {
         let db = Database::open_in_memory().unwrap();
         assert_eq!(count_applied(&db) as usize, MIGRATIONS.len());
+    }
+
+    #[test]
+    fn test_fresh_file_db_uses_incremental_auto_vacuum() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("claudette.db");
+
+        let db = Database::open(&path).unwrap();
+
+        assert_eq!(auto_vacuum_mode(&db), SQLITE_AUTO_VACUUM_INCREMENTAL);
+    }
+
+    #[test]
+    fn test_existing_file_db_converts_to_incremental_auto_vacuum() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("claudette.db");
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "PRAGMA auto_vacuum=NONE;
+                 CREATE TABLE preexisting_table (id INTEGER PRIMARY KEY, payload BLOB);
+                 INSERT INTO preexisting_table (payload) VALUES (zeroblob(65536));",
+            )
+            .unwrap();
+            assert_eq!(
+                conn.query_row("PRAGMA auto_vacuum", [], |r| r.get::<_, i64>(0))
+                    .unwrap(),
+                0
+            );
+        }
+
+        let db = Database::open(&path).unwrap();
+
+        assert_eq!(auto_vacuum_mode(&db), SQLITE_AUTO_VACUUM_INCREMENTAL);
+        let preserved: i64 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM preexisting_table", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(preserved, 1);
     }
 
     /// Pin the keybinding rename: after the renaming migration runs,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -116,16 +116,12 @@ impl Database {
     }
 
     fn run_space_maintenance(&self) {
-        match self.ensure_incremental_auto_vacuum() {
-            Ok(true) => {}
-            Ok(false) => self.best_effort_incremental_vacuum(INCREMENTAL_VACUUM_PAGES_AFTER_DELETE),
-            Err(e) => {
-                tracing::warn!(
-                    target: "claudette::db",
-                    error = %e,
-                    "database space maintenance skipped"
-                );
-            }
+        if let Err(e) = self.ensure_incremental_auto_vacuum() {
+            tracing::warn!(
+                target: "claudette::db",
+                error = %e,
+                "database space maintenance skipped"
+            );
         }
     }
 
@@ -459,6 +455,12 @@ mod tests {
             .unwrap()
     }
 
+    fn freelist_count(db: &Database) -> i64 {
+        db.conn()
+            .query_row("PRAGMA freelist_count", [], |r| r.get(0))
+            .unwrap()
+    }
+
     /// Apply the SQL bodies of the first N pre-redesign migrations directly,
     /// then set `PRAGMA user_version = N`, producing a DB that looks exactly
     /// like one from before the redesign at that version.
@@ -558,6 +560,32 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM preexisting_table", [], |r| r.get(0))
             .unwrap();
         assert_eq!(preserved, 1);
+    }
+
+    #[test]
+    fn test_open_does_not_incrementally_vacuum_converted_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("claudette.db");
+        let freelist_before = {
+            let db = Database::open(&path).unwrap();
+            db.conn()
+                .execute_batch(
+                    "CREATE TABLE vacuum_probe (id INTEGER PRIMARY KEY, payload BLOB);
+                     INSERT INTO vacuum_probe (payload) VALUES (zeroblob(1048576));
+                     DELETE FROM vacuum_probe;",
+                )
+                .unwrap();
+            let freelist_before = freelist_count(&db);
+            assert!(
+                freelist_before > 0,
+                "test setup should leave free pages to reclaim"
+            );
+            freelist_before
+        };
+
+        let db = Database::open(&path).unwrap();
+
+        assert_eq!(freelist_count(&db), freelist_before);
     }
 
     #[test]

--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -500,8 +500,9 @@ impl Database {
     pub fn delete_workspace_with_summary(&self, id: &str) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
         Self::materialize_workspace_summary_tx(&tx, id)?;
-        tx.execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
+        let deleted = tx.execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
         tx.commit()?;
+        self.best_effort_incremental_vacuum_after_delete(deleted);
         Ok(())
     }
 
@@ -552,8 +553,9 @@ impl Database {
             return Ok(false);
         }
         Self::materialize_workspace_summary_tx(&tx, id)?;
-        tx.execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
+        let deleted = tx.execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
         tx.commit()?;
+        self.best_effort_incremental_vacuum_after_delete(deleted);
         Ok(true)
     }
 
@@ -570,8 +572,9 @@ impl Database {
         for ws_id in &ws_ids {
             Self::materialize_workspace_summary_tx(&tx, ws_id)?;
         }
-        tx.execute("DELETE FROM repositories WHERE id = ?1", params![id])?;
+        let deleted = tx.execute("DELETE FROM repositories WHERE id = ?1", params![id])?;
         tx.commit()?;
+        self.best_effort_incremental_vacuum_after_delete(deleted);
         Ok(())
     }
 
@@ -657,8 +660,10 @@ impl Database {
     }
 
     pub fn delete_workspace(&self, id: &str) -> Result<(), rusqlite::Error> {
-        self.conn
+        let deleted = self
+            .conn
             .execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
+        self.best_effort_incremental_vacuum_after_delete(deleted);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Fixes #906 by adding SQLite space reclamation to Claudette's core database lifecycle.

- enables incremental auto-vacuum for newly created databases before schema creation
- converts existing `auto_vacuum=NONE` databases with a one-time `VACUUM` outside the SQL migration runner
- configures a 30 second SQLite busy timeout so concurrent writers wait during the first-upgrade `VACUUM` instead of immediately failing with `SQLITE_BUSY`
- runs bounded best-effort `incremental_vacuum` after high-churn deletes that can cascade through `checkpoint_files`
- documents the first-upgrade compaction lifecycle and `claudette::db` log target in Diagnostics
- adds regression coverage for fresh DB mode, existing DB conversion, busy timeout configuration, FULL-mode auto-vacuum handling, no routine open-time incremental vacuum work, and checkpoint BLOB page reclamation

## Root Cause

`checkpoint_files` stores file snapshots as BLOBs and is churned by checkpoint rollback, conversation clearing, workspace cleanup, and repository cleanup. SQLite was running with `auto_vacuum=NONE`, and Claudette never invoked `VACUUM` or `incremental_vacuum`, so deleted BLOB pages stayed on the freelist forever instead of returning to the OS.

## Implementation Notes

Fresh databases now set `PRAGMA auto_vacuum=INCREMENTAL` before migrations create any tables, which is the only point where SQLite can apply the mode without a rewrite.

Existing field databases are handled after migrations by setting incremental mode and running a one-time `VACUUM`. This intentionally lives outside the migration runner because migrations execute in transactions and SQLite does not allow `VACUUM` inside a transaction.

The first upgraded open of an existing bloated database can block while SQLite rewrites the DB file. That is the intentional trade-off for reclaiming already-stranded pages, and it may affect cold-start latency for very large databases. Every connection now has a 30 second busy timeout so concurrent opens/writes wait during that maintenance window instead of failing immediately.

Existing `auto_vacuum=FULL` databases are left unchanged because FULL already returns freed pages to the OS on each commit. Claudette has not created FULL databases itself, but preserving that mode avoids an unnecessary rewrite for user/dev databases.

After the conversion, routine database opens only verify that compaction mode is in place. They do not run incremental vacuum work. Delete paths that commonly free large pages trigger a bounded incremental vacuum after their delete transaction commits. The cleanup is best-effort and logs warnings instead of failing user-facing delete operations if SQLite remains busy.

## Peer Review Follow-Up

- Addressed: added `busy_timeout` coverage for first-upgrade `VACUUM` vs concurrent writes.
- Documented: called out the one-time cold-start trade-off for existing bloated databases in both the PR and Diagnostics docs.
- Clarified: FULL auto-vacuum databases are explicitly left alone with a code comment and regression test.
- Cleaned up: removed the dead `.max(1)` guard after the positive freelist check.

## Copilot Follow-Up

- Limited open-time space maintenance to one-time conversion only, avoiding incremental vacuum work on ordinary command-triggered database opens.
- Kept the `INCREMENTAL_VACUUM_PAGES_AFTER_DELETE` constant scoped to post-delete cleanup again.
- Added Diagnostics documentation for database compaction, the one-time `VACUUM`, and the `claudette::db` logging target.

## Validation

- `nix develop -c cargo fmt --all --check`
- `nix develop -c cargo test -p claudette db:: -- --nocapture`
- `nix develop -c cargo clippy -p claudette --all-targets --all-features`
- `cd site && bun install --frozen-lockfile && bun run build`
- `git diff --check`
