### PR TITLE
fix(chat): reset transcript view on session switch

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.staleTranscript.test.tsx
+++ b/src/ui/src/components/chat/ChatPanel.staleTranscript.test.tsx
@@ -1,0 +1,365 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAppStore } from "../../stores/useAppStore";
+import type { ChatMessage, ChatSession, Repository, Workspace } from "../../types";
+import { ChatPanel } from "./ChatPanel";
+
+const serviceMocks = vi.hoisted(() => ({
+  clearConversation: vi.fn(),
+  forkWorkspaceAtCheckpoint: vi.fn(),
+  getAppSetting: vi.fn(() => Promise.resolve(null)),
+  launchCodexLogin: vi.fn(),
+  listCheckpoints: vi.fn(() => Promise.resolve([])),
+  listSlashCommands: vi.fn(() => Promise.resolve([])),
+  loadAttachmentData: vi.fn(),
+  loadAttachmentsForSession: vi.fn(() => Promise.resolve([])),
+  loadChatHistoryPage: vi.fn(() =>
+    Promise.resolve({
+      messages: [],
+      attachments: [],
+      has_more: false,
+      total_count: 0,
+    }),
+  ),
+  loadCompletedTurns: vi.fn(() => Promise.resolve([])),
+  loadDiffFiles: vi.fn(),
+  openReleaseNotes: vi.fn(),
+  openUsageSettings: vi.fn(),
+  readPlanFile: vi.fn(),
+  recordSlashCommandUsage: vi.fn(),
+  sendRemoteCommand: vi.fn(),
+  setAppSetting: vi.fn(),
+  steerQueuedChatMessage: vi.fn(),
+  stopAgent: vi.fn(),
+  submitAgentAnswer: vi.fn(),
+  submitAgentApproval: vi.fn(),
+  submitPlanApproval: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallbackOrOptions?: string | Record<string, unknown>) =>
+      typeof fallbackOrOptions === "string" ? fallbackOrOptions : key,
+  }),
+}));
+
+vi.mock("../../services/tauri", () => serviceMocks);
+
+vi.mock("../../hooks/useStickyScroll", () => ({
+  useStickyScroll: () => ({
+    isAtBottom: true,
+    scrollToBottom: vi.fn(),
+    restoreScrollPosition: vi.fn(),
+    handleContentChanged: vi.fn(),
+    markUserScrollIntent: vi.fn(),
+    suppressNextAutoScrollRef: { current: false },
+  }),
+}));
+
+vi.mock("../../hooks/usePreventScrollBounce", () => ({
+  usePreventScrollBounce: vi.fn(),
+}));
+
+vi.mock("../shared/WorkspacePanelHeader", () => ({
+  WorkspacePanelHeader: () => <div data-testid="workspace-header" />,
+}));
+
+vi.mock("./SessionTabs", () => ({
+  SessionTabs: () => <div data-testid="session-tabs" />,
+}));
+
+vi.mock("./WorkspaceEmptyTabs", () => ({
+  WorkspaceEmptyTabs: () => <div data-testid="workspace-empty-tabs" />,
+}));
+
+vi.mock("./OverlayScrollbar", () => ({
+  OverlayScrollbar: () => null,
+}));
+
+vi.mock("./ChatSearchBar", () => ({
+  ChatSearchBar: () => null,
+}));
+
+vi.mock("./ScrollToBottomPill", () => ({
+  ScrollToBottomPill: () => null,
+}));
+
+vi.mock("./ChatInputArea", () => ({
+  ChatInputArea: () => <div data-testid="composer" />,
+}));
+
+vi.mock("./ChatEmptyState", () => ({
+  ChatEmptyState: () => (
+    <div data-testid="empty-state">Send a message to start a conversation</div>
+  ),
+}));
+
+vi.mock("./StreamingMessage", () => ({
+  StreamingMessage: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid="streaming-message">streaming:{sessionId}</div>
+  ),
+}));
+
+vi.mock("./StreamingThinkingBlock", () => ({
+  StreamingThinkingBlock: () => <div data-testid="streaming-thinking" />,
+}));
+
+vi.mock("./CurrentTurnTaskProgress", () => ({
+  CurrentTurnTaskProgress: () => <div data-testid="task-progress" />,
+}));
+
+vi.mock("./CliInvocationBanner", () => ({
+  CliInvocationBanner: () => null,
+}));
+
+vi.mock("./AgentQuestionCard", () => ({
+  AgentQuestionCard: () => null,
+}));
+
+vi.mock("./PlanApprovalCard", () => ({
+  PlanApprovalCard: () => null,
+}));
+
+vi.mock("./AgentApprovalCard", () => ({
+  AgentApprovalCard: () => null,
+}));
+
+vi.mock("./ChatErrorBanner", () => ({
+  ChatErrorBanner: () => null,
+}));
+
+vi.mock("../auth/ChatAuthFailureCallout", () => ({
+  ChatAuthFailureCallout: () => null,
+}));
+
+vi.mock("./SetupScriptBanner", () => ({
+  SetupScriptBanner: () => null,
+}));
+
+vi.mock("./AttachmentContextMenu", () => ({
+  AttachmentContextMenu: () => null,
+}));
+
+vi.mock("./AttachmentLightbox", () => ({
+  AttachmentLightbox: () => null,
+}));
+
+vi.mock("./MessagesWithTurns", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    MessagesWithTurns: ({
+      messages,
+      sessionId,
+      streamingMessageNode,
+    }: {
+      messages: ChatMessage[];
+      sessionId: string;
+      streamingMessageNode?: React.ReactNode;
+    }) => {
+      const [initialMessages] = React.useState(messages);
+      return (
+        <div data-testid="messages-with-turns" data-session-id={sessionId}>
+          {initialMessages.map((message) => (
+            <div key={message.id}>{message.content}</div>
+          ))}
+          {streamingMessageNode}
+        </div>
+      );
+    },
+  };
+});
+
+const WORKSPACE_ID = "workspace-1";
+const SESSION_WITH_MESSAGES = "session-with-messages";
+const NEW_SESSION = "new-session";
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+function makeWorkspace(): Workspace {
+  return {
+    id: WORKSPACE_ID,
+    repository_id: "repo-1",
+    name: "Workspace",
+    worktree_path: "/repo",
+    branch_name: "main",
+    status: "Active",
+    status_line: "",
+    created_at: "2026-05-20T00:00:00.000Z",
+    sort_order: 0,
+    remote_connection_id: null,
+    agent_status: "Idle",
+  };
+}
+
+function makeRepository(): Repository {
+  return {
+    id: "repo-1",
+    name: "Repo",
+    path: "/repo",
+    path_slug: "repo",
+    icon: null,
+    created_at: "2026-05-20T00:00:00.000Z",
+    setup_script: null,
+    custom_instructions: null,
+    sort_order: 0,
+    branch_rename_preferences: null,
+    setup_script_auto_run: false,
+    archive_script: null,
+    archive_script_auto_run: false,
+    base_branch: null,
+    default_remote: null,
+    path_valid: true,
+    remote_connection_id: null,
+  };
+}
+
+function makeSession(id: string, name: string): ChatSession {
+  return {
+    id,
+    workspace_id: WORKSPACE_ID,
+    session_id: null,
+    name,
+    name_edited: false,
+    turn_count: 0,
+    sort_order: 0,
+    status: "Active",
+    created_at: "2026-05-20T00:00:00.000Z",
+    archived_at: null,
+    cli_invocation: null,
+    agent_status: "Idle",
+    needs_attention: false,
+    attention_kind: null,
+  };
+}
+
+function makeMessage(sessionId: string, content: string): ChatMessage {
+  return {
+    id: `${sessionId}-message`,
+    workspace_id: WORKSPACE_ID,
+    chat_session_id: sessionId,
+    role: "Assistant",
+    content,
+    cost_usd: null,
+    duration_ms: null,
+    created_at: "2026-05-20T00:00:00.000Z",
+    thinking: null,
+    input_tokens: null,
+    output_tokens: null,
+    cache_read_tokens: null,
+    cache_creation_tokens: null,
+  };
+}
+
+async function renderChatPanel() {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<ChatPanel />);
+  });
+}
+
+beforeEach(() => {
+  serviceMocks.getAppSetting.mockClear();
+  serviceMocks.loadChatHistoryPage.mockClear();
+  serviceMocks.listCheckpoints.mockClear();
+  serviceMocks.loadCompletedTurns.mockClear();
+  useAppStore.setState({
+    workspaces: [makeWorkspace()],
+    repositories: [makeRepository()],
+    selectedWorkspaceId: WORKSPACE_ID,
+    sessionsByWorkspace: {
+      [WORKSPACE_ID]: [
+        makeSession(SESSION_WITH_MESSAGES, "Existing chat"),
+        makeSession(NEW_SESSION, "New chat"),
+      ],
+    },
+    selectedSessionIdByWorkspaceId: {
+      [WORKSPACE_ID]: SESSION_WITH_MESSAGES,
+    },
+    sessionsLoadedByWorkspace: {
+      [WORKSPACE_ID]: true,
+    },
+    chatMessages: {
+      [SESSION_WITH_MESSAGES]: [
+        makeMessage(SESSION_WITH_MESSAGES, "old transcript should disappear"),
+      ],
+      [NEW_SESSION]: [],
+    },
+    chatPagination: {
+      [SESSION_WITH_MESSAGES]: {
+        hasMore: false,
+        isLoadingMore: false,
+        totalCount: 1,
+        oldestMessageId: `${SESSION_WITH_MESSAGES}-message`,
+      },
+      [NEW_SESSION]: {
+        hasMore: false,
+        isLoadingMore: false,
+        totalCount: 0,
+        oldestMessageId: null,
+      },
+    },
+    streamingContent: {},
+    streamingThinking: {},
+    pendingTypewriter: {},
+    completedTurns: {},
+    toolActivities: {},
+    runningSetupScripts: {},
+    queuedMessages: {},
+    diffTabsByWorkspace: {},
+    fileTabsByWorkspace: {},
+  });
+});
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => {
+      root!.unmount();
+    });
+  }
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("ChatPanel transcript session switches", () => {
+  it("remounts the transcript subtree so a new session cannot show stale messages", async () => {
+    await renderChatPanel();
+    expect(container?.textContent).toContain("old transcript should disappear");
+
+    await act(async () => {
+      useAppStore.setState((state) => ({
+        selectedSessionIdByWorkspaceId: {
+          ...state.selectedSessionIdByWorkspaceId,
+          [WORKSPACE_ID]: NEW_SESSION,
+        },
+        streamingContent: {
+          ...state.streamingContent,
+          [NEW_SESSION]: "new session stream",
+        },
+      }));
+    });
+
+    expect(container?.textContent).not.toContain("old transcript should disappear");
+    expect(container?.textContent).toContain(`streaming:${NEW_SESSION}`);
+  });
+
+  it("renders an empty new chat without the previous session transcript", async () => {
+    await renderChatPanel();
+
+    await act(async () => {
+      useAppStore.getState().selectSession(WORKSPACE_ID, NEW_SESSION);
+    });
+
+    expect(container?.textContent).not.toContain("old transcript should disappear");
+    expect(container?.textContent).toContain(
+      "Send a message to start a conversation",
+    );
+  });
+});

--- a/src/ui/src/components/chat/ChatPanel.staleTranscript.test.tsx
+++ b/src/ui/src/components/chat/ChatPanel.staleTranscript.test.tsx
@@ -47,7 +47,13 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
-vi.mock("../../services/tauri", () => serviceMocks);
+vi.mock("../../services/tauri", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/tauri")>();
+  return {
+    ...actual,
+    ...serviceMocks,
+  };
+});
 
 vi.mock("../../hooks/useStickyScroll", () => ({
   useStickyScroll: () => ({

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -550,6 +550,13 @@ export function ChatPanel() {
       .workspaces.find((w) => w.id === selectedWorkspaceId);
     const sessionId = activeSessionId;
     const isLocal = !currentWs?.remote_connection_id;
+    const isCurrentHistoryLoad = () => {
+      const state = useAppStore.getState();
+      return (
+        state.selectedWorkspaceId === selectedWorkspaceId &&
+        state.selectedSessionIdByWorkspaceId[selectedWorkspaceId] === sessionId
+      );
+    };
 
     debugChat("ChatPanel", "load-history:start", {
       sessionId,
@@ -558,7 +565,7 @@ export function ChatPanel() {
     });
 
     const onMessages = (msgs: ChatMessage[], attachments?: import("../../types").ChatAttachment[], pageState?: import("../../types").ChatPaginationState) => {
-      if (cancelled) return;
+      if (cancelled || !isCurrentHistoryLoad()) return;
       // The paginated backend already drops legacy empty-assistant rows so
       // `total_count` matches the page contents. The remote (non-paginated)
       // path still needs the filter — apply it only when no pageState exists.
@@ -616,7 +623,7 @@ export function ChatPanel() {
         if (!isRunning) {
           loadCompletedTurns(sessionId)
             .then((turnData) => {
-              if (cancelled) return;
+              if (cancelled || !isCurrentHistoryLoad()) return;
               const turns = reconstructCompletedTurns(filtered, turnData, loadGlobalOffset);
               debugChat("ChatPanel", "load-completed-turns:success", {
                 sessionId,
@@ -673,7 +680,7 @@ export function ChatPanel() {
       const setCheckpoints = useAppStore.getState().setCheckpoints;
       listCheckpoints(sessionId)
         .then((cps) => {
-          if (cancelled) return;
+          if (cancelled || !isCurrentHistoryLoad()) return;
           setCheckpoints(sessionId, cps);
         })
         .catch((e) => console.error("Failed to load checkpoints:", e));
@@ -1568,6 +1575,7 @@ export function ChatPanel() {
           />
           {messages.length === 0 && !hasStreaming && !runningSetupScriptSource ? (
             <ChatEmptyState
+              key={activeSessionId ?? "no-active-session"}
               workspaceEnvironmentPreparing={workspaceEnvironmentPreparing}
               workspaceId={selectedWorkspaceId}
             />
@@ -1581,6 +1589,7 @@ export function ChatPanel() {
               )}
               {activeSessionId && selectedWorkspaceId && (
                 <MessagesWithTurns
+                  key={activeSessionId}
                   messages={messages}
                   workspaceId={selectedWorkspaceId}
                   sessionId={activeSessionId}


### PR DESCRIPTION
## Summary

- Reset the chat transcript renderer when the active chat session changes so stale message DOM/state cannot survive a tab switch.
- Guard chat history, completed-turn, and checkpoint hydration callbacks so late async responses only apply while their workspace/session is still selected.
- Add a regression test that simulates a sticky transcript renderer and verifies a newly selected empty chat stays clear of the previous transcript.

## Root Cause

Issue #936 showed a new `Cmd/Ctrl+T` chat tab rendering both the empty-state placeholder and a previous session's transcript. The store path already resolved the new session to an empty message list, so the bug was in the frontend render/hydration path rather than persisted chat rows.

The fix keys the session-specific transcript surfaces by `activeSessionId` and adds a live selection token check around async hydration callbacks. That covers both the stale child-renderer case and the race where an older history request resolves after the user has moved to a different session.

## Validation

- `cd src/ui && bun run test ChatPanel.staleTranscript.test.tsx`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run lint` (passes with existing warnings only)
- `cd src/ui && bun run test`
- `cd src/ui && bun run build`

Closes #936
