### PR TITLE
feat(chat): show env prep empty state

### DIFF
--- a/src/ui/src/components/chat/ChatEmptyState.test.tsx
+++ b/src/ui/src/components/chat/ChatEmptyState.test.tsx
@@ -2,14 +2,21 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ChatEmptyState } from "./ChatEmptyState";
+
+const hookMocks = vi.hoisted(() => ({
+  useEnvElapsedSeconds: vi.fn<() => { plugin: string | null; seconds: number | null }>(
+    () => ({ plugin: null, seconds: null }),
+  ),
+}));
 
 const translations: Record<string, string> = {
   send_message_to_start: "Send a message to start a conversation",
   empty_preparing_env: "Preparing workspace environment…",
   empty_preparing_env_with_plugin: "Preparing {{plugin}} ({{seconds}}s)…",
+  empty_preparing_env_with_plugin_static: "Preparing {{plugin}}…",
   empty_preparing_env_subtitle:
     "You'll be able to send a message in a moment.",
 };
@@ -28,6 +35,10 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
+vi.mock("../../hooks/useEnvElapsedSeconds", () => ({
+  useEnvElapsedSeconds: hookMocks.useEnvElapsedSeconds,
+}));
+
 const mountedRoots: Root[] = [];
 const mountedContainers: HTMLElement[] = [];
 
@@ -42,6 +53,14 @@ async function render(node: React.ReactNode): Promise<HTMLElement> {
   });
   return container;
 }
+
+beforeEach(() => {
+  hookMocks.useEnvElapsedSeconds.mockReset();
+  hookMocks.useEnvElapsedSeconds.mockReturnValue({
+    plugin: null,
+    seconds: null,
+  });
+});
 
 afterEach(async () => {
   for (const root of mountedRoots.splice(0).reverse()) {
@@ -59,24 +78,25 @@ describe("ChatEmptyState", () => {
     const container = await render(
       <ChatEmptyState
         workspaceEnvironmentPreparing={false}
-        envPlugin={null}
-        envSeconds={null}
+        workspaceId="ws-1"
       />,
     );
 
     expect(container.textContent).toBe("Send a message to start a conversation");
+    expect(hookMocks.useEnvElapsedSeconds).toHaveBeenCalledWith(null);
   });
 
   it("explains that env preparation is blocking the first send", async () => {
     const container = await render(
       <ChatEmptyState
         workspaceEnvironmentPreparing
-        envPlugin={null}
-        envSeconds={null}
+        workspaceId="ws-1"
       />,
     );
 
     expect(container.querySelector("[role='status']")).toBeTruthy();
+    expect(container.querySelector("[role='status']")?.getAttribute("aria-label"))
+      .toBe("Preparing workspace environment…");
     expect(container.textContent).toContain("Preparing workspace environment…");
     expect(container.textContent).toContain(
       "You'll be able to send a message in a moment.",
@@ -87,14 +107,19 @@ describe("ChatEmptyState", () => {
   });
 
   it("includes the active env-provider stage when progress is available", async () => {
+    hookMocks.useEnvElapsedSeconds.mockReturnValueOnce({
+      plugin: "env-direnv",
+      seconds: 12,
+    });
     const container = await render(
       <ChatEmptyState
         workspaceEnvironmentPreparing
-        envPlugin="env-direnv"
-        envSeconds={12}
+        workspaceId="ws-1"
       />,
     );
 
     expect(container.textContent).toContain("Preparing direnv (12s)…");
+    expect(container.querySelector("[role='status']")?.getAttribute("aria-label"))
+      .toBe("Preparing direnv…");
   });
 });

--- a/src/ui/src/components/chat/ChatEmptyState.test.tsx
+++ b/src/ui/src/components/chat/ChatEmptyState.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ChatEmptyState } from "./ChatEmptyState";
+
+const translations: Record<string, string> = {
+  send_message_to_start: "Send a message to start a conversation",
+  empty_preparing_env: "Preparing workspace environment…",
+  empty_preparing_env_with_plugin: "Preparing {{plugin}} ({{seconds}}s)…",
+  empty_preparing_env_subtitle:
+    "You'll be able to send a message in a moment.",
+};
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string | number>) => {
+      let value = translations[key] ?? key;
+      if (options) {
+        for (const [name, replacement] of Object.entries(options)) {
+          value = value.replace(`{{${name}}}`, String(replacement));
+        }
+      }
+      return value;
+    },
+  }),
+}));
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function render(node: React.ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return container;
+}
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
+describe("ChatEmptyState", () => {
+  it("invites sending when the workspace environment is ready", async () => {
+    const container = await render(
+      <ChatEmptyState
+        workspaceEnvironmentPreparing={false}
+        envPlugin={null}
+        envSeconds={null}
+      />,
+    );
+
+    expect(container.textContent).toBe("Send a message to start a conversation");
+  });
+
+  it("explains that env preparation is blocking the first send", async () => {
+    const container = await render(
+      <ChatEmptyState
+        workspaceEnvironmentPreparing
+        envPlugin={null}
+        envSeconds={null}
+      />,
+    );
+
+    expect(container.querySelector("[role='status']")).toBeTruthy();
+    expect(container.textContent).toContain("Preparing workspace environment…");
+    expect(container.textContent).toContain(
+      "You'll be able to send a message in a moment.",
+    );
+    expect(container.textContent).not.toContain(
+      "Send a message to start a conversation",
+    );
+  });
+
+  it("includes the active env-provider stage when progress is available", async () => {
+    const container = await render(
+      <ChatEmptyState
+        workspaceEnvironmentPreparing
+        envPlugin="env-direnv"
+        envSeconds={12}
+      />,
+    );
+
+    expect(container.textContent).toContain("Preparing direnv (12s)…");
+  });
+});

--- a/src/ui/src/components/chat/ChatEmptyState.tsx
+++ b/src/ui/src/components/chat/ChatEmptyState.tsx
@@ -1,0 +1,43 @@
+import { LoaderCircle } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { formatEnvProviderName } from "../../utils/workspaceEnvironment";
+import styles from "./ChatPanel.module.css";
+
+interface ChatEmptyStateProps {
+  workspaceEnvironmentPreparing: boolean;
+  envPlugin: string | null;
+  envSeconds: number | null;
+}
+
+export function ChatEmptyState({
+  workspaceEnvironmentPreparing,
+  envPlugin,
+  envSeconds,
+}: ChatEmptyStateProps) {
+  const { t } = useTranslation("chat");
+
+  if (!workspaceEnvironmentPreparing) {
+    return <div className={styles.empty}>{t("send_message_to_start")}</div>;
+  }
+
+  const title =
+    envPlugin && envSeconds !== null
+      ? t("empty_preparing_env_with_plugin", {
+          plugin: formatEnvProviderName(envPlugin),
+          seconds: envSeconds,
+        })
+      : t("empty_preparing_env");
+
+  return (
+    <div
+      className={`${styles.empty} ${styles.emptyPreparing}`}
+      role="status"
+      aria-live="polite"
+    >
+      <LoaderCircle size={20} className={styles.emptySpinner} />
+      <div className={styles.emptyTitle}>{title}</div>
+      <div className={styles.emptySub}>{t("empty_preparing_env_subtitle")}</div>
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/ChatEmptyState.tsx
+++ b/src/ui/src/components/chat/ChatEmptyState.tsx
@@ -1,42 +1,53 @@
 import { LoaderCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
+import { useEnvElapsedSeconds } from "../../hooks/useEnvElapsedSeconds";
 import { formatEnvProviderName } from "../../utils/workspaceEnvironment";
 import styles from "./ChatPanel.module.css";
 
 interface ChatEmptyStateProps {
   workspaceEnvironmentPreparing: boolean;
-  envPlugin: string | null;
-  envSeconds: number | null;
+  workspaceId: string | null;
 }
 
 export function ChatEmptyState({
   workspaceEnvironmentPreparing,
-  envPlugin,
-  envSeconds,
+  workspaceId,
 }: ChatEmptyStateProps) {
   const { t } = useTranslation("chat");
+  const { plugin: envPlugin, seconds: envSeconds } = useEnvElapsedSeconds(
+    workspaceEnvironmentPreparing ? workspaceId : null,
+  );
 
   if (!workspaceEnvironmentPreparing) {
     return <div className={styles.empty}>{t("send_message_to_start")}</div>;
   }
 
+  const providerName = envPlugin ? formatEnvProviderName(envPlugin) : null;
   const title =
-    envPlugin && envSeconds !== null
+    providerName && envSeconds !== null
       ? t("empty_preparing_env_with_plugin", {
-          plugin: formatEnvProviderName(envPlugin),
+          plugin: providerName,
           seconds: envSeconds,
         })
       : t("empty_preparing_env");
+  const ariaTitle = providerName
+    ? t("empty_preparing_env_with_plugin_static", {
+        plugin: providerName,
+      })
+    : t("empty_preparing_env");
 
   return (
     <div
       className={`${styles.empty} ${styles.emptyPreparing}`}
       role="status"
       aria-live="polite"
+      aria-label={ariaTitle}
     >
       <LoaderCircle size={20} className={styles.emptySpinner} />
-      <div className={styles.emptyTitle}>{title}</div>
+      <div className={styles.emptyTitle} aria-hidden="true">
+        {title}
+      </div>
       <div className={styles.emptySub}>{t("empty_preparing_env_subtitle")}</div>
     </div>
   );

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -49,6 +49,7 @@ import { PinnedPromptsBar } from "./PinnedPromptsBar";
 import { extractMentionPaths } from "./queuedMessageEditing";
 import { SlashCommandPicker } from "./SlashCommandPicker";
 import { useSlashPicker } from "../../hooks/useSlashPicker";
+import { formatEnvProviderName } from "../../utils/workspaceEnvironment";
 import { hasUltrathink, renderUltrathinkText } from "./ultrathink";
 import styles from "./ChatPanel.module.css";
 
@@ -240,16 +241,7 @@ export function ChatInputArea({
     ? envPlugin && envSeconds !== null
       ? t("composer_placeholder_preparing_env_with_plugin", {
           defaultValue: "Preparing {{plugin}} ({{seconds}}s)…",
-          plugin:
-            envPlugin === "env-direnv"
-              ? "direnv"
-              : envPlugin === "env-mise"
-                ? "mise"
-                : envPlugin === "env-dotenv"
-                  ? "dotenv"
-                  : envPlugin === "env-nix-devshell"
-                    ? "nix"
-                    : envPlugin,
+          plugin: formatEnvProviderName(envPlugin),
           seconds: envSeconds,
         })
       : t("composer_placeholder_preparing_env")

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -150,6 +150,27 @@
   font-family: var(--font-mono);
 }
 
+.emptyPreparing::before {
+  content: none;
+}
+
+.emptySpinner {
+  animation: preparingForkSpin 1s linear infinite;
+  color: var(--accent-primary);
+  opacity: 0.7;
+}
+
+.emptyTitle {
+  color: var(--text-muted);
+}
+
+.emptySub {
+  max-width: 360px;
+  text-align: center;
+  line-height: 1.45;
+  color: var(--text-faint);
+}
+
 .errorBanner {
   background: var(--accent-error-bg);
   border: 1px solid var(--accent-error-border);

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -67,7 +67,6 @@ import { PlanApprovalCard } from "./PlanApprovalCard";
 import { AgentApprovalCard } from "./AgentApprovalCard";
 import { ScrollToBottomPill } from "./ScrollToBottomPill";
 import { useStickyScroll } from "../../hooks/useStickyScroll";
-import { useEnvElapsedSeconds } from "../../hooks/useEnvElapsedSeconds";
 import { tooltipWithHotkey } from "../../hotkeys/display";
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
 import { usePreventScrollBounce } from "../../hooks/usePreventScrollBounce";
@@ -93,9 +92,6 @@ export function ChatPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const workspaceEnvironmentPreparing = useAppStore((s) =>
     isWorkspaceEnvironmentPreparing(s, s.selectedWorkspaceId),
-  );
-  const { plugin: envPlugin, seconds: envSeconds } = useEnvElapsedSeconds(
-    selectedWorkspaceId,
   );
   const activeSessionId = useAppStore((s) =>
     s.selectedWorkspaceId
@@ -1573,8 +1569,7 @@ export function ChatPanel() {
           {messages.length === 0 && !hasStreaming && !runningSetupScriptSource ? (
             <ChatEmptyState
               workspaceEnvironmentPreparing={workspaceEnvironmentPreparing}
-              envPlugin={envPlugin}
-              envSeconds={envSeconds}
+              workspaceId={selectedWorkspaceId}
             />
           ) : (
             <>

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -67,6 +67,7 @@ import { PlanApprovalCard } from "./PlanApprovalCard";
 import { AgentApprovalCard } from "./AgentApprovalCard";
 import { ScrollToBottomPill } from "./ScrollToBottomPill";
 import { useStickyScroll } from "../../hooks/useStickyScroll";
+import { useEnvElapsedSeconds } from "../../hooks/useEnvElapsedSeconds";
 import { tooltipWithHotkey } from "../../hotkeys/display";
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
 import { usePreventScrollBounce } from "../../hooks/usePreventScrollBounce";
@@ -83,6 +84,7 @@ import { CurrentTurnTaskProgress } from "./CurrentTurnTaskProgress";
 import { ChatInputArea } from "./ChatInputArea";
 import { EMPTY_ACTIVITIES } from "./chatConstants";
 import { QueuedMessagesPopover } from "./QueuedMessagesPopover";
+import { ChatEmptyState } from "./ChatEmptyState";
 
 const EMPTY_QUEUED_MESSAGES: QueuedMessage[] = [];
 
@@ -91,6 +93,9 @@ export function ChatPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const workspaceEnvironmentPreparing = useAppStore((s) =>
     isWorkspaceEnvironmentPreparing(s, s.selectedWorkspaceId),
+  );
+  const { plugin: envPlugin, seconds: envSeconds } = useEnvElapsedSeconds(
+    selectedWorkspaceId,
   );
   const activeSessionId = useAppStore((s) =>
     s.selectedWorkspaceId
@@ -1566,9 +1571,11 @@ export function ChatPanel() {
             sessionId={activeChatSessionRecord?.id}
           />
           {messages.length === 0 && !hasStreaming && !runningSetupScriptSource ? (
-            <div className={styles.empty}>
-              Send a message to start a conversation
-            </div>
+            <ChatEmptyState
+              workspaceEnvironmentPreparing={workspaceEnvironmentPreparing}
+              envPlugin={envPlugin}
+              envSeconds={envSeconds}
+            />
           ) : (
             <>
               {isLoadingMore && (

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -1,5 +1,8 @@
 {
   "send_message_to_start": "Send a message to start a conversation",
+  "empty_preparing_env": "Preparing workspace environment…",
+  "empty_preparing_env_with_plugin": "Preparing {{plugin}} ({{seconds}}s)…",
+  "empty_preparing_env_subtitle": "You'll be able to send a message in a moment.",
   "compacting_label": "Compacting context…",
   "compacting_aria": "Compacting context, {{elapsed}} elapsed",
   "processing_aria": "Processing, {{elapsed}} elapsed",

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -2,6 +2,7 @@
   "send_message_to_start": "Send a message to start a conversation",
   "empty_preparing_env": "Preparing workspace environment…",
   "empty_preparing_env_with_plugin": "Preparing {{plugin}} ({{seconds}}s)…",
+  "empty_preparing_env_with_plugin_static": "Preparing {{plugin}}…",
   "empty_preparing_env_subtitle": "You'll be able to send a message in a moment.",
   "compacting_label": "Compacting context…",
   "compacting_aria": "Compacting context, {{elapsed}} elapsed",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -1,5 +1,8 @@
 {
   "send_message_to_start": "Envía un mensaje para iniciar una conversación",
+  "empty_preparing_env": "Preparando el entorno del espacio de trabajo…",
+  "empty_preparing_env_with_plugin": "Preparando {{plugin}} ({{seconds}}s)…",
+  "empty_preparing_env_subtitle": "Podrás enviar un mensaje en un momento.",
   "compacting_label": "Compactando contexto…",
   "compacting_aria": "Compactando contexto, {{elapsed}} transcurridos",
   "processing_aria": "Procesando, {{elapsed}} transcurridos",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -2,6 +2,7 @@
   "send_message_to_start": "Envía un mensaje para iniciar una conversación",
   "empty_preparing_env": "Preparando el entorno del espacio de trabajo…",
   "empty_preparing_env_with_plugin": "Preparando {{plugin}} ({{seconds}}s)…",
+  "empty_preparing_env_with_plugin_static": "Preparando {{plugin}}…",
   "empty_preparing_env_subtitle": "Podrás enviar un mensaje en un momento.",
   "compacting_label": "Compactando contexto…",
   "compacting_aria": "Compactando contexto, {{elapsed}} transcurridos",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -2,6 +2,7 @@
   "send_message_to_start": "メッセージを送信して会話を開始してください",
   "empty_preparing_env": "ワークスペース環境を準備中…",
   "empty_preparing_env_with_plugin": "{{plugin}} を準備中（{{seconds}}秒）…",
+  "empty_preparing_env_with_plugin_static": "{{plugin}} を準備中…",
   "empty_preparing_env_subtitle": "まもなくメッセージを送信できるようになります。",
   "compacting_label": "コンテキストを圧縮中…",
   "compacting_aria": "コンテキストを圧縮中、経過時間 {{elapsed}}",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -1,5 +1,8 @@
 {
   "send_message_to_start": "メッセージを送信して会話を開始してください",
+  "empty_preparing_env": "ワークスペース環境を準備中…",
+  "empty_preparing_env_with_plugin": "{{plugin}} を準備中（{{seconds}}秒）…",
+  "empty_preparing_env_subtitle": "まもなくメッセージを送信できるようになります。",
   "compacting_label": "コンテキストを圧縮中…",
   "compacting_aria": "コンテキストを圧縮中、経過時間 {{elapsed}}",
   "processing_aria": "処理中、経過時間 {{elapsed}}",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -2,6 +2,7 @@
   "send_message_to_start": "Envie uma mensagem para iniciar uma conversa",
   "empty_preparing_env": "Preparando ambiente do workspace…",
   "empty_preparing_env_with_plugin": "Preparando {{plugin}} ({{seconds}}s)…",
+  "empty_preparing_env_with_plugin_static": "Preparando {{plugin}}…",
   "empty_preparing_env_subtitle": "Você poderá enviar uma mensagem em instantes.",
   "compacting_label": "Compactando contexto…",
   "compacting_aria": "Compactando contexto, {{elapsed}} decorrido",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -1,5 +1,8 @@
 {
   "send_message_to_start": "Envie uma mensagem para iniciar uma conversa",
+  "empty_preparing_env": "Preparando ambiente do workspace…",
+  "empty_preparing_env_with_plugin": "Preparando {{plugin}} ({{seconds}}s)…",
+  "empty_preparing_env_subtitle": "Você poderá enviar uma mensagem em instantes.",
   "compacting_label": "Compactando contexto…",
   "compacting_aria": "Compactando contexto, {{elapsed}} decorrido",
   "processing_aria": "Processando, {{elapsed}} decorrido",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -2,6 +2,7 @@
   "send_message_to_start": "发送消息以开始对话",
   "empty_preparing_env": "正在准备工作区环境…",
   "empty_preparing_env_with_plugin": "正在准备 {{plugin}}（{{seconds}} 秒）…",
+  "empty_preparing_env_with_plugin_static": "正在准备 {{plugin}}…",
   "empty_preparing_env_subtitle": "稍后即可发送消息。",
   "compacting_label": "正在压缩上下文…",
   "compacting_aria": "正在压缩上下文，已用 {{elapsed}}",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -1,5 +1,8 @@
 {
   "send_message_to_start": "发送消息以开始对话",
+  "empty_preparing_env": "正在准备工作区环境…",
+  "empty_preparing_env_with_plugin": "正在准备 {{plugin}}（{{seconds}} 秒）…",
+  "empty_preparing_env_subtitle": "稍后即可发送消息。",
   "compacting_label": "正在压缩上下文…",
   "compacting_aria": "正在压缩上下文，已用 {{elapsed}}",
   "processing_aria": "处理中，已用 {{elapsed}}",

--- a/src/ui/src/utils/workspaceEnvironment.test.ts
+++ b/src/ui/src/utils/workspaceEnvironment.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from "vitest";
 import type { AppState } from "../stores/useAppStore";
 import type { Workspace } from "../types/workspace";
 import type { WorkspaceEnvironmentPreparation } from "../stores/slices/workspacesSlice";
-import { isWorkspaceEnvironmentPreparing } from "./workspaceEnvironment";
+import {
+  formatEnvProviderName,
+  isWorkspaceEnvironmentPreparing,
+} from "./workspaceEnvironment";
 
 function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
   return {
@@ -102,5 +105,20 @@ describe("isWorkspaceEnvironmentPreparing", () => {
     // paths resolve env on their own.
     const state = makeState([makeWorkspace()], {});
     expect(isWorkspaceEnvironmentPreparing(state, "ws-1")).toBe(false);
+  });
+});
+
+describe("formatEnvProviderName", () => {
+  it("formats bundled env-provider ids for display", () => {
+    expect(formatEnvProviderName("env-direnv")).toBe("direnv");
+    expect(formatEnvProviderName("env-mise")).toBe("mise");
+    expect(formatEnvProviderName("env-dotenv")).toBe("dotenv");
+    expect(formatEnvProviderName("env-nix-devshell")).toBe("nix");
+  });
+
+  it("keeps unknown provider ids visible", () => {
+    expect(formatEnvProviderName("env-custom-toolchain")).toBe(
+      "env-custom-toolchain",
+    );
   });
 });

--- a/src/ui/src/utils/workspaceEnvironment.ts
+++ b/src/ui/src/utils/workspaceEnvironment.ts
@@ -91,3 +91,18 @@ export function isWorkspaceEnvironmentPreparing(
   if (!workspace || workspace.remote_connection_id) return false;
   return state.workspaceEnvironment[workspaceId]?.status === "preparing";
 }
+
+export function formatEnvProviderName(plugin: string): string {
+  switch (plugin) {
+    case "env-direnv":
+      return "direnv";
+    case "env-mise":
+      return "mise";
+    case "env-dotenv":
+      return "dotenv";
+    case "env-nix-devshell":
+      return "nix";
+    default:
+      return plugin;
+  }
+}


### PR DESCRIPTION
## Summary
- Replace the empty chat pane's “Send a message to start a conversation” invite while the workspace environment is preparing.
- Add a status-style empty state with a spinner, a short “you can send soon” explanation, and the active env-provider stage/timer when available.
- Share env-provider display-name formatting with the composer placeholder and add localized strings for the new state.

## Why
When a freshly opened workspace is still resolving env providers, the composer already shows “Preparing nix…” and blocks send. The message pane could still invite the user to send a first message, which made the UI read as contradictory.

## Validation
- `bun run test src/components/chat/ChatEmptyState.test.tsx src/components/chat/ChatInputArea.test.ts src/utils/workspaceEnvironment.test.ts`
- `bunx tsc -b`
- `bun run lint` (passes with existing warnings)
- `bun run lint:css`
- `bun run build`
- `git diff --check`

Closes #930