### PR TITLE
fix(pi): repair turn/context lifecycle — visible auto-compaction, accurate meter, unhanging tool calls

### DIFF
--- a/site/src/content/docs/features/providers/pi.mdx
+++ b/site/src/content/docs/features/providers/pi.mdx
@@ -84,6 +84,35 @@ Beyond the dedicated Pi card, Ollama, LM Studio, OpenAI API, Custom OpenAI, and 
 - `/login` for a Pi-selected chat opens the **Pi provider picker** modal (Pi is multi-provider, so `/login` doesn't blind-launch one OAuth flow the way it does for Codex or Claude Code — you pick which provider to configure).
 - `/permissions` keeps controlling Claudette's permission mode for Pi, Claude Code, and Codex.
 
+## Context Lifecycle
+
+Pi sessions surface the same end-of-turn affordances as the Claude CLI gateway:
+
+- **Auto-compaction is visible.** When Pi's native context manager fires
+  `compaction_start` for any trigger — manual `/compact`, threshold (the
+  `keepRecentTokens` budget), or overflow (context window exhausted) —
+  the chat flips to **Compacting context…** instead of leaving a
+  generic spinner. On success the `compact_boundary` divider renders
+  the pre/post token counts and the meter resets to the post-compaction
+  baseline; on auto-compaction failure the status returns to **Running**
+  without a divider so the surviving turn keeps streaming.
+- **The context meter shows end-of-turn occupancy.** The meter reads
+  `AgentSession.getContextUsage()` (Pi's own end-of-turn context size +
+  the model's actual context window) rather than a cumulative tally
+  across the agent loop's internal LLM rounds. A 136 k turn on a 272 k
+  model reads ~50%, not 1100%.
+
+## Tool Execution
+
+Pi tool calls — including the shell-backed `bash` and Pi's exec tools —
+resolve as soon as the spawned command exits, even when the command
+backgrounded a descendant that inherited stdout / stderr (a typical
+example is `bash -c "codex exec …"`, where the Codex CLI forks helper
+processes that hold the inherited pipe open). If you press Stop on the
+chat, the running command is cancelled via the abort signal. There is
+no automatic per-command timeout; pressing Stop is the only way to
+cancel a genuinely stuck command.
+
 ## Troubleshooting
 
 **Refresh models returns only the seed models.** Make sure `pi auth` has been run and provider configuration exists in Pi. Then click **Refresh models** again.

--- a/src-pi-harness/src/main.ts
+++ b/src-pi-harness/src/main.ts
@@ -629,6 +629,13 @@ function runCommand(program: string, args: string[], cwd: string, signal?: Abort
     let stdoutEnded = false;
     let stderrEnded = false;
     let resolved = false;
+    // Set if we had to force-close a stream that hadn't reached EOF.
+    // Means a descendant inherited the pipe (the case this whole
+    // rewrite exists for) OR the child wrote enough output that libuv
+    // hadn't finished draining before our `setImmediate` ran. Either
+    // way the caller deserves a truthful "we may have cut off tail
+    // output" flag instead of a silent partial result.
+    let forcedClose = false;
 
     const finalize = () => {
       if (resolved) return;
@@ -641,7 +648,7 @@ function runCommand(program: string, args: string[], cwd: string, signal?: Abort
         stdout: stdout.text(),
         stderr: stderr.text(),
         exitCode,
-        truncated: stdout.wasTruncated() || stderr.wasTruncated(),
+        truncated: stdout.wasTruncated() || stderr.wasTruncated() || forcedClose,
         limitBytes: MAX_COMMAND_OUTPUT_BYTES,
       });
     };
@@ -664,8 +671,14 @@ function runCommand(program: string, args: string[], cwd: string, signal?: Abort
       // I/O phase — no arbitrary delay, just the standard
       // "drain pending callbacks" idiom.
       setImmediate(() => {
-        if (!stdoutEnded) child.stdout.destroy();
-        if (!stderrEnded) child.stderr.destroy();
+        if (!stdoutEnded) {
+          forcedClose = true;
+          child.stdout.destroy();
+        }
+        if (!stderrEnded) {
+          forcedClose = true;
+          child.stderr.destroy();
+        }
         // If a descendant is holding the pipe, the streams won't emit
         // `'end'` — finalize directly.
         finalize();
@@ -988,9 +1001,34 @@ type PiIterationUsage = {
   modelContextWindow?: number;
 };
 
+type PiAggregateUsage = {
+  /** Sum of `input` across every assistant message in this turn. */
+  inputTokens: number;
+  /** Sum of `output` across every assistant message in this turn. */
+  outputTokens: number;
+  /** Sum of `cacheRead` across every assistant message in this turn. */
+  cacheReadTokens: number;
+  /** Sum of `cacheWrite` across every assistant message in this turn. */
+  cacheCreationTokens: number;
+  /** Sum of `totalTokens` across every assistant message in this turn,
+   *  falling back to `input+output+cacheRead+cacheWrite` per message
+   *  when the provider didn't populate it. */
+  totalTokens?: number;
+};
+
 type PiTurnUsage = {
-  /** Per-final-call snapshot — what the meter needs to show
-   *  end-of-turn context occupancy. */
+  /** Cumulative usage across every assistant message in the turn.
+   *  Drives `TokenUsage`'s top-level fields, which the TurnFooter /
+   *  CompletedTurn surface as "total work for this Claudette-level
+   *  turn". Documented by `pickMeterUsageFromResult` as the aggregate
+   *  semantics. Multi-iteration turns (agent loop with tool calls)
+   *  must use the cumulative figure here, not the final-call snapshot,
+   *  otherwise the footer under-reports. */
+  aggregate?: PiAggregateUsage;
+  /** Per-final-call snapshot — populates `TokenUsage.iterations[0]`,
+   *  which `pickMeterUsageFromResult` reads in preference to the
+   *  top-level aggregate for the ContextMeter's end-of-turn occupancy
+   *  reading. */
   iteration?: PiIterationUsage;
   /** Cumulative cost across all assistant messages in the turn. Drives
    *  the USAGE popover; not used by the context meter. */
@@ -1074,19 +1112,53 @@ function extractAgentEndUsage(
   const messages = Array.isArray(event.messages) ? event.messages : [];
   let totalCostUsd = 0;
   let sawUsage = false;
+  const aggregate: PiAggregateUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+  };
+  let aggregateTotal = 0;
+  let sawAggregateTotal = false;
   for (const message of messages) {
     if (!message || typeof message !== "object") continue;
     const m = message as {
       role?: string;
-      usage?: { cost?: { total?: unknown } };
+      usage?: {
+        input?: unknown;
+        output?: unknown;
+        cacheRead?: unknown;
+        cacheWrite?: unknown;
+        totalTokens?: unknown;
+        cost?: { total?: unknown };
+      };
     };
     if (m.role !== "assistant" || !m.usage) continue;
     sawUsage = true;
+    const input = finiteNumber(m.usage.input) ?? 0;
+    const output = finiteNumber(m.usage.output) ?? 0;
+    const cacheRead = finiteNumber(m.usage.cacheRead) ?? 0;
+    const cacheWrite = finiteNumber(m.usage.cacheWrite) ?? 0;
+    aggregate.inputTokens += input;
+    aggregate.outputTokens += output;
+    aggregate.cacheReadTokens += cacheRead;
+    aggregate.cacheCreationTokens += cacheWrite;
+    const messageTotal = finiteNumber(m.usage.totalTokens);
+    if (messageTotal !== undefined) {
+      aggregateTotal += messageTotal;
+      sawAggregateTotal = true;
+    } else {
+      aggregateTotal += input + output + cacheRead + cacheWrite;
+    }
     totalCostUsd += finiteNumber(m.usage.cost?.total) ?? 0;
+  }
+  if (sawAggregateTotal || aggregateTotal > 0) {
+    aggregate.totalTokens = aggregateTotal;
   }
   const iteration = buildIterationUsage(event);
   if (!sawUsage && !iteration) return undefined;
   const out: PiTurnUsage = { totalCostUsd };
+  if (sawUsage) out.aggregate = aggregate;
   if (iteration) out.iteration = iteration;
   if (startedAt !== undefined) {
     out.durationMs = Math.max(0, Date.now() - startedAt);

--- a/src-pi-harness/src/main.ts
+++ b/src-pi-harness/src/main.ts
@@ -585,6 +585,29 @@ function makeStreamCapture(limitBytes: number) {
   };
 }
 
+/**
+ * Run a command and capture its stdout/stderr to a per-stream cap.
+ *
+ * Resolves on the child's `'exit'` event, NOT `'close'`. `'close'` waits
+ * for the child AND every stdio pipe FD to reach EOF — a grandchild that
+ * inherited stdout/stderr (the textbook example: `bash -c "codex exec …"`,
+ * where `codex` forks helper processes) keeps the pipe open, so `'close'`
+ * never fires and the tool call hangs forever even though the visible
+ * command has finished.
+ *
+ * We listen to both `'exit'` (process terminated) and the streams' `'end'`
+ * (EOF reached on the pipe). On exit we yield one event-loop tick via
+ * `setImmediate` so libuv delivers any `'data'` callbacks already queued
+ * for the just-died child, then if a pipe is still open — a descendant is
+ * holding it — we forcibly destroy our read end. The descendant gets
+ * EPIPE on its next write, which is correct: its parent died, it has no
+ * standing to keep writing to our captured stream.
+ *
+ * This intentionally has no wall-clock timeout. Users press Stop to
+ * cancel a genuinely stuck command; an arbitrary cap would either
+ * interrupt legitimate long jobs (builds, large test suites) or be loose
+ * enough to be useless.
+ */
 function runCommand(program: string, args: string[], cwd: string, signal?: AbortSignal) {
   return new Promise<{
     stdout: string;
@@ -600,16 +623,54 @@ function runCommand(program: string, args: string[], cwd: string, signal?: Abort
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => stdout.push(chunk));
     child.stderr.on("data", (chunk: string) => stderr.push(chunk));
-    child.on("error", reject);
-    child.on("close", (exitCode) =>
+
+    let exited = false;
+    let exitCode: number | null = null;
+    let stdoutEnded = false;
+    let stderrEnded = false;
+    let resolved = false;
+
+    const finalize = () => {
+      if (resolved) return;
+      // Only finalize once we know the process exited. The `setImmediate`
+      // path below handles the case where exit fires but the pipes never
+      // EOF (descendant holding the FD).
+      if (!exited) return;
+      resolved = true;
       resolveCommand({
         stdout: stdout.text(),
         stderr: stderr.text(),
         exitCode,
         truncated: stdout.wasTruncated() || stderr.wasTruncated(),
         limitBytes: MAX_COMMAND_OUTPUT_BYTES,
-      }),
-    );
+      });
+    };
+
+    child.stdout.on("end", () => {
+      stdoutEnded = true;
+      finalize();
+    });
+    child.stderr.on("end", () => {
+      stderrEnded = true;
+      finalize();
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      exited = true;
+      exitCode = code;
+      // Yield to libuv so any `'data'` callbacks already queued for
+      // bytes the child wrote before it died get delivered to our
+      // capture before we close. `setImmediate` runs after the current
+      // I/O phase — no arbitrary delay, just the standard
+      // "drain pending callbacks" idiom.
+      setImmediate(() => {
+        if (!stdoutEnded) child.stdout.destroy();
+        if (!stderrEnded) child.stderr.destroy();
+        // If a descendant is holding the pipe, the streams won't emit
+        // `'end'` — finalize directly.
+        finalize();
+      });
+    });
   });
 }
 
@@ -907,12 +968,32 @@ function extractAgentEndError(event: { messages?: unknown }): string | undefined
   return undefined;
 }
 
-type PiTurnUsage = {
-  totalTokens?: number;
+type PiIterationUsage = {
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
   cacheCreationTokens: number;
+  /** End-of-turn context occupancy. Sourced from
+   * `AgentSession.getContextUsage().tokens` when available — that is Pi's
+   * authoritative figure (uses the last assistant usage and walks any
+   * trailing messages), which is also what Pi itself uses to decide
+   * whether auto-compaction should fire. Falls back to the last
+   * assistant message's `usage.totalTokens` when the session API
+   * returns null (e.g. right after a compaction, before the next LLM
+   * response). */
+  totalTokens?: number;
+  /** Runtime context window for the current model. Lets the meter use
+   * the model's actual capacity rather than the static value baked into
+   * the UI's model registry. */
+  modelContextWindow?: number;
+};
+
+type PiTurnUsage = {
+  /** Per-final-call snapshot — what the meter needs to show
+   *  end-of-turn context occupancy. */
+  iteration?: PiIterationUsage;
+  /** Cumulative cost across all assistant messages in the turn. Drives
+   *  the USAGE popover; not used by the context meter. */
   totalCostUsd: number;
   durationMs?: number;
 };
@@ -921,20 +1002,28 @@ function finiteNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-function extractAgentEndUsage(
-  event: { messages?: unknown },
-  startedAt?: number,
-): PiTurnUsage | undefined {
+/**
+ * Resolve the per-final-call usage snapshot the context meter reads.
+ *
+ * Pi's `AssistantMessage.usage` is per-call (not cumulative); summing
+ * across messages — which the harness used to do — produces a figure
+ * that grows roughly as `num_iterations × actual_context`, hitting
+ * megatokens on long tool-use chains. The meter needs the size of the
+ * model's most recent prompt, which is exactly the last assistant
+ * message's usage block.
+ *
+ * For `totalTokens` we prefer `session.getContextUsage()` because Pi
+ * computes it the same way auto-compaction does (last-assistant usage
+ * plus an estimate for any trailing non-assistant messages) and
+ * handles the post-compaction "no usage yet" baseline by returning
+ * `tokens: null`. When the session API is unavailable (no session, or
+ * returned undefined) we fall back to the last assistant's
+ * `usage.totalTokens` so the meter still shows something useful.
+ */
+function buildIterationUsage(event: { messages?: unknown }): PiIterationUsage | undefined {
   const messages = Array.isArray(event.messages) ? event.messages : [];
-  const totals: PiTurnUsage = {
-    inputTokens: 0,
-    outputTokens: 0,
-    cacheReadTokens: 0,
-    cacheCreationTokens: 0,
-    totalCostUsd: 0,
-  };
-  let sawUsage = false;
-  for (const message of messages) {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
     if (!message || typeof message !== "object") continue;
     const m = message as {
       role?: string;
@@ -944,29 +1033,65 @@ function extractAgentEndUsage(
         cacheRead?: unknown;
         cacheWrite?: unknown;
         totalTokens?: unknown;
-        cost?: { total?: unknown };
       };
     };
     if (m.role !== "assistant" || !m.usage) continue;
-    sawUsage = true;
     const input = finiteNumber(m.usage.input) ?? 0;
     const output = finiteNumber(m.usage.output) ?? 0;
     const cacheRead = finiteNumber(m.usage.cacheRead) ?? 0;
     const cacheWrite = finiteNumber(m.usage.cacheWrite) ?? 0;
-    totals.inputTokens += input;
-    totals.outputTokens += output;
-    totals.cacheReadTokens += cacheRead;
-    totals.cacheCreationTokens += cacheWrite;
-    totals.totalCostUsd += finiteNumber(m.usage.cost?.total) ?? 0;
-    totals.totalTokens =
-      (totals.totalTokens ?? 0) +
-      (finiteNumber(m.usage.totalTokens) ?? input + output + cacheRead + cacheWrite);
+    const lastTotal = finiteNumber(m.usage.totalTokens);
+
+    let sessionTokens: number | undefined;
+    let sessionContextWindow: number | undefined;
+    try {
+      const usage = state.session?.getContextUsage();
+      if (usage) {
+        sessionTokens = finiteNumber(usage.tokens);
+        sessionContextWindow = finiteNumber(usage.contextWindow);
+      }
+    } catch {
+      // `getContextUsage()` reads internal session state; if Pi changes
+      // its shape under us, fall through to the last-assistant fallback.
+    }
+
+    return {
+      inputTokens: input,
+      outputTokens: output,
+      cacheReadTokens: cacheRead,
+      cacheCreationTokens: cacheWrite,
+      totalTokens: sessionTokens ?? lastTotal,
+      modelContextWindow: sessionContextWindow,
+    };
   }
-  if (!sawUsage) return undefined;
+  return undefined;
+}
+
+function extractAgentEndUsage(
+  event: { messages?: unknown },
+  startedAt?: number,
+): PiTurnUsage | undefined {
+  const messages = Array.isArray(event.messages) ? event.messages : [];
+  let totalCostUsd = 0;
+  let sawUsage = false;
+  for (const message of messages) {
+    if (!message || typeof message !== "object") continue;
+    const m = message as {
+      role?: string;
+      usage?: { cost?: { total?: unknown } };
+    };
+    if (m.role !== "assistant" || !m.usage) continue;
+    sawUsage = true;
+    totalCostUsd += finiteNumber(m.usage.cost?.total) ?? 0;
+  }
+  const iteration = buildIterationUsage(event);
+  if (!sawUsage && !iteration) return undefined;
+  const out: PiTurnUsage = { totalCostUsd };
+  if (iteration) out.iteration = iteration;
   if (startedAt !== undefined) {
-    totals.durationMs = Math.max(0, Date.now() - startedAt);
+    out.durationMs = Math.max(0, Date.now() - startedAt);
   }
-  return totals;
+  return out;
 }
 
 function routeSessionEvent(event: AgentSessionEvent): void {

--- a/src/agent/pi_sdk.rs
+++ b/src/agent/pi_sdk.rs
@@ -14,8 +14,8 @@ use tokio::sync::oneshot;
 use super::environment::build_agent_command;
 use super::{
     AgentEvent, AssistantMessage, ContentBlock, ControlRequestInner, Delta, FileAttachment,
-    InnerStreamEvent, StartContentBlock, StreamEvent, TokenUsage, TurnHandle, UserContentBlock,
-    UserEventMessage, UserMessageContent,
+    InnerStreamEvent, StartContentBlock, StreamEvent, TokenUsage, TokenUsageIteration, TurnHandle,
+    UserContentBlock, UserEventMessage, UserMessageContent,
 };
 
 type PiStdin = Arc<tokio::sync::Mutex<ChildStdin>>;
@@ -687,6 +687,33 @@ impl PiSdkSession {
     }
 }
 
+/// Per-final-call usage snapshot emitted by the harness on `turn_end`.
+/// Maps onto Claudette's `TokenUsage` shape (specifically the
+/// `iterations[0]` slot that `pickMeterUsageFromResult` reads first),
+/// translating Pi's `Usage` field names (`input`, `output`, `cacheRead`,
+/// `cacheWrite`) into Claudette's wire names.
+#[derive(Debug, Clone, Deserialize)]
+struct PiIterationUsage {
+    #[serde(default, rename = "inputTokens")]
+    input_tokens: Option<u64>,
+    #[serde(default, rename = "outputTokens")]
+    output_tokens: Option<u64>,
+    #[serde(default, rename = "cacheReadTokens")]
+    cache_read_tokens: Option<u64>,
+    #[serde(default, rename = "cacheCreationTokens")]
+    cache_creation_tokens: Option<u64>,
+    /// Authoritative end-of-turn context size from
+    /// `AgentSession.getContextUsage().tokens`, or the last assistant
+    /// `usage.totalTokens` when the session API returns null/undefined.
+    #[serde(default, rename = "totalTokens")]
+    total_tokens: Option<u64>,
+    /// Runtime context window from
+    /// `AgentSession.getContextUsage().contextWindow`. When present it
+    /// overrides the static UI model-registry capacity.
+    #[serde(default, rename = "modelContextWindow")]
+    model_context_window: Option<u64>,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
 enum PiHarnessMessage {
@@ -751,16 +778,18 @@ enum PiHarnessMessage {
     TurnEnd {
         #[serde(default)]
         error: Option<String>,
-        #[serde(default, rename = "totalTokens")]
-        total_tokens: Option<u64>,
-        #[serde(default, rename = "inputTokens")]
-        input_tokens: Option<u64>,
-        #[serde(default, rename = "outputTokens")]
-        output_tokens: Option<u64>,
-        #[serde(default, rename = "cacheReadTokens")]
-        cache_read_tokens: Option<u64>,
-        #[serde(default, rename = "cacheCreationTokens")]
-        cache_creation_tokens: Option<u64>,
+        /// Per-final-call usage snapshot, populated by the harness from
+        /// the last `AssistantMessage.usage` plus
+        /// `AgentSession.getContextUsage()` for the authoritative
+        /// end-of-turn context size. The Rust side routes this into
+        /// `TokenUsage.iterations[0]`, which `pickMeterUsageFromResult`
+        /// reads in preference to the top-level aggregate.
+        ///
+        /// Absent on resumed pre-fix sessions; the meter then falls back
+        /// to the aggregate (the legacy over-reporting behavior, but no
+        /// worse than what shipped before).
+        #[serde(default)]
+        iteration: Option<PiIterationUsage>,
         #[serde(default, rename = "totalCostUsd")]
         total_cost_usd: Option<f64>,
         #[serde(default, rename = "durationMs")]
@@ -782,9 +811,16 @@ enum PiHarnessMessage {
     /// user `/compact`), `"threshold"` (auto-compaction crossed the
     /// keep-recent budget), or `"overflow"` (context window exhausted).
     /// Arrives on the same session subscription as turn events.
+    ///
+    /// We currently flip the UI to "Compacting" regardless of trigger,
+    /// so `reason` isn't read on the route side — but the harness
+    /// continues to send it for log/diagnostic clarity and future
+    /// per-trigger affordances. `#[allow(dead_code)]` keeps the field
+    /// in the deserialized shape without tripping the unused-field lint.
     #[serde(rename = "compaction_start")]
     CompactionStart {
         #[serde(default)]
+        #[allow(dead_code)]
         reason: Option<String>,
     },
     /// Pi finished native context compaction. The sidecar flattens Pi's
@@ -1149,11 +1185,7 @@ async fn route_pi_message(
         }
         PiHarnessMessage::TurnEnd {
             error,
-            total_tokens,
-            input_tokens,
-            output_tokens,
-            cache_read_tokens,
-            cache_creation_tokens,
+            iteration,
             total_cost_usd,
             duration_ms,
         } => {
@@ -1213,35 +1245,53 @@ async fn route_pi_message(
                 (false, Some(err)) => format!("{}\n\n{}", output.text, err),
                 _ => output.text.clone(),
             };
+            // Pi's per-final-call usage rides `iteration` (a separate
+            // snapshot sourced from the last assistant message + Pi's
+            // own `AgentSession.getContextUsage()`). The Claudette
+            // `TokenUsage` shape exposes that to the context meter via
+            // `iterations[0]`, which `pickMeterUsageFromResult` reads in
+            // preference to the top-level aggregate. The top-level
+            // fields stay populated from the same snapshot so the USAGE
+            // popover and the meter agree.
+            let usage = iteration.as_ref().map(|it| {
+                let input = it.input_tokens.unwrap_or(0);
+                let output = it.output_tokens.unwrap_or(0);
+                TokenUsage {
+                    total_tokens: it.total_tokens,
+                    input_tokens: input,
+                    output_tokens: output,
+                    cache_creation_input_tokens: it.cache_creation_tokens,
+                    cache_read_input_tokens: it.cache_read_tokens,
+                    model_context_window: it.model_context_window,
+                    iterations: Some(vec![TokenUsageIteration {
+                        total_tokens: it.total_tokens,
+                        input_tokens: input,
+                        output_tokens: output,
+                        cache_creation_input_tokens: it.cache_creation_tokens,
+                        cache_read_input_tokens: it.cache_read_tokens,
+                        model_context_window: it.model_context_window,
+                    }]),
+                }
+            });
             let _ = event_tx.send(AgentEvent::Stream(StreamEvent::Result {
                 subtype: subtype.to_string(),
                 result: Some(result_text),
                 total_cost_usd,
                 duration_ms,
-                usage: input_tokens
-                    .zip(output_tokens)
-                    .map(|(input_tokens, output_tokens)| TokenUsage {
-                        total_tokens,
-                        input_tokens,
-                        output_tokens,
-                        cache_creation_input_tokens: cache_creation_tokens,
-                        cache_read_input_tokens: cache_read_tokens,
-                        model_context_window: None,
-                        iterations: None,
-                    }),
+                usage,
             }));
             output.text.clear();
             output.thinking.clear();
         }
-        PiHarnessMessage::CompactionStart { reason } => {
-            // A manual /compact runs through `start_compact`'s dedicated
-            // per-turn pump; flip the UI to "Compacting" so the user
-            // sees progress, mirroring the Codex compacting affordance.
-            // Auto-compaction (threshold/overflow) fires inside a live
-            // turn that already owns the status indicator — leave it.
-            if reason.as_deref() == Some("manual") {
-                let _ = event_tx.send(pi_compacting_status_event());
-            }
+        PiHarnessMessage::CompactionStart { .. } => {
+            // Always flip the UI to "Compacting" — the turn's existing
+            // spinner is a generic "Running" indicator, not a compacting
+            // affordance, so users had no visual cue that auto-compaction
+            // (threshold/overflow) was the reason a turn paused mid-stream.
+            // `CompactionEnd` clears the status by emitting either
+            // `compact_boundary` (success) or the synthetic `status:running`
+            // event (auto-abort) — see the matching branch below.
+            let _ = event_tx.send(pi_compacting_status_event());
         }
         PiHarnessMessage::CompactionEnd {
             reason,
@@ -1257,9 +1307,14 @@ async fn route_pi_message(
                 // No context was freed. For a manual /compact surface a
                 // visible notice as an assistant text block (Pi's
                 // harness already routes operational errors this way).
-                // Auto-compaction failures stay quiet: the turn
-                // continues and a `will_retry` run may still succeed, so
-                // a mid-turn notice would just be noise.
+                // Auto-compaction failures stay quiet on the chat
+                // surface: the turn continues and a `will_retry` run may
+                // still succeed, so a mid-turn notice would be noise.
+                // But we MUST clear the "Compacting" status the matching
+                // `CompactionStart` set — no `compact_boundary` will
+                // follow on the abort path, so without an explicit
+                // status reset `agent_status` would stay stuck on
+                // "Compacting" until the turn itself ends.
                 if is_manual {
                     let detail = error_message
                         .as_deref()
@@ -1273,14 +1328,17 @@ async fn route_pi_message(
                             }],
                         },
                     }));
-                } else if !will_retry {
-                    tracing::warn!(
-                        target: "claudette::agent",
-                        subsystem = "pi-sdk",
-                        reason = reason.as_deref().unwrap_or("unknown"),
-                        error = error_message.as_deref().unwrap_or(""),
-                        "pi auto-compaction failed"
-                    );
+                } else {
+                    if !will_retry {
+                        tracing::warn!(
+                            target: "claudette::agent",
+                            subsystem = "pi-sdk",
+                            reason = reason.as_deref().unwrap_or("unknown"),
+                            error = error_message.as_deref().unwrap_or(""),
+                            "pi auto-compaction failed"
+                        );
+                    }
+                    let _ = event_tx.send(pi_status_running_event());
                 }
             } else {
                 // Success → compact_boundary System event. `send.rs`'s
@@ -1459,6 +1517,32 @@ fn pi_compacting_status_event() -> AgentEvent {
     })
 }
 
+/// Companion to [`pi_compacting_status_event`]: clears the "Compacting"
+/// affordance without producing a compaction divider. Emitted when an
+/// auto-compaction aborts mid-turn — the turn keeps streaming, so the
+/// status needs to flip back to "Running" but no `compact_boundary`
+/// belongs in the chat (the abort freed no context). Frontend handles
+/// `status: "running"` by setting `agent_status` back to `"Running"`.
+fn pi_status_running_event() -> AgentEvent {
+    AgentEvent::Stream(StreamEvent::System {
+        subtype: "status".to_string(),
+        session_id: None,
+        state: None,
+        detail: None,
+        task_id: None,
+        tool_use_id: None,
+        output_file: None,
+        summary: None,
+        description: None,
+        last_tool_name: None,
+        usage: None,
+        status: Some("running".to_string()),
+        compact_result: None,
+        compact_metadata: None,
+        command_line: None,
+    })
+}
+
 /// `compact_boundary` System event for a successful Pi compaction.
 /// `send_chat_message`'s sentinel writer persists the `COMPACTION:...`
 /// row from `compact_metadata`, and the `CompactionDivider` renders.
@@ -1548,14 +1632,70 @@ mod tests {
         rx.try_recv().ok()
     }
 
+    /// The harness emits per-final-call usage under the `iteration`
+    /// key (with `inputTokens`/`outputTokens`/`cacheRead`/`cacheWrite`
+    /// /`totalTokens`/`modelContextWindow` shape). The Rust side has
+    /// to deserialize that shape verbatim — a refactor that renames or
+    /// reshapes any field here silently breaks the context meter,
+    /// because the fallback path drops back to the old cumulative
+    /// aggregate. Pin the wire format.
+    #[test]
+    fn turn_end_iteration_wire_format() {
+        let line = r#"{
+            "type": "turn_end",
+            "iteration": {
+                "inputTokens": 136900,
+                "outputTokens": 3000,
+                "cacheReadTokens": 0,
+                "cacheCreationTokens": 0,
+                "totalTokens": 139900,
+                "modelContextWindow": 272000
+            },
+            "totalCostUsd": 0.42,
+            "durationMs": 513000
+        }"#;
+        let msg: PiHarnessMessage = serde_json::from_str(line).unwrap();
+        match msg {
+            PiHarnessMessage::TurnEnd {
+                iteration: Some(it),
+                total_cost_usd,
+                duration_ms,
+                ..
+            } => {
+                assert_eq!(it.input_tokens, Some(136_900));
+                assert_eq!(it.output_tokens, Some(3000));
+                assert_eq!(it.total_tokens, Some(139_900));
+                assert_eq!(it.model_context_window, Some(272_000));
+                assert_eq!(total_cost_usd, Some(0.42));
+                assert_eq!(duration_ms, Some(513_000));
+            }
+            other => panic!("expected TurnEnd with iteration, got {other:?}"),
+        }
+    }
+
+    /// Sessions resumed mid-stream from an older harness build won't
+    /// send `iteration`. The deserializer must accept that case and
+    /// let the route layer skip building a TokenUsage rather than
+    /// blow up the reader loop.
+    #[test]
+    fn turn_end_without_iteration_parses() {
+        let line = r#"{"type":"turn_end"}"#;
+        let msg: PiHarnessMessage = serde_json::from_str(line).unwrap();
+        assert!(matches!(
+            msg,
+            PiHarnessMessage::TurnEnd {
+                iteration: None,
+                total_cost_usd: None,
+                duration_ms: None,
+                error: None,
+            }
+        ));
+    }
+
     fn turn_end(error: Option<&str>) -> PiHarnessMessage {
         PiHarnessMessage::TurnEnd {
             error: error.map(str::to_string),
-            total_tokens: None,
-            input_tokens: None,
-            output_tokens: None,
-            cache_read_tokens: None,
-            cache_creation_tokens: None,
+            iteration: None,
             total_cost_usd: None,
             duration_ms: None,
         }
@@ -1564,11 +1704,14 @@ mod tests {
     fn turn_end_with_usage() -> PiHarnessMessage {
         PiHarnessMessage::TurnEnd {
             error: None,
-            total_tokens: Some(175),
-            input_tokens: Some(100),
-            output_tokens: Some(50),
-            cache_read_tokens: Some(20),
-            cache_creation_tokens: Some(5),
+            iteration: Some(PiIterationUsage {
+                input_tokens: Some(100),
+                output_tokens: Some(50),
+                cache_read_tokens: Some(20),
+                cache_creation_tokens: Some(5),
+                total_tokens: Some(175),
+                model_context_window: Some(272_000),
+            }),
             total_cost_usd: Some(0.0123),
             duration_ms: Some(4321),
         }
@@ -2246,6 +2389,15 @@ mod tests {
                 assert_eq!(usage.output_tokens, 50);
                 assert_eq!(usage.cache_read_input_tokens, Some(20));
                 assert_eq!(usage.cache_creation_input_tokens, Some(5));
+                assert_eq!(usage.model_context_window, Some(272_000));
+                let iters = usage.iterations.expect("iterations[0] must be populated");
+                assert_eq!(iters.len(), 1);
+                assert_eq!(iters[0].input_tokens, 100);
+                assert_eq!(iters[0].output_tokens, 50);
+                assert_eq!(iters[0].cache_read_input_tokens, Some(20));
+                assert_eq!(iters[0].cache_creation_input_tokens, Some(5));
+                assert_eq!(iters[0].total_tokens, Some(175));
+                assert_eq!(iters[0].model_context_window, Some(272_000));
                 assert_eq!(total_cost_usd, Some(0.0123));
                 assert_eq!(duration_ms, Some(4321));
             }
@@ -2620,11 +2772,13 @@ mod tests {
         assert!(try_recv_now(&mut rx).is_none());
     }
 
-    /// Auto-compaction (threshold/overflow) fires inside a live turn
-    /// that already owns the status indicator — its `compaction_start`
-    /// must not stomp it with a stray status event.
+    /// Auto-compaction (threshold/overflow) must also flip the UI to
+    /// "Compacting". The active turn's generic "Running" spinner is
+    /// indistinguishable from a normal LLM call, so without this event
+    /// users had no signal that Pi paused to compact — they saw a
+    /// stalled turn and ran `/compact` manually.
     #[tokio::test]
-    async fn route_compaction_start_threshold_emits_nothing() {
+    async fn route_compaction_start_threshold_emits_compacting_status() {
         let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
@@ -2637,7 +2791,41 @@ mod tests {
             },
         )
         .await;
+        match next_event(&mut rx).await {
+            AgentEvent::Stream(StreamEvent::System {
+                subtype, status, ..
+            }) => {
+                assert_eq!(subtype, "status");
+                assert_eq!(status.as_deref(), Some("compacting"));
+            }
+            other => panic!("expected status System event, got {other:?}"),
+        }
         assert!(try_recv_now(&mut rx).is_none());
+    }
+
+    /// Same goes for `overflow` (context window exhausted) — the user
+    /// needs the same affordance regardless of which auto-trigger
+    /// fired.
+    #[tokio::test]
+    async fn route_compaction_start_overflow_emits_compacting_status() {
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::CompactionStart {
+                reason: Some("overflow".to_string()),
+            },
+        )
+        .await;
+        match next_event(&mut rx).await {
+            AgentEvent::Stream(StreamEvent::System { status, .. }) => {
+                assert_eq!(status.as_deref(), Some("compacting"));
+            }
+            other => panic!("expected status System event, got {other:?}"),
+        }
     }
 
     /// A successful manual `compaction_end` produces exactly the
@@ -2778,10 +2966,13 @@ mod tests {
         );
     }
 
-    /// An auto-compaction failure must not inject a stray mid-turn
-    /// notice or Result — the turn it rides owns those.
+    /// An auto-compaction failure must not inject a notice or
+    /// terminating Result — the turn it rides owns those — but it MUST
+    /// clear the "Compacting" status that the matching
+    /// `CompactionStart` set. Otherwise `agent_status` stays stuck on
+    /// "Compacting" until the turn itself ends.
     #[tokio::test]
-    async fn route_compaction_end_threshold_aborted_is_quiet() {
+    async fn route_compaction_end_threshold_aborted_emits_running_status() {
         let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
         route_pi_message(
             &event_tx,
@@ -2800,7 +2991,19 @@ mod tests {
             },
         )
         .await;
-        assert!(try_recv_now(&mut rx).is_none());
+        match next_event(&mut rx).await {
+            AgentEvent::Stream(StreamEvent::System {
+                subtype, status, ..
+            }) => {
+                assert_eq!(subtype, "status");
+                assert_eq!(status.as_deref(), Some("running"));
+            }
+            other => panic!("expected status:running System event, got {other:?}"),
+        }
+        assert!(
+            try_recv_now(&mut rx).is_none(),
+            "must not emit a boundary or notice on auto-abort",
+        );
     }
 
     /// Unknown variants (e.g. a future-protocol message Claudette

--- a/src/agent/pi_sdk.rs
+++ b/src/agent/pi_sdk.rs
@@ -687,6 +687,30 @@ impl PiSdkSession {
     }
 }
 
+/// Cumulative-across-the-turn usage emitted by the harness on
+/// `turn_end`. Populates the top-level `TokenUsage` fields, which
+/// `TurnFooter` / `CompletedTurn` surface as "total work for this
+/// Claudette-level turn" (see `pickMeterUsageFromResult`'s docs and the
+/// `aggregate semantics` comment in `useAgentStream.ts`'s `result`
+/// branch). Sums every assistant message's `usage.*` for this turn so
+/// the footer doesn't under-report on multi-iteration agent loops.
+#[derive(Debug, Clone, Deserialize)]
+struct PiAggregateUsage {
+    #[serde(default, rename = "inputTokens")]
+    input_tokens: Option<u64>,
+    #[serde(default, rename = "outputTokens")]
+    output_tokens: Option<u64>,
+    #[serde(default, rename = "cacheReadTokens")]
+    cache_read_tokens: Option<u64>,
+    #[serde(default, rename = "cacheCreationTokens")]
+    cache_creation_tokens: Option<u64>,
+    /// Sum of per-message `totalTokens`. Distinct from
+    /// `PiIterationUsage::total_tokens`, which is end-of-turn context
+    /// occupancy.
+    #[serde(default, rename = "totalTokens")]
+    total_tokens: Option<u64>,
+}
+
 /// Per-final-call usage snapshot emitted by the harness on `turn_end`.
 /// Maps onto Claudette's `TokenUsage` shape (specifically the
 /// `iterations[0]` slot that `pickMeterUsageFromResult` reads first),
@@ -778,16 +802,23 @@ enum PiHarnessMessage {
     TurnEnd {
         #[serde(default)]
         error: Option<String>,
+        /// Cumulative-across-the-turn totals. Populates the top-level
+        /// `TokenUsage` fields the TurnFooter / CompletedTurn surface
+        /// as "total work for this turn".
+        ///
+        /// Absent on resumed pre-fix sessions (a sidecar predating
+        /// this payload). In that case the route layer skips building
+        /// a `TokenUsage` entirely — the meter holds its previous
+        /// reading and the footer omits token counts, which is the
+        /// same fail-safe as a missing CLI `usage` block.
+        #[serde(default)]
+        aggregate: Option<PiAggregateUsage>,
         /// Per-final-call usage snapshot, populated by the harness from
         /// the last `AssistantMessage.usage` plus
         /// `AgentSession.getContextUsage()` for the authoritative
         /// end-of-turn context size. The Rust side routes this into
         /// `TokenUsage.iterations[0]`, which `pickMeterUsageFromResult`
         /// reads in preference to the top-level aggregate.
-        ///
-        /// Absent on resumed pre-fix sessions; the meter then falls back
-        /// to the aggregate (the legacy over-reporting behavior, but no
-        /// worse than what shipped before).
         #[serde(default)]
         iteration: Option<PiIterationUsage>,
         #[serde(default, rename = "totalCostUsd")]
@@ -1185,6 +1216,7 @@ async fn route_pi_message(
         }
         PiHarnessMessage::TurnEnd {
             error,
+            aggregate,
             iteration,
             total_cost_usd,
             duration_ms,
@@ -1245,34 +1277,74 @@ async fn route_pi_message(
                 (false, Some(err)) => format!("{}\n\n{}", output.text, err),
                 _ => output.text.clone(),
             };
-            // Pi's per-final-call usage rides `iteration` (a separate
-            // snapshot sourced from the last assistant message + Pi's
-            // own `AgentSession.getContextUsage()`). The Claudette
-            // `TokenUsage` shape exposes that to the context meter via
-            // `iterations[0]`, which `pickMeterUsageFromResult` reads in
-            // preference to the top-level aggregate. The top-level
-            // fields stay populated from the same snapshot so the USAGE
-            // popover and the meter agree.
-            let usage = iteration.as_ref().map(|it| {
-                let input = it.input_tokens.unwrap_or(0);
-                let output = it.output_tokens.unwrap_or(0);
-                TokenUsage {
-                    total_tokens: it.total_tokens,
-                    input_tokens: input,
-                    output_tokens: output,
-                    cache_creation_input_tokens: it.cache_creation_tokens,
-                    cache_read_input_tokens: it.cache_read_tokens,
-                    model_context_window: it.model_context_window,
-                    iterations: Some(vec![TokenUsageIteration {
+            // Pi splits the usage payload into two snapshots:
+            //  * `aggregate` — cumulative across every assistant message
+            //    in this turn. Drives `TokenUsage`'s top-level fields
+            //    (TurnFooter / CompletedTurn semantics).
+            //  * `iteration` — per-final-call snapshot built from the
+            //    last `AssistantMessage.usage` plus
+            //    `AgentSession.getContextUsage()`. Drives
+            //    `iterations[0]`, which `pickMeterUsageFromResult` reads
+            //    in preference to the aggregate for the ContextMeter's
+            //    end-of-turn occupancy reading.
+            //
+            // `model_context_window` lives only on `iteration` (Pi's
+            // session API exposes it there); it's also lifted to the
+            // top level so consumers that don't crack iterations get
+            // the live capacity. Either snapshot is sufficient to
+            // populate a `TokenUsage` — emit one only when at least
+            // one is present, so resumed pre-fix sessions (no payload
+            // at all) result in `usage: None` rather than a zeroed
+            // misreading.
+            let usage = if aggregate.is_some() || iteration.is_some() {
+                let iterations = iteration.as_ref().map(|it| {
+                    vec![TokenUsageIteration {
                         total_tokens: it.total_tokens,
-                        input_tokens: input,
-                        output_tokens: output,
+                        input_tokens: it.input_tokens.unwrap_or(0),
+                        output_tokens: it.output_tokens.unwrap_or(0),
                         cache_creation_input_tokens: it.cache_creation_tokens,
                         cache_read_input_tokens: it.cache_read_tokens,
                         model_context_window: it.model_context_window,
-                    }]),
-                }
-            });
+                    }]
+                });
+                // Aggregate is the source of truth for top-level
+                // fields; fall back to iteration when aggregate is
+                // missing (older harness builds that only sent
+                // iteration). model_context_window is iteration-only.
+                let agg_input = aggregate
+                    .as_ref()
+                    .and_then(|a| a.input_tokens)
+                    .or_else(|| iteration.as_ref().and_then(|it| it.input_tokens))
+                    .unwrap_or(0);
+                let agg_output = aggregate
+                    .as_ref()
+                    .and_then(|a| a.output_tokens)
+                    .or_else(|| iteration.as_ref().and_then(|it| it.output_tokens))
+                    .unwrap_or(0);
+                let agg_cache_read = aggregate
+                    .as_ref()
+                    .and_then(|a| a.cache_read_tokens)
+                    .or_else(|| iteration.as_ref().and_then(|it| it.cache_read_tokens));
+                let agg_cache_creation = aggregate
+                    .as_ref()
+                    .and_then(|a| a.cache_creation_tokens)
+                    .or_else(|| iteration.as_ref().and_then(|it| it.cache_creation_tokens));
+                let agg_total = aggregate
+                    .as_ref()
+                    .and_then(|a| a.total_tokens)
+                    .or_else(|| iteration.as_ref().and_then(|it| it.total_tokens));
+                Some(TokenUsage {
+                    total_tokens: agg_total,
+                    input_tokens: agg_input,
+                    output_tokens: agg_output,
+                    cache_creation_input_tokens: agg_cache_creation,
+                    cache_read_input_tokens: agg_cache_read,
+                    model_context_window: iteration.as_ref().and_then(|it| it.model_context_window),
+                    iterations,
+                })
+            } else {
+                None
+            };
             let _ = event_tx.send(AgentEvent::Stream(StreamEvent::Result {
                 subtype: subtype.to_string(),
                 result: Some(result_text),
@@ -1632,17 +1704,29 @@ mod tests {
         rx.try_recv().ok()
     }
 
-    /// The harness emits per-final-call usage under the `iteration`
-    /// key (with `inputTokens`/`outputTokens`/`cacheRead`/`cacheWrite`
-    /// /`totalTokens`/`modelContextWindow` shape). The Rust side has
-    /// to deserialize that shape verbatim — a refactor that renames or
-    /// reshapes any field here silently breaks the context meter,
-    /// because the fallback path drops back to the old cumulative
-    /// aggregate. Pin the wire format.
+    /// The harness emits two usage snapshots on `turn_end`:
+    ///  * `aggregate` (cumulative across all assistant messages in
+    ///    this Claudette-level turn) — drives the TurnFooter.
+    ///  * `iteration` (per-final-call) — drives the ContextMeter via
+    ///    `TokenUsage.iterations[0]`.
+    ///
+    /// Both use the `inputTokens` / `outputTokens` / `cacheReadTokens`
+    /// / `cacheCreationTokens` / `totalTokens` shape; `iteration` also
+    /// carries `modelContextWindow`. The Rust side has to deserialize
+    /// that shape verbatim — a refactor that renames or reshapes any
+    /// field here silently regresses the meter or the footer. Pin the
+    /// wire format.
     #[test]
-    fn turn_end_iteration_wire_format() {
+    fn turn_end_usage_wire_format() {
         let line = r#"{
             "type": "turn_end",
+            "aggregate": {
+                "inputTokens": 410700,
+                "outputTokens": 9000,
+                "cacheReadTokens": 0,
+                "cacheCreationTokens": 0,
+                "totalTokens": 419700
+            },
             "iteration": {
                 "inputTokens": 136900,
                 "outputTokens": 3000,
@@ -1657,11 +1741,15 @@ mod tests {
         let msg: PiHarnessMessage = serde_json::from_str(line).unwrap();
         match msg {
             PiHarnessMessage::TurnEnd {
+                aggregate: Some(agg),
                 iteration: Some(it),
                 total_cost_usd,
                 duration_ms,
                 ..
             } => {
+                assert_eq!(agg.input_tokens, Some(410_700));
+                assert_eq!(agg.output_tokens, Some(9000));
+                assert_eq!(agg.total_tokens, Some(419_700));
                 assert_eq!(it.input_tokens, Some(136_900));
                 assert_eq!(it.output_tokens, Some(3000));
                 assert_eq!(it.total_tokens, Some(139_900));
@@ -1669,21 +1757,22 @@ mod tests {
                 assert_eq!(total_cost_usd, Some(0.42));
                 assert_eq!(duration_ms, Some(513_000));
             }
-            other => panic!("expected TurnEnd with iteration, got {other:?}"),
+            other => panic!("expected TurnEnd with both snapshots, got {other:?}"),
         }
     }
 
     /// Sessions resumed mid-stream from an older harness build won't
-    /// send `iteration`. The deserializer must accept that case and
-    /// let the route layer skip building a TokenUsage rather than
-    /// blow up the reader loop.
+    /// send `aggregate` or `iteration`. The deserializer must accept
+    /// that case and let the route layer skip building a TokenUsage
+    /// rather than blow up the reader loop.
     #[test]
-    fn turn_end_without_iteration_parses() {
+    fn turn_end_without_usage_parses() {
         let line = r#"{"type":"turn_end"}"#;
         let msg: PiHarnessMessage = serde_json::from_str(line).unwrap();
         assert!(matches!(
             msg,
             PiHarnessMessage::TurnEnd {
+                aggregate: None,
                 iteration: None,
                 total_cost_usd: None,
                 duration_ms: None,
@@ -1695,6 +1784,7 @@ mod tests {
     fn turn_end(error: Option<&str>) -> PiHarnessMessage {
         PiHarnessMessage::TurnEnd {
             error: error.map(str::to_string),
+            aggregate: None,
             iteration: None,
             total_cost_usd: None,
             duration_ms: None,
@@ -1702,8 +1792,18 @@ mod tests {
     }
 
     fn turn_end_with_usage() -> PiHarnessMessage {
+        // Multi-iteration turn: the agent loop ran three model calls, so
+        // aggregate is roughly 3 × per-final-call. The footer reads the
+        // aggregate; the meter reads `iterations[0]` (the per-final-call).
         PiHarnessMessage::TurnEnd {
             error: None,
+            aggregate: Some(PiAggregateUsage {
+                input_tokens: Some(300),
+                output_tokens: Some(150),
+                cache_read_tokens: Some(60),
+                cache_creation_tokens: Some(15),
+                total_tokens: Some(525),
+            }),
             iteration: Some(PiIterationUsage {
                 input_tokens: Some(100),
                 output_tokens: Some(50),
@@ -2384,12 +2484,24 @@ mod tests {
                 ..
             }) => {
                 let usage = usage.expect("Pi usage should be forwarded");
-                assert_eq!(usage.total_tokens, Some(175));
-                assert_eq!(usage.input_tokens, 100);
-                assert_eq!(usage.output_tokens, 50);
-                assert_eq!(usage.cache_read_input_tokens, Some(20));
-                assert_eq!(usage.cache_creation_input_tokens, Some(5));
+                // Top-level fields are the cumulative turn aggregate
+                // (TurnFooter / CompletedTurn semantics). They must
+                // NOT be the per-final-call snapshot — otherwise a
+                // multi-iteration turn under-reports total work.
+                assert_eq!(usage.total_tokens, Some(525));
+                assert_eq!(usage.input_tokens, 300);
+                assert_eq!(usage.output_tokens, 150);
+                assert_eq!(usage.cache_read_input_tokens, Some(60));
+                assert_eq!(usage.cache_creation_input_tokens, Some(15));
+                // model_context_window is iteration-only on the
+                // protocol side (Pi exposes it via getContextUsage),
+                // but we lift it to the top level too so consumers
+                // that don't crack `iterations` still see the live
+                // capacity.
                 assert_eq!(usage.model_context_window, Some(272_000));
+                // iterations[0] is the per-final-call snapshot for the
+                // ContextMeter — must reflect just the final call, not
+                // the cumulative.
                 let iters = usage.iterations.expect("iterations[0] must be populated");
                 assert_eq!(iters.len(), 1);
                 assert_eq!(iters[0].input_tokens, 100);
@@ -2400,6 +2512,86 @@ mod tests {
                 assert_eq!(iters[0].model_context_window, Some(272_000));
                 assert_eq!(total_cost_usd, Some(0.0123));
                 assert_eq!(duration_ms, Some(4321));
+            }
+            other => panic!("expected Result, got {other:?}"),
+        }
+    }
+
+    /// Pre-aggregate harness builds (or any future sidecar variant
+    /// that emits only the per-final-call snapshot) must still
+    /// produce a usable `TokenUsage`. The route layer falls back to
+    /// the iteration values for the top-level fields when aggregate
+    /// is absent — better to show single-iteration totals than no
+    /// totals at all.
+    #[tokio::test]
+    async fn turn_end_iteration_only_falls_back_to_iteration_for_top_level() {
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        turn_output.lock().await.text.push_str("answer");
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            PiHarnessMessage::TurnEnd {
+                error: None,
+                aggregate: None,
+                iteration: Some(PiIterationUsage {
+                    input_tokens: Some(100),
+                    output_tokens: Some(50),
+                    cache_read_tokens: Some(20),
+                    cache_creation_tokens: Some(5),
+                    total_tokens: Some(175),
+                    model_context_window: Some(272_000),
+                }),
+                total_cost_usd: None,
+                duration_ms: None,
+            },
+        )
+        .await;
+        let _assistant = next_event(&mut rx).await;
+        match next_event(&mut rx).await {
+            AgentEvent::Stream(StreamEvent::Result {
+                usage: Some(usage), ..
+            }) => {
+                // No aggregate available → top-level mirrors iteration.
+                assert_eq!(usage.input_tokens, 100);
+                assert_eq!(usage.output_tokens, 50);
+                assert_eq!(usage.cache_read_input_tokens, Some(20));
+                assert_eq!(usage.cache_creation_input_tokens, Some(5));
+                assert_eq!(usage.total_tokens, Some(175));
+                let iters = usage.iterations.expect("iterations populated");
+                assert_eq!(iters[0].input_tokens, 100);
+            }
+            other => panic!("expected Result with usage, got {other:?}"),
+        }
+    }
+
+    /// Turn-end with neither aggregate nor iteration (a sidecar
+    /// predating this payload, or a turn that produced no LLM usage
+    /// at all) must produce `usage: None` rather than zeroes. Zeroes
+    /// would poison the meter; `None` lets it hold its previous
+    /// reading.
+    #[tokio::test]
+    async fn turn_end_without_usage_emits_no_token_usage() {
+        let (event_tx, control_tx, mut rx, pending, turn_output, init_cache) = pi_state();
+        turn_output.lock().await.text.push_str("answer");
+        route_pi_message(
+            &event_tx,
+            &control_tx,
+            &pending,
+            &turn_output,
+            &init_cache,
+            turn_end(None),
+        )
+        .await;
+        let _assistant = next_event(&mut rx).await;
+        match next_event(&mut rx).await {
+            AgentEvent::Stream(StreamEvent::Result { usage, .. }) => {
+                assert!(
+                    usage.is_none(),
+                    "no aggregate + no iteration → no TokenUsage"
+                );
             }
             other => panic!("expected Result, got {other:?}"),
         }

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -352,12 +352,22 @@ export function useAgentStream() {
               }
             }
             // Compaction lifecycle: status -> "compacting" marks start;
-            // compact_boundary marks end.
+            // compact_boundary marks success-path end. `status: "running"`
+            // is the abort-path counterpart — emitted by the Pi harness
+            // when an auto-compaction failed mid-turn, where there's no
+            // boundary divider to clear the Compacting affordance.
             if (
               streamEvent.subtype === "status" &&
               streamEvent.status === "compacting"
             ) {
               updateWorkspace(wsId, { agent_status: "Compacting" });
+              break;
+            }
+            if (
+              streamEvent.subtype === "status" &&
+              streamEvent.status === "running"
+            ) {
+              updateWorkspace(wsId, { agent_status: "Running" });
               break;
             }
             if (


### PR DESCRIPTION
## Summary

Closes #925.

Four related defects in Pi-backed sessions shared a root area (Pi harness ↔ Rust route ↔ UI state) and are fixed together:

1. **Auto-compaction is now visible** — threshold/overflow compactions show the same "Compacting context…" affordance as `/compact`. Auto-compaction aborts cleanly return to "Running" without leaving the chat stuck on "Compacting".
2. **Context meter shows end-of-turn occupancy** instead of a cumulative `num_iterations × actual_context` figure. A 136 k turn on a 272 k window now reads ~50%, not 1100%.
3. **`bash`/exec tool calls no longer hang forever** when the spawned command exits but a grandchild has inherited stdout/stderr (the textbook offender: `bash -c "codex exec …"`).
4. **End-of-turn hang is gone** — same root cause as (3); the unresolved tool-call Promise was blocking `agent_end`.

No DB / IPC / CLI contract changes. Spans `src/agent/pi_sdk.rs` (pi-sdk gated), the Pi harness sidecar (`src-pi-harness/`), `src/ui/src/hooks/useAgentStream.ts`, and the Pi feature docs.

## Detail

### Symptom 1 — auto-compaction was invisible

`pi_sdk.rs` previously gated the "Compacting" status event on `reason == "manual"`. The justification was a misread of the parallel Codex bug (#909) — that bug was about the *terminating Result* cutting the turn short, not about the status affordance. The Compacting indicator is just a UI hint and can fire independently.

- Drop the manual-only gate on `CompactionStart`; emit `pi_compacting_status_event()` for every trigger.
- Add `pi_status_running_event()` (a `status: "running"` System event) for the auto-compaction **abort** path. Without it, `agent_status` would stay stuck on "Compacting" since no `compact_boundary` follows an aborted compaction.
- `useAgentStream.ts` handles the new `status: "running"` branch — the active turn keeps streaming, no divider rendered.

Pi already correctly gated the terminating `Result` to manual-only (`pi_compaction_finish_event()`) — left untouched.

### Symptom 2 — context meter showed bogus totals (3.0M / 272.0k)

The meter (`pickMeterUsageFromResult`) reads `usage.iterations[0]` first. Pi was sending `iterations: None`, so the meter fell back to a cumulative aggregate. The harness's `extractAgentEndUsage` walked every assistant message in `agent_end.messages` and **summed** their per-call `usage` blocks — producing `num_iterations × actual_context`. The 8m 33s turn in the bug report hit 3.0M tokens this way (10× the 272k window).

Fix uses Pi's own SDK APIs instead of bespoke math:

- Harness picks the **last** `AssistantMessage.usage` for the per-call snapshot. Pi's `Usage` is per-call by design; summing across messages was always wrong.
- For total context size, harness calls `AgentSession.getContextUsage()` — Pi's authoritative figure, the same value Pi uses internally to decide whether auto-compaction should fire. `contextWindow` rides along so the meter uses the model's live capacity instead of the static UI registry value.
- Falls back to the last assistant's `usage.totalTokens` if `getContextUsage()` returns null (post-compaction baseline before the next LLM call).
- New `iteration` field on the harness `turn_end` payload. Rust deserializes it into `PiIterationUsage` and routes into `TokenUsage.iterations[0]` (plus the top-level aggregate, so meter and USAGE popover agree).
- Cumulative cost across assistant messages is still summed — that's what the USAGE popover wants.

### Symptom 4 — bash/tool calls hung forever after the command finished

`runCommand` in `src-pi-harness/src/main.ts` resolved on Node's `'close'` event, which waits for the child **and every stdio pipe FD** to reach EOF. When a grandchild inherits stdout/stderr (e.g. `codex exec` spawning helper / app-server processes), the kernel pipe stays open after the direct child exits — `'close'` never fires, the tool's `execute()` Promise never resolves, the chat shows a perpetual spinner even though the command itself finished.

Structural fix (no arbitrary timeouts):

- Resolve on `'exit'` (the process actually terminated, regardless of inherited pipes).
- After `'exit'`, yield one event-loop tick via `setImmediate` so libuv delivers any `'data'` callbacks already queued for bytes the child wrote before it died.
- If stdout/stderr haven't emitted `'end'` by then, `destroy()` our read ends. A descendant still holding the FD will get `EPIPE` on its next write — correct behavior since its parent died.

Smoke test: `bash -c "echo hello; (sleep 30) &"` previously hung 30s, now resolves in ~11ms with full output captured. Per discussion in #925 there is intentionally **no** overall wall-clock timeout; pressing Stop remains the cancel path.

### Symptom 3 — turns hung at end-of-turn

Confirmed to be the same root cause as Symptom 4. When `runCommand` doesn't resolve:
- The tool's `execute()` Promise never settles
- Pi's agent loop blocks waiting on `tool_execution_end`
- `agent_end` never fires
- From Claudette's perspective the chat summary already rendered, then a fresh "Running" spinner persists indefinitely

Fixed by the `runCommand` change above; no separate fix.

## Files changed

- `src/agent/pi_sdk.rs` — `CompactionStart` ungated, `CompactionEnd` auto-abort emits `status:"running"`, new `PiIterationUsage` struct + `pi_status_running_event` helper, `TurnEnd` now consumes `iteration` and populates `TokenUsage.iterations[0]`.
- `src-pi-harness/src/main.ts` — `runCommand` rewritten to resolve on `'exit'` with pipe-destroy fallback; `extractAgentEndUsage` rewritten around last-message + `AgentSession.getContextUsage()`.
- `src/ui/src/hooks/useAgentStream.ts` — handle `status:"running"` as the auto-compaction abort signal.
- `site/src/content/docs/features/providers/pi.mdx` — new **Context Lifecycle** and **Tool Execution** sections.

## Test plan

- [x] `cargo test -p claudette --features pi-sdk pi_sdk` — 54/54 pass (5 new/updated tests cover compacting status for threshold/overflow, auto-abort returning to Running, the new `iteration` wire format, fallback when absent, and the meter usage selection)
- [x] `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cd src/ui && bunx tsc -b` — clean
- [x] `bun run test` — 232 files / 2716 tests pass
- [x] `bun run typecheck` in `src-pi-harness/` — clean
- [x] Smoke test for `runCommand` pipe-holding descendant — 11ms (was 30s+)
- [ ] Manual: run a long-context Pi turn that auto-compacts; verify Compacting affordance appears and clears
- [ ] Manual: confirm meter reads sane percentages after a multi-iteration Pi turn
- [ ] Manual: run a `bash` tool that backgrounds a process inheriting stdout (e.g. `codex exec`); verify the tool call resolves promptly

## Notes for review

- Pi's wire vocabulary (`manual` / `threshold` / `overflow`) is preserved in the divider trigger label; only the *gating* behavior changed.
- The new `iteration` payload is `Option<PiIterationUsage>`. Sessions resumed from a pre-fix harness build will see `iteration: None` and fall back to no `TokenUsage` (no worse than the existing aggregate-fallback path).
- `runCommand` keeps the existing `MAX_COMMAND_OUTPUT_BYTES` cap, truncation flag, and AbortSignal wiring.