### PR TITLE
fix(chat): remove false-firing "Agent may be stuck" turn affordance

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -557,26 +557,6 @@
   font-family: var(--font-mono);
 }
 
-.stuckHint {
-  color: var(--text-muted);
-  font-size: 12px;
-}
-
-.stuckCancel {
-  border: 1px solid var(--divider);
-  border-radius: 6px;
-  background: var(--chat-input-bg);
-  color: var(--text-primary);
-  font: inherit;
-  font-size: 12px;
-  padding: 3px 8px;
-  cursor: pointer;
-}
-
-.stuckCancel:hover {
-  background: var(--hover-bg);
-}
-
 .compactingLabel {
   color: var(--accent-primary);
   font-size: 12px;

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -87,7 +87,6 @@ import { QueuedMessagesPopover } from "./QueuedMessagesPopover";
 import { ChatEmptyState } from "./ChatEmptyState";
 
 const EMPTY_QUEUED_MESSAGES: QueuedMessage[] = [];
-const STUCK_TURN_SECONDS = 180;
 
 export function ChatPanel() {
   const { t } = useTranslation("chat");
@@ -514,12 +513,6 @@ export function ChatPanel() {
 
   const elapsed = useWorkspaceElapsedSeconds(selectedWorkspaceId, isRunning);
   const formatElapsed = formatElapsedSeconds;
-  const showStuckAffordance =
-    isRunning &&
-    !pendingQuestion &&
-    !pendingPlan &&
-    !pendingApproval &&
-    elapsed >= STUCK_TURN_SECONDS;
 
   // Load persisted permission level when the active session changes.
   useEffect(() => {
@@ -1768,24 +1761,6 @@ export function ChatPanel() {
                     <span className={styles.compactingLabel}>{t("compacting_label")}</span>
                   )}
                   <span className={styles.elapsed}>{formatElapsed(elapsed)}</span>
-                  {showStuckAffordance && (
-                    <>
-                      <span className={styles.stuckHint}>
-                        {t("processing_stuck_hint", {
-                          defaultValue: "Agent may be stuck",
-                        })}
-                      </span>
-                      <button
-                        type="button"
-                        className={styles.stuckCancel}
-                        onClick={handleStop}
-                      >
-                        {t("processing_stuck_cancel", {
-                          defaultValue: "Cancel",
-                        })}
-                      </button>
-                    </>
-                  )}
                 </div>
               )}
 


### PR DESCRIPTION
## What

Removes the stuck-turn cancel affordance introduced in #939 — the "Agent may be stuck" hint and inline **Cancel** button that appeared on the processing indicator once a turn had been running for 180 seconds.

## Why

`STUCK_TURN_SECONDS = 180` has no relationship to whether an agent is actually stuck. Large agentic runs and Pi-backed sessions routinely run well past three minutes, so the affordance **false-fires on healthy turns** and reads as alarming UI noise. It is being removed deliberately, not deprecated.

## Changes

- Delete the `STUCK_TURN_SECONDS` constant and the `showStuckAffordance` gate (`ChatPanel.tsx`).
- Delete the "Agent may be stuck" hint + Cancel `<button>` JSX from the processing indicator.
- Delete the `.stuckHint` / `.stuckCancel` / `.stuckCancel:hover` rules (`ChatPanel.module.css`).

2 files changed, 45 deletions — no behavior added.

## Not affected

- Stopping a running turn is unchanged — still available via the composer's existing Stop control (`onStop={handleStop}`). Only the spurious mid-turn hint is gone.
- `processing` indicator, elapsed timer, and `compacting` label are untouched.
- The inline `t()` calls used `defaultValue` only — no locale keys to remove. No docs reference the affordance.

## Notes

Genuine end-of-turn hangs on Pi/Codex backends are a real, separate problem tracked in #925 — this PR does not touch that.

## Checks

- `bunx tsc -b` — passes
- `bun run lint:css` — passes (token + font-stack checks)
