### PR TITLE
feat: queue project view workspace sends

### DIFF
--- a/site/src/content/docs/features/project-view-issues-prs.mdx
+++ b/site/src/content/docs/features/project-view-issues-prs.mdx
@@ -34,6 +34,8 @@ Right-click any issue or PR row for:
 
   The submenu lists the same models the chat panel's model picker would show, with the same alternative-backends and OAuth gating. If you have no models available (alt-backends off and no Claude auth), the submenu shows a single disabled "No models available" row instead of silently swallowing the click.
 
+  You can pick models for several issue/PR rows in quick succession. Claudette queues the workspace creates so each distinct row still gets its own workspace and starter prompt, while an accidental repeat click on the same row is collapsed instead of creating a duplicate.
+
 ## Issue / PR ↔ workspace association
 
 When you send an issue or PR to a workspace, Claudette records the link — which workspace was spun up for which upstream item — and surfaces it on both sides:

--- a/src/ui/src/components/project/sendToNewWorkspace.test.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.test.ts
@@ -206,6 +206,13 @@ describe("sendToNewWorkspace", () => {
 
     expect(mockedCreate).toHaveBeenCalledWith("repo-1", {
       selectOnCreate: true,
+      idempotencyKey: [
+        "project-send",
+        ISSUE_ARGS.repoId,
+        ISSUE_ARGS.kind,
+        String(ISSUE_ARGS.number),
+        ISSUE_ARGS.url,
+      ].join(":"),
     });
     expect(mockedApplyModel).toHaveBeenCalledWith(
       "sess-1",
@@ -249,7 +256,7 @@ describe("sendToNewWorkspace", () => {
     expect(mockedSend.mock.calls[0][11]).toBe("openrouter");
   });
 
-  it("surfaces a toast and skips the send when the create single-flight guard fires", async () => {
+  it("surfaces a toast and skips the send when the create idempotency guard fires", async () => {
     mockedCreate.mockResolvedValue(null);
 
     await sendToNewWorkspace(ISSUE_ARGS);
@@ -257,7 +264,7 @@ describe("sendToNewWorkspace", () => {
     expect(mockedApplyModel).not.toHaveBeenCalled();
     expect(mockedSend).not.toHaveBeenCalled();
     const toasts = useAppStore.getState().toasts;
-    expect(toasts.some((t) => /already being created/i.test(t.message))).toBe(
+    expect(toasts.some((t) => /already being sent/i.test(t.message))).toBe(
       true,
     );
   });

--- a/src/ui/src/components/project/sendToNewWorkspace.test.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.test.ts
@@ -213,6 +213,7 @@ describe("sendToNewWorkspace", () => {
         String(ISSUE_ARGS.number),
         ISSUE_ARGS.url,
       ].join(":"),
+      onIdempotencyDuplicate: expect.any(Function),
     });
     expect(mockedApplyModel).toHaveBeenCalledWith(
       "sess-1",
@@ -257,7 +258,10 @@ describe("sendToNewWorkspace", () => {
   });
 
   it("surfaces a toast and skips the send when the create idempotency guard fires", async () => {
-    mockedCreate.mockResolvedValue(null);
+    mockedCreate.mockImplementationOnce((_repoId, options) => {
+      options?.onIdempotencyDuplicate?.();
+      return Promise.resolve(null);
+    });
 
     await sendToNewWorkspace(ISSUE_ARGS);
 
@@ -267,6 +271,20 @@ describe("sendToNewWorkspace", () => {
     expect(toasts.some((t) => /already being sent/i.test(t.message))).toBe(
       true,
     );
+  });
+
+  it("does not add a duplicate toast when create returns null for another reason", async () => {
+    mockedCreate.mockResolvedValue(null);
+
+    await sendToNewWorkspace(ISSUE_ARGS);
+
+    expect(mockedApplyModel).not.toHaveBeenCalled();
+    expect(mockedSend).not.toHaveBeenCalled();
+    expect(
+      useAppStore
+        .getState()
+        .toasts.some((t) => /already being sent/i.test(t.message)),
+    ).toBe(false);
   });
 
   it("toasts a confirmation after a successful send", async () => {

--- a/src/ui/src/components/project/sendToNewWorkspace.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.ts
@@ -45,14 +45,16 @@ export async function sendToNewWorkspace(
   const outcome = await createWorkspaceOrchestrated(args.repoId, {
     selectOnCreate: true,
     idempotencyKey: sendIdempotencyKey(args),
+    onIdempotencyDuplicate: () => {
+      store.addToast(
+        `#${args.number} is already being sent to a new workspace.`,
+      );
+    },
   });
   if (!outcome) {
-    // The idempotency guard fired — this exact item is already queued
-    // or creating. Surface a toast so the click doesn't appear to
-    // silently no-op, while distinct issue/PR sends continue to queue.
-    store.addToast(
-      `#${args.number} is already being sent to a new workspace.`,
-    );
+    // Either the duplicate callback above already surfaced the true
+    // same-item repeat, or the orchestrator handled a backend in-flight
+    // rejection with its own repo-scoped toast.
     return;
   }
   const { workspaceId, sessionId } = outcome;

--- a/src/ui/src/components/project/sendToNewWorkspace.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.ts
@@ -44,11 +44,15 @@ export async function sendToNewWorkspace(
   const store = useAppStore.getState();
   const outcome = await createWorkspaceOrchestrated(args.repoId, {
     selectOnCreate: true,
+    idempotencyKey: sendIdempotencyKey(args),
   });
   if (!outcome) {
-    // The single-flight guard fired — another create is mid-flight.
-    // Surface a toast so the click doesn't appear to silently no-op.
-    store.addToast("A workspace is already being created. Try again in a moment.");
+    // The idempotency guard fired — this exact item is already queued
+    // or creating. Surface a toast so the click doesn't appear to
+    // silently no-op, while distinct issue/PR sends continue to queue.
+    store.addToast(
+      `#${args.number} is already being sent to a new workspace.`,
+    );
     return;
   }
   const { workspaceId, sessionId } = outcome;
@@ -125,6 +129,16 @@ export async function sendToNewWorkspace(
     messageId,
   );
   store.addToast(`Sent #${args.number} to a new workspace`);
+}
+
+function sendIdempotencyKey(args: SendToNewWorkspaceArgs): string {
+  return [
+    "project-send",
+    args.repoId,
+    args.kind,
+    String(args.number),
+    args.url,
+  ].join(":");
 }
 
 export function renderStarterPrompt(args: SendToNewWorkspaceArgs): string {

--- a/src/ui/src/hooks/useCreateWorkspace.test.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.test.ts
@@ -25,7 +25,10 @@ vi.mock("../services/tauri", () => ({
   notifyWorkspaceSelected: vi.fn(() => Promise.resolve()),
 }));
 
-import { createWorkspaceOrchestrated } from "./useCreateWorkspace";
+import {
+  __resetCreateWorkspaceOrchestrationForTests,
+  createWorkspaceOrchestrated,
+} from "./useCreateWorkspace";
 import { useAppStore } from "../stores/useAppStore";
 import type { Repository } from "../types/repository";
 import type { Workspace } from "../types";
@@ -71,6 +74,7 @@ function makeWorkspace(id: string, repoId = "repo-1"): Workspace {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  __resetCreateWorkspaceOrchestrationForTests();
   // Reset only the slices the orchestrator touches; leave the rest of the
   // store at its initial value so unrelated selectors don't surprise us.
   useAppStore.setState({
@@ -86,9 +90,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // Belt-and-suspenders: even if a test forgot to await a returned promise,
-  // make sure the module-level single-flight latch is cleared so the next
-  // test starts from a clean slate.
+  __resetCreateWorkspaceOrchestrationForTests();
   useAppStore.setState({ creatingWorkspaceRepoId: null });
 });
 
@@ -125,7 +127,7 @@ describe("createWorkspaceOrchestrated", () => {
     expect(useAppStore.getState().creatingWorkspaceRepoId).toBeNull();
   });
 
-  it("single-flight: a second concurrent call returns null without re-entering", async () => {
+  it("dedupes a second concurrent call with the same default key", async () => {
     // Hold createWorkspace open until we've fired the second call. This is
     // the regression we care about — without the module-level guard, the
     // welcome card's CTA + Cmd+Shift+N hotkey could double-create when
@@ -151,7 +153,7 @@ describe("createWorkspaceOrchestrated", () => {
     mockGetRepoConfig.mockRejectedValue(new Error("no config"));
 
     const first = createWorkspaceOrchestrated("repo-1");
-    // Yield once so `first` reaches the `creationInFlight = true` line and
+    // Yield once so `first` claims the default idempotency key and
     // the awaited generateWorkspaceName resolves.
     await Promise.resolve();
     await Promise.resolve();
@@ -168,7 +170,7 @@ describe("createWorkspaceOrchestrated", () => {
     const firstResult = await first;
     expect(firstResult).toEqual({ workspaceId: "w1", sessionId: "s1" });
 
-    // After the first resolves the latch must release so a fresh call
+    // After the first resolves the key must release so a fresh call
     // can proceed — the guard is not a permanent kill switch.
     mockCreateWorkspace.mockResolvedValueOnce({
       workspace: makeWorkspace("w2"),
@@ -177,6 +179,84 @@ describe("createWorkspaceOrchestrated", () => {
     });
     const third = await createWorkspaceOrchestrated("repo-1");
     expect(third).toEqual({ workspaceId: "w2", sessionId: "s2" });
+  });
+
+  it("queues concurrent calls with distinct idempotency keys", async () => {
+    let releaseFirst!: (v: {
+      workspace: Workspace;
+      default_session_id: string;
+      setup_result: null;
+    }) => void;
+    const firstPending = new Promise<{
+      workspace: Workspace;
+      default_session_id: string;
+      setup_result: null;
+    }>((resolve) => {
+      releaseFirst = resolve;
+    });
+    mockGenerateWorkspaceName
+      .mockResolvedValueOnce({
+        slug: "calm-protea",
+        display: "calm protea",
+        message: null,
+      })
+      .mockResolvedValueOnce({
+        slug: "bold-aster",
+        display: "bold aster",
+        message: null,
+      });
+    mockCreateWorkspace
+      .mockReturnValueOnce(firstPending)
+      .mockResolvedValueOnce({
+        workspace: makeWorkspace("w2"),
+        default_session_id: "s2",
+        setup_result: null,
+      });
+    mockGetRepoConfig.mockRejectedValue(new Error("no config"));
+
+    const first = createWorkspaceOrchestrated("repo-1", {
+      idempotencyKey: "issue-1",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const second = createWorkspaceOrchestrated("repo-1", {
+      idempotencyKey: "issue-2",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The second create is queued behind the first, not rejected and
+    // not allowed to collide with the backend's per-repo guard.
+    expect(mockGenerateWorkspaceName).toHaveBeenCalledTimes(1);
+    expect(mockCreateWorkspace).toHaveBeenCalledTimes(1);
+
+    releaseFirst({
+      workspace: makeWorkspace("w1"),
+      default_session_id: "s1",
+      setup_result: null,
+    });
+
+    await expect(first).resolves.toEqual({
+      workspaceId: "w1",
+      sessionId: "s1",
+    });
+    await expect(second).resolves.toEqual({
+      workspaceId: "w2",
+      sessionId: "s2",
+    });
+    expect(mockCreateWorkspace).toHaveBeenNthCalledWith(
+      1,
+      "repo-1",
+      "calm-protea",
+      true,
+    );
+    expect(mockCreateWorkspace).toHaveBeenNthCalledWith(
+      2,
+      "repo-1",
+      "bold-aster",
+      true,
+    );
   });
 
   it("auto-runs the setup script when the repo opted in", async () => {
@@ -286,7 +366,7 @@ describe("createWorkspaceOrchestrated", () => {
     expect(useAppStore.getState().selectedWorkspaceId).toBeNull();
   });
 
-  it("clears the in-flight latch even when createWorkspace throws", async () => {
+  it("clears the in-flight key even when createWorkspace throws", async () => {
     mockGenerateWorkspaceName.mockResolvedValue({
       slug: "calm-protea",
       display: "calm protea",
@@ -318,9 +398,9 @@ describe("createWorkspaceOrchestrated", () => {
   it("treats the backend in-flight rejection as benign: toast, null, restored selection, no error log", async () => {
     // The backend's `create_workspace` refuses a second create for a repo
     // that already has one running (issue #896). That guard survives a
-    // webview reload — unlike the module-level latch — so the orchestrator
+    // webview reload — unlike the module-level key set — so the orchestrator
     // must treat the rejection as benign: surface a calm toast, return
-    // null (the same shape as the in-process single-flight early-return),
+    // null (the same shape as the in-process idempotency early-return),
     // restore the pre-create selection rather than yanking the user to
     // the dashboard, and not log it at error level (nothing failed).
     const addToast = vi.fn();
@@ -349,7 +429,7 @@ describe("createWorkspaceOrchestrated", () => {
     const out = await createWorkspaceOrchestrated("repo-1");
     expect(out).toBeNull();
 
-    // A toast was surfaced and the latch released so a retry can proceed.
+    // A toast was surfaced and the key released so a retry can proceed.
     expect(addToast).toHaveBeenCalledTimes(1);
     expect(addToast.mock.calls[0][0]).toMatch(/already being created/i);
     expect(useAppStore.getState().creatingWorkspaceRepoId).toBeNull();

--- a/src/ui/src/hooks/useCreateWorkspace.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.ts
@@ -71,6 +71,9 @@ export interface CreateWorkspaceOptions {
    *  issue/PR sends pass an item-specific key so distinct sends queue while
    *  an accidental re-fire of the same row still collapses to one create. */
   idempotencyKey?: string;
+  /** Called only when `idempotencyKey` is already in flight. Other `null`
+   *  outcomes, such as a backend in-flight rejection, do not call this. */
+  onIdempotencyDuplicate?: () => void;
 }
 
 // Module-level queue/idempotency state. Lives outside the hook so the
@@ -112,7 +115,10 @@ export async function createWorkspaceOrchestrated(
 ): Promise<CreateWorkspaceOutcome | null> {
   const idempotencyKey =
     options.idempotencyKey ?? DEFAULT_CREATE_IDEMPOTENCY_KEY;
-  if (createKeysInFlight.has(idempotencyKey)) return null;
+  if (createKeysInFlight.has(idempotencyKey)) {
+    options.onIdempotencyDuplicate?.();
+    return null;
+  }
   createKeysInFlight.add(idempotencyKey);
 
   const runAfterPrior = createQueueTail.then(
@@ -313,7 +319,7 @@ async function runCreateWorkspaceOrchestrated(
 
 export type UseCreateWorkspaceOptions = Omit<
   CreateWorkspaceOptions,
-  "idempotencyKey"
+  "idempotencyKey" | "onIdempotencyDuplicate"
 >;
 
 /** React hook wrapping `createWorkspaceOrchestrated` with local React

--- a/src/ui/src/hooks/useCreateWorkspace.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.ts
@@ -66,14 +66,28 @@ export interface CreateWorkspaceOptions {
    *  callers usually want the new workspace to be selected. The Sidebar already
    *  selects on click, so allow opting out from there. Defaults to true. */
   selectOnCreate?: boolean;
+  /** Stable key for a user gesture that should only create one workspace.
+   *  The default keeps manual "New workspace" clicks single-flight. Project
+   *  issue/PR sends pass an item-specific key so distinct sends queue while
+   *  an accidental re-fire of the same row still collapses to one create. */
+  idempotencyKey?: string;
 }
 
-// Module-level single-flight guard. Lives outside the hook so the
+// Module-level queue/idempotency state. Lives outside the hook so the
 // non-hook entry point (`createWorkspaceOrchestrated`, used by the
-// Cmd+Shift+N hotkey) and the hook share the same in-flight semaphore;
-// otherwise a hotkey press while the welcome card's CTA is mid-flight
-// could double-trigger the slug generator and produce two workspaces.
-let creationInFlight = false;
+// Cmd+Shift+N hotkey) and the hook share the same duplicate protection.
+// The queue keeps git/worktree creates sequential, while the key set keeps
+// accidental re-fires of the same gesture from minting duplicates.
+let createQueueTail: Promise<void> = Promise.resolve();
+const createKeysInFlight = new Set<string>();
+
+const DEFAULT_CREATE_IDEMPOTENCY_KEY = "manual-workspace-create";
+
+/** @internal test helper: clears module-level queue state between tests. */
+export function __resetCreateWorkspaceOrchestrationForTests(): void {
+  createQueueTail = Promise.resolve();
+  createKeysInFlight.clear();
+}
 
 /** Single-source-of-truth orchestration shared between the React hook
  *  and the keyboard-shortcut path. Mirrors the original Sidebar.tsx
@@ -96,8 +110,31 @@ export async function createWorkspaceOrchestrated(
   repoId: string,
   options: CreateWorkspaceOptions = {},
 ): Promise<CreateWorkspaceOutcome | null> {
-  if (creationInFlight) return null;
-  creationInFlight = true;
+  const idempotencyKey =
+    options.idempotencyKey ?? DEFAULT_CREATE_IDEMPOTENCY_KEY;
+  if (createKeysInFlight.has(idempotencyKey)) return null;
+  createKeysInFlight.add(idempotencyKey);
+
+  const runAfterPrior = createQueueTail.then(
+    () => runCreateWorkspaceOrchestrated(repoId, options),
+    () => runCreateWorkspaceOrchestrated(repoId, options),
+  );
+  createQueueTail = runAfterPrior.then(
+    () => undefined,
+    () => undefined,
+  );
+
+  try {
+    return await runAfterPrior;
+  } finally {
+    createKeysInFlight.delete(idempotencyKey);
+  }
+}
+
+async function runCreateWorkspaceOrchestrated(
+  repoId: string,
+  options: CreateWorkspaceOptions = {},
+): Promise<CreateWorkspaceOutcome | null> {
   const { selectOnCreate = true } = options;
   const store = useAppStore.getState();
   // Selection in effect before this create runs. If a benign backend
@@ -242,8 +279,8 @@ export async function createWorkspaceOrchestrated(
     // logs/telemetry as a failure, and it should leave the user where
     // they were rather than yanking them to the dashboard. Tear the
     // placeholder down restoring the pre-create selection, surface a
-    // calm toast, and return null — the same shape as the module-level
-    // `creationInFlight` early-return. See issue #896.
+    // calm toast, and return null — the same shape as the in-process
+    // idempotency early-return. See issue #896.
     if (isCreateInFlightRejection(e)) {
       if (placeholderId) {
         useAppStore
@@ -271,11 +308,13 @@ export async function createWorkspaceOrchestrated(
     throw e;
   } finally {
     useAppStore.getState().setCreatingWorkspaceRepoId(null);
-    creationInFlight = false;
   }
 }
 
-export type UseCreateWorkspaceOptions = CreateWorkspaceOptions;
+export type UseCreateWorkspaceOptions = Omit<
+  CreateWorkspaceOptions,
+  "idempotencyKey"
+>;
 
 /** React hook wrapping `createWorkspaceOrchestrated` with local React
  *  state so a button can disable itself while the call is in flight.


### PR DESCRIPTION
## Summary

- Replace the frontend global workspace-create mutex with a queued/idempotent orchestration path.
- Give project-view issue/PR sends stable per-item idempotency keys so distinct rows queue and each gets its own workspace and starter prompt.
- Preserve duplicate-create protection for accidental repeat gestures and backend reload races.
- Document the new project-view multi-send behavior.

## Root Cause

Issue #914 exposed that the frontend creationInFlight boolean rejected every second create while the first workspace was still provisioning. That protected issue #896 duplicate-create regression, but it also dropped intentional backlog fan-out sends before their starter prompts could be dispatched.

## User Impact

Developers can now right-click several project-view issues or PRs in quick succession and send each to a separate new workspace. Claudette serializes the actual workspace creates to keep git/worktree operations safe, while repeated clicks on the same item collapse instead of creating duplicates.

## Validation

- bun run test src/hooks/useCreateWorkspace.test.ts src/components/project/sendToNewWorkspace.test.ts
- bunx tsc -b
- bun run lint
- bun run lint:css
- bun run build
- git diff --check

Closes #914