### PR TITLE
fix: stabilize live elapsed turn timer

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -70,6 +70,7 @@ import { useStickyScroll } from "../../hooks/useStickyScroll";
 import { tooltipWithHotkey } from "../../hotkeys/display";
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
 import { usePreventScrollBounce } from "../../hooks/usePreventScrollBounce";
+import { useWorkspaceElapsedSeconds } from "../../hooks/useWorkspaceElapsedSeconds";
 import styles from "./ChatPanel.module.css";
 import { formatElapsedSeconds } from "./chatHelpers";
 import { ScrollContext } from "./ScrollContext";
@@ -502,21 +503,7 @@ export function ChatPanel() {
     }
   }, [activeSessionIdsKey]);
 
-  // Elapsed timer for running agent.
-  const promptStartTime = useAppStore(
-    (s) => (selectedWorkspaceId ? s.promptStartTime[selectedWorkspaceId] ?? null : null)
-  );
-  const [elapsed, setElapsed] = useState(0);
-  useEffect(() => {
-    if (!isRunning || promptStartTime == null) return;
-    setElapsed(Math.floor((Date.now() - promptStartTime) / 1000));
-    const interval = setInterval(() => {
-      const newElapsed = Math.floor((Date.now() - promptStartTime) / 1000);
-      setElapsed((prev) => (prev === newElapsed ? prev : newElapsed));
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [isRunning, promptStartTime]);
-
+  const elapsed = useWorkspaceElapsedSeconds(selectedWorkspaceId, isRunning);
   const formatElapsed = formatElapsedSeconds;
   const showStuckAffordance =
     isRunning &&

--- a/src/ui/src/components/chat/chatMessageDispatch.ts
+++ b/src/ui/src/components/chat/chatMessageDispatch.ts
@@ -1,12 +1,16 @@
 import { sendChatMessage, sendRemoteCommand } from "../../services/tauri";
 import { useAppStore } from "../../stores/useAppStore";
 import type { PermissionLevel } from "../../stores/useAppStore";
-import type { AttachmentInput, ChatMessage } from "../../types/chat";
+import type { AttachmentInput } from "../../types/chat";
 import { shouldDisable1mContext } from "./chatHelpers";
 import {
   buildSendFailureSystemMessage,
   shouldRecordSendFailureInChat,
 } from "./chatSendFailure";
+import {
+  markChatTurnStarting,
+  rollbackChatTurnStarting,
+} from "./chatTurnLifecycle";
 import { resolveUltrathinkEffort } from "./ultrathink";
 
 interface DispatchChatMessageArgs {
@@ -22,15 +26,6 @@ export interface DispatchChatMessageResult {
   messageId: string;
 }
 
-interface MarkChatTurnStartingArgs {
-  sessionId: string;
-  workspaceId: string;
-  messageId: string;
-  content: string;
-  attachments?: AttachmentInput[];
-  startedAt?: number;
-}
-
 function resolveSessionWorkspace(sessionId: string) {
   const state = useAppStore.getState();
   for (const [workspaceId, sessions] of Object.entries(state.sessionsByWorkspace)) {
@@ -41,80 +36,6 @@ function resolveSessionWorkspace(sessionId: string) {
     return { workspaceId, workspace, session };
   }
   return null;
-}
-
-function addPersistedUserMessageToStore(
-  sessionId: string,
-  workspaceId: string,
-  messageId: string,
-  content: string,
-  attachments?: AttachmentInput[],
-) {
-  const store = useAppStore.getState();
-  const message: ChatMessage = {
-    id: messageId,
-    workspace_id: workspaceId,
-    chat_session_id: sessionId,
-    role: "User",
-    content,
-    cost_usd: null,
-    duration_ms: null,
-    created_at: new Date().toISOString(),
-    thinking: null,
-    input_tokens: null,
-    output_tokens: null,
-    cache_read_tokens: null,
-    cache_creation_tokens: null,
-  };
-  store.addChatMessage(sessionId, message);
-
-  if (!attachments?.length) return;
-  const optimisticAttachments = attachments.map((attachment) => ({
-    id: crypto.randomUUID(),
-    message_id: messageId,
-    filename: attachment.filename,
-    media_type: attachment.media_type,
-    data_base64: attachment.data_base64,
-    text_content: attachment.text_content ?? null,
-    width: null,
-    height: null,
-    size_bytes: Math.ceil(attachment.data_base64.length * 0.75),
-  }));
-  useAppStore.getState().addChatAttachments(sessionId, optimisticAttachments);
-}
-
-export function markChatTurnStarting({
-  sessionId,
-  workspaceId,
-  messageId,
-  content,
-  attachments,
-  startedAt = Date.now(),
-}: MarkChatTurnStartingArgs) {
-  const state = useAppStore.getState();
-  state.setQueuedMessageAutoDispatchPaused(sessionId, false);
-  state.clearAgentQuestion(sessionId);
-  state.clearPlanApproval(sessionId);
-  state.clearAgentApproval(sessionId);
-  state.finishTypewriterDrain(sessionId);
-  addPersistedUserMessageToStore(
-    sessionId,
-    workspaceId,
-    messageId,
-    content,
-    attachments,
-  );
-  state.updateWorkspace(workspaceId, { agent_status: "Running" });
-  state.setPromptStartTime(workspaceId, startedAt);
-  state.updateChatSession(sessionId, { agent_status: "Running" });
-  state.clearUnreadCompletion(workspaceId);
-}
-
-export function rollbackChatTurnStarting(sessionId: string, workspaceId: string) {
-  const state = useAppStore.getState();
-  state.updateWorkspace(workspaceId, { agent_status: "Idle" });
-  state.updateChatSession(sessionId, { agent_status: "Idle" });
-  state.clearPromptStartTime(workspaceId);
 }
 
 export async function dispatchChatMessage({

--- a/src/ui/src/components/chat/chatMessageDispatch.ts
+++ b/src/ui/src/components/chat/chatMessageDispatch.ts
@@ -22,6 +22,15 @@ export interface DispatchChatMessageResult {
   messageId: string;
 }
 
+interface MarkChatTurnStartingArgs {
+  sessionId: string;
+  workspaceId: string;
+  messageId: string;
+  content: string;
+  attachments?: AttachmentInput[];
+  startedAt?: number;
+}
+
 function resolveSessionWorkspace(sessionId: string) {
   const state = useAppStore.getState();
   for (const [workspaceId, sessions] of Object.entries(state.sessionsByWorkspace)) {
@@ -74,6 +83,40 @@ function addPersistedUserMessageToStore(
   useAppStore.getState().addChatAttachments(sessionId, optimisticAttachments);
 }
 
+export function markChatTurnStarting({
+  sessionId,
+  workspaceId,
+  messageId,
+  content,
+  attachments,
+  startedAt = Date.now(),
+}: MarkChatTurnStartingArgs) {
+  const state = useAppStore.getState();
+  state.setQueuedMessageAutoDispatchPaused(sessionId, false);
+  state.clearAgentQuestion(sessionId);
+  state.clearPlanApproval(sessionId);
+  state.clearAgentApproval(sessionId);
+  state.finishTypewriterDrain(sessionId);
+  addPersistedUserMessageToStore(
+    sessionId,
+    workspaceId,
+    messageId,
+    content,
+    attachments,
+  );
+  state.updateWorkspace(workspaceId, { agent_status: "Running" });
+  state.setPromptStartTime(workspaceId, startedAt);
+  state.updateChatSession(sessionId, { agent_status: "Running" });
+  state.clearUnreadCompletion(workspaceId);
+}
+
+export function rollbackChatTurnStarting(sessionId: string, workspaceId: string) {
+  const state = useAppStore.getState();
+  state.updateWorkspace(workspaceId, { agent_status: "Idle" });
+  state.updateChatSession(sessionId, { agent_status: "Idle" });
+  state.clearPromptStartTime(workspaceId);
+}
+
 export async function dispatchChatMessage({
   sessionId,
   content,
@@ -91,16 +134,13 @@ export async function dispatchChatMessage({
   let state = useAppStore.getState();
   const permissionLevel: PermissionLevel = state.permissionLevel[sessionId] ?? "full";
 
-  state.setQueuedMessageAutoDispatchPaused(sessionId, false);
-  state.clearAgentQuestion(sessionId);
-  state.clearPlanApproval(sessionId);
-  state.clearAgentApproval(sessionId);
-  state.finishTypewriterDrain(sessionId);
-  addPersistedUserMessageToStore(sessionId, workspaceId, messageId, trimmed, attachments);
-  state.updateWorkspace(workspaceId, { agent_status: "Running" });
-  state.setPromptStartTime(workspaceId, Date.now());
-  state.updateChatSession(sessionId, { agent_status: "Running" });
-  state.clearUnreadCompletion(workspaceId);
+  markChatTurnStarting({
+    sessionId,
+    workspaceId,
+    messageId,
+    content: trimmed,
+    attachments,
+  });
 
   try {
     state = useAppStore.getState();
@@ -149,9 +189,7 @@ export async function dispatchChatMessage({
   } catch (e) {
     const errMsg = String(e);
     const current = useAppStore.getState();
-    current.updateWorkspace(workspaceId, { agent_status: "Idle" });
-    current.updateChatSession(sessionId, { agent_status: "Idle" });
-    current.clearPromptStartTime(workspaceId);
+    rollbackChatTurnStarting(sessionId, workspaceId);
     if (shouldRecordSendFailureInChat(errMsg)) {
       current.addChatMessage(
         sessionId,

--- a/src/ui/src/components/chat/chatTurnLifecycle.test.ts
+++ b/src/ui/src/components/chat/chatTurnLifecycle.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAppStore } from "../../stores/useAppStore";
+import type { ChatSession } from "../../types/chat";
+import type { TerminalTab } from "../../types/terminal";
+import type { Workspace } from "../../types/workspace";
+import {
+  markChatTurnStarting,
+  rollbackChatTurnStarting,
+} from "./chatTurnLifecycle";
+
+function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    id: "ws-1",
+    repository_id: "repo-1",
+    name: "workspace",
+    branch_name: "fix/timer",
+    worktree_path: "/tmp/workspace",
+    status: "Active",
+    agent_status: "Idle",
+    status_line: "",
+    created_at: "2026-05-21T00:00:00Z",
+    sort_order: 0,
+    remote_connection_id: null,
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<ChatSession> = {}): ChatSession {
+  return {
+    id: "session-1",
+    workspace_id: "ws-1",
+    session_id: null,
+    name: "New chat",
+    name_edited: false,
+    turn_count: 0,
+    sort_order: 0,
+    status: "Active",
+    created_at: "2026-05-21T00:00:00Z",
+    archived_at: null,
+    cli_invocation: null,
+    agent_status: "Idle",
+    needs_attention: false,
+    attention_kind: null,
+    ...overrides,
+  };
+}
+
+function makeBackgroundTask(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: 10,
+    workspace_id: "ws-1",
+    title: "Task",
+    kind: "agent_task",
+    is_script_output: false,
+    sort_order: 0,
+    created_at: "2026-05-21T00:00:00Z",
+    task_status: "running",
+    ...overrides,
+  };
+}
+
+describe("chat turn lifecycle", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      workspaces: [makeWorkspace()],
+      sessionsByWorkspace: { "ws-1": [makeSession()] },
+      chatMessages: {},
+      chatAttachments: {},
+      promptStartTime: {},
+      unreadCompletions: new Set(),
+      agentBackgroundTasksBySessionId: {},
+    });
+  });
+
+  it("marks a chat turn as running with a per-workspace timer anchor", () => {
+    markChatTurnStarting({
+      sessionId: "session-1",
+      workspaceId: "ws-1",
+      messageId: "message-1",
+      content: "Please fix this",
+      startedAt: 1_700_000_000_000,
+    });
+
+    const state = useAppStore.getState();
+    expect(state.promptStartTime["ws-1"]).toBe(1_700_000_000_000);
+    expect(state.workspaces[0]?.agent_status).toBe("Running");
+    expect(state.sessionsByWorkspace["ws-1"]?.[0]?.agent_status).toBe(
+      "Running",
+    );
+    expect(state.chatMessages["session-1"]?.[0]).toMatchObject({
+      id: "message-1",
+      role: "User",
+      content: "Please fix this",
+    });
+  });
+
+  it("keeps the workspace running and preserves the timer when rolling back one of two running sessions", () => {
+    useAppStore.setState({
+      promptStartTime: { "ws-1": 1_700_000_000_000 },
+      workspaces: [makeWorkspace({ agent_status: "Running" })],
+      sessionsByWorkspace: {
+        "ws-1": [
+          makeSession({ id: "session-1", agent_status: "Running" }),
+          makeSession({ id: "session-2", agent_status: "Running" }),
+        ],
+      },
+    });
+
+    rollbackChatTurnStarting("session-1", "ws-1");
+
+    const state = useAppStore.getState();
+    expect(state.sessionsByWorkspace["ws-1"]?.[0]?.agent_status).toBe("Idle");
+    expect(state.sessionsByWorkspace["ws-1"]?.[1]?.agent_status).toBe(
+      "Running",
+    );
+    expect(state.workspaces[0]?.agent_status).toBe("Running");
+    expect(state.promptStartTime["ws-1"]).toBe(1_700_000_000_000);
+  });
+
+  it("restores IdleWithBackground when rollback leaves only a running background task", () => {
+    useAppStore.setState({
+      promptStartTime: { "ws-1": 1_700_000_000_000 },
+      workspaces: [makeWorkspace({ agent_status: "Running" })],
+      sessionsByWorkspace: {
+        "ws-1": [makeSession({ id: "session-1", agent_status: "Running" })],
+      },
+      agentBackgroundTasksBySessionId: {
+        "session-1": [makeBackgroundTask()],
+      },
+    });
+
+    rollbackChatTurnStarting("session-1", "ws-1");
+
+    const state = useAppStore.getState();
+    expect(state.sessionsByWorkspace["ws-1"]?.[0]?.agent_status).toBe("Idle");
+    expect(state.workspaces[0]?.agent_status).toBe("IdleWithBackground");
+    expect(state.promptStartTime["ws-1"]).toBeUndefined();
+  });
+});

--- a/src/ui/src/components/chat/chatTurnLifecycle.ts
+++ b/src/ui/src/components/chat/chatTurnLifecycle.ts
@@ -1,0 +1,126 @@
+import { useAppStore, type AppState } from "../../stores/useAppStore";
+import type { AttachmentInput, ChatMessage } from "../../types/chat";
+
+interface MarkChatTurnStartingArgs {
+  sessionId: string;
+  workspaceId: string;
+  messageId: string;
+  content: string;
+  attachments?: AttachmentInput[];
+  startedAt?: number;
+}
+
+function addPersistedUserMessageToStore(
+  sessionId: string,
+  workspaceId: string,
+  messageId: string,
+  content: string,
+  attachments?: AttachmentInput[],
+) {
+  const store = useAppStore.getState();
+  const message: ChatMessage = {
+    id: messageId,
+    workspace_id: workspaceId,
+    chat_session_id: sessionId,
+    role: "User",
+    content,
+    cost_usd: null,
+    duration_ms: null,
+    created_at: new Date().toISOString(),
+    thinking: null,
+    input_tokens: null,
+    output_tokens: null,
+    cache_read_tokens: null,
+    cache_creation_tokens: null,
+  };
+  store.addChatMessage(sessionId, message);
+
+  if (!attachments?.length) return;
+  const optimisticAttachments = attachments.map((attachment) => ({
+    id: crypto.randomUUID(),
+    message_id: messageId,
+    filename: attachment.filename,
+    media_type: attachment.media_type,
+    data_base64: attachment.data_base64,
+    text_content: attachment.text_content ?? null,
+    width: null,
+    height: null,
+    size_bytes: Math.ceil(attachment.data_base64.length * 0.75),
+  }));
+  useAppStore.getState().addChatAttachments(sessionId, optimisticAttachments);
+}
+
+function hasRunningActiveSession(state: AppState, workspaceId: string): boolean {
+  return (state.sessionsByWorkspace[workspaceId] ?? []).some(
+    (session) =>
+      session.status === "Active" && session.agent_status === "Running",
+  );
+}
+
+function hasActiveBackgroundTask(state: AppState, workspaceId: string): boolean {
+  const activeSessionIds = new Set(
+    (state.sessionsByWorkspace[workspaceId] ?? [])
+      .filter((session) => session.status === "Active")
+      .map((session) => session.id),
+  );
+  return Object.entries(state.agentBackgroundTasksBySessionId).some(
+    ([sessionId, tabs]) =>
+      activeSessionIds.has(sessionId) &&
+      tabs.some((tab) => {
+        const status = (tab.task_status ?? "").toLowerCase();
+        return status === "starting" || status === "running";
+      }),
+  );
+}
+
+export function syncWorkspaceTurnStatus(workspaceId: string) {
+  const state = useAppStore.getState();
+  state.updateWorkspace(workspaceId, {
+    agent_status: hasRunningActiveSession(state, workspaceId)
+      ? "Running"
+      : hasActiveBackgroundTask(state, workspaceId)
+        ? "IdleWithBackground"
+        : "Idle",
+  });
+}
+
+export function clearPromptStartTimeIfWorkspaceIdle(workspaceId: string) {
+  const state = useAppStore.getState();
+  if (!hasRunningActiveSession(state, workspaceId)) {
+    state.clearPromptStartTime(workspaceId);
+  }
+}
+
+export function markChatTurnStarting({
+  sessionId,
+  workspaceId,
+  messageId,
+  content,
+  attachments,
+  startedAt = Date.now(),
+}: MarkChatTurnStartingArgs) {
+  const state = useAppStore.getState();
+  state.setQueuedMessageAutoDispatchPaused(sessionId, false);
+  state.clearAgentQuestion(sessionId);
+  state.clearPlanApproval(sessionId);
+  state.clearAgentApproval(sessionId);
+  state.finishTypewriterDrain(sessionId);
+  addPersistedUserMessageToStore(
+    sessionId,
+    workspaceId,
+    messageId,
+    content,
+    attachments,
+  );
+  state.updateWorkspace(workspaceId, { agent_status: "Running" });
+  state.setPromptStartTime(workspaceId, startedAt);
+  state.updateChatSession(sessionId, { agent_status: "Running" });
+  state.clearUnreadCompletion(workspaceId);
+}
+
+export function rollbackChatTurnStarting(sessionId: string, workspaceId: string) {
+  const state = useAppStore.getState();
+  state.updateChatSession(sessionId, { agent_status: "Idle" });
+  syncWorkspaceTurnStatus(workspaceId);
+  clearPromptStartTimeIfWorkspaceIdle(workspaceId);
+}

--- a/src/ui/src/components/layout/Dashboard.tsx
+++ b/src/ui/src/components/layout/Dashboard.tsx
@@ -17,6 +17,7 @@ import { useScmProvider } from "../../hooks/useScmProvider";
 import { restoreWorkspace } from "../../services/tauri";
 import { RepoIssuesSection } from "../project/RepoIssuesSection";
 import { RepoPullRequestsSection } from "../project/RepoPullRequestsSection";
+import { useWorkspaceElapsedSeconds } from "../../hooks/useWorkspaceElapsedSeconds";
 import styles from "./Dashboard.module.css";
 
 /** Strip markdown syntax for a clean one-line preview. */
@@ -61,19 +62,7 @@ const WorkspaceCard = memo(function WorkspaceCard({
   // also uses it for grouping; here we only need this row's slice.
   const summary = useAppStore((s) => s.scmSummary[ws.id]);
   const isRunning = isAgentBusy(ws.agent_status);
-  const promptStartTime = useAppStore((s) => s.promptStartTime[ws.id] ?? null);
-  const [elapsed, setElapsed] = useState(0);
-  useEffect(() => {
-    if (!isRunning || promptStartTime == null) {
-      setElapsed(0);
-      return;
-    }
-    setElapsed(Math.floor((Date.now() - promptStartTime) / 1000));
-    const interval = setInterval(() => {
-      setElapsed(Math.floor((Date.now() - promptStartTime) / 1000));
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [isRunning, promptStartTime]);
+  const elapsed = useWorkspaceElapsedSeconds(ws.id, isRunning);
 
   const statusColor =
     isRunning

--- a/src/ui/src/components/project/sendToNewWorkspace.test.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.test.ts
@@ -22,6 +22,7 @@ vi.mock("../chat/applySelectedModel", () => ({
 }));
 vi.mock("../../services/tauri", () => ({
   sendChatMessage: vi.fn().mockResolvedValue(undefined),
+  sendRemoteCommand: vi.fn().mockResolvedValue(undefined),
   createWorkspaceScmLink: vi.fn(),
 }));
 
@@ -83,10 +84,18 @@ beforeEach(() => {
   mockedCreateLink.mockImplementation((a) =>
     Promise.resolve(makeLinkFromArgs(a)),
   );
-  useAppStore.setState({ chatMessages: {}, toasts: [], workspaceScmLinks: {} });
+  useAppStore.setState({
+    chatMessages: {},
+    toasts: [],
+    workspaceScmLinks: {},
+    promptStartTime: {},
+    workspaces: [],
+    sessionsByWorkspace: {},
+  });
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
@@ -235,6 +244,9 @@ describe("sendToNewWorkspace", () => {
     expect(sendArgs[4]).toBe("claude-opus-4-7"); // model
     expect(sendArgs[11]).toBe("anthropic"); // backendId
     expect(sendArgs[13]).toBe(messages[0].id); // messageId
+    expect(useAppStore.getState().promptStartTime["ws-1"]).toEqual(
+      expect.any(Number),
+    );
   });
 
   it("routes through the model's explicit providerId", async () => {
@@ -365,5 +377,6 @@ describe("sendToNewWorkspace", () => {
       workspace_id: "ws-6",
       number: ISSUE_ARGS.number,
     });
+    expect(useAppStore.getState().promptStartTime["ws-6"]).toBeUndefined();
   });
 });

--- a/src/ui/src/components/project/sendToNewWorkspace.test.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.test.ts
@@ -22,7 +22,6 @@ vi.mock("../chat/applySelectedModel", () => ({
 }));
 vi.mock("../../services/tauri", () => ({
   sendChatMessage: vi.fn().mockResolvedValue(undefined),
-  sendRemoteCommand: vi.fn().mockResolvedValue(undefined),
   createWorkspaceScmLink: vi.fn(),
 }));
 

--- a/src/ui/src/components/project/sendToNewWorkspace.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.ts
@@ -2,6 +2,10 @@ import { useAppStore } from "../../stores/useAppStore";
 import { createWorkspaceOrchestrated } from "../../hooks/useCreateWorkspace";
 import { applySelectedModel } from "../chat/applySelectedModel";
 import { createWorkspaceScmLink, sendChatMessage } from "../../services/tauri";
+import {
+  markChatTurnStarting,
+  rollbackChatTurnStarting,
+} from "../chat/chatMessageDispatch";
 import type { Model } from "../chat/modelRegistry";
 import type { ContextMenuItem } from "../shared/ContextMenu";
 
@@ -85,51 +89,40 @@ export async function sendToNewWorkspace(
     console.error("[sendToNewWorkspace] failed to persist SCM link:", e);
   }
   const prompt = renderStarterPrompt(args);
-  // Optimistically insert the user's prompt into the chat store BEFORE
-  // firing the send. Without this the new workspace opens straight to
-  // the agent's first reply with no visible record of what was asked —
-  // mirrors what `chatMessageDispatch.dispatchChatMessage` does via
-  // `addPersistedUserMessageToStore`. We pass an explicit `messageId`
-  // so the optimistic row and the backend-persisted row collapse onto
-  // the same key when the chat stream echoes the user turn back.
   const messageId = crypto.randomUUID();
-  useAppStore.getState().addChatMessage(sessionId, {
-    id: messageId,
-    workspace_id: workspaceId,
-    chat_session_id: sessionId,
-    role: "User",
-    content: prompt,
-    cost_usd: null,
-    duration_ms: null,
-    created_at: new Date().toISOString(),
-    thinking: null,
-    input_tokens: null,
-    output_tokens: null,
-    cache_read_tokens: null,
-    cache_creation_tokens: null,
-  });
-  await sendChatMessage(
+  markChatTurnStarting({
     sessionId,
-    prompt,
-    /* mentionedFiles */ undefined,
-    /* permissionLevel */ undefined,
-    args.modelId,
-    /* fastMode */ undefined,
-    /* thinkingEnabled */ undefined,
-    /* planMode */ undefined,
-    /* effort */ undefined,
-    /* chromeEnabled */ undefined,
-    /* disable1mContext */ undefined,
-    // Route the first turn through the provider we just persisted via
-    // `applySelectedModel`. Without this the backend resolves a default
-    // (often the global "Anthropic Claude Code" card), so a Pi-routed
-    // model id that also exists on multiple backends could fire on the
-    // wrong one for turn 1 even though the toolbar shows the right
-    // provider. Matches chatMessageDispatch's `selectedProvider` arg.
-    provider,
-    /* attachments */ undefined,
+    workspaceId,
     messageId,
-  );
+    content: prompt,
+  });
+  try {
+    await sendChatMessage(
+      sessionId,
+      prompt,
+      /* mentionedFiles */ undefined,
+      /* permissionLevel */ undefined,
+      args.modelId,
+      /* fastMode */ undefined,
+      /* thinkingEnabled */ undefined,
+      /* planMode */ undefined,
+      /* effort */ undefined,
+      /* chromeEnabled */ undefined,
+      /* disable1mContext */ undefined,
+      // Route the first turn through the provider we just persisted via
+      // `applySelectedModel`. Without this the backend resolves a default
+      // (often the global "Anthropic Claude Code" card), so a Pi-routed
+      // model id that also exists on multiple backends could fire on the
+      // wrong one for turn 1 even though the toolbar shows the right
+      // provider. Matches chatMessageDispatch's `selectedProvider` arg.
+      provider,
+      /* attachments */ undefined,
+      messageId,
+    );
+  } catch (e) {
+    rollbackChatTurnStarting(sessionId, workspaceId);
+    throw e;
+  }
   store.addToast(`Sent #${args.number} to a new workspace`);
 }
 

--- a/src/ui/src/components/project/sendToNewWorkspace.ts
+++ b/src/ui/src/components/project/sendToNewWorkspace.ts
@@ -5,7 +5,7 @@ import { createWorkspaceScmLink, sendChatMessage } from "../../services/tauri";
 import {
   markChatTurnStarting,
   rollbackChatTurnStarting,
-} from "../chat/chatMessageDispatch";
+} from "../chat/chatTurnLifecycle";
 import type { Model } from "../chat/modelRegistry";
 import type { ContextMenuItem } from "../shared/ContextMenu";
 

--- a/src/ui/src/hooks/useAgentStream.sessionRenamed.test.tsx
+++ b/src/ui/src/hooks/useAgentStream.sessionRenamed.test.tsx
@@ -92,6 +92,7 @@ beforeEach(() => {
     toolActivities: {},
     streamingContent: {},
     streamingThinking: {},
+    promptStartTime: {},
     sessionsByWorkspace: {
       "ws-1": [
         {
@@ -211,6 +212,107 @@ describe("useAgentStream — session-renamed listener", () => {
       inputJson: JSON.stringify({ file_path: "/repo/src/app.ts" }),
       summary: "/repo/src/app.ts",
     });
+  });
+
+  it("seeds the live elapsed timer from the first stream event when dispatch missed it", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    await mountHook();
+    const handlers = registeredHandlers.get("agent-stream") ?? [];
+    expect(handlers.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      for (const handler of handlers) {
+        handler({
+          payload: {
+            workspace_id: "ws-1",
+            chat_session_id: "session-1",
+            event: {
+              Stream: {
+                type: "system",
+                subtype: "init",
+              },
+            },
+          },
+        });
+      }
+    });
+
+    expect(useAppStore.getState().promptStartTime["ws-1"]).toBe(
+      1_700_000_000_000,
+    );
+  });
+
+  it("keeps an existing live elapsed timer anchor when stream events arrive", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    useAppStore.getState().setPromptStartTime("ws-1", 1_699_999_990_000);
+    await mountHook();
+    const handlers = registeredHandlers.get("agent-stream") ?? [];
+
+    await act(async () => {
+      for (const handler of handlers) {
+        handler({
+          payload: {
+            workspace_id: "ws-1",
+            chat_session_id: "session-1",
+            event: {
+              Stream: {
+                type: "system",
+                subtype: "init",
+              },
+            },
+          },
+        });
+      }
+    });
+
+    expect(useAppStore.getState().promptStartTime["ws-1"]).toBe(
+      1_699_999_990_000,
+    );
+  });
+
+  it("keeps the workspace timer while a sibling active session is still running", async () => {
+    const session = useAppStore.getState().sessionsByWorkspace["ws-1"]![0]!;
+    useAppStore.setState({
+      promptStartTime: { "ws-1": 1_699_999_990_000 },
+      sessionsByWorkspace: {
+        "ws-1": [
+          { ...session, id: "session-1", agent_status: "Running" },
+          { ...session, id: "session-2", agent_status: "Running" },
+        ],
+      },
+    });
+    await mountHook();
+    const handlers = registeredHandlers.get("agent-stream") ?? [];
+
+    await act(async () => {
+      for (const handler of handlers) {
+        handler({
+          payload: {
+            workspace_id: "ws-1",
+            chat_session_id: "session-1",
+            event: { ProcessExited: { exit_code: 0 } },
+          },
+        });
+      }
+    });
+    expect(useAppStore.getState().promptStartTime["ws-1"]).toBe(
+      1_699_999_990_000,
+    );
+
+    await act(async () => {
+      for (const handler of handlers) {
+        handler({
+          payload: {
+            workspace_id: "ws-1",
+            chat_session_id: "session-2",
+            event: { ProcessExited: { exit_code: 0 } },
+          },
+        });
+      }
+    });
+    expect(useAppStore.getState().promptStartTime["ws-1"]).toBeUndefined();
   });
 
   it("falls back to rendering AskUserQuestion from the streamed tool block", async () => {

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -251,6 +251,24 @@ export function useAgentStream() {
     });
   };
 
+  const ensurePromptStartTime = (wsId: string) => {
+    const state = useAppStore.getState();
+    if (state.promptStartTime[wsId] == null) {
+      state.setPromptStartTime(wsId, Date.now());
+    }
+  };
+
+  const clearPromptStartTimeIfWorkspaceIdle = (wsId: string) => {
+    const state = useAppStore.getState();
+    const hasRunningSession = (state.sessionsByWorkspace[wsId] ?? []).some(
+      (session) =>
+        session.status === "Active" && session.agent_status === "Running",
+    );
+    if (!hasRunningSession) {
+      state.clearPromptStartTime(wsId);
+    }
+  };
+
   useEffect(() => {
     // Guard against StrictMode double-mount: the async unlisten() promise
     // can't block React's synchronous remount, so a stale listener may
@@ -288,7 +306,7 @@ export function useAgentStream() {
         // User stop or crash has no prior `result` → Stopped.
         updateChatSession(sessionId, { agent_status: wasFinalized ? "Idle" : "Stopped" });
         syncWorkspaceAgentStatus(wsId);
-        useAppStore.getState().clearPromptStartTime(wsId);
+        clearPromptStartTimeIfWorkspaceIdle(wsId);
         setStreamingContent(sessionId, "");
         clearStreamingThinking(sessionId);
         clearBlockToolsForSession(blockToolMapRef.current, sessionId);
@@ -307,6 +325,7 @@ export function useAgentStream() {
 
       if (!("Stream" in agentEvent)) return;
       const streamEvent = agentEvent.Stream;
+      ensurePromptStartTime(wsId);
 
       // Handle different stream event types based on the Rust enum serialization
       if ("type" in streamEvent) {
@@ -722,7 +741,7 @@ export function useAgentStream() {
             turnSawUsageRef.current[sessionId] = false;
             updateChatSession(sessionId, { agent_status: "Idle" });
             syncWorkspaceAgentStatus(wsId);
-            useAppStore.getState().clearPromptStartTime(wsId);
+            clearPromptStartTimeIfWorkspaceIdle(wsId);
             useAppStore.getState().markWorkspaceAsUnread(wsId);
             break;
           }

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -35,6 +35,10 @@ import {
   firstApprovalDetailString,
   initialToolInputJson,
 } from "./useAgentStreamLogic";
+import {
+  clearPromptStartTimeIfWorkspaceIdle,
+  syncWorkspaceTurnStatus,
+} from "../components/chat/chatTurnLifecycle";
 
 const ASK_USER_QUESTION_TOOL = "AskUserQuestion";
 const ASK_USER_QUESTION_FALLBACK_DELAY_MS = 500;
@@ -225,47 +229,10 @@ export function useAgentStream() {
   // gating) — it is not displayed verbatim. Call this whenever a session
   // or background task transitions so the aggregate stays accurate even
   // with concurrent sessions and async task updates.
-  const syncWorkspaceAgentStatus = (wsId: string) => {
-    const state = useAppStore.getState();
-    const sessions = state.sessionsByWorkspace[wsId] ?? [];
-    const anyRunning = sessions.some(
-      (s) => s.status === "Active" && s.agent_status === "Running",
-    );
-    const activeSessionIds = new Set(
-      sessions.filter((s) => s.status === "Active").map((s) => s.id),
-    );
-    const anyBackground = Object.entries(state.agentBackgroundTasksBySessionId)
-      .some(([sessionId, tabs]) =>
-        activeSessionIds.has(sessionId) &&
-        tabs.some((tab) => {
-          const status = (tab.task_status ?? "").toLowerCase();
-          return status === "starting" || status === "running";
-        }),
-      );
-    state.updateWorkspace(wsId, {
-      agent_status: anyRunning
-        ? "Running"
-        : anyBackground
-          ? "IdleWithBackground"
-          : "Idle",
-    });
-  };
-
   const ensurePromptStartTime = (wsId: string) => {
     const state = useAppStore.getState();
     if (state.promptStartTime[wsId] == null) {
       state.setPromptStartTime(wsId, Date.now());
-    }
-  };
-
-  const clearPromptStartTimeIfWorkspaceIdle = (wsId: string) => {
-    const state = useAppStore.getState();
-    const hasRunningSession = (state.sessionsByWorkspace[wsId] ?? []).some(
-      (session) =>
-        session.status === "Active" && session.agent_status === "Running",
-    );
-    if (!hasRunningSession) {
-      state.clearPromptStartTime(wsId);
     }
   };
 
@@ -305,7 +272,7 @@ export function useAgentStream() {
         // Natural completion emits a `result` event (wasFinalized=true) → Idle.
         // User stop or crash has no prior `result` → Stopped.
         updateChatSession(sessionId, { agent_status: wasFinalized ? "Idle" : "Stopped" });
-        syncWorkspaceAgentStatus(wsId);
+        syncWorkspaceTurnStatus(wsId);
         clearPromptStartTimeIfWorkspaceIdle(wsId);
         setStreamingContent(sessionId, "");
         clearStreamingThinking(sessionId);
@@ -740,7 +707,7 @@ export function useAgentStream() {
             turnFinalizedRef.current[sessionId] = true;
             turnSawUsageRef.current[sessionId] = false;
             updateChatSession(sessionId, { agent_status: "Idle" });
-            syncWorkspaceAgentStatus(wsId);
+            syncWorkspaceTurnStatus(wsId);
             clearPromptStartTimeIfWorkspaceIdle(wsId);
             useAppStore.getState().markWorkspaceAsUnread(wsId);
             break;
@@ -1269,7 +1236,7 @@ export function useAgentStream() {
           agent_status: hasRunningBackground ? "IdleWithBackground" : "Idle",
         });
       }
-      syncWorkspaceAgentStatus(wsId);
+      syncWorkspaceTurnStatus(wsId);
     });
     return () => {
       active = false;

--- a/src/ui/src/hooks/useWorkspaceElapsedSeconds.test.tsx
+++ b/src/ui/src/hooks/useWorkspaceElapsedSeconds.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "../stores/useAppStore";
+import { useWorkspaceElapsedSeconds } from "./useWorkspaceElapsedSeconds";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function renderProbe(
+  workspaceId: string | null,
+  isRunning: boolean,
+): Promise<void> {
+  function Probe() {
+    const elapsed = useWorkspaceElapsedSeconds(workspaceId, isRunning);
+    return <span data-testid="elapsed">{elapsed}</span>;
+  }
+
+  if (!container) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  }
+
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+}
+
+describe("useWorkspaceElapsedSeconds", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    useAppStore.setState({ promptStartTime: {} });
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root!.unmount();
+      });
+    }
+    root = null;
+    container?.remove();
+    container = null;
+    vi.useRealTimers();
+  });
+
+  it("seeds a missing per-workspace timer anchor while running", async () => {
+    await renderProbe("ws-1", true);
+
+    expect(useAppStore.getState().promptStartTime["ws-1"]).toBe(
+      1_700_000_000_000,
+    );
+    expect(container?.textContent).toBe("0");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500);
+    });
+    expect(container?.textContent).toBe("2");
+  });
+
+  it("uses each workspace's own timer anchor", async () => {
+    useAppStore.getState().setPromptStartTime("ws-1", 1_699_999_990_000);
+    useAppStore.getState().setPromptStartTime("ws-2", 1_699_999_970_000);
+
+    await renderProbe("ws-1", true);
+    expect(container?.textContent).toBe("10");
+
+    await renderProbe("ws-2", true);
+    expect(container?.textContent).toBe("30");
+  });
+
+  it("resets elapsed output when the workspace stops running", async () => {
+    useAppStore.getState().setPromptStartTime("ws-1", 1_699_999_990_000);
+
+    await renderProbe("ws-1", true);
+    expect(container?.textContent).toBe("10");
+
+    await renderProbe("ws-1", false);
+    expect(container?.textContent).toBe("0");
+  });
+});

--- a/src/ui/src/hooks/useWorkspaceElapsedSeconds.ts
+++ b/src/ui/src/hooks/useWorkspaceElapsedSeconds.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { useAppStore } from "../stores/useAppStore";
+
+export function useWorkspaceElapsedSeconds(
+  workspaceId: string | null | undefined,
+  isRunning: boolean,
+): number {
+  const promptStartTime = useAppStore((s) =>
+    workspaceId ? s.promptStartTime[workspaceId] ?? null : null,
+  );
+  const setPromptStartTime = useAppStore((s) => s.setPromptStartTime);
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    if (!workspaceId || !isRunning) {
+      setElapsed(0);
+      return;
+    }
+
+    const startTime = promptStartTime ?? Date.now();
+    if (promptStartTime == null) {
+      setPromptStartTime(workspaceId, startTime);
+    }
+
+    const updateElapsed = () => {
+      setElapsed(Math.max(0, Math.floor((Date.now() - startTime) / 1000)));
+    };
+
+    updateElapsed();
+    const interval = setInterval(updateElapsed, 1000);
+    return () => clearInterval(interval);
+  }, [isRunning, promptStartTime, setPromptStartTime, workspaceId]);
+
+  return elapsed;
+}


### PR DESCRIPTION
## Summary

Closes #943.

This fixes the unreliable live elapsed timer for in-progress turns, especially runs started from the project view's GitHub issue / PR "Send to new workspace" flow.

## Root Cause

The normal chat send path and the project-dispatch path had drifted:

- `dispatchChatMessage` set `promptStartTime`, marked the workspace/session as running, inserted the optimistic user message, and cleared unread completion state.
- `sendToNewWorkspace` called `sendChatMessage` directly and only copied part of that setup, so issue-dispatched runs could start without a timer anchor and render as stuck at `0s`.
- ChatPanel also owned a single elapsed-state value scoped to the selected workspace, which made it easy for visible running indicators to share stale state instead of deriving from their own workspace anchor.
- Stream `result` / `ProcessExited` cleanup cleared the workspace timer immediately, even when another active session in the same workspace was still running.

## Changes

- Added shared chat turn-start helpers in `chatMessageDispatch.ts` and reused them from both normal chat sends and project issue/PR sends.
- Added `useWorkspaceElapsedSeconds`, a per-workspace elapsed timer hook used by ChatPanel and Dashboard.
- Made the elapsed hook defensively seed a missing timer anchor when a workspace is already running.
- Made `useAgentStream` seed missing timer anchors from the first live stream event, covering any future dispatch path that forgets to initialize one.
- Changed stream cleanup so a workspace timer is only cleared once no active session in that workspace is still running.
- Added regression coverage for project dispatch timer setup, stream fallback seeding, sibling-session timer preservation, and per-workspace elapsed derivation.

## Validation

- `bun run test -- src/components/project/sendToNewWorkspace.test.ts src/hooks/useAgentStream.sessionRenamed.test.tsx src/hooks/useWorkspaceElapsedSeconds.test.tsx`
- `bunx tsc -b`
- `bun run lint` exits 0; existing unrelated warnings remain.
