### PR TITLE
fix(env-direnv): cache thrashes on workspaces with no source changes

### DIFF
--- a/plugins/env-direnv/init.lua
+++ b/plugins/env-direnv/init.lua
@@ -30,7 +30,8 @@ function M.detect(args)
 end
 
 function M.export(args)
-    local envrc_path = join(worktree_of(args), ".envrc")
+    local worktree = worktree_of(args)
+    local envrc_path = join(worktree, ".envrc")
     -- Streaming so direnv's own informative stderr (e.g.
     -- `direnv: loading .envrc`, `direnv: using flake`, the `+VAR -VAR`
     -- diff) flows into the EnvProvisioningConsole as it happens. The
@@ -135,10 +136,41 @@ function M.export(args)
         -- hash-format change in direnv.
         return basename:match("^[0-9a-f]+$") ~= nil and #basename >= 32
     end
+    -- We also DROP anything under the worktree's own `.direnv/`
+    -- directory. nix-direnv (and `layout`-based plain direnv) write
+    -- derived build artifacts there on every evaluation —
+    -- `flake-profile-<sha>` symlinks, `flake-inputs/`, `added_paths`,
+    -- `bin/nix-direnv-reload`, profile rc files — and direnv lists
+    -- them in `DIRENV_WATCHES` so its *shell hook* re-runs after a
+    -- rebuild. For the EnvCache, though, those files are OUTPUT, not
+    -- source: watching them means every successful direnv evaluation
+    -- re-touches a watched path and primes the next spurious
+    -- invalidation (the same post-`cache.put` FSEvents race the
+    -- allow/deny stamp filter above documents, in a new spot). The
+    -- legitimate source files — `.envrc`, `flake.nix`, `flake.lock`,
+    -- and anything `watch_file`/`dotenv` pulls in — live OUTSIDE
+    -- `.direnv/`, so dropping the whole directory loses no real
+    -- invalidation trigger.
+    --
+    -- The match is anchored to the `<worktree>/.direnv/` prefix on
+    -- purpose. A bare `.direnv` path-component check would mis-fire
+    -- and filter out the real `.envrc` / `flake.lock` of a workspace
+    -- that itself happens to live under some unrelated `.direnv/`
+    -- ancestor directory. `.direnv` is direnv's reserved, default
+    -- layout-dir name, so the prefix test reliably identifies these
+    -- artifacts without enumerating nix-direnv's version-dependent
+    -- internal filenames.
+    local direnv_layout_prefix = worktree .. "/.direnv/"
+    local function is_direnv_layout_artifact(path)
+        if type(path) ~= "string" then return false end
+        return path:sub(1, #direnv_layout_prefix) == direnv_layout_prefix
+    end
     local watched = {}
     local seen = {}
     local function add(path)
-        if path and not seen[path] and not is_direnv_stamp(path) then
+        if path and not seen[path]
+            and not is_direnv_stamp(path)
+            and not is_direnv_layout_artifact(path) then
             seen[path] = true
             table.insert(watched, path)
         end

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -1370,7 +1370,16 @@ pub fn setup_env_watcher(app: AppHandle) {
     let trust_probe_versions: Arc<Mutex<HashMap<(String, String), u64>>> =
         Arc::new(Mutex::new(HashMap::new()));
     let watcher = match EnvWatcher::new(Arc::new(move |worktree, plugin| {
-        cache.invalidate(worktree, Some(plugin));
+        // A watcher event means *some* watched path was touched, but
+        // `touch`, `git checkout`, save-on-noop editors, and
+        // nix-direnv re-evaluation all fire events without changing
+        // bytes. `invalidate_if_stale` re-checks content and evicts
+        // only on a real change (issue #888) — when it keeps the
+        // entry there is nothing for the UI to refetch and no trust
+        // state to re-probe, so skip both the event and the probe.
+        if !cache.invalidate_if_stale(worktree, plugin) {
+            return;
+        }
         let worktree_path = worktree.to_string_lossy().into_owned();
         let plugin_name = plugin.to_string();
         let _ = app_for_cb.emit(

--- a/src/env_provider/cache.rs
+++ b/src/env_provider/cache.rs
@@ -1,30 +1,60 @@
 //! In-memory cache for env-provider exports, keyed by `(worktree, plugin_name)`.
 //!
-//! The cache stores each plugin's last [`ProviderExport`] alongside the
-//! mtimes of the files it reported as `watched`. On lookup, we re-stat
-//! those files; if all mtimes are unchanged, the cached entry is
-//! returned and the plugin's `export` operation is skipped (no Lua VM
-//! spin-up, no subprocess).
+//! The cache stores each plugin's last [`ProviderExport`] alongside an
+//! mtime + content-hash fingerprint of every file it reported as
+//! `watched`. On lookup we re-check those files with a two-tier test:
 //!
-//! Scope of invalidation covered by v1:
-//! - `.envrc` / `mise.toml` / `.env` / `flake.lock` edits → mtime
-//!   changes → cache miss → re-export.
-//! - File deletion → stat fails → treated as "mtime changed" → miss.
+//! 1. **mtime compare** (cheap, no file reads). If every watched
+//!    file's mtime is unchanged, the entry is fresh — return it and
+//!    skip the plugin's `export` (no Lua VM spin-up, no subprocess).
+//! 2. **content hash** (slow path, only on an mtime mismatch). A bare
+//!    mtime bump is not proof of a content change — `git checkout`,
+//!    `touch`, save-on-noop editors, and nix-direnv re-evaluation all
+//!    move mtimes forward without changing bytes. When mtime moved we
+//!    hash the file: identical bytes → still fresh (and we heal the
+//!    stored mtime so the next lookup takes the cheap path again);
+//!    changed bytes → stale → re-export.
 //!
-//! Not covered (v2+ work):
+//! This two-tier check is what keeps the cache warm on a workspace
+//! whose `.envrc` / `flake.nix` / `flake.lock` content never changed
+//! even as agents, terminals, and git operations churn file mtimes.
+//!
+//! Scope of invalidation:
+//! - `.envrc` / `mise.toml` / `.env` / `flake.lock` content edits →
+//!   hash mismatch → cache miss → re-export.
+//! - File deletion → stat fails → treated as "changed" → miss.
+//!
+//! Not covered:
 //! - A plugin starts watching a *new* file on a later call (e.g. user
 //!   adds `.envrc.local`). We only know what the previous export told
 //!   us to watch. Acceptable because direnv's `DIRENV_WATCHES` updates
-//!   inside `.envrc` — the `.envrc` mtime changing forces a re-eval.
+//!   inside `.envrc` — the `.envrc` content changing forces a re-eval.
 //! - User runs `direnv deny` without editing `.envrc` → cache stays
-//!   fresh until next `.envrc` mtime change. Workaround: UI "Reload".
+//!   fresh until next `.envrc` content change. Workaround: UI "Reload".
 
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 use std::time::SystemTime;
 
 use super::types::{EnvMap, ProviderExport};
+
+/// Invalidation fingerprint for a single watched file, captured at
+/// store time.
+#[derive(Debug, Clone, PartialEq)]
+struct WatchedFile {
+    /// Absolute path of the file.
+    path: PathBuf,
+    /// Modification time at store time. `None` when the file was
+    /// missing/unreadable — a later `Some` means it appeared.
+    mtime: Option<SystemTime>,
+    /// Content hash at store time, mirroring `mtime`'s `None` for a
+    /// missing/unreadable file. This is what lets a forward mtime bump
+    /// with byte-identical content stay a cache *hit* instead of
+    /// thrashing a re-export.
+    hash: Option<u64>,
+}
 
 /// Cache entry for a single `(worktree, plugin)` pair.
 #[derive(Debug, Clone)]
@@ -32,9 +62,9 @@ pub struct CacheEntry {
     /// Exported env. Kept separate from `ProviderExport` so we can
     /// clone cheaply without re-walking the watched list.
     pub env: EnvMap,
-    /// Files we watch for invalidation, paired with their mtime at the
-    /// time of the last successful export.
-    pub watched: Vec<(PathBuf, Option<SystemTime>)>,
+    /// Files we watch for invalidation, paired with the mtime +
+    /// content hash captured at the last successful export.
+    watched: Vec<WatchedFile>,
     /// When this entry was written.
     pub evaluated_at: SystemTime,
 }
@@ -51,54 +81,67 @@ impl EnvCache {
         Self::default()
     }
 
-    /// Return the cached entry if all watched files' current mtimes
-    /// match the stored values. Any change → stale → returns `None`.
+    /// Return the cached entry if its watched files are still fresh.
+    ///
+    /// "Fresh" is decided by the two-tier check in [`check_freshness`]:
+    /// an unchanged mtime is an instant hit; an mtime that moved
+    /// forward but left content byte-identical is *also* a hit (and we
+    /// heal the stored mtime so the next call is cheap again); a real
+    /// content change — or a watched file appearing/disappearing —
+    /// returns `None`.
     pub fn get_fresh(&self, worktree: &Path, plugin: &str) -> Option<CacheEntry> {
         let key = (worktree.to_path_buf(), plugin.to_string());
         let guard = self.entries.read().unwrap();
-        let entry = guard.get(&key)?.clone();
+        let mut entry = guard.get(&key)?.clone();
         drop(guard);
 
-        if all_mtimes_match(&entry.watched) {
-            Some(entry)
-        } else {
-            None
+        match check_freshness(&entry.watched) {
+            Freshness::Fresh => Some(entry),
+            Freshness::Rehashed(refreshed) => {
+                entry.watched = refreshed;
+                // Heal the stored entry so a future lookup hits the
+                // cheap mtime path instead of re-hashing. Best-effort:
+                // only write back if the entry wasn't replaced or
+                // evicted in the meantime (same `evaluated_at`).
+                if let Ok(mut guard) = self.entries.write()
+                    && let Some(stored) = guard.get_mut(&key)
+                    && stored.evaluated_at == entry.evaluated_at
+                {
+                    stored.watched = entry.watched.clone();
+                }
+                Some(entry)
+            }
+            Freshness::Stale => None,
         }
     }
 
     /// Store (or overwrite) the cache entry for `(worktree, plugin)`.
     ///
     /// Returns `Some(evaluated_at)` if the entry was stored, or `None`
-    /// if it was dropped because a watched file's mtime changed between
-    /// the two snapshots we take (before-store and after-store). The
-    /// race we're guarding:
+    /// if it was dropped because a watched file changed between the
+    /// two fingerprint snapshots we take (before-store and
+    /// after-store). The race we're guarding:
     ///
     ///   t0: plugin's `export()` captures env based on on-disk content
-    ///   t1: we snapshot mtimes ("first")
-    ///   t2: we snapshot mtimes again ("second")
+    ///   t1: we snapshot mtime+hash ("first")
+    ///   t2: we snapshot mtime+hash again ("second")
     ///   t3: caller stores the entry
     ///
     /// If a file changes during [t1, t2] we see it here and refuse to
-    /// cache — the next resolve will re-run `export()` and pick up the
+    /// cache — the next resolve re-runs `export()` and picks up the
     /// fresh state. A change during [t0, t1] still slips through (we
-    /// cache stale env under the post-change mtime), but the window is
-    /// microseconds and — being bounded above by the slowest syscall —
-    /// small enough that not-caching-at-all would be more wasteful than
-    /// the occasional stale turn. File-content hashing would fully close
-    /// this and is v2 work.
+    /// cache stale env under the post-change fingerprint), but the
+    /// window is microseconds — small enough that not-caching-at-all
+    /// would be more wasteful than the occasional stale turn.
     pub fn put(
         &self,
         worktree: &Path,
         plugin: &str,
         export: &ProviderExport,
     ) -> Option<SystemTime> {
-        let first: Vec<(PathBuf, Option<SystemTime>)> = export
-            .watched
-            .iter()
-            .map(|p| (p.clone(), mtime(p)))
-            .collect();
-        let second: Vec<Option<SystemTime>> = export.watched.iter().map(|p| mtime(p)).collect();
-        if first.iter().zip(second.iter()).any(|((_, a), b)| a != b) {
+        let first: Vec<WatchedFile> = export.watched.iter().map(|p| snapshot(p)).collect();
+        let second: Vec<WatchedFile> = export.watched.iter().map(|p| snapshot(p)).collect();
+        if first != second {
             return None;
         }
 
@@ -124,7 +167,7 @@ impl EnvCache {
             .read()
             .unwrap()
             .get(&key)
-            .map(|entry| entry.watched.iter().map(|(p, _)| p.clone()).collect())
+            .map(|entry| entry.watched.iter().map(|wf| wf.path.clone()).collect())
             .unwrap_or_default()
     }
 
@@ -162,15 +205,80 @@ impl EnvCache {
     }
 }
 
+/// Outcome of re-checking a cache entry's watched files against the
+/// current filesystem state.
+enum Freshness {
+    /// Every watched file matched on mtime alone — the cheap path,
+    /// no file reads.
+    Fresh,
+    /// One or more files' mtimes moved but their content hashes still
+    /// match. The entry is still valid; the vec carries the watched
+    /// list with refreshed mtimes so the caller can write it back and
+    /// let the next check take the cheap mtime path.
+    Rehashed(Vec<WatchedFile>),
+    /// A watched file's content actually changed, or it appeared /
+    /// disappeared — the entry must be re-exported.
+    Stale,
+}
+
+/// Two-tier freshness check: mtime first (cheap), content hash only on
+/// an mtime mismatch (slow path). See the module doc for the rationale
+/// — a bare mtime bump is not proof a file's bytes changed.
+fn check_freshness(watched: &[WatchedFile]) -> Freshness {
+    let mut refreshed: Option<Vec<WatchedFile>> = None;
+    for (i, wf) in watched.iter().enumerate() {
+        let current_mtime = mtime(&wf.path);
+        if current_mtime == wf.mtime {
+            continue;
+        }
+        // mtime moved — fall back to a content hash before declaring
+        // the entry stale. `git checkout`, `touch`, nix-direnv
+        // re-evaluation, and save-on-noop editors all bump mtime
+        // forward without changing a byte; those must NOT invalidate.
+        if content_hash(&wf.path) != wf.hash {
+            return Freshness::Stale;
+        }
+        // Same bytes, new mtime: heal the stored mtime so the next
+        // check is a cheap compare again instead of another hash.
+        refreshed.get_or_insert_with(|| watched.to_vec())[i].mtime = current_mtime;
+    }
+    match refreshed {
+        Some(list) => Freshness::Rehashed(list),
+        None => Freshness::Fresh,
+    }
+}
+
+/// Capture a watched file's invalidation fingerprint (mtime + content
+/// hash) at store time.
+fn snapshot(path: &Path) -> WatchedFile {
+    WatchedFile {
+        path: path.to_path_buf(),
+        mtime: mtime(path),
+        hash: content_hash(path),
+    }
+}
+
 /// Read a file's mtime, returning `None` if the file is missing or
-/// unreadable. A missing file on lookup counts as "mtime changed" vs.
-/// its previous `Some(_)` — it will not match, so the cache misses.
+/// unreadable. A missing file on lookup counts as "changed" vs. its
+/// previous `Some(_)` — it will not match, so the cache misses.
 fn mtime(path: &Path) -> Option<SystemTime> {
     std::fs::metadata(path).ok()?.modified().ok()
 }
 
-fn all_mtimes_match(watched: &[(PathBuf, Option<SystemTime>)]) -> bool {
-    watched.iter().all(|(p, stored)| mtime(p) == *stored)
+/// Hash a file's full contents, returning `None` for a missing or
+/// unreadable file (mirroring [`mtime`]). Only called on the slow path
+/// — an mtime mismatch — so the read cost is paid once per benign
+/// mtime bump, not on every cache lookup.
+///
+/// `DefaultHasher` (SipHash) is fine here: the digest only ever lives
+/// in-memory and is compared within a single process run, so the
+/// "not stable across Rust versions" caveat doesn't apply, and a
+/// 64-bit collision on a handful of small config files is negligible.
+fn content_hash(path: &Path) -> Option<u64> {
+    let bytes = std::fs::read(path).ok()?;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    Some(hasher.finish())
 }
 
 #[cfg(test)]
@@ -222,7 +330,51 @@ mod tests {
 
         assert!(
             cache.get_fresh(tmp.path(), "env-direnv").is_none(),
-            "mtime change must invalidate"
+            "mtime change with new content must invalidate"
+        );
+    }
+
+    #[test]
+    fn get_fresh_survives_mtime_bump_with_identical_content() {
+        // The core regression for issue #888: `git checkout`, `touch`,
+        // nix-direnv re-evaluation, and save-on-noop editors all move a
+        // watched file's mtime forward without changing its bytes. The
+        // content-hash fallback must keep the entry a cache *hit*.
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("flake.lock");
+        let content = r#"{ "nodes": {}, "version": 7 }"#;
+        std::fs::write(&file, content).unwrap();
+
+        let cache = EnvCache::new();
+        assert!(
+            cache
+                .put(tmp.path(), "env-direnv", &export_with_watched(&file))
+                .is_some()
+        );
+        assert!(cache.get_fresh(tmp.path(), "env-direnv").is_some());
+
+        // Bump mtime forward, byte-for-byte identical content.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(&file, content).unwrap();
+
+        assert!(
+            cache.get_fresh(tmp.path(), "env-direnv").is_some(),
+            "identical content must stay a cache hit despite the mtime bump"
+        );
+
+        // The heal step should have rewritten the stored mtime, so a
+        // second lookup is fresh too (and takes the cheap path).
+        assert!(
+            cache.get_fresh(tmp.path(), "env-direnv").is_some(),
+            "healed entry must remain a cache hit on the next lookup"
+        );
+
+        // A real content change still invalidates.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(&file, r#"{ "nodes": { "x": 1 }, "version": 7 }"#).unwrap();
+        assert!(
+            cache.get_fresh(tmp.path(), "env-direnv").is_none(),
+            "an actual content change must still invalidate"
         );
     }
 

--- a/src/env_provider/cache.rs
+++ b/src/env_provider/cache.rs
@@ -207,19 +207,49 @@ impl EnvCache {
     /// to evict, nothing to notify.
     pub fn invalidate_if_stale(&self, worktree: &Path, plugin: &str) -> bool {
         let key = (worktree.to_path_buf(), plugin.to_string());
-        let mut guard = self.entries.write().unwrap();
-        let Some(entry) = guard.get_mut(&key) else {
-            return false;
+        // Snapshot the watched list under a read lock, then release it
+        // before `check_freshness` runs its stat/read syscalls — same
+        // discipline as `get_fresh`. An IO-heavy watcher burst must not
+        // block unrelated `get_fresh` / `put` calls (the cache is one
+        // `RwLock` shared across all worktrees and plugins).
+        let (watched, evaluated_at) = {
+            let guard = self.entries.read().unwrap();
+            match guard.get(&key) {
+                Some(entry) => (entry.watched.clone(), entry.evaluated_at),
+                None => return false,
+            }
         };
-        match check_freshness(&entry.watched) {
+
+        match check_freshness(&watched) {
             Freshness::Fresh => false,
             Freshness::Rehashed(refreshed) => {
-                entry.watched = refreshed;
+                // Heal the stored mtimes — best-effort, and only if the
+                // entry is still the one we checked (a concurrent `put`
+                // would have replaced it with a fresher snapshot).
+                if let Ok(mut guard) = self.entries.write()
+                    && let Some(stored) = guard.get_mut(&key)
+                    && stored.evaluated_at == evaluated_at
+                {
+                    stored.watched = refreshed;
+                }
                 false
             }
             Freshness::Stale => {
-                guard.remove(&key);
-                true
+                // Evict — but only if the entry is still the one we
+                // checked. A `put` racing between our read snapshot and
+                // here means a fresh export already landed; don't drop
+                // that one (and report "not invalidated" so the caller
+                // skips the UI event).
+                let mut guard = self.entries.write().unwrap();
+                if guard
+                    .get(&key)
+                    .is_some_and(|stored| stored.evaluated_at == evaluated_at)
+                {
+                    guard.remove(&key);
+                    true
+                } else {
+                    false
+                }
             }
         }
     }
@@ -273,7 +303,22 @@ fn check_freshness(watched: &[WatchedFile]) -> Freshness {
         // the entry stale. `git checkout`, `touch`, nix-direnv
         // re-evaluation, and save-on-noop editors all bump mtime
         // forward without changing a byte; those must NOT invalidate.
-        if content_hash(&wf.path) != wf.hash {
+        //
+        // The hash equality only proves "unchanged" when BOTH the
+        // stored and current hashes exist. `content_hash` returns
+        // `None` for anything it can't read as a byte stream — most
+        // importantly a watched *directory* (a `watch_dir` target),
+        // but also a file gone unreadable. For those we cannot prove
+        // byte-equality, so an mtime change is treated as stale: the
+        // correct conservative fallback (a directory's mtime moving
+        // means an entry was added/removed inside it). Without the
+        // `Some`/`Some` guard a watched directory would hash to
+        // `None == None` and be wrongly healed.
+        let unchanged = matches!(
+            (wf.hash, content_hash(&wf.path)),
+            (Some(stored), Some(current)) if stored == current
+        );
+        if !unchanged {
             return Freshness::Stale;
         }
         // Same bytes, new mtime: heal the stored mtime so the next
@@ -413,6 +458,37 @@ mod tests {
         assert!(
             cache.get_fresh(tmp.path(), "env-direnv").is_none(),
             "an actual content change must still invalidate"
+        );
+    }
+
+    #[test]
+    fn get_fresh_invalidates_on_watched_directory_mtime_change() {
+        // A `watch_dir` target is a directory — `content_hash` can't
+        // read it as a byte stream, so its stored hash is `None`. An
+        // mtime bump (a file added/removed inside) must still
+        // invalidate: with no content hash to compare, mtime is the
+        // only signal, and a directory's mtime moving is a real
+        // change. Guards against a `None == None` hash compare wrongly
+        // "healing" a directory whose contents changed.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("watched_dir");
+        std::fs::create_dir(&dir).unwrap();
+
+        let cache = EnvCache::new();
+        assert!(
+            cache
+                .put(tmp.path(), "env-direnv", &export_with_watched(&dir))
+                .is_some()
+        );
+        assert!(cache.get_fresh(tmp.path(), "env-direnv").is_some());
+
+        // Add a file inside → the directory's own mtime moves.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(dir.join("new.txt"), "x").unwrap();
+
+        assert!(
+            cache.get_fresh(tmp.path(), "env-direnv").is_none(),
+            "a watched directory whose contents changed must invalidate"
         );
     }
 

--- a/src/env_provider/cache.rs
+++ b/src/env_provider/cache.rs
@@ -186,6 +186,44 @@ impl EnvCache {
         }
     }
 
+    /// Re-check a single `(worktree, plugin)` entry against the
+    /// filesystem and evict it **only if a watched file's content
+    /// actually changed**. Returns `true` if the entry was evicted.
+    ///
+    /// This is the content-aware counterpart to [`invalidate`], meant
+    /// for the fs-watcher callback. A watcher event means *some*
+    /// watched path was touched — but `touch`, `git checkout`,
+    /// save-on-noop editors, and nix-direnv re-evaluation all fire
+    /// events without changing bytes. Evicting unconditionally on
+    /// every event is exactly the cache thrash issue #888 is about:
+    /// the reactive watcher would otherwise drop the entry before
+    /// [`get_fresh`]'s own two-tier check ever gets to run.
+    ///
+    /// So this applies the same [`check_freshness`] test the lazy
+    /// path uses: unchanged content keeps the entry (and heals its
+    /// stored mtimes so the next `get_fresh` is cheap); genuinely
+    /// changed content removes it and returns `true` so the caller
+    /// can notify the UI. A missing entry returns `false` — nothing
+    /// to evict, nothing to notify.
+    pub fn invalidate_if_stale(&self, worktree: &Path, plugin: &str) -> bool {
+        let key = (worktree.to_path_buf(), plugin.to_string());
+        let mut guard = self.entries.write().unwrap();
+        let Some(entry) = guard.get_mut(&key) else {
+            return false;
+        };
+        match check_freshness(&entry.watched) {
+            Freshness::Fresh => false,
+            Freshness::Rehashed(refreshed) => {
+                entry.watched = refreshed;
+                false
+            }
+            Freshness::Stale => {
+                guard.remove(&key);
+                true
+            }
+        }
+    }
+
     /// Forget every cache entry for a given plugin, across all
     /// worktrees. Called when a plugin's global enable state or
     /// settings change — any cached export is potentially stale.
@@ -424,6 +462,55 @@ mod tests {
         assert_eq!(cache.len(), 1);
         assert!(cache.get_fresh(tmp.path(), "env-direnv").is_none());
         assert!(cache.get_fresh(tmp.path(), "env-mise").is_some());
+    }
+
+    #[test]
+    fn invalidate_if_stale_keeps_entry_on_byte_identical_change() {
+        // The reactive-watcher counterpart to
+        // `get_fresh_survives_mtime_bump_with_identical_content`: a
+        // watcher event fired by a `touch` / checkout / save-on-noop
+        // must NOT evict when the bytes are unchanged (issue #888).
+        // Without this, the watcher drops the entry before
+        // `get_fresh`'s own two-tier check can run.
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("flake.lock");
+        let content = r#"{ "nodes": {}, "version": 7 }"#;
+        std::fs::write(&file, content).unwrap();
+
+        let cache = EnvCache::new();
+        assert!(
+            cache
+                .put(tmp.path(), "env-direnv", &export_with_watched(&file))
+                .is_some()
+        );
+
+        // mtime bump, identical content → watcher event, but no evict.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(&file, content).unwrap();
+        assert!(
+            !cache.invalidate_if_stale(tmp.path(), "env-direnv"),
+            "a byte-identical change must not evict"
+        );
+        assert!(
+            cache.get_fresh(tmp.path(), "env-direnv").is_some(),
+            "entry must survive a byte-identical watcher event"
+        );
+
+        // A real content change → eviction, returns true.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(&file, r#"{ "nodes": { "x": 1 }, "version": 7 }"#).unwrap();
+        assert!(
+            cache.invalidate_if_stale(tmp.path(), "env-direnv"),
+            "a real content change must evict"
+        );
+        assert!(cache.get_fresh(tmp.path(), "env-direnv").is_none());
+    }
+
+    #[test]
+    fn invalidate_if_stale_on_missing_entry_is_a_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = EnvCache::new();
+        assert!(!cache.invalidate_if_stale(tmp.path(), "env-direnv"));
     }
 
     #[test]

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -740,6 +740,154 @@ fn direnv_export_stamp_filter_keeps_legit_paths_containing_direnv_segments() {
 }
 
 #[test]
+fn direnv_export_watches_list_drops_nix_direnv_layout_artifacts() {
+    // Regression for issue #888: nix-direnv writes derived build
+    // artifacts into the worktree's own `.direnv/` directory
+    // (`flake-profile-<sha>` symlinks + `.rc`, `flake-inputs/`,
+    // `bin/nix-direnv-reload`, `added_paths`) and direnv reports them
+    // in `DIRENV_WATCHES` for its shell hook. Watching them is
+    // self-defeating — every successful evaluation re-touches one and
+    // primes the next spurious cache eviction. They must be dropped;
+    // the real source files outside `.direnv/` must survive.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".envrc"), "use flake\n").unwrap();
+    let worktree = tmp.path().to_string_lossy().into_owned();
+    let envrc_path = format!("{worktree}/.envrc");
+    let flake_nix = format!("{worktree}/flake.nix");
+    let flake_lock = format!("{worktree}/flake.lock");
+    let layout_artifacts = [
+        format!("{worktree}/.direnv/flake-profile-3b9c1f2a"),
+        format!("{worktree}/.direnv/flake-profile-3b9c1f2a.rc"),
+        format!("{worktree}/.direnv/flake-inputs/abcd1234"),
+        format!("{worktree}/.direnv/bin/nix-direnv-reload"),
+        format!("{worktree}/.direnv/added_paths"),
+    ];
+    let mut paths: Vec<&str> = vec![envrc_path.as_str(), flake_nix.as_str(), flake_lock.as_str()];
+    paths.extend(layout_artifacts.iter().map(|s| s.as_str()));
+    let encoded = encode_direnv_watches(&paths);
+
+    let lua = make_vm("env-direnv", &["direnv"], tmp.path());
+    let env_json = serde_json::to_string(&serde_json::json!({
+        "FOO": "bar",
+        "DIRENV_WATCHES": encoded,
+    }))
+    .unwrap();
+    let stub = format!(
+        r#"
+        host.exec = function(cmd, args)
+            if cmd ~= "direnv" then error("expected cmd='direnv', got: " .. tostring(cmd)) end
+            if type(args) ~= "table" or args[1] ~= "export" or args[2] ~= "json" or args[3] ~= nil then
+                error("expected args={{'export','json'}}")
+            end
+            return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
+        end
+        "#
+    );
+    lua.load(&stub).exec().unwrap();
+
+    let script = format!(
+        r#"
+        local M = (function() {src} end)()
+        return M.export({{ worktree = "{path}" }})
+        "#,
+        src = DIRENV_SRC,
+        path = worktree.replace('\\', "\\\\"),
+    );
+    let result: mlua::Table = lua.load(&script).eval().unwrap();
+    let watched_tbl: mlua::Table = result.get("watched").unwrap();
+    let len = watched_tbl.len().unwrap() as usize;
+    let watched: Vec<String> = (1..=len)
+        .map(|i| watched_tbl.get::<String>(i).unwrap())
+        .collect();
+
+    // Real source files survive — the legitimate invalidation triggers.
+    for src_path in [&envrc_path, &flake_nix, &flake_lock] {
+        assert!(
+            watched.contains(src_path),
+            "{src_path} must survive the .direnv layout filter; got {watched:?}"
+        );
+    }
+    // nix-direnv's internal artifacts are dropped.
+    for artifact in &layout_artifacts {
+        assert!(
+            !watched.contains(artifact),
+            "nix-direnv artifact {artifact} leaked into watched; cache will thrash. got {watched:?}"
+        );
+    }
+}
+
+#[test]
+fn direnv_export_layout_filter_is_anchored_to_worktree() {
+    // The `.direnv/` filter must be anchored to `<worktree>/.direnv/`,
+    // not match a bare `.direnv` path component anywhere. A workspace
+    // whose worktree itself happens to live under an unrelated
+    // `.direnv/` ancestor directory must keep its real `.envrc` /
+    // `flake.lock` — dropping those would silently stop the EnvCache
+    // from noticing genuine edits.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".envrc"), "use flake\n").unwrap();
+    // A worktree path that contains `.direnv` as an ancestor segment.
+    let worktree = "/home/dev/.direnv/checkouts/myrepo";
+    let envrc_path = format!("{worktree}/.envrc");
+    let flake_lock = format!("{worktree}/flake.lock");
+    // A genuine nix-direnv artifact under THIS worktree's own
+    // `.direnv/` — still must be dropped.
+    let real_artifact = format!("{worktree}/.direnv/flake-profile-deadbeef");
+    let encoded = encode_direnv_watches(&[
+        envrc_path.as_str(),
+        flake_lock.as_str(),
+        real_artifact.as_str(),
+    ]);
+
+    let lua = make_vm("env-direnv", &["direnv"], tmp.path());
+    let env_json = serde_json::to_string(&serde_json::json!({
+        "FOO": "bar",
+        "DIRENV_WATCHES": encoded,
+    }))
+    .unwrap();
+    let stub = format!(
+        r#"
+        host.exec = function(cmd, args)
+            if cmd ~= "direnv" then error("expected cmd='direnv', got: " .. tostring(cmd)) end
+            if type(args) ~= "table" or args[1] ~= "export" or args[2] ~= "json" or args[3] ~= nil then
+                error("expected args={{'export','json'}}")
+            end
+            return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
+        end
+        "#
+    );
+    lua.load(&stub).exec().unwrap();
+
+    let script = format!(
+        r#"
+        local M = (function() {src} end)()
+        return M.export({{ worktree = "{path}" }})
+        "#,
+        src = DIRENV_SRC,
+        path = worktree.replace('\\', "\\\\"),
+    );
+    let result: mlua::Table = lua.load(&script).eval().unwrap();
+    let watched_tbl: mlua::Table = result.get("watched").unwrap();
+    let len = watched_tbl.len().unwrap() as usize;
+    let watched: Vec<String> = (1..=len)
+        .map(|i| watched_tbl.get::<String>(i).unwrap())
+        .collect();
+
+    assert!(
+        watched.contains(&envrc_path),
+        ".envrc under a `.direnv` ancestor must survive; got {watched:?}"
+    );
+    assert!(
+        watched.contains(&flake_lock),
+        "flake.lock under a `.direnv` ancestor must survive; got {watched:?}"
+    );
+    assert!(
+        !watched.contains(&real_artifact),
+        "the worktree's own .direnv/ artifact must still be dropped; got {watched:?}"
+    );
+}
+
+#[test]
 fn direnv_export_strip_is_prefix_based_for_future_markers() {
     // The strip matches `^DIRENV_` rather than a hardcoded deny-list,
     // so if direnv ships a new internal marker (e.g. `DIRENV_LAYOUT_*`

--- a/src/env_provider/watcher.rs
+++ b/src/env_provider/watcher.rs
@@ -114,11 +114,19 @@ struct WatcherState {
 impl EnvWatcher {
     /// Build a watcher. The callback fires on every detected change
     /// to any registered path, once per `(worktree, plugin)` key that
-    /// was subscribed to it. Typical implementation:
+    /// was subscribed to it. A filesystem event is necessary but not
+    /// sufficient for eviction — `touch` / `git checkout` /
+    /// save-on-noop bump mtimes without changing bytes — so the
+    /// callback should funnel through `EnvCache::invalidate_if_stale`
+    /// (content-aware) rather than `invalidate` (unconditional), and
+    /// only notify the UI when it actually evicted. Typical
+    /// implementation:
     ///
     /// ```ignore
     /// EnvWatcher::new(Arc::new(move |worktree, plugin| {
-    ///     cache.invalidate(worktree, Some(plugin));
+    ///     if !cache.invalidate_if_stale(worktree, plugin) {
+    ///         return;
+    ///     }
     ///     let _ = app_handle.emit("env-cache-invalidated",
     ///         EnvCacheInvalidatedPayload {
     ///             worktree_path: worktree.to_string_lossy().into(),

--- a/src/env_provider/watcher.rs
+++ b/src/env_provider/watcher.rs
@@ -182,6 +182,19 @@ impl EnvWatcher {
             // re-acquire the lock).
             drop(state);
             for (worktree, plugin) in fired {
+                // One line per invalidation so a "direnv reloaded but I
+                // changed nothing" report can be traced back to the
+                // exact watched path that fired. `event.paths` is the
+                // raw backend report; the matched key is what the
+                // callback evicts.
+                tracing::debug!(
+                    target: "claudette::env-watcher",
+                    worktree = %worktree.display(),
+                    plugin = %plugin,
+                    paths = ?event.paths,
+                    kind = ?event.kind,
+                    "watched path changed; invalidating env cache",
+                );
                 cb(&worktree, &plugin);
             }
         };

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
@@ -507,6 +507,69 @@ describe("useWorkspaceEnvironmentPreparation", () => {
     }
   });
 
+  it("does not re-flip a completed workspace to 'preparing' after a dropped Tauri response", async () => {
+    // Regression for the Copilot review finding on PR #912: on a
+    // dropped Tauri response the prep promise never settles, so
+    // `.then` / `.catch` never run `clearPreparingTimer()`. The
+    // backend still emits `complete`, which finalizes the workspace —
+    // and must ALSO cancel the pending spinner-delay timer. Otherwise
+    // the orphaned timer fires 150ms later, sees a non-"preparing"
+    // status, and drags the finished workspace back to "preparing":
+    // a stuck, blocked composer.
+    vi.useFakeTimers();
+    try {
+      serviceMocks.prepareWorkspaceEnvironment.mockReturnValue(
+        new Promise<void>(() => undefined),
+      );
+      useAppStore.setState({
+        selectedWorkspaceId: "ws-1",
+        workspaces: [makeWorkspace()],
+      });
+
+      const { fire } = await withCapturedProgressListener();
+
+      await renderHarness();
+
+      // A cache-miss resolve completing entirely within the spinner
+      // delay window: started → preparing, complete → ready.
+      fire({
+        workspace_id: "ws-1",
+        plugin: "env-direnv",
+        phase: "started",
+        elapsed_ms: 0,
+      });
+      fire({
+        workspace_id: "ws-1",
+        plugin: "env-direnv",
+        phase: "finished",
+        elapsed_ms: 5,
+        ok: true,
+      });
+      fire({
+        workspace_id: "ws-1",
+        plugin: "",
+        phase: "complete",
+        elapsed_ms: 0,
+      });
+      expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+        status: "ready",
+      });
+
+      // `complete` must have cancelled the spinner-delay timer —
+      // crossing the delay must NOT regress the finished workspace.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(
+          __TEST__.PREPARING_SPINNER_DELAY_MS + 500,
+        );
+      });
+      expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+        status: "ready",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("transitions to 'error' on 'complete' when any plugin reported failure (dropped Err response recovery)", async () => {
     // The Windows IPC-drop variant where the bug bites hardest: the
     // backend prep returned Err (e.g. direnv .envrc blocked), but

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
@@ -20,7 +20,10 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockResolvedValue(() => undefined),
 }));
 
-import { useWorkspaceEnvironmentPreparation } from "./useWorkspaceEnvironmentPreparation";
+import {
+  __TEST__,
+  useWorkspaceEnvironmentPreparation,
+} from "./useWorkspaceEnvironmentPreparation";
 
 function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
   return {
@@ -263,59 +266,159 @@ describe("useWorkspaceEnvironmentPreparation", () => {
     expect(serviceMocks.prepareWorkspaceEnvironment).toHaveBeenCalledTimes(1);
   });
 
-  it("leaves status at 'preparing' when selection changes mid-flight; cancelled guard prevents stale resolution from toasting", async () => {
-    // Previously this test pinned cleanup-sets-idle behavior. That
-    // behaviour was the source of a Windows-specific UI lock: when
-    // WebView2 dropped the Tauri response message for the prep
-    // command, the second mount's `cancelled` guard swallowed any
-    // late resolution, and status stayed at "idle" / "preparing"
-    // forever with no path back to "ready". The cleanup no longer
-    // mutates status, and the `cancelled` flag is retained only to
-    // suppress stale toasts from `.catch`. The actual recovery for
-    // a dropped Tauri response lives in the Complete progress event
-    // — see the "recovers from a dropped Tauri response" test below.
-    let resolvePreparation!: () => void;
-    serviceMocks.prepareWorkspaceEnvironment.mockReturnValue(
-      new Promise<void>((resolve) => {
-        resolvePreparation = resolve;
-      }),
-    );
-    useAppStore.setState({
-      selectedWorkspaceId: "ws-1",
-      workspaces: [makeWorkspace()],
-    });
+  it("delays the 'preparing' spinner and keeps it across a mid-flight selection change", async () => {
+    // Issue #888 hot-cache fix: the workspace is NOT flipped to
+    // "preparing" synchronously on selection — a cached resolve would
+    // return first and the spinner would never have been warranted.
+    // Only once the spinner delay elapses with the resolve still in
+    // flight does the status become "preparing".
+    //
+    // This also pins the original mid-flight contract: once
+    // "preparing", a selection change runs cleanup (which does NOT
+    // mutate status) and sets the `cancelled` guard, so a late stale
+    // resolution can't silently flip the abandoned workspace to
+    // "ready". The Complete progress event is the lifecycle-
+    // independent recovery path — see the "recovers from a dropped
+    // Tauri response" test below.
+    vi.useFakeTimers();
+    try {
+      let resolvePreparation!: () => void;
+      serviceMocks.prepareWorkspaceEnvironment.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolvePreparation = resolve;
+        }),
+      );
+      useAppStore.setState({
+        selectedWorkspaceId: "ws-1",
+        workspaces: [makeWorkspace()],
+      });
 
-    await renderHarness();
-    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
-      status: "preparing",
-    });
+      await renderHarness();
+      // No synchronous "preparing" — that was the flicker bug.
+      expect(
+        useAppStore.getState().workspaceEnvironment["ws-1"],
+      ).toBeUndefined();
 
-    act(() => {
-      useAppStore.setState({ selectedWorkspaceId: null });
-    });
+      // Spinner delay elapses, resolve still pending → "preparing".
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(
+          __TEST__.PREPARING_SPINNER_DELAY_MS + 50,
+        );
+      });
+      expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+        status: "preparing",
+      });
 
-    // Cleanup ran but does NOT touch status — the in-flight prep
-    // promise is still pending. The user-visible recovery for a
-    // mid-flight navigate-away lives in the Complete progress
-    // event (Rust-side Drop fires it regardless of where the
-    // resolve was initiated), not in this hook's cleanup.
-    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
-      status: "preparing",
-    });
+      act(() => {
+        useAppStore.setState({ selectedWorkspaceId: null });
+      });
 
-    await act(async () => {
-      resolvePreparation();
-      await Promise.resolve();
-    });
+      // Cleanup ran but does NOT touch status — the in-flight prep
+      // promise is still pending. The user-visible recovery for a
+      // mid-flight navigate-away lives in the Complete progress
+      // event (Rust-side Drop fires it regardless of where the
+      // resolve was initiated), not in this hook's cleanup.
+      expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+        status: "preparing",
+      });
 
-    // The `.then` checks `cancelled` (set true by cleanup) and
-    // returns early — status is NOT silently flipped to "ready"
-    // for a workspace whose effect has torn down. The Complete
-    // progress event remains the lifecycle-independent recovery
-    // path for any workspace genuinely stuck at "preparing".
-    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
-      status: "preparing",
-    });
+      await act(async () => {
+        resolvePreparation();
+        await Promise.resolve();
+      });
+
+      // The `.then` checks `cancelled` (set true by cleanup) and
+      // returns early — status is NOT silently flipped to "ready"
+      // for a workspace whose effect has torn down. The Complete
+      // progress event remains the lifecycle-independent recovery
+      // path for any workspace genuinely stuck at "preparing".
+      expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+        status: "preparing",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not flash 'preparing' on a hot-cache resolve that beats the spinner delay", async () => {
+    // The core issue #888 acceptance: re-selecting an already-loaded
+    // workspace must not show "Preparing direnv…". The resolve is
+    // awaited first; the cached round-trip settles well within the
+    // spinner delay, the timer is cleared, and the status goes
+    // straight to "ready" — never through "preparing".
+    vi.useFakeTimers();
+    try {
+      serviceMocks.prepareWorkspaceEnvironment.mockResolvedValue(undefined);
+      useAppStore.setState({
+        selectedWorkspaceId: "ws-1",
+        workspaces: [makeWorkspace()],
+        workspaceEnvironment: { "ws-1": { status: "ready" } },
+      });
+
+      await renderHarness();
+      // Flush the resolved IPC promise's microtasks WITHOUT advancing
+      // wall-clock past the spinner delay.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Straight to "ready", no intermediate "preparing".
+      expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+        status: "ready",
+      });
+
+      // The pending spinner timer was cleared by the resolve, so
+      // crossing the delay cannot retroactively flip it.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(
+          __TEST__.PREPARING_SPINNER_DELAY_MS + 500,
+        );
+      });
+      expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+        status: "ready",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels the pending spinner when selection changes before the delay elapses", async () => {
+    // If the user switches away inside the spinner-delay window, the
+    // timer must be cleared on cleanup — otherwise the workspace they
+    // already left would flip to "preparing" after the fact.
+    vi.useFakeTimers();
+    try {
+      serviceMocks.prepareWorkspaceEnvironment.mockReturnValue(
+        new Promise<void>(() => undefined),
+      );
+      useAppStore.setState({
+        selectedWorkspaceId: "ws-1",
+        workspaces: [makeWorkspace()],
+      });
+
+      await renderHarness();
+      expect(
+        useAppStore.getState().workspaceEnvironment["ws-1"],
+      ).toBeUndefined();
+
+      // Switch away before the spinner delay elapses.
+      act(() => {
+        useAppStore.setState({ selectedWorkspaceId: null });
+      });
+
+      // Crossing the delay must not resurrect the spinner.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(
+          __TEST__.PREPARING_SPINNER_DELAY_MS + 500,
+        );
+      });
+      expect(
+        useAppStore.getState().workspaceEnvironment["ws-1"],
+      ).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   /**
@@ -359,38 +462,49 @@ describe("useWorkspaceEnvironmentPreparation", () => {
     // emits a `complete` progress event as the resolve loop tears
     // down. This test mimics that event and pins the recovery: any
     // workspace still showing `"preparing"` flips to `"ready"`.
-    serviceMocks.prepareWorkspaceEnvironment.mockReturnValue(
-      new Promise<void>(() => undefined),
-    );
-    useAppStore.setState({
-      selectedWorkspaceId: "ws-1",
-      workspaces: [makeWorkspace()],
-    });
+    //
+    // With the issue #888 spinner delay the workspace reaches
+    // "preparing" via the delay timer (the resolve never settles), and
+    // the `complete` event then flips it to "ready" exactly as before.
+    vi.useFakeTimers();
+    try {
+      serviceMocks.prepareWorkspaceEnvironment.mockReturnValue(
+        new Promise<void>(() => undefined),
+      );
+      useAppStore.setState({
+        selectedWorkspaceId: "ws-1",
+        workspaces: [makeWorkspace()],
+      });
 
-    const { fire } = await withCapturedProgressListener();
+      const { fire } = await withCapturedProgressListener();
 
-    await renderHarness();
-    await act(async () => {
-      await Promise.resolve();
-    });
+      await renderHarness();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(
+          __TEST__.PREPARING_SPINNER_DELAY_MS + 50,
+        );
+      });
 
-    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
-      status: "preparing",
-    });
+      expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+        status: "preparing",
+      });
 
-    // Fire the `complete` event the Rust-side sink would emit at the
-    // end of every resolve, regardless of which Tauri command
-    // initiated it.
-    fire({
-      workspace_id: "ws-1",
-      plugin: "",
-      phase: "complete",
-      elapsed_ms: 0,
-    });
+      // Fire the `complete` event the Rust-side sink would emit at the
+      // end of every resolve, regardless of which Tauri command
+      // initiated it.
+      fire({
+        workspace_id: "ws-1",
+        plugin: "",
+        phase: "complete",
+        elapsed_ms: 0,
+      });
 
-    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
-      status: "ready",
-    });
+      expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+        status: "ready",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("transitions to 'error' on 'complete' when any plugin reported failure (dropped Err response recovery)", async () => {

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
@@ -150,6 +150,16 @@ export function useWorkspaceEnvironmentPreparation() {
   // each Complete so a subsequent resolve starts fresh.
   const failedDuringResolveRef = useRef<Map<string, boolean>>(new Map());
 
+  // Per-workspace cancel functions for the pending spinner-delay
+  // timers armed by the per-selection effect below. The `complete`
+  // progress handler reaches in here to cancel a workspace's timer
+  // once its resolve is done — critical for the dropped-Tauri-
+  // response case, where the prep promise never settles so
+  // `.then`/`.catch` never run to clear the timer themselves. Without
+  // this a late timer fires after `complete` already finalized the
+  // workspace and re-flips it to "preparing" — a stuck, blocked UI.
+  const spinnerTimerClearsRef = useRef<Map<string, () => void>>(new Map());
+
   // Global listener: subscribe once per app session and route every
   // workspace_env_progress event into the store, regardless of which
   // workspace is currently selected. This lets the sidebar show a
@@ -184,6 +194,12 @@ export function useWorkspaceEnvironmentPreparation() {
         // the spawn_pty / agent-spawn paths where no dedicated
         // `.then` handler exists to finalize the status.
         setWorkspaceEnvironmentProgress(workspace_id, null);
+        // The resolve is done — cancel any pending spinner-delay timer
+        // for this workspace so it can't fire late and strand the
+        // workspace back at "preparing". This is the recovery for a
+        // dropped Tauri response, where the prep promise never settles
+        // and `.then`/`.catch` never clear the timer themselves.
+        spinnerTimerClearsRef.current.get(workspace_id)?.();
         const anyFailed = failed.get(workspace_id) ?? false;
         failed.delete(workspace_id);
         const cur =
@@ -319,17 +335,23 @@ export function useWorkspaceEnvironmentPreparation() {
     // that through `setWorkspaceEnvironmentProgress`, which forces the
     // status to "preparing" (with the richer per-plugin elapsed-time
     // fields the sidebar needs).
+    const spinnerTimers = spinnerTimerClearsRef.current;
     let preparingTimer: ReturnType<typeof setTimeout> | undefined = setTimeout(
       () => {
         preparingTimer = undefined;
+        spinnerTimers.delete(workspaceId);
         if (cancelled) return;
-        // If progress events already moved us to "preparing" (a real
-        // cold resolve is in flight), leave their `current_plugin` /
-        // `started_at` fields intact — a bare `setWorkspaceEnvironment`
-        // here would blank the sidebar's "(Ns)…" elapsed-time hint.
+        // Only promote a genuine pre-resolve state. A workspace the
+        // resolve already finalized (`ready` / `error`) must never be
+        // dragged back to "preparing" — and one a `started` progress
+        // event already moved to "preparing" keeps its richer
+        // `current_plugin` / `started_at` fields untouched. A slow
+        // resolve still in flight sits at `undefined` / `"idle"`; for
+        // that the spinner is warranted, and the eventual `complete`
+        // event recovers it back to "ready".
         const cur =
           useAppStore.getState().workspaceEnvironment[workspaceId]?.status;
-        if (cur !== "preparing") {
+        if (cur === undefined || cur === "idle") {
           setWorkspaceEnvironment(workspaceId, "preparing");
         }
       },
@@ -340,7 +362,12 @@ export function useWorkspaceEnvironmentPreparation() {
         clearTimeout(preparingTimer);
         preparingTimer = undefined;
       }
+      spinnerTimers.delete(workspaceId);
     };
+    // Register so the `complete` progress handler can cancel this
+    // timer even when the prep promise never settles (a dropped Tauri
+    // response) and `.then` / `.catch` never run to clear it.
+    spinnerTimers.set(workspaceId, clearPreparingTimer);
 
     // The recovery path for a dropped Tauri response on Windows
     // lives in the progress listener above: the `Complete` phase

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
@@ -89,6 +89,15 @@ function looksLikeMissingWorkspace(message: string): boolean {
   return message.toLowerCase().includes("workspace not found");
 }
 
+/**
+ * How long a workspace-selection env resolve may run before the UI is
+ * flipped to a "Preparing …" spinner. A cached resolve returns within
+ * one IPC round-trip — far under this threshold — so the common
+ * hot-cache path never renders the spinner at all (issue #888). Only a
+ * genuine cold export crosses it.
+ */
+const PREPARING_SPINNER_DELAY_MS = 150;
+
 export function useWorkspaceEnvironmentPreparation() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const selectedWorkspaceRemoteConnectionId = useAppStore((s) => {
@@ -292,7 +301,46 @@ export function useWorkspaceEnvironmentPreparation() {
 
     const workspaceId = selectedWorkspaceId;
     let cancelled = false;
-    setWorkspaceEnvironment(workspaceId, "preparing");
+
+    // Hot-cache path: don't flip the workspace to "preparing"
+    // synchronously. A cached env resolve returns within one IPC
+    // round-trip — the backend's work is sub-millisecond on a cache
+    // hit — so eagerly rendering "Preparing direnv…" guarantees a
+    // spinner flicker on every workspace switch even when nothing
+    // reloaded. Instead, arm a short timer: if the resolve hasn't come
+    // back by then it's a genuine cold export and the spinner is
+    // warranted. A fast (cached) resolve clears the timer before it
+    // fires, so the status goes straight to "ready" with no
+    // intermediate "preparing" frame.
+    //
+    // Cache *misses* still surface a spinner without waiting on this
+    // timer: the backend emits `workspace_env_progress {started}` for
+    // every plugin it actually runs, and the listener above routes
+    // that through `setWorkspaceEnvironmentProgress`, which forces the
+    // status to "preparing" (with the richer per-plugin elapsed-time
+    // fields the sidebar needs).
+    let preparingTimer: ReturnType<typeof setTimeout> | undefined = setTimeout(
+      () => {
+        preparingTimer = undefined;
+        if (cancelled) return;
+        // If progress events already moved us to "preparing" (a real
+        // cold resolve is in flight), leave their `current_plugin` /
+        // `started_at` fields intact — a bare `setWorkspaceEnvironment`
+        // here would blank the sidebar's "(Ns)…" elapsed-time hint.
+        const cur =
+          useAppStore.getState().workspaceEnvironment[workspaceId]?.status;
+        if (cur !== "preparing") {
+          setWorkspaceEnvironment(workspaceId, "preparing");
+        }
+      },
+      PREPARING_SPINNER_DELAY_MS,
+    );
+    const clearPreparingTimer = () => {
+      if (preparingTimer !== undefined) {
+        clearTimeout(preparingTimer);
+        preparingTimer = undefined;
+      }
+    };
 
     // The recovery path for a dropped Tauri response on Windows
     // lives in the progress listener above: the `Complete` phase
@@ -305,6 +353,7 @@ export function useWorkspaceEnvironmentPreparation() {
     // surface a stale toast for a workspace the user already left.
     prepareWorkspaceEnvironment(workspaceId)
       .then((payload) => {
+        clearPreparingTimer();
         if (cancelled) return;
         // The backend also emits `workspace_env_trust_needed`, but
         // Tauri listener registration is async. On a fast cached
@@ -317,6 +366,7 @@ export function useWorkspaceEnvironmentPreparation() {
         setWorkspaceEnvironment(workspaceId, "ready");
       })
       .catch((err) => {
+        clearPreparingTimer();
         if (cancelled) return;
         const message = String(err);
         // The workspace row is gone from the DB but still showing in the
@@ -347,7 +397,10 @@ export function useWorkspaceEnvironmentPreparation() {
       // to permanently lock the UI when the second-invocation
       // closure swallowed its own resolution. The `Complete` event
       // (Rust-side Drop) is the recovery mechanism; nothing here
-      // needs to force an interim state.
+      // needs to force an interim state. We do cancel the pending
+      // spinner timer so a workspace the user already left can't
+      // flip to "preparing" after the fact.
+      clearPreparingTimer();
       cancelled = true;
     };
   }, [
@@ -363,4 +416,8 @@ export function useWorkspaceEnvironmentPreparation() {
 
 // Internal: exposed for vitest. The hook is the only production
 // consumer.
-export const __TEST__ = { looksLikeTrustError, looksLikeMissingWorkspace };
+export const __TEST__ = {
+  looksLikeTrustError,
+  looksLikeMissingWorkspace,
+  PREPARING_SPINNER_DELAY_MS,
+};


### PR DESCRIPTION
## Summary

Fixes #888 — an already-loaded direnv / nix-direnv workspace would repeatedly fall back to `Preparing direnv (Ns)…` (mid agent-turn, or on re-selection) even though no `.envrc` / `flake.nix` / `flake.lock` content changed.

The issue identified three independent causes; this PR fixes all three, plus the gap a Codex peer review surfaced.

## Root causes & fixes

### 1. nix-direnv layout artifacts polluted the watch list (`plugins/env-direnv/init.lua`)
nix-direnv writes derived build artifacts into the worktree's own `.direnv/` directory on **every** evaluation — `flake-profile-<sha>` symlinks, `flake-inputs/`, `added_paths`, `bin/nix-direnv-reload`, profile rc files — and direnv reports them in `DIRENV_WATCHES` so its *shell hook* re-runs after a rebuild. For the env cache those files are **output, not source**: watching them means each successful evaluation re-touches a watched path and arms the next spurious eviction (the same post-`cache.put` FSEvents race the existing allow/deny stamp filter documents).

Fix: drop anything under `<worktree>/.direnv/` from the watch list. The match is **anchored to the worktree prefix** — a bare `.direnv` path-component check would mis-fire and filter out the real `.envrc` / `flake.lock` of a workspace that itself lives under some unrelated `.direnv/` ancestor directory.

### 2. mtime-only invalidation thrashed on no-op bumps (`src/env_provider/cache.rs`)
The cache compared `SystemTime` exactly. `git checkout`, `touch`, save-on-noop editors, and nix-direnv re-evaluation all bump mtime forward **without changing bytes**, so the cache treated "mtime moved, content identical" as a cache miss.

Fix: a **two-tier freshness check**. mtime compare first (cheap, no file reads); on a mismatch the file is hashed and the entry stays fresh when the bytes are identical. The stored mtime is then *healed* so the next lookup takes the cheap path again — the file read is paid once per benign bump, not on every resolve.

### 3. Hot-cache UI flicker (`useWorkspaceEnvironmentPreparation.ts`)
The hook flipped the workspace to `"preparing"` **synchronously** before awaiting the resolve IPC, so even an instant cache hit flashed `Preparing direnv…` on every workspace switch.

Fix: the status flips to `"preparing"` only if the resolve hasn't returned within a 150 ms delay. A cached resolve returns within one IPC round-trip and clears the timer first — no spinner frame. Cache *misses* still spin immediately via the backend's `started` progress event.

### 4. Reactive watcher evicted before the hash check could run (Codex peer-review finding)
The first three fixes left a gap: when the native `EnvWatcher` is active, a no-op filesystem event still called `cache.invalidate()` and **dropped the entry outright** — before `get_fresh`'s two-tier check ever ran. The hash fallback only helped when reactive watching was unavailable.

Fix: `EnvCache::invalidate_if_stale` — the content-aware counterpart to `invalidate`. It runs the same `check_freshness` test and evicts **only when a watched file's bytes actually changed** (healing mtimes otherwise). The watcher callback now funnels through it and only emits `env-cache-invalidated` / schedules the trust probe on a real eviction.

Diagnostics: a `tracing::debug!` line was added to the watcher's invalidation dispatch (`target: claudette::env-watcher`) so a future "reloaded but I changed nothing" report can be traced to the exact path + event kind that fired.

## Acceptance criteria

- [x] After env is `ready`, agent activity / nix-direnv re-evaluation does not evict the cache while `.envrc` / `flake.nix` / `flake.lock` content hashes are unchanged.
- [x] Re-selecting an already-loaded workspace does not show `Preparing direnv …` (hot-cache path — no synchronous flip).
- [x] Switching git branches to one with identical `.envrc` / `flake.nix` / `flake.lock` bytes does not trigger a re-resolve.
- [x] Legitimate invalidations still work: editing `.envrc`, bumping `flake.lock` content, deleting `.envrc` all still produce a fresh `Preparing direnv …` cycle.
- [x] Settings → Env panel "Reload" still force-invalidates (unconditional `invalidate`, untouched).

## Testing

- **Rust**: `cargo test -p claudette env_provider::cache` — 10 pass (incl. 3 new: byte-identical mtime bump, `invalidate_if_stale` content-aware eviction, no-op on missing entry). Plugin tests — 2 new (`.direnv/` artifacts dropped; worktree-anchored filter). `cargo clippy` clean, `cargo fmt` clean.
- **`claudette-tauri`**: `cargo check` clean (CI feature set) after staging the CLI sidecar.
- **Frontend**: full vitest suite — **2632 pass**; `tsc -b` clean. 2 existing hook tests updated to pin the new hot-cache behavior; 3 new tests added (no flicker on hot-cache resolve, spinner-delay, timer cancelled on mid-flight selection change).

## Docs

Intentionally undocumented: the change is an internal cache-correctness fix plus a UI anti-flicker bug fix — no new setting, command, flag, or shortcut. `per-repo-settings.mdx`'s description of the env-resolve spinner remains accurate.

## Notes

The three FSEvents-based `env_provider::watcher` tests are pre-existing flaky (confirmed pass/fail/pass across repeated runs on a clean checkout) — they wait up to 3 s for an OS filesystem-watch callback. Unrelated to this change, which only adds an inert `tracing::debug!` line to `watcher.rs`.
