### PR TITLE
perf(command-palette): speed up Cmd+P file search

### DIFF
--- a/src/ui/src/components/command-palette/CommandPalette.module.css
+++ b/src/ui/src/components/command-palette/CommandPalette.module.css
@@ -104,6 +104,10 @@
   padding: var(--space-1);
 }
 
+.virtualFileList {
+  position: relative;
+}
+
 .empty {
   padding: var(--space-6);
   text-align: center;
@@ -132,6 +136,13 @@
   border-radius: var(--radius-lg);
   cursor: pointer;
   transition: background var(--transition-fast);
+}
+
+.fileResult {
+  position: absolute;
+  top: 0;
+  inset-inline: var(--space-1);
+  height: 52px;
 }
 
 .result:hover {
@@ -175,6 +186,12 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.matchHighlight {
+  color: var(--accent-primary);
+  background: transparent;
+  font-weight: var(--fw-semibold);
 }
 
 /* Keyboard shortcut badges */

--- a/src/ui/src/components/command-palette/CommandPalette.module.css
+++ b/src/ui/src/components/command-palette/CommandPalette.module.css
@@ -142,7 +142,6 @@
   position: absolute;
   top: 0;
   inset-inline: var(--space-1);
-  height: 52px;
 }
 
 .result:hover {

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -1,6 +1,14 @@
-import { useState, useMemo, useEffect, useRef, useCallback } from "react";
+import {
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  useCallback,
+  useDeferredValue,
+  type ReactNode,
+} from "react";
 import { useTranslation } from "react-i18next";
-import { Search, ChevronLeft } from "lucide-react";
+import { Search, ChevronLeft, File } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import { applyTheme, applyUserFonts, findTheme, loadAllThemes, cacheThemePreference, getThemeDataAttr } from "../../utils/theme";
 import {
@@ -33,12 +41,49 @@ import {
   buildThemeCommands,
   buildModelCommands,
   buildEffortCommands,
-  buildFileCommands,
   groupCommandsByCategory,
   type FileEntry,
   type GroupedCommands,
 } from "./commands";
+import {
+  DEFAULT_FILE_SEARCH_LIMIT,
+  prepareFileSearchIndex,
+  searchFileIndex,
+  type FileSearchResult,
+} from "./fileFuzzySearch";
 import styles from "./CommandPalette.module.css";
+
+const FILE_RESULT_ROW_HEIGHT = 52;
+const FILE_RESULT_OVERSCAN = 6;
+
+function renderHighlightedText(text: string, matches: readonly number[]) {
+  if (matches.length === 0) return text;
+  const matchSet = new Set(matches);
+  const chunks: ReactNode[] = [];
+  let plainStart = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    if (!matchSet.has(index)) continue;
+    if (plainStart < index) {
+      chunks.push(text.slice(plainStart, index));
+    }
+    chunks.push(
+      <mark key={`${index}-${text[index]}`} className={styles.matchHighlight}>
+        {text[index]}
+      </mark>,
+    );
+    plainStart = index + 1;
+  }
+  if (plainStart < text.length) {
+    chunks.push(text.slice(plainStart));
+  }
+  return chunks;
+}
+
+function dirnameMatches(result: FileSearchResult): number[] {
+  const dirnameLength = result.entry.dirname.length;
+  if (dirnameLength === 0) return [];
+  return result.pathMatches.filter((index) => index < dirnameLength);
+}
 
 export function CommandPalette() {
   const { t } = useTranslation("chat");
@@ -126,6 +171,8 @@ export function CommandPalette() {
   const [fileEntries, setFileEntries] = useState<FileEntry[]>([]);
   const [filesLoading, setFilesLoading] = useState(false);
   const [filesLoadError, setFilesLoadError] = useState<string | null>(null);
+  const [resultsScrollTop, setResultsScrollTop] = useState(0);
+  const [resultsViewportHeight, setResultsViewportHeight] = useState(0);
   // Monotonic token bumped on each `enterFileMode` invocation so a late
   // `listWorkspaceFiles` response from a previous workspace can detect it's
   // stale and skip overwriting `fileEntries` with the wrong list.
@@ -147,6 +194,26 @@ export function CommandPalette() {
     const id = requestAnimationFrame(() => inputRef.current?.focus());
     return () => cancelAnimationFrame(id);
   }, [mode]);
+
+  useEffect(() => {
+    const el = resultsRef.current;
+    if (!el) return;
+    const updateHeight = () => setResultsViewportHeight(el.clientHeight);
+    updateHeight();
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", updateHeight);
+      return () => window.removeEventListener("resize", updateHeight);
+    }
+    const resizeObserver = new ResizeObserver(updateHeight);
+    resizeObserver.observe(el);
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const el = resultsRef.current;
+    if (el) el.scrollTop = 0;
+    setResultsScrollTop(0);
+  }, [mode, query]);
 
   const close = toggleCommandPalette;
 
@@ -417,28 +484,29 @@ export function CommandPalette() {
     [selectedModel, selectedModelProvider, effortLevel, selectedSessionId, t],
   );
 
-  const fileCommands = useMemo(
-    () =>
-      buildFileCommands(
-        fileEntries,
-        (path) => {
-          if (selectedWorkspaceId) openFileTab(selectedWorkspaceId, path);
-        },
-        close,
-      ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [fileEntries, selectedWorkspaceId],
+  const fileSearchIndex = useMemo(
+    () => prepareFileSearchIndex(fileEntries),
+    [fileEntries],
   );
+  const deferredFileQuery = useDeferredValue(mode === "file" ? query : "");
+  const fileResults = useMemo(
+    () =>
+      mode === "file"
+        ? searchFileIndex(fileSearchIndex, deferredFileQuery, DEFAULT_FILE_SEARCH_LIMIT)
+        : [],
+    [deferredFileQuery, fileSearchIndex, mode],
+  );
+  const fileSearchSettled = mode !== "file" || deferredFileQuery === query;
 
   // Active command list based on mode
   const activeCommands =
     mode === "theme" ? themeCommands
     : mode === "model" ? modelCommands
     : mode === "effort" ? effortCommands
-    : mode === "file" ? fileCommands
     : mainCommands;
 
   const filteredCommands = useMemo(() => {
+    if (mode === "file") return [];
     if (!query.trim()) return activeCommands;
 
     const scored = activeCommands
@@ -450,7 +518,7 @@ export function CommandPalette() {
       .sort((a, b) => b.score - a.score);
 
     return scored.map(({ cmd }) => cmd);
-  }, [activeCommands, query]);
+  }, [activeCommands, mode, query]);
 
   const grouped = useMemo<GroupedCommands[]>(() => {
     if (mode === "theme") {
@@ -459,9 +527,7 @@ export function CommandPalette() {
         : [];
     }
     if (mode === "file") {
-      return filteredCommands.length > 0
-        ? [{ category: "navigation", label: "Files", commands: filteredCommands }]
-        : [];
+      return [];
     }
     // When searching, show a flat ranked list (no category grouping)
     // so the relevance sort isn't overridden by category order.
@@ -481,18 +547,19 @@ export function CommandPalette() {
     () => grouped.flatMap((g) => g.commands),
     [grouped],
   );
+  const resultCount = mode === "file" ? fileResults.length : flatCommands.length;
 
   // Keep the highlight within bounds when filtering shrinks the list
   // (e.g. typing extra characters that remove matches under the cursor).
   useEffect(() => {
-    if (flatCommands.length === 0) {
+    if (resultCount === 0) {
       if (selectedIndex !== 0) setSelectedIndex(0);
       return;
     }
-    if (selectedIndex > flatCommands.length - 1) {
-      setSelectedIndex(flatCommands.length - 1);
+    if (selectedIndex > resultCount - 1) {
+      setSelectedIndex(resultCount - 1);
     }
-  }, [flatCommands.length, selectedIndex]);
+  }, [resultCount, selectedIndex]);
 
   // Theme live preview on arrow navigation (only in theme mode)
   useEffect(() => {
@@ -520,19 +587,42 @@ export function CommandPalette() {
 
   // Scroll selected item into view
   useEffect(() => {
+    if (mode === "file") {
+      const el = resultsRef.current;
+      if (!el) return;
+      const top = selectedIndex * FILE_RESULT_ROW_HEIGHT;
+      const bottom = top + FILE_RESULT_ROW_HEIGHT;
+      if (top < el.scrollTop) {
+        el.scrollTop = top;
+      } else if (bottom > el.scrollTop + el.clientHeight) {
+        el.scrollTop = bottom - el.clientHeight;
+      }
+      return;
+    }
     const el = resultsRef.current?.querySelector(`[data-index="${selectedIndex}"]`);
     el?.scrollIntoView({ block: "nearest" });
-  }, [selectedIndex]);
+  }, [mode, selectedIndex]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
       setSelectedIndex((i) =>
-        flatCommands.length === 0 ? 0 : Math.min(i + 1, flatCommands.length - 1),
+        resultCount === 0 ? 0 : Math.min(i + 1, resultCount - 1),
       );
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter" && mode === "file") {
+      e.preventDefault();
+      const currentResults = fileSearchSettled
+        ? fileResults
+        : searchFileIndex(fileSearchIndex, query, DEFAULT_FILE_SEARCH_LIMIT);
+      const selectedResult = currentResults[selectedIndex] ?? currentResults[0];
+      if (!selectedResult) return;
+      if (selectedWorkspaceId) {
+        openFileTab(selectedWorkspaceId, selectedResult.entry.path);
+      }
+      close();
     } else if (e.key === "Enter" && flatCommands[selectedIndex]) {
       e.preventDefault();
       flatCommands[selectedIndex].execute();
@@ -591,6 +681,25 @@ export function CommandPalette() {
     }
   };
 
+  const visibleFileRange = useMemo(() => {
+    if (mode !== "file") return { start: 0, end: 0 };
+    const viewport = resultsViewportHeight || 360;
+    const start = Math.max(
+      0,
+      Math.floor(resultsScrollTop / FILE_RESULT_ROW_HEIGHT) - FILE_RESULT_OVERSCAN,
+    );
+    const visibleCount = Math.ceil(viewport / FILE_RESULT_ROW_HEIGHT) + FILE_RESULT_OVERSCAN * 2;
+    return {
+      start,
+      end: Math.min(fileResults.length, start + visibleCount),
+    };
+  }, [fileResults.length, mode, resultsScrollTop, resultsViewportHeight]);
+  const visibleFileResults = useMemo(
+    () => fileResults.slice(visibleFileRange.start, visibleFileRange.end),
+    [fileResults, visibleFileRange.end, visibleFileRange.start],
+  );
+  const fileResultsHeight = fileResults.length * FILE_RESULT_ROW_HEIGHT;
+
   let flatIndex = 0;
 
   return (
@@ -645,14 +754,61 @@ export function CommandPalette() {
           )}
         </div>
 
-        <div className={styles.results} ref={resultsRef}>
-          {filteredCommands.length === 0 ? (
+        <div
+          className={styles.results}
+          ref={resultsRef}
+          onScroll={(e) => {
+            if (mode === "file") {
+              setResultsScrollTop(e.currentTarget.scrollTop);
+            }
+          }}
+        >
+          {resultCount === 0 ? (
             <div className={styles.empty}>
               {mode === "theme" ? "No matching themes"
                 : mode === "model" ? "No matching models"
                 : mode === "effort" ? "No matching levels"
                 : mode === "file" ? (filesLoading ? "Loading files..." : filesLoadError ? `Failed to load files: ${filesLoadError}` : "No matching files")
                 : "No matching commands"}
+            </div>
+          ) : mode === "file" ? (
+            <div
+              className={styles.virtualFileList}
+              style={{ height: fileResultsHeight }}
+            >
+              {visibleFileResults.map((result, offset) => {
+                const idx = visibleFileRange.start + offset;
+                const dirname = result.entry.dirname;
+                return (
+                  <div
+                    key={result.entry.path}
+                    data-index={idx}
+                    className={`${styles.result} ${styles.fileResult} ${idx === selectedIndex ? styles.resultSelected : ""}`}
+                    style={{ transform: `translateY(${idx * FILE_RESULT_ROW_HEIGHT}px)` }}
+                    onClick={() => {
+                      if (!fileSearchSettled) return;
+                      if (selectedWorkspaceId) {
+                        openFileTab(selectedWorkspaceId, result.entry.path);
+                      }
+                      close();
+                    }}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onMouseEnter={() => setSelectedIndex(idx)}
+                  >
+                    <File size={18} className={styles.resultIcon} />
+                    <div className={styles.resultBody}>
+                      <div className={styles.resultName}>
+                        {renderHighlightedText(result.entry.basename, result.basenameMatches)}
+                      </div>
+                      {dirname && (
+                        <div className={styles.resultDescription}>
+                          {renderHighlightedText(dirname, dirnameMatches(result))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           ) : (
             grouped.map((group) => {

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -784,7 +784,10 @@ export function CommandPalette() {
                     key={result.entry.path}
                     data-index={idx}
                     className={`${styles.result} ${styles.fileResult} ${idx === selectedIndex ? styles.resultSelected : ""}`}
-                    style={{ transform: `translateY(${idx * FILE_RESULT_ROW_HEIGHT}px)` }}
+                    style={{
+                      height: FILE_RESULT_ROW_HEIGHT,
+                      transform: `translateY(${idx * FILE_RESULT_ROW_HEIGHT}px)`,
+                    }}
                     onClick={() => {
                       if (!fileSearchSettled) return;
                       if (selectedWorkspaceId) {

--- a/src/ui/src/components/command-palette/fileFuzzySearch.test.ts
+++ b/src/ui/src/components/command-palette/fileFuzzySearch.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  prepareFileSearchIndex,
+  searchFileIndex,
+} from "./fileFuzzySearch";
+import type { FileEntry } from "./commands";
+
+function files(paths: string[]): FileEntry[] {
+  return paths.map((path) => ({ path, is_directory: false }));
+}
+
+describe("fileFuzzySearch", () => {
+  it("matches VSCode-style basename subsequences", () => {
+    const index = prepareFileSearchIndex(files([
+      "src/ui/FooBarPanel.tsx",
+      "src/ui/FooPanel.tsx",
+      "src/ui/bar.ts",
+    ]));
+
+    const results = searchFileIndex(index, "fbp");
+
+    expect(results[0]?.entry.path).toBe("src/ui/FooBarPanel.tsx");
+    expect(results[0]?.basenameMatches).toEqual([0, 3, 6]);
+  });
+
+  it("matches mid-path subsequences and returns full-path ranges", () => {
+    const index = prepareFileSearchIndex(files([
+      "src/ui/src/components/command-palette/CommandPalette.tsx",
+      "src/ui/src/components/chat/ChatPanel.tsx",
+    ]));
+
+    const results = searchFileIndex(index, "cmdpal");
+
+    expect(results[0]?.entry.path).toBe(
+      "src/ui/src/components/command-palette/CommandPalette.tsx",
+    );
+    expect(results[0]?.pathMatches.length).toBe(6);
+    expect(results[0]?.pathMatches[0]).toBeGreaterThan(0);
+  });
+
+  it("ranks exact and prefix basename matches above path-only matches", () => {
+    const index = prepareFileSearchIndex(files([
+      "src/actions/command.ts",
+      "src/components/CommandPalette.tsx",
+      "src/command/palette.ts",
+    ]));
+
+    const [first, second, third] = searchFileIndex(index, "command");
+
+    expect(first.entry.path).toBe("src/actions/command.ts");
+    expect(second.entry.path).toBe("src/components/CommandPalette.tsx");
+    expect(third.entry.path).toBe("src/command/palette.ts");
+  });
+
+  it("filters directories out of the prepared index", () => {
+    const index = prepareFileSearchIndex([
+      { path: "src/components", is_directory: true },
+      { path: "src/components/App.tsx", is_directory: false },
+    ]);
+
+    expect(index.map((entry) => entry.path)).toEqual(["src/components/App.tsx"]);
+  });
+
+  it("bounds empty-query results instead of returning every file", () => {
+    const index = prepareFileSearchIndex(
+      Array.from({ length: 10_000 }, (_, i) => ({
+        path: `src/generated/File${i}.ts`,
+        is_directory: false,
+      })),
+    );
+
+    const started = performance.now();
+    const results = searchFileIndex(index, "", 200);
+    const elapsed = performance.now() - started;
+
+    expect(results).toHaveLength(200);
+    expect(results[0]?.entry.path).toBe("src/generated/File0.ts");
+    expect(elapsed).toBeLessThan(25);
+  });
+
+  it("keeps large-list fuzzy matching bounded by the top result limit", () => {
+    const index = prepareFileSearchIndex([
+      ...Array.from({ length: 10_000 }, (_, i) => ({
+        path: `src/generated/Component${i}.tsx`,
+        is_directory: false,
+      })),
+      { path: "src/ui/FooBarPanel.tsx", is_directory: false },
+    ]);
+
+    const results = searchFileIndex(index, "fbp", 20);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.entry.path).toBe("src/ui/FooBarPanel.tsx");
+  });
+});

--- a/src/ui/src/components/command-palette/fileFuzzySearch.test.ts
+++ b/src/ui/src/components/command-palette/fileFuzzySearch.test.ts
@@ -69,13 +69,24 @@ describe("fileFuzzySearch", () => {
       })),
     );
 
-    const started = performance.now();
     const results = searchFileIndex(index, "", 200);
-    const elapsed = performance.now() - started;
 
     expect(results).toHaveLength(200);
     expect(results[0]?.entry.path).toBe("src/generated/File0.ts");
-    expect(elapsed).toBeLessThan(25);
+  });
+
+  it("bounds broad fuzzy-query results instead of returning every match", () => {
+    const index = prepareFileSearchIndex(
+      Array.from({ length: 10_000 }, (_, i) => ({
+        path: `src/alpha/File${i}.ts`,
+        is_directory: false,
+      })),
+    );
+
+    const results = searchFileIndex(index, "a", 50);
+
+    expect(results).toHaveLength(50);
+    expect(results.every((result) => result.pathMatches.length > 0)).toBe(true);
   });
 
   it("keeps large-list fuzzy matching bounded by the top result limit", () => {

--- a/src/ui/src/components/command-palette/fileFuzzySearch.ts
+++ b/src/ui/src/components/command-palette/fileFuzzySearch.ts
@@ -1,0 +1,179 @@
+import type { FileEntry } from "./commands";
+
+export interface PreparedFileSearchEntry {
+  path: string;
+  basename: string;
+  dirname: string;
+  lowerPath: string;
+  lowerBasename: string;
+  pathBoundaries: Uint8Array;
+  basenameStart: number;
+}
+
+export interface FileSearchResult {
+  entry: PreparedFileSearchEntry;
+  score: number;
+  basenameMatches: number[];
+  pathMatches: number[];
+}
+
+interface SegmentScore {
+  score: number;
+  matches: number[];
+}
+
+const SCORE_EXACT = 12_000;
+const SCORE_PREFIX = 4_000;
+const SCORE_SUBSEQUENCE = 1_000;
+const SCORE_CONSECUTIVE = 70;
+const SCORE_BOUNDARY = 90;
+const SCORE_SEPARATOR = 45;
+const SCORE_CAMEL = 35;
+const SCORE_EARLY = 2;
+const SCORE_GAP_PENALTY = 18;
+const SCORE_PATH_BASENAME_RANGE = 550;
+
+export const DEFAULT_FILE_SEARCH_LIMIT = 200;
+
+export function prepareFileSearchIndex(files: FileEntry[]): PreparedFileSearchEntry[] {
+  return files
+    .filter((file) => !file.is_directory)
+    .map((file) => {
+      const basenameStart = file.path.lastIndexOf("/") + 1;
+      const basename = file.path.slice(basenameStart);
+      return {
+        path: file.path,
+        basename,
+        dirname: basenameStart > 0 ? file.path.slice(0, basenameStart - 1) : "",
+        lowerPath: file.path.toLowerCase(),
+        lowerBasename: basename.toLowerCase(),
+        pathBoundaries: computeBoundaries(file.path),
+        basenameStart,
+      };
+    });
+}
+
+export function searchFileIndex(
+  index: readonly PreparedFileSearchEntry[],
+  query: string,
+  limit = DEFAULT_FILE_SEARCH_LIMIT,
+): FileSearchResult[] {
+  const normalizedQuery = normalizeQuery(query);
+  if (!normalizedQuery) {
+    return index.slice(0, limit).map((entry, order) => ({
+      entry,
+      score: -order,
+      basenameMatches: [],
+      pathMatches: [],
+    }));
+  }
+
+  const results: FileSearchResult[] = [];
+  for (const entry of index) {
+    const basenameScore = scoreSegment(
+      entry.lowerBasename,
+      entry.pathBoundaries,
+      normalizedQuery,
+      entry.basenameStart,
+    );
+    const pathScore = scoreSegment(
+      entry.lowerPath,
+      entry.pathBoundaries,
+      normalizedQuery,
+      0,
+    );
+    if (!basenameScore && !pathScore) continue;
+
+    const basenameBoost = basenameScore
+      ? SCORE_PATH_BASENAME_RANGE + basenameScore.score * 1.8
+      : 0;
+    const pathBoost = pathScore ? pathScore.score : 0;
+    const score = basenameBoost + pathBoost - entry.path.length * 0.6;
+    results.push({
+      entry,
+      score,
+      basenameMatches: basenameScore?.matches ?? [],
+      pathMatches: pathScore?.matches ?? [],
+    });
+  }
+
+  results.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.entry.path.localeCompare(b.entry.path);
+  });
+  return results.slice(0, limit);
+}
+
+function normalizeQuery(query: string): string {
+  return query.trim().toLowerCase().replace(/\s+/g, "");
+}
+
+function scoreSegment(
+  target: string,
+  boundaries: Uint8Array,
+  query: string,
+  boundaryOffset: number,
+): SegmentScore | null {
+  if (query.length === 0) return { score: 0, matches: [] };
+  const matches = fuzzyMatch(target, query);
+  if (!matches) return null;
+
+  const exact = target === query ? SCORE_EXACT : 0;
+  const prefix = matches[0] === 0 ? SCORE_PREFIX : 0;
+  let score = SCORE_SUBSEQUENCE + exact + prefix;
+  let previous = -1;
+  for (let i = 0; i < matches.length; i += 1) {
+    const index = matches[i];
+    const boundary = boundaries[index + boundaryOffset] ?? 0;
+    if (boundary > 0) score += SCORE_BOUNDARY;
+    if (boundary === 2) score += SCORE_SEPARATOR;
+    if (boundary === 3) score += SCORE_CAMEL;
+    if (previous >= 0) {
+      const gap = index - previous - 1;
+      if (gap === 0) {
+        score += SCORE_CONSECUTIVE;
+      } else {
+        score -= Math.min(280, gap * SCORE_GAP_PENALTY);
+      }
+    }
+    previous = index;
+  }
+  score -= matches[0] * SCORE_EARLY;
+  return { score, matches };
+}
+
+function fuzzyMatch(target: string, query: string): number[] | null {
+  const matches: number[] = [];
+  let searchFrom = 0;
+  for (const char of query) {
+    const index = target.indexOf(char, searchFrom);
+    if (index === -1) return null;
+    matches.push(index);
+    searchFrom = index + 1;
+  }
+  return matches;
+}
+
+function computeBoundaries(value: string): Uint8Array {
+  const boundaries = new Uint8Array(value.length);
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    const prev = index > 0 ? value[index - 1] : "";
+    if (index === 0) {
+      boundaries[index] = 2;
+    } else if (prev === "/" || prev === "-" || prev === "_" || prev === "." || prev === " ") {
+      boundaries[index] = 2;
+    } else if (isLower(prev) && isUpper(char)) {
+      boundaries[index] = 3;
+    }
+  }
+  return boundaries;
+}
+
+function isLower(char: string): boolean {
+  return char >= "a" && char <= "z";
+}
+
+function isUpper(char: string): boolean {
+  return char >= "A" && char <= "Z";
+}

--- a/src/ui/src/components/command-palette/fileFuzzySearch.ts
+++ b/src/ui/src/components/command-palette/fileFuzzySearch.ts
@@ -89,19 +89,15 @@ export function searchFileIndex(
       : 0;
     const pathBoost = pathScore ? pathScore.score : 0;
     const score = basenameBoost + pathBoost - entry.path.length * 0.6;
-    results.push({
+    pushTopResult(results, {
       entry,
       score,
       basenameMatches: basenameScore?.matches ?? [],
       pathMatches: pathScore?.matches ?? [],
-    });
+    }, limit);
   }
 
-  results.sort((a, b) => {
-    if (b.score !== a.score) return b.score - a.score;
-    return a.entry.path.localeCompare(b.entry.path);
-  });
-  return results.slice(0, limit);
+  return results;
 }
 
 function normalizeQuery(query: string): string {
@@ -152,6 +148,42 @@ function fuzzyMatch(target: string, query: string): number[] | null {
     searchFrom = index + 1;
   }
   return matches;
+}
+
+function pushTopResult(
+  results: FileSearchResult[],
+  candidate: FileSearchResult,
+  limit: number,
+): void {
+  if (limit <= 0) return;
+  if (results.length === 0) {
+    results.push(candidate);
+    return;
+  }
+  const worst = results[results.length - 1];
+  if (results.length >= limit && compareResults(candidate, worst) >= 0) {
+    return;
+  }
+
+  let low = 0;
+  let high = results.length;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    if (compareResults(candidate, results[mid]) < 0) {
+      high = mid;
+    } else {
+      low = mid + 1;
+    }
+  }
+  results.splice(low, 0, candidate);
+  if (results.length > limit) {
+    results.pop();
+  }
+}
+
+function compareResults(a: FileSearchResult, b: FileSearchResult): number {
+  if (b.score !== a.score) return b.score - a.score;
+  return a.entry.path.localeCompare(b.entry.path);
 }
 
 function computeBoundaries(value: string): Uint8Array {

--- a/src/ui/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/ui/src/hooks/useKeyboardShortcuts.test.ts
@@ -34,6 +34,18 @@ async function pressEscape() {
   });
 }
 
+async function pressQuickOpenHotkey() {
+  await act(async () => {
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "p",
+        ctrlKey: true,
+        bubbles: true,
+      }),
+    );
+  });
+}
+
 describe("shouldDeferSettingsEscapeForElement", () => {
   it("keeps Settings Escape local to focused native fields", () => {
     expect(shouldDeferSettingsEscapeForElement(document.createElement("input")))
@@ -100,5 +112,45 @@ describe("useKeyboardShortcuts Settings Escape", () => {
 
     await pressEscape();
     expect(useAppStore.getState().settingsOpen).toBe(false);
+  });
+});
+
+describe("useKeyboardShortcuts command palette quick-open toggle", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    useAppStore.setState({
+      activeModal: null,
+      commandPaletteOpen: true,
+      commandPaletteInitialMode: null,
+      fuzzyFinderOpen: false,
+      selectedWorkspaceId: "ws-1",
+      settingsOpen: false,
+      settingsOverlayCount: 0,
+    });
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root!.unmount();
+      });
+    }
+    root = null;
+    container = null;
+    document.body.innerHTML = "";
+    useAppStore.setState({
+      commandPaletteOpen: false,
+      commandPaletteInitialMode: null,
+      selectedWorkspaceId: null,
+    });
+  });
+
+  it("dismisses the command palette when the quick-open hotkey is pressed again", async () => {
+    await renderHarness();
+
+    await pressQuickOpenHotkey();
+
+    expect(useAppStore.getState().commandPaletteOpen).toBe(false);
+    expect(useAppStore.getState().commandPaletteInitialMode).toBeNull();
   });
 });

--- a/src/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/src/ui/src/hooks/useKeyboardShortcuts.ts
@@ -128,12 +128,16 @@ export function useKeyboardShortcuts() {
 
       const overlayOpen =
         state.settingsOpen || !!state.activeModal || state.commandPaletteOpen || state.fuzzyFinderOpen;
+      const filePaletteAction =
+        action === "global.open-command-palette-file-mode" ||
+        action === "global.open-command-palette-file-mode-alt";
       if (
         overlayOpen &&
         action !== "global.open-settings" &&
         action !== "global.toggle-command-palette" &&
         action !== "global.toggle-fuzzy-finder" &&
-        action !== "global.show-keyboard-shortcuts"
+        action !== "global.show-keyboard-shortcuts" &&
+        !(state.commandPaletteOpen && filePaletteAction)
       ) return;
       if (action === "global.toggle-plan-mode" && (!activeSessionId || isInteractive)) return;
 
@@ -214,6 +218,10 @@ export function useKeyboardShortcuts() {
             return;
           case "global.open-command-palette-file-mode":
           case "global.open-command-palette-file-mode-alt":
+            if (useAppStore.getState().commandPaletteOpen) {
+              toggleCommandPalette();
+              return;
+            }
             if (selectedWorkspaceId) openCommandPaletteFileMode();
             return;
           case "global.toggle-right-sidebar":


### PR DESCRIPTION
## Summary

Closes #932.

This rewrites Cmd+P file mode so it no longer routes a 10k-file workspace through the generic command-palette scoring/rendering path. The file list cache from #863 remains the source of truth, but file search now uses a compact prepared index and a dedicated fuzzy matcher tuned for quick-open style file lookup.

## Root Cause

Cmd+P file mode was still building one heavyweight `Command` object per file, including closures and keyword arrays, then synchronously rescoring and sorting the full command list on every keystroke. It also reused `scoreCommand`, which only handled substring-ish matching, so VSCode-style subsequences like `fbp` for `FooBarPanel.tsx` could not match. The result list rendered all matches into the DOM, so empty file mode could mount thousands of rows.

## Changes

- Added `fileFuzzySearch.ts` with a prepared file index:
  - filters directories once
  - stores basename, dirname, lowercased path/basename, basename offset, and boundary metadata
  - supports subsequence matching with bonuses for prefix, path separators, camelCase boundaries, consecutive runs, and basename relevance
  - returns match ranges for highlighting
- Changed `CommandPalette` file mode to bypass `buildFileCommands` / `scoreCommand` entirely.
- Bounded file search output to the top results and added hand-rolled fixed-row virtualization so only visible file rows render.
- Added `useDeferredValue` for file queries so typing stays responsive, while resolving Enter against the current query if deferred results are still catching up.
- Added match highlighting for filenames and matched directory characters.
- Kept non-file command palette behavior on the existing generic command scorer.

## Validation

- `cd src/ui && bun run test -- src/components/command-palette/fileFuzzySearch.test.ts src/components/command-palette/commands.test.ts`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run lint:css`
- `git diff --check`
- Codex peer review pass on the committed diff found and prompted a stale deferred-result Enter fix.
- Two follow-up Codex peer review passes on the amended diff found no blocking issues.

## Notes

The matcher tests cover VSCode-style basename subsequences, mid-path matches, ranking, match ranges, directory filtering, empty-query bounding, and synthetic large file lists. Remaining useful follow-up coverage would be component-level tests for virtualized rows, keyboard navigation after scroll, and stale deferred-result click/Enter behavior.
