### PR TITLE
feat(toast): move toast notifications to upper-right corner

### DIFF
--- a/src/ui/src/components/layout/Toast.module.css
+++ b/src/ui/src/components/layout/Toast.module.css
@@ -1,12 +1,22 @@
 .container {
   position: fixed;
-  bottom: 16px;
+  top: 16px;
   right: 16px;
   z-index: 9999;
   display: flex;
   flex-direction: column;
   gap: 8px;
   pointer-events: none;
+}
+
+/* macOS draws an overlay title bar (`titleBarStyle: "Overlay"`) — the
+   top ~38px strip is an OS-owned drag region. Push the toast stack
+   below it so toasts never overlap the drag region (which would steal
+   window-drag from those pixels) and keep the same 16px breathing room
+   the non-mac platforms get from the window edge. 38px matches the
+   title-bar clearance hardcoded elsewhere (sidebar/settings headers). */
+[data-platform="mac"] .container {
+  top: 54px;
 }
 
 .toast {
@@ -48,7 +58,7 @@
 @keyframes toastIn {
   from {
     opacity: 0;
-    transform: translateY(8px);
+    transform: translateY(-8px);
   }
   to {
     opacity: 1;


### PR DESCRIPTION
## Summary

Closes #920.

Toast notifications were anchored to the **lower-right** corner, far from where the user's attention sits (chat, sidebar, title-bar actions) and below the natural reading flow — easy to miss. This moves the shared toast stack to the **upper-right** corner.

## Changes

Single file — `src/ui/src/components/layout/Toast.module.css`:

- **`.container`**: `bottom: 16px` → `top: 16px` (base case — Linux/Windows, no overlay title bar).
- **New `[data-platform="mac"] .container { top: 54px }`**: clears the macOS overlay title bar. AppLayout already sets `data-platform="mac"` on its root, which contains `<ToastContainer />`. `54px` = `38px` OS-owned drag region + `16px` breathing room. Without the offset, toast pixels overlapping the drag region would steal window-drag. `38px` matches the title-bar clearance already hardcoded in the sidebar (`padding-top: 38px`) and Settings drag region (`height: 38px`).
- **`toastIn` keyframe**: flipped the slide direction (`translateY(8px)` → `translateY(-8px)`) so toasts ease **down** into the top-anchored container instead of up.

`flex-direction: column` already grows the stack downward from the top anchor, so no markup change was needed. `z-index: 9999` and `pointer-events` are unchanged — layering above modals and click-through behavior preserved.

## Acceptance criteria

- [x] Toasts appear in the upper-right corner on macOS / Linux / Windows.
- [x] On macOS the offset clears the overlay title bar (38px) — no drag-region overlap.
- [x] Entry animation slides toasts down into place.
- [x] Multiple stacked toasts grow downward from the top anchor (`flex-direction: column`, unchanged).
- [x] `z-index` / `pointer-events` unchanged.
- [x] `bunx tsc -b` clean; `bun run lint:css` passes.

## Testing

- `bunx tsc -b` — clean.
- `bun run lint:css` — design-token + font checks pass.
- No tests reference `ToastContainer` directly (only a mock in `AppLayout.terminal.test.tsx`), so none needed updating.
- Not visually verified in a running app — only a production `/Applications/Claudette.app` was running locally, which is excluded from dev UAT. The macOS title-bar clearance should be confirmed on a dev build before merge.

No store, IPC, or behavior change — placement only. No docs change needed (toast position isn't a documented surface).