### PR TITLE
fix(chat): preserve steering prompt preview during workspace switches

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -136,8 +136,12 @@ export function ChatPanel() {
   const chatScrollTopBySessionRef = useRef(new Map<string, number>());
   const restoringChatScrollSessionsRef = useRef(new Set<string>());
   const [error, setError] = useState<string | null>(null);
-  const [isSteeringQueued, setIsSteeringQueued] = useState(false);
-  const [pendingSteerContent, setPendingSteerContent] = useState<string | null>(null);
+  const isSteeringQueued = useAppStore((s) =>
+    activeSessionId ? s.queuedMessageSteering[activeSessionId] === true : false,
+  );
+  const pendingSteerContent = useAppStore((s) =>
+    activeSessionId ? s.queuedMessageSteeringContent[activeSessionId] ?? null : null,
+  );
   const setQueuedMessageEditing = useAppStore((s) => s.setQueuedMessageEditing);
   const setQueuedMessageSteering = useAppStore((s) => s.setQueuedMessageSteering);
   const isMac = isMacHotkeyPlatform();
@@ -910,12 +914,6 @@ export function ChatPanel() {
     // Re-attach on session switch so the sessionId ref stays in sync.
   }, [activeSessionId]);
 
-  // Clear any in-flight steer indicator when the active session changes so
-  // the banner from session A never leaks into session B's view.
-  useEffect(() => {
-    setPendingSteerContent(null);
-  }, [activeSessionId]);
-
   // Auto-scroll when new content arrives — respects user intent via useStickyScroll.
   // Only scrolls if the user is already at/near the bottom.
   const prevMsgCountRef = useRef<Record<string, number>>({});
@@ -1031,9 +1029,7 @@ export function ChatPanel() {
       ? [...mentionedFiles]
       : undefined;
     setError(null);
-    setIsSteeringQueued(true);
-    setQueuedMessageSteering(sessionId, true);
-    setPendingSteerContent(content.trim() || null);
+    setQueuedMessageSteering(sessionId, true, content);
     try {
       const checkpoint = await steerQueuedChatMessage(
         sessionId,
@@ -1058,9 +1054,7 @@ export function ChatPanel() {
       setQueuedMessage(sessionId, content, mentionedFilesArray, attachments);
       setError(errMsg);
     } finally {
-      setIsSteeringQueued(false);
       setQueuedMessageSteering(sessionId, false);
-      setPendingSteerContent(null);
     }
   };
 
@@ -1085,10 +1079,8 @@ export function ChatPanel() {
       return;
     }
 
-    setIsSteeringQueued(true);
-    setQueuedMessageSteering(sessionId, true);
-    setPendingSteerContent(content.trim() || null);
     removeQueuedMessage(sessionId, queuedMessage.id);
+    setQueuedMessageSteering(sessionId, true, content);
     try {
       const checkpoint = await steerQueuedChatMessage(
         sessionId,
@@ -1111,9 +1103,7 @@ export function ChatPanel() {
       setQueuedMessage(sessionId, content, mentionedFiles, attachments);
       setError(errMsg);
     } finally {
-      setIsSteeringQueued(false);
       setQueuedMessageSteering(sessionId, false);
-      setPendingSteerContent(null);
     }
   };
 

--- a/src/ui/src/hooks/useQueuedMessageAutoDispatch.test.tsx
+++ b/src/ui/src/hooks/useQueuedMessageAutoDispatch.test.tsx
@@ -96,6 +96,7 @@ describe("useQueuedMessageAutoDispatch", () => {
       queuedMessageAutoDispatchPaused: {},
       queuedMessageEditing: {},
       queuedMessageSteering: {},
+      queuedMessageSteeringContent: {},
       chatMessages: {},
       chatAttachments: {},
       promptStartTime: {},
@@ -206,7 +207,9 @@ describe("useQueuedMessageAutoDispatch", () => {
     useAppStore.getState().setQueuedMessage("ghost-session", "stale follow up");
     useAppStore.getState().setQueuedMessageAutoDispatchPaused("ghost-session", true);
     useAppStore.getState().setQueuedMessageEditing("ghost-session", true);
-    useAppStore.getState().setQueuedMessageSteering("ghost-session", true);
+    useAppStore
+      .getState()
+      .setQueuedMessageSteering("ghost-session", true, "stale follow up");
 
     await mountHook();
     await flushQueuedDispatch();
@@ -217,5 +220,6 @@ describe("useQueuedMessageAutoDispatch", () => {
     expect(state.queuedMessageAutoDispatchPaused["ghost-session"]).toBeUndefined();
     expect(state.queuedMessageEditing["ghost-session"]).toBeUndefined();
     expect(state.queuedMessageSteering["ghost-session"]).toBeUndefined();
+    expect(state.queuedMessageSteeringContent["ghost-session"]).toBeUndefined();
   });
 });

--- a/src/ui/src/stores/slices/agentInteractionSlice.ts
+++ b/src/ui/src/stores/slices/agentInteractionSlice.ts
@@ -147,6 +147,7 @@ export interface AgentInteractionSlice {
   queuedMessageAutoDispatchPaused: Record<string, boolean>;
   queuedMessageEditing: Record<string, boolean>;
   queuedMessageSteering: Record<string, boolean>;
+  queuedMessageSteeringContent: Record<string, string>;
   setQueuedMessage: (
     sessionId: string,
     content: string,
@@ -162,7 +163,11 @@ export interface AgentInteractionSlice {
   clearQueuedMessage: (sessionId: string) => void;
   setQueuedMessageAutoDispatchPaused: (sessionId: string, paused: boolean) => void;
   setQueuedMessageEditing: (sessionId: string, editing: boolean) => void;
-  setQueuedMessageSteering: (sessionId: string, steering: boolean) => void;
+  setQueuedMessageSteering: (
+    sessionId: string,
+    steering: boolean,
+    content?: string | null,
+  ) => void;
 }
 
 export const createAgentInteractionSlice: StateCreator<
@@ -276,6 +281,7 @@ export const createAgentInteractionSlice: StateCreator<
   queuedMessageAutoDispatchPaused: {},
   queuedMessageEditing: {},
   queuedMessageSteering: {},
+  queuedMessageSteeringContent: {},
   setQueuedMessage: (sessionId, content, mentionedFiles, attachments) =>
     set((s) => ({
       queuedMessages: {
@@ -331,11 +337,16 @@ export const createAgentInteractionSlice: StateCreator<
           [sessionId]: _steering,
           ...steeringRest
         } = s.queuedMessageSteering;
+        const {
+          [sessionId]: _steeringContent,
+          ...steeringContentRest
+        } = s.queuedMessageSteeringContent;
         return {
           queuedMessages: rest,
           queuedMessageAutoDispatchPaused: pausedRest,
           queuedMessageEditing: editingRest,
           queuedMessageSteering: steeringRest,
+          queuedMessageSteeringContent: steeringContentRest,
         };
       }
       return {
@@ -360,11 +371,16 @@ export const createAgentInteractionSlice: StateCreator<
         [sessionId]: _steering,
         ...steeringRest
       } = s.queuedMessageSteering;
+      const {
+        [sessionId]: _steeringContent,
+        ...steeringContentRest
+      } = s.queuedMessageSteeringContent;
       return {
         queuedMessages: rest,
         queuedMessageAutoDispatchPaused: pausedRest,
         queuedMessageEditing: editingRest,
         queuedMessageSteering: steeringRest,
+        queuedMessageSteeringContent: steeringContentRest,
       };
     }),
   setQueuedMessageAutoDispatchPaused: (sessionId, paused) =>
@@ -403,22 +419,43 @@ export const createAgentInteractionSlice: StateCreator<
         },
       };
     }),
-  setQueuedMessageSteering: (sessionId, steering) =>
+  setQueuedMessageSteering: (sessionId, steering, content) =>
     set((s) => {
       const current = s.queuedMessageSteering[sessionId] === true;
-      if (current === steering) return s;
+      const trimmedContent = content?.trim() ?? "";
+      const currentContent = s.queuedMessageSteeringContent[sessionId] ?? "";
+      if (current === steering && (!steering || currentContent === trimmedContent)) {
+        return s;
+      }
       if (!steering) {
         const {
           [sessionId]: _,
           ...rest
         } = s.queuedMessageSteering;
-        return { queuedMessageSteering: rest };
+        const {
+          [sessionId]: _content,
+          ...contentRest
+        } = s.queuedMessageSteeringContent;
+        return {
+          queuedMessageSteering: rest,
+          queuedMessageSteeringContent: contentRest,
+        };
       }
+      const {
+        [sessionId]: _content,
+        ...contentRest
+      } = s.queuedMessageSteeringContent;
       return {
         queuedMessageSteering: {
           ...s.queuedMessageSteering,
           [sessionId]: true,
         },
+        queuedMessageSteeringContent: trimmedContent
+          ? {
+              ...s.queuedMessageSteeringContent,
+              [sessionId]: trimmedContent,
+            }
+          : contentRest,
       };
     }),
 });

--- a/src/ui/src/stores/slices/chatSessionsSlice.ts
+++ b/src/ui/src/stores/slices/chatSessionsSlice.ts
@@ -141,6 +141,8 @@ export const createChatSessionsSlice: StateCreator<
       delete nextQueuedEditing[sessionId];
       const nextQueuedSteering = { ...s.queuedMessageSteering };
       delete nextQueuedSteering[sessionId];
+      const nextQueuedSteeringContent = { ...s.queuedMessageSteeringContent };
+      delete nextQueuedSteeringContent[sessionId];
       return {
         sessionsByWorkspace: next,
         selectedSessionIdByWorkspaceId: nextSelected,
@@ -150,6 +152,7 @@ export const createChatSessionsSlice: StateCreator<
         queuedMessageAutoDispatchPaused: nextQueuedPaused,
         queuedMessageEditing: nextQueuedEditing,
         queuedMessageSteering: nextQueuedSteering,
+        queuedMessageSteeringContent: nextQueuedSteeringContent,
       };
     }),
   selectSession: (workspaceId, sessionId) =>

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -127,7 +127,13 @@ describe("Claudette terminal setting", () => {
 
 describe("queued messages", () => {
   beforeEach(() => {
-    useAppStore.setState({ queuedMessages: {} });
+    useAppStore.setState({
+      queuedMessages: {},
+      queuedMessageAutoDispatchPaused: {},
+      queuedMessageEditing: {},
+      queuedMessageSteering: {},
+      queuedMessageSteeringContent: {},
+    });
   });
 
   it("updates a queued message in place", () => {
@@ -187,6 +193,46 @@ describe("queued messages", () => {
       id: first.id,
       content: "edited",
     });
+  });
+
+  it("keeps steering prompt text with the per-session steering flag until steering ends", () => {
+    useAppStore
+      .getState()
+      .setQueuedMessageSteering("session-1", true, "  refine this approach  ");
+
+    let state = useAppStore.getState();
+    expect(state.queuedMessageSteering["session-1"]).toBe(true);
+    expect(state.queuedMessageSteeringContent["session-1"]).toBe(
+      "refine this approach",
+    );
+
+    useAppStore.getState().setQueuedMessageSteering("session-1", false);
+
+    state = useAppStore.getState();
+    expect(state.queuedMessageSteering["session-1"]).toBeUndefined();
+    expect(state.queuedMessageSteeringContent["session-1"]).toBeUndefined();
+  });
+
+  it("does not invent prompt text for attachment-only steering", () => {
+    useAppStore.getState().setQueuedMessageSteering("session-1", true, "   ");
+
+    const state = useAppStore.getState();
+    expect(state.queuedMessageSteering["session-1"]).toBe(true);
+    expect(state.queuedMessageSteeringContent["session-1"]).toBeUndefined();
+  });
+
+  it("clears steering prompt text when the queued session is emptied", () => {
+    const store = useAppStore.getState();
+    store.setQueuedMessage("session-1", "follow up");
+    store.setQueuedMessageSteering("session-1", true, "follow up");
+
+    const queuedId = useAppStore.getState().queuedMessages["session-1"]?.[0]?.id;
+    expect(queuedId).toBeTruthy();
+    store.removeQueuedMessage("session-1", queuedId!);
+
+    const state = useAppStore.getState();
+    expect(state.queuedMessageSteering["session-1"]).toBeUndefined();
+    expect(state.queuedMessageSteeringContent["session-1"]).toBeUndefined();
   });
 });
 
@@ -266,6 +312,9 @@ describe("queued message auto-dispatch pause", () => {
     useAppStore.setState({
       queuedMessages: {},
       queuedMessageAutoDispatchPaused: {},
+      queuedMessageEditing: {},
+      queuedMessageSteering: {},
+      queuedMessageSteeringContent: {},
     });
   });
 


### PR DESCRIPTION
## Summary

- Move the in-flight steering prompt preview from local ChatPanel state into per-session Zustand state.
- Keep queued-message steering, queue cleanup, session cleanup, and stale auto-dispatch cleanup aligned with the new preview state.
- Add regressions for prompt text persistence, attachment-only fallback behavior, and stale steering cleanup.

## Root Cause

The steering banner combined two state lifetimes. The active steering flag lived in global per-session store state, so it survived leaving a workspace and coming back while the steer request was still in flight. The text preview for that same banner lived in ChatPanel local state, so remounting the panel reset the preview to null. With the flag still true but the preview gone, the UI rendered the attachment fallback string: `Sending attachment...`.

## User Impact

Switching away from a workspace during a mid-turn steering send no longer loses the typed steering prompt in the pending banner. Text steering prompts continue showing the actual prompt after remount, while attachment-only steering still uses the attachment fallback.

## Validation

- `cd src/ui && bun run test -- src/stores/useAppStore.test.ts src/hooks/useQueuedMessageAutoDispatch.test.tsx`
- `cd src/ui && bunx tsc -b`
- `git diff --check`
