### PR TITLE
refactor(chat): split ChatPanel responsibilities

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,20 +1,10 @@
-import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { useRef, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  LoaderCircle,
-  SendHorizontal,
-} from "lucide-react";
-import { ChatErrorBanner } from "./ChatErrorBanner";
-import { ChatSearchBar } from "./ChatSearchBar";
-import { OverlayScrollbar } from "./OverlayScrollbar";
+import { LoaderCircle } from "lucide-react";
 import { WorkspaceEmptyTabs } from "./WorkspaceEmptyTabs";
 import { useAppStore } from "../../stores/useAppStore";
-import { isWorkspaceEnvironmentPreparing } from "../../utils/workspaceEnvironment";
 import {
-  loadAttachmentData,
-  loadChatHistoryPage,
   loadAttachmentsForSession,
-  listCheckpoints,
   listSlashCommands,
   loadCompletedTurns,
   openReleaseNotes,
@@ -23,10 +13,6 @@ import {
   sendRemoteCommand,
   steerQueuedChatMessage,
   stopAgent,
-  submitAgentAnswer,
-  submitAgentApproval,
-  submitPlanApproval,
-  getAppSetting,
   setAppSetting,
   clearConversation,
   readPlanFile,
@@ -37,364 +23,117 @@ import {
 import { resolveSessionHarness } from "./resolveSessionHarness";
 import { applySelectedModel } from "./applySelectedModel";
 import { findLatestPlanFilePath } from "./planFilePath";
-import type { PermissionLevel, QueuedMessage } from "../../stores/useAppStore";
+import type { PermissionLevel } from "../../stores/useAppStore";
 import { dispatchChatMessage } from "./chatMessageDispatch";
 import { reconstructCompletedTurns } from "../../utils/reconstructTurns";
-import { extractLatestCallUsage } from "../../utils/extractLatestCallUsage";
-import type { AttachmentInput, ChatMessage } from "../../types/chat";
-import { debugChat } from "../../utils/chatDebug";
-import { AttachmentContextMenu } from "./AttachmentContextMenu";
-import { buildAttachmentMenuLabels } from "./attachmentContextMenuLabels";
-import { AttachmentLightbox } from "./AttachmentLightbox";
-import {
-  downloadAttachment,
-  openAttachmentInBrowser,
-  openAttachmentWithDefaultApp,
-  copyAttachmentToClipboard,
-  shareAttachment,
-  isShareSupported,
-  type DownloadableAttachment,
-} from "../../utils/attachmentDownload";
+import type { AttachmentInput } from "../../types/chat";
 import {
   parseSlashInput,
   resolveNativeHandler,
 } from "./nativeSlashCommands";
-import { extractCompactionEvents } from "../../utils/compactionSentinel";
 import { WorkspacePanelHeader } from "../shared/WorkspacePanelHeader";
 import { SessionTabs } from "./SessionTabs";
-import { AgentQuestionCard } from "./AgentQuestionCard";
-import { PlanApprovalCard } from "./PlanApprovalCard";
-import { AgentApprovalCard } from "./AgentApprovalCard";
-import { ScrollToBottomPill } from "./ScrollToBottomPill";
-import { useStickyScroll } from "../../hooks/useStickyScroll";
-import { tooltipWithHotkey } from "../../hotkeys/display";
-import { isMacHotkeyPlatform } from "../../hotkeys/platform";
-import { usePreventScrollBounce } from "../../hooks/usePreventScrollBounce";
 import { useWorkspaceElapsedSeconds } from "../../hooks/useWorkspaceElapsedSeconds";
 import styles from "./ChatPanel.module.css";
-import { formatElapsedSeconds } from "./chatHelpers";
-import { ScrollContext } from "./ScrollContext";
-import { StreamingThinkingBlock } from "./StreamingThinkingBlock";
-import { StreamingMessage } from "./StreamingMessage";
-import { MessagesWithTurns } from "./MessagesWithTurns";
-import { ChatAuthFailureCallout } from "../auth/ChatAuthFailureCallout";
-import { CliInvocationBanner } from "./CliInvocationBanner";
-import { SetupScriptBanner } from "./SetupScriptBanner";
-import { CurrentTurnTaskProgress } from "./CurrentTurnTaskProgress";
-import { ChatInputArea } from "./ChatInputArea";
-import { EMPTY_ACTIVITIES } from "./chatConstants";
-import { QueuedMessagesPopover } from "./QueuedMessagesPopover";
-import { ChatEmptyState } from "./ChatEmptyState";
-
-const EMPTY_QUEUED_MESSAGES: QueuedMessage[] = [];
+import { useChatPanelStore } from "./useChatPanelStore";
+import { useChatPanelAttachments } from "./useChatPanelAttachments";
+import { useChatPanelSessionLifecycle } from "./useChatPanelSessionLifecycle";
+import { ChatPanelAttachmentOverlays } from "./ChatPanelAttachmentOverlays";
+import { ChatPanelSessionView } from "./ChatPanelSessionView";
 
 export function ChatPanel() {
   const { t } = useTranslation("chat");
-  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
-  const workspaceEnvironmentPreparing = useAppStore((s) =>
-    isWorkspaceEnvironmentPreparing(s, s.selectedWorkspaceId),
-  );
-  const workspaceEnvironmentError = useAppStore((s) =>
-    s.selectedWorkspaceId &&
-      s.workspaceEnvironment[s.selectedWorkspaceId]?.status === "error"
-      ? s.workspaceEnvironment[s.selectedWorkspaceId]?.error ??
-        t("environment_error_fallback", {
-          defaultValue: "Workspace environment setup failed.",
-        })
-      : null,
-  );
-  const activeSessionId = useAppStore((s) =>
-    s.selectedWorkspaceId
-      ? s.selectedSessionIdByWorkspaceId[s.selectedWorkspaceId] ?? null
-      : null,
-  );
-  const activeSessionIdsKey = useAppStore((s) =>
-    selectedWorkspaceId
-      ? (s.sessionsByWorkspace[selectedWorkspaceId] ?? [])
-          .map((session) => session.id)
-          .join("\0")
-      : "",
-  );
-  const workspaces = useAppStore((s) => s.workspaces);
-  const repositories = useAppStore((s) => s.repositories);
-  const chatMessages = useAppStore((s) => s.chatMessages);
-  const setChatMessages = useAppStore((s) => s.setChatMessages);
-  // Treat `null` (probe-in-flight) as available so we don't briefly
-  // hide the Download menu item on a working host. See `dialog.rs`
-  // for why this gate exists — the dialog plugin panics from the
-  // Rust side on portal-less Linux and no JS try/catch can recover.
-  const fileDialogAvailable = useAppStore((s) => s.fileDialogAvailable);
-  const browseAvailable = fileDialogAvailable !== false;
-  const runningSetupScriptSource = useAppStore((s) =>
-    activeSessionId ? s.runningSetupScripts[activeSessionId] : undefined,
-  );
-  const hydrateCompletedTurns = useAppStore((s) => s.hydrateCompletedTurns);
-  const addChatMessage = useAppStore((s) => s.addChatMessage);
-  const enqueueTerminalCommand = useAppStore((s) => s.enqueueTerminalCommand);
-  const setChatPagination = useAppStore((s) => s.setChatPagination);
-  const chatPaginationState = useAppStore((s) =>
-    activeSessionId ? s.chatPagination[activeSessionId] : undefined,
-  );
-  const openPluginSettings = useAppStore((s) => s.openPluginSettings);
-  const usageInsightsEnabled = useAppStore((s) => s.usageInsightsEnabled);
-  const openSettings = useAppStore((s) => s.openSettings);
-  const appVersion = useAppStore((s) => s.appVersion);
-  const keybindings = useAppStore((s) => s.keybindings);
-  const slashCommandsByWorkspace = useAppStore((s) => s.slashCommandsByWorkspace);
-  const setSlashCommandsCache = useAppStore((s) => s.setSlashCommands);
+  const {
+    activeChatSessionRecord,
+    activeSessionId,
+    activeSessionIdsKey,
+    activitiesCount,
+    addChatMessage,
+    addCheckpoint,
+    appVersion,
+    beginPendingFork,
+    browseAvailable,
+    cancelPendingFork,
+    chatAuthLoginRequestId,
+    chatAuthLoginStartedRequestId,
+    clearAgentApproval,
+    clearAgentQuestion,
+    clearPlanApproval,
+    clearQueuedMessage,
+    commitPendingFork,
+    completedTurnsCount,
+    defaultBranch,
+    enqueueTerminalCommand,
+    globalOffset,
+    hasMore,
+    hasPendingTypewriter,
+    hasStreaming,
+    hasThinking,
+    hydrateCompletedTurns,
+    isLoadingMore,
+    isRunning,
+    isSteeringQueued,
+    messages,
+    noOpenTabs,
+    oldestMessageId,
+    openChatAuthLoginPanel,
+    openPluginSettings,
+    openSettings,
+    pendingApproval,
+    pendingCreateRepoName,
+    pendingCreateWorkspaceName,
+    pendingForkSourceName,
+    pendingPlan,
+    pendingQuestion,
+    pendingSteerContent,
+    queuedMessages,
+    removeQueuedMessage,
+    repo,
+    runningSetupScriptSource,
+    searchQuery,
+    selectedWorkspaceId,
+    sessionsLoaded,
+    setChatAuthLoginStartedRequestId,
+    setChatMessages,
+    setChatPagination,
+    setPermissionLevel,
+    setPlanMode,
+    setQueuedMessage,
+    setQueuedMessageAutoDispatchPaused,
+    setQueuedMessageEditing,
+    setQueuedMessageSteering,
+    setSlashCommandsCache,
+    showChatAuthLoginPanel,
+    showThinkingBlocks,
+    slashCommandsByWorkspace,
+    steerQueuedTooltip,
+    toolDisplayMode,
+    updateQueuedMessage,
+    usageInsightsEnabled,
+    workspaceEnvironmentError,
+    workspaceEnvironmentPreparing,
+    ws,
+  } = useChatPanelStore();
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const processingRef = useRef<HTMLDivElement>(null);
-  const chatScrollTopBySessionRef = useRef(new Map<string, number>());
   const restoringChatScrollSessionsRef = useRef(new Set<string>());
   const [error, setError] = useState<string | null>(null);
-  const isSteeringQueued = useAppStore((s) =>
-    activeSessionId ? s.queuedMessageSteering[activeSessionId] === true : false,
-  );
-  const pendingSteerContent = useAppStore((s) =>
-    activeSessionId ? s.queuedMessageSteeringContent[activeSessionId] ?? null : null,
-  );
-  const setQueuedMessageEditing = useAppStore((s) => s.setQueuedMessageEditing);
-  const setQueuedMessageSteering = useAppStore((s) => s.setQueuedMessageSteering);
-  const isMac = isMacHotkeyPlatform();
-  const steerQueuedTooltip = tooltipWithHotkey(
-    t("steer_queued"),
-    "chat.steer-immediate",
-    keybindings,
-    isMac,
-  );
 
-  // Cmd/Ctrl+F search bar state. `searchQuery` flows down to message
-  // renderers as the highlight trigger; an empty string short-circuits the
-  // wrappers' DOM-walk pass entirely, so search-off has zero render cost.
-  const chatSearchOpen = useAppStore(
-    (s) => (selectedWorkspaceId ? s.chatSearch[selectedWorkspaceId]?.open ?? false : false),
-  );
-  const chatSearchQuery = useAppStore(
-    (s) => (selectedWorkspaceId ? s.chatSearch[selectedWorkspaceId]?.query ?? "" : ""),
-  );
-  const searchQuery = chatSearchOpen ? chatSearchQuery : "";
-
-  const [attachmentMenu, setAttachmentMenu] = useState<{
-    x: number;
-    y: number;
-    attachment: DownloadableAttachment;
-    /** Persisted PDFs hydrate without data_base64 (it's stripped to keep
-     *  the initial IPC small). When the menu fires for one, hold the row
-     *  id so each action can lazy-load the bytes via loadAttachmentData
-     *  before downloading / copying. */
-    attachmentId?: string;
-  } | null>(null);
-
-  const openAttachmentMenu = useCallback(
-    (e: React.MouseEvent, attachment: DownloadableAttachment, attachmentId?: string) => {
-      e.preventDefault();
-      setAttachmentMenu({
-        x: e.clientX,
-        y: e.clientY,
-        attachment,
-        attachmentId,
-      });
-    },
-    [],
-  );
-
-  /** Resolves an attachment's data_base64, fetching from the backend on
-   *  demand if it was stripped during hydration. Returns a fresh object
-   *  so callers can pass it straight into download / copy helpers. */
-  const ensureAttachmentBytes = useCallback(
-    async (
-      attachment: DownloadableAttachment,
-      attachmentId?: string,
-    ): Promise<DownloadableAttachment> => {
-      if (attachment.data_base64 || !attachmentId) return attachment;
-      const data_base64 = await loadAttachmentData(attachmentId);
-      return { ...attachment, data_base64 };
-    },
-    [],
-  );
-
-  const [lightbox, setLightbox] = useState<{
-    attachment: DownloadableAttachment;
-    returnFocus: HTMLElement | null;
-  } | null>(null);
-
-  const openLightbox = useCallback(
-    (e: React.MouseEvent, attachment: DownloadableAttachment) => {
-      setLightbox({
-        attachment,
-        returnFocus: (e.currentTarget as HTMLElement) ?? null,
-      });
-    },
-    [],
-  );
-
-  // navigator.canShare({ files: [probe] }) doesn't change across re-renders —
-  // it's a function of the platform / webview capabilities. Compute once.
-  const shareSupported = useMemo(() => isShareSupported(), []);
+  const {
+    attachmentMenu,
+    ensureAttachmentBytes,
+    lightbox,
+    openAttachmentMenu,
+    openLightbox,
+    setAttachmentMenu,
+    setLightbox,
+    shareSupported,
+  } = useChatPanelAttachments();
 
   // Prompt history: stores past user inputs per session.
   const historyRef = useRef<Record<string, string[]>>({});
   const historyIndexRef = useRef(-1);
   const draftRef = useRef("");
-
-  const defaultBranchesMap = useAppStore((s) => s.defaultBranches);
-
-  const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
-  const repo = repositories.find((r) => r.id === ws?.repository_id);
-  const defaultBranch = repo ? defaultBranchesMap[repo.id] : undefined;
-
-  // When the user clicks Fork, `handleFork` inserts a placeholder
-  // workspace and registers it in `pendingForks` so this panel can
-  // render a "Preparing fork from <source>…" placard instead of the
-  // normal session UI for the brief window before the backend
-  // returns.  Resolve the source workspace's display name here so the
-  // placard tells the user what they're forking *from*, which is
-  // information they had a half-second ago and may otherwise lose
-  // track of with the optimistic navigation.
-  const pendingForkSourceName = useAppStore((s) => {
-    if (!s.selectedWorkspaceId) return null;
-    const sourceId = s.pendingForks[s.selectedWorkspaceId];
-    if (!sourceId) return null;
-    return s.workspaces.find((w) => w.id === sourceId)?.name ?? null;
-  });
-
-  // Sibling of `pendingForkSourceName` for the optimistic-create
-  // placeholder. Resolves the repo's display name so the placard
-  // reads "Preparing workspace in <repo>…" — gives the user the
-  // same "here's what's happening" affordance the fork case has,
-  // without exposing the auto-generated slug (the slug is also
-  // visible in the placeholder's sidebar row, so doubling it here
-  // is noise).
-  const pendingCreateRepoName = useAppStore((s) => {
-    if (!s.selectedWorkspaceId) return null;
-    const repoId = s.pendingCreates[s.selectedWorkspaceId];
-    if (!repoId) return null;
-    return s.repositories.find((r) => r.id === repoId)?.name ?? null;
-  });
-  // The placeholder workspace's own name (the generated slug). Shown
-  // as a secondary line in the placard so the user knows which row
-  // in the sidebar the placard corresponds to.
-  const pendingCreateWorkspaceName = useAppStore((s) => {
-    if (!s.selectedWorkspaceId) return null;
-    if (!s.pendingCreates[s.selectedWorkspaceId]) return null;
-    return s.workspaces.find((w) => w.id === s.selectedWorkspaceId)?.name ?? null;
-  });
-
-  // Counts feeding the "all tabs closed" empty state. Each selector is
-  // intentionally a `.length || 0` so the subscribed value is a primitive —
-  // returning the array would re-fire on every reference change.
-  const activeSessionCount = useAppStore((s) =>
-    selectedWorkspaceId
-      ? (s.sessionsByWorkspace[selectedWorkspaceId] ?? []).filter(
-          (sess) => sess.status === "Active",
-        ).length
-      : 0,
-  );
-  const diffTabCount = useAppStore((s) =>
-    selectedWorkspaceId
-      ? (s.diffTabsByWorkspace[selectedWorkspaceId] ?? []).length
-      : 0,
-  );
-  const fileTabCount = useAppStore((s) =>
-    selectedWorkspaceId
-      ? (s.fileTabsByWorkspace[selectedWorkspaceId] ?? []).length
-      : 0,
-  );
-  // Sessions are fetched lazily by SessionTabs' mount effect, so there's a
-  // ~50-150ms window between a workspace becoming selected and its sessions
-  // landing in the store. Without this flag, `noOpenTabs` reads `true` for
-  // that window and ChatPanel briefly renders `WorkspaceEmptyTabs` — which
-  // shares its visual chrome with the Welcome card, so the flash looks
-  // identical to "Start a workspace in X." on every workspace switch / app
-  // launch. Gate the empty-state branch on a confirmed load so we only show
-  // it when the list is genuinely empty.
-  const sessionsLoaded = useAppStore((s) =>
-    selectedWorkspaceId
-      ? s.sessionsLoadedByWorkspace[selectedWorkspaceId] === true
-      : false,
-  );
-  const noOpenTabs =
-    sessionsLoaded &&
-    activeSessionCount === 0 &&
-    diffTabCount === 0 &&
-    fileTabCount === 0;
-  const messages = activeSessionId
-    ? chatMessages[activeSessionId] || []
-    : [];
-  const hasMore = chatPaginationState?.hasMore ?? false;
-  const isLoadingMore = chatPaginationState?.isLoadingMore ?? false;
-  const paginationTotalCount = chatPaginationState?.totalCount ?? messages.length;
-  const oldestMessageId = chatPaginationState?.oldestMessageId ?? null;
-  // Global 0-based index of the first loaded message in the full message sequence.
-  // Zero for new/fully-loaded sessions; positive for paginated sessions where
-  // older messages have not been fetched yet.
-  const globalOffset = paginationTotalCount - messages.length;
-
-  // Subscribe only to boolean — avoids re-render on every streaming character
-  const hasStreaming = useAppStore(
-    (s) => !!(activeSessionId && s.streamingContent[activeSessionId])
-  );
-  const hasPendingTypewriter = useAppStore(
-    (s) => !!(activeSessionId && s.pendingTypewriter[activeSessionId])
-  );
-  const hasThinking = useAppStore(
-    (s) => !!(activeSessionId && s.streamingThinking[activeSessionId])
-  );
-  const showThinkingBlocks = useAppStore(
-    (s) => activeSessionId ? s.showThinkingBlocks[activeSessionId] === true : false
-  );
-  const activitiesCount = useAppStore(
-    (s) => (activeSessionId ? (s.toolActivities[activeSessionId] ?? EMPTY_ACTIVITIES).length : 0),
-  );
-  const completedTurnsCount = useAppStore(
-    (s) => (activeSessionId ? (s.completedTurns[activeSessionId] || []).length : 0)
-  );
-  const setPermissionLevel = useAppStore((s) => s.setPermissionLevel);
-  const pendingQuestion = useAppStore(
-    (s) => (activeSessionId ? s.agentQuestions[activeSessionId] ?? null : null)
-  );
-  const clearAgentQuestion = useAppStore((s) => s.clearAgentQuestion);
-  const pendingPlan = useAppStore(
-    (s) => (activeSessionId ? s.planApprovals[activeSessionId] ?? null : null)
-  );
-  const clearPlanApproval = useAppStore((s) => s.clearPlanApproval);
-  const pendingApproval = useAppStore(
-    (s) => (activeSessionId ? s.agentApprovals[activeSessionId] ?? null : null)
-  );
-  const clearAgentApproval = useAppStore((s) => s.clearAgentApproval);
-  const setPlanMode = useAppStore((s) => s.setPlanMode);
-  const queuedMessages = useAppStore(
-    (s) =>
-      activeSessionId
-        ? s.queuedMessages[activeSessionId] ?? EMPTY_QUEUED_MESSAGES
-        : EMPTY_QUEUED_MESSAGES,
-  );
-  const setQueuedMessage = useAppStore((s) => s.setQueuedMessage);
-  const updateQueuedMessage = useAppStore((s) => s.updateQueuedMessage);
-  const removeQueuedMessage = useAppStore((s) => s.removeQueuedMessage);
-  const clearQueuedMessage = useAppStore((s) => s.clearQueuedMessage);
-  const setQueuedMessageAutoDispatchPaused = useAppStore(
-    (s) => s.setQueuedMessageAutoDispatchPaused,
-  );
-  const addCheckpoint = useAppStore((s) => s.addCheckpoint);
-  const beginPendingFork = useAppStore((s) => s.beginPendingFork);
-  const commitPendingFork = useAppStore((s) => s.commitPendingFork);
-  const cancelPendingFork = useAppStore((s) => s.cancelPendingFork);
-  const toolDisplayMode = useAppStore((s) => s.toolDisplayMode);
-  const activeSessionStatus = useAppStore((s) => {
-    if (!activeSessionId || !selectedWorkspaceId) return "Idle" as const;
-    const sessions = s.sessionsByWorkspace[selectedWorkspaceId];
-    return sessions?.find((sess) => sess.id === activeSessionId)?.agent_status ?? "Idle" as const;
-  });
-  const isRunning = activeSessionStatus === "Running";
-  const activeChatSessionRecord = useAppStore((s) =>
-    selectedWorkspaceId
-      ? (s.sessionsByWorkspace[selectedWorkspaceId] ?? []).find(
-          (cs) => cs.id === activeSessionId,
-        ) ?? null
-      : null,
-  );
-  const cliInvocation = activeChatSessionRecord?.cli_invocation ?? null;
 
   const clearQueuedMessagesAndCancelEdit = (sessionId: string) => {
     clearQueuedMessage(sessionId);
@@ -478,485 +217,43 @@ export function ChatPanel() {
     ],
   );
 
-  // Sticky scroll: auto-follow when at bottom, stop when user scrolls up.
+  const elapsed = useWorkspaceElapsedSeconds(selectedWorkspaceId, isRunning);
+
   const {
     isAtBottom,
-    scrollToBottom,
-    restoreScrollPosition,
-    handleContentChanged,
     markUserScrollIntent,
-    suppressNextAutoScrollRef,
-  } = useStickyScroll(messagesContainerRef);
-  usePreventScrollBounce(messagesContainerRef);
-
-  // Memoize context value to avoid re-rendering StreamingMessage on every parent render.
-  const scrollContextValue = useMemo(
-    () => ({ handleContentChanged, suppressNextAutoScrollRef }),
-    [handleContentChanged, suppressNextAutoScrollRef],
-  );
-
-  useEffect(() => {
-    const activeSessionIds = new Set(
-      activeSessionIdsKey ? activeSessionIdsKey.split("\0") : [],
-    );
-    for (const sessionId of chatScrollTopBySessionRef.current.keys()) {
-      if (!activeSessionIds.has(sessionId)) {
-        chatScrollTopBySessionRef.current.delete(sessionId);
-      }
-    }
-    for (const sessionId of restoringChatScrollSessionsRef.current.keys()) {
-      if (!activeSessionIds.has(sessionId)) {
-        restoringChatScrollSessionsRef.current.delete(sessionId);
-      }
-    }
-  }, [activeSessionIdsKey]);
-
-  const elapsed = useWorkspaceElapsedSeconds(selectedWorkspaceId, isRunning);
-  const formatElapsed = formatElapsedSeconds;
-
-  // Load persisted permission level when the active session changes.
-  useEffect(() => {
-    if (!activeSessionId) return;
-    let cancelled = false;
-    getAppSetting(`permission_level:${activeSessionId}`)
-      .then((val) => {
-        if (cancelled) return;
-        if (val === "readonly" || val === "standard" || val === "full") {
-          setPermissionLevel(activeSessionId, val);
-        }
-      })
-      .catch((err) => {
-        console.error("Failed to load permission level:", err);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [activeSessionId, setPermissionLevel]);
-
-  // Load chat history when the active session changes, seed prompt history from it.
-  useEffect(() => {
-    if (!activeSessionId || !selectedWorkspaceId) return;
-    let cancelled = false;
-    setError(null);
-    historyIndexRef.current = -1;
-    draftRef.current = "";
-
-    const currentWs = useAppStore
-      .getState()
-      .workspaces.find((w) => w.id === selectedWorkspaceId);
-    const sessionId = activeSessionId;
-    const isLocal = !currentWs?.remote_connection_id;
-    const isCurrentHistoryLoad = () => {
-      const state = useAppStore.getState();
-      return (
-        state.selectedWorkspaceId === selectedWorkspaceId &&
-        state.selectedSessionIdByWorkspaceId[selectedWorkspaceId] === sessionId
-      );
-    };
-
-    debugChat("ChatPanel", "load-history:start", {
-      sessionId,
-      isLocal,
-      agentStatus: currentWs?.agent_status ?? null,
-    });
-
-    const onMessages = (msgs: ChatMessage[], attachments?: import("../../types").ChatAttachment[], pageState?: import("../../types").ChatPaginationState) => {
-      if (cancelled || !isCurrentHistoryLoad()) return;
-      // The paginated backend already drops legacy empty-assistant rows so
-      // `total_count` matches the page contents. The remote (non-paginated)
-      // path still needs the filter — apply it only when no pageState exists.
-      const filtered = pageState
-        ? msgs
-        : msgs.filter(
-            (m) => m.role !== "Assistant" || m.content.trim() !== "" || !!m.thinking
-          );
-      debugChat("ChatPanel", "load-history:success", {
-        sessionId,
-        rawMessageCount: msgs.length,
-        filteredMessageCount: filtered.length,
-        messageIds: filtered.map((msg) => msg.id),
-      });
-      setChatMessages(sessionId, filtered);
-      if (attachments) {
-        useAppStore.getState().setChatAttachments(sessionId, attachments);
-      }
-      if (pageState) {
-        setChatPagination(sessionId, pageState);
-      }
-      // Global index of the first loaded message — needed below so persisted
-      // CompletedTurn rows whose checkpoint sits inside the loaded window
-      // resolve to the correct GLOBAL afterMessageIndex.
-      const loadGlobalOffset = pageState
-        ? pageState.totalCount - filtered.length
-        : 0;
-      historyRef.current[sessionId] = filtered
-        .filter((m) => m.role === "User")
-        .map((m) => m.content);
-      // Seed the ContextMeter from the last assistant message's per-call
-      // token data. If none is available (fresh / pre-migration workspace),
-      // clear any stale value so the meter hides.
-      const callUsage = extractLatestCallUsage(filtered);
-      const store = useAppStore.getState();
-      if (callUsage) store.setLatestTurnUsage(sessionId, callUsage);
-      else store.clearLatestTurnUsage(sessionId);
-      // Phase 3: seed compactionEvents by scanning for COMPACTION: sentinels.
-      store.setCompactionEvents(sessionId, extractCompactionEvents(filtered));
-
-      // Load persisted completed turns and reconstruct with correct positions.
-      // Skip if the agent is currently running — the in-memory state from
-      // finalizeTurn() is more current than the DB and must not be overwritten.
-      if (isLocal) {
-        const sessions = useAppStore.getState().sessionsByWorkspace[selectedWorkspaceId] ?? [];
-        const thisSession = sessions.find((s) => s.id === sessionId);
-        const isRunning = thisSession?.agent_status === "Running";
-        debugChat("ChatPanel", "load-completed-turns:gate", {
-          sessionId,
-          isRunning,
-          currentCompletedTurnIds: (useAppStore.getState().completedTurns[sessionId] || []).map(
-            (turn) => turn.id
-          ),
-        });
-        if (!isRunning) {
-          loadCompletedTurns(sessionId)
-            .then((turnData) => {
-              if (cancelled || !isCurrentHistoryLoad()) return;
-              const turns = reconstructCompletedTurns(filtered, turnData, loadGlobalOffset);
-              debugChat("ChatPanel", "load-completed-turns:success", {
-                sessionId,
-                dbTurnIds: turnData.map((turn) => turn.checkpoint_id),
-                reconstructedTurnIds: turns.map((turn) => turn.id),
-              });
-              hydrateCompletedTurns(sessionId, turns);
-            })
-            .catch((e) => console.error("Failed to load completed turns:", e));
-        }
-      }
-    };
-
-    if (isLocal) {
-      // Skip the reload when we've already loaded this session — otherwise
-      // bouncing between long conversations would drop any older pages the
-      // user already scrolled through and snap them back to the newest 50.
-      // CompletedTurns and attachments are kept live in the store via the
-      // streaming path, so re-fetching from the DB here would also clobber
-      // in-flight state.
-      const existingPagination =
-        useAppStore.getState().chatPagination[sessionId];
-      if (existingPagination) {
-        debugChat("ChatPanel", "load-history:skip-already-loaded", {
-          sessionId,
-          totalCount: existingPagination.totalCount,
-        });
-      } else {
-        // Load newest page of messages and their attachments in one round-trip.
-        loadChatHistoryPage(sessionId, 50)
-          .then((page) => {
-            onMessages(page.messages, page.attachments, {
-              hasMore: page.has_more,
-              isLoadingMore: false,
-              totalCount: page.total_count,
-              oldestMessageId: page.messages[0]?.id ?? null,
-            });
-          })
-          .catch((e) => console.error("Failed to load chat history:", e));
-      }
-    } else {
-      sendRemoteCommand(currentWs!.remote_connection_id!, "load_chat_history", {
-        chat_session_id: sessionId,
-      })
-        .then((data) => {
-          const msgs = (data as { messages?: ChatMessage[] })?.messages ?? (data as ChatMessage[]);
-          onMessages(msgs);
-        })
-        .catch((e) => console.error("Failed to load chat history:", e));
-    }
-
-    // Load checkpoints for rollback support.
-    if (isLocal) {
-      const setCheckpoints = useAppStore.getState().setCheckpoints;
-      listCheckpoints(sessionId)
-        .then((cps) => {
-          if (cancelled || !isCurrentHistoryLoad()) return;
-          setCheckpoints(sessionId, cps);
-        })
-        .catch((e) => console.error("Failed to load checkpoints:", e));
-    }
-
-    return () => {
-      cancelled = true;
-    };
-  }, [activeSessionId, selectedWorkspaceId, setChatMessages, setChatPagination, hydrateCompletedTurns]);
-
-  // Preserve chat position while moving between chat, Monaco, and diff views.
-  // Without this, opening a file link can snap long chats back to bottom.
-  useEffect(() => {
-    if (!activeSessionId) return;
-    const savedScrollTop = chatScrollTopBySessionRef.current.get(activeSessionId);
-    if (savedScrollTop == null) {
-      restoringChatScrollSessionsRef.current.delete(activeSessionId);
-      scrollToBottom();
-      return;
-    }
-    restoringChatScrollSessionsRef.current.add(activeSessionId);
-    let cancelled = false;
-    let frameId: number | null = null;
-    let attempts = 0;
-    const restore = () => {
-      if (cancelled) return;
-      restoreScrollPosition(savedScrollTop);
-      attempts += 1;
-      const container = messagesContainerRef.current;
-      const maxScrollTop = container
-        ? Math.max(0, container.scrollHeight - container.clientHeight)
-        : 0;
-      const expectedTop = Math.min(savedScrollTop, maxScrollTop);
-      if (
-        attempts < 8 &&
-        container &&
-        Math.abs(container.scrollTop - expectedTop) > 1
-      ) {
-        frameId = requestAnimationFrame(restore);
-      } else {
-        restoringChatScrollSessionsRef.current.delete(activeSessionId);
-      }
-    };
-    frameId = requestAnimationFrame(restore);
-    return () => {
-      cancelled = true;
-      restoringChatScrollSessionsRef.current.delete(activeSessionId);
-      if (frameId !== null) cancelAnimationFrame(frameId);
-    };
-  }, [activeSessionId, restoreScrollPosition, scrollToBottom]);
-
-  useEffect(() => {
-    if (!activeSessionId) return;
-    const container = messagesContainerRef.current;
-    return () => {
-      if (
-        container &&
-        !restoringChatScrollSessionsRef.current.has(activeSessionId)
-      ) {
-        chatScrollTopBySessionRef.current.set(activeSessionId, container.scrollTop);
-        restoringChatScrollSessionsRef.current.add(activeSessionId);
-      }
-    };
-  }, [activeSessionId]);
-
-  const rememberChatScrollPosition = useCallback(() => {
-    if (!activeSessionId) return;
-    const container = messagesContainerRef.current;
-    if (!container) return;
-    chatScrollTopBySessionRef.current.set(activeSessionId, container.scrollTop);
-    restoringChatScrollSessionsRef.current.add(activeSessionId);
-  }, [activeSessionId]);
-
-  // Load older messages when the user scrolls to the top of the message list.
-  const hasMoreRef = useRef(false);
-  hasMoreRef.current = hasMore;
-  const isLoadingMoreRef = useRef(false);
-  isLoadingMoreRef.current = isLoadingMore;
-  const oldestMessageIdRef = useRef<string | null>(null);
-  oldestMessageIdRef.current = oldestMessageId;
-  const activeSessionIdRef = useRef<string | null>(null);
-  activeSessionIdRef.current = activeSessionId;
-  const showChatAuthLoginPanel = useAppStore((s) => s.chatAuthLoginPanelOpen);
-  const chatAuthLoginRequestId = useAppStore((s) => s.chatAuthLoginRequestId);
-  const chatAuthLoginStartedRequestId = useAppStore(
-    (s) => s.chatAuthLoginStartedRequestId,
-  );
-  const openChatAuthLoginPanel = useAppStore((s) => s.openChatAuthLoginPanel);
-  const setChatAuthLoginStartedRequestId = useAppStore(
-    (s) => s.setChatAuthLoginStartedRequestId,
-  );
+    rememberChatScrollPosition,
+    scrollContextValue,
+    scrollToBottom,
+  } = useChatPanelSessionLifecycle({
+    activeSessionId,
+    activeSessionIdsKey,
+    activitiesCount,
+    completedTurnsCount,
+    draftRef,
+    hasMore,
+    hasStreaming,
+    historyIndexRef,
+    historyRef,
+    hydrateCompletedTurns,
+    isLoadingMore,
+    isRunning,
+    messages,
+    messagesContainerRef,
+    oldestMessageId,
+    pendingApproval,
+    pendingPlan,
+    pendingQuestion,
+    restoringChatScrollSessionsRef,
+    selectedWorkspaceId,
+    setChatMessages,
+    setChatPagination,
+    setError,
+    setPermissionLevel,
+  });
   const startChatClaudeAuthLogin = useCallback(async () => {
     openChatAuthLoginPanel();
   }, [openChatAuthLoginPanel]);
-
-  useEffect(() => {
-    const container = messagesContainerRef.current;
-    if (!container) return;
-
-    const onScroll = () => {
-      if (
-        activeSessionIdRef.current &&
-        !restoringChatScrollSessionsRef.current.has(activeSessionIdRef.current)
-      ) {
-        chatScrollTopBySessionRef.current.set(
-          activeSessionIdRef.current,
-          container.scrollTop,
-        );
-      }
-      if (
-        container.scrollTop < 200 &&
-        hasMoreRef.current &&
-        !isLoadingMoreRef.current &&
-        activeSessionIdRef.current &&
-        oldestMessageIdRef.current
-      ) {
-        const sessionId = activeSessionIdRef.current;
-        const cursorId = oldestMessageIdRef.current;
-        const store = useAppStore.getState();
-        const pagination = store.chatPagination[sessionId];
-        if (!pagination) return;
-
-        // Flip the ref synchronously: subsequent scroll events fire before
-        // React commits the store update, so without this guard fast scrolls
-        // at the top can dispatch multiple page fetches with the same cursor
-        // and prepend the same rows repeatedly.
-        isLoadingMoreRef.current = true;
-        store.setChatPagination(sessionId, { ...pagination, isLoadingMore: true });
-        const prevScrollHeight = container.scrollHeight;
-
-        loadChatHistoryPage(sessionId, 50, cursorId)
-          .then((page) => {
-            // Staleness guard: if the user switched sessions, cleared the
-            // conversation, or scrolled further while this fetch was in
-            // flight, the response is no longer applicable. Bail before
-            // mutating any state — applying it would prepend old rows back
-            // into a session that has moved on. We still reset the source
-            // session's `isLoadingMore` flag if it's safe (pagination state
-            // unchanged for that session), so the user can retry on return.
-            const liveStore = useAppStore.getState();
-            const livePagination = liveStore.chatPagination[sessionId];
-            const stillCurrent =
-              activeSessionIdRef.current === sessionId &&
-              livePagination &&
-              livePagination.oldestMessageId === cursorId;
-            if (!stillCurrent) {
-              if (livePagination && livePagination.isLoadingMore) {
-                liveStore.setChatPagination(sessionId, {
-                  ...livePagination,
-                  isLoadingMore: false,
-                });
-              }
-              return;
-            }
-            liveStore.prependChatMessages(sessionId, page.messages);
-            liveStore.prependChatAttachments(sessionId, page.attachments);
-            // Merge live `totalCount` (which may have grown via streaming
-            // `addChatMessage` while the request was in flight) with the
-            // server snapshot. `totalCount` must stay monotonic per session
-            // — moving it backwards would shift `globalOffset` and corrupt
-            // CompletedTurn placement until the next full reload.
-            const liveTotal =
-              useAppStore.getState().chatPagination[sessionId]?.totalCount ?? 0;
-            liveStore.setChatPagination(sessionId, {
-              hasMore: page.has_more,
-              isLoadingMore: false,
-              totalCount: Math.max(page.total_count, liveTotal),
-              oldestMessageId: page.messages[0]?.id ?? cursorId,
-            });
-            // Backfill prompt history: Shift+Up walks `historyRef`, which was
-            // seeded from the initial page only. Without this, older user
-            // messages stay invisible to history navigation even after the
-            // user scrolls them into view.
-            const olderUserPrompts = page.messages
-              .filter((m) => m.role === "User")
-              .map((m) => m.content);
-            if (olderUserPrompts.length > 0) {
-              const existing = historyRef.current[sessionId] ?? [];
-              historyRef.current[sessionId] = [
-                ...olderUserPrompts,
-                ...existing,
-              ];
-            }
-            // Restore scroll position so prepended messages don't push the
-            // view upward.
-            requestAnimationFrame(() => {
-              container.scrollTop += container.scrollHeight - prevScrollHeight;
-            });
-            // Re-hydrate persisted completed turns: any whose checkpoint
-            // message_id was in the just-loaded older range was filtered out
-            // of `reconstructCompletedTurns` on the initial load. Re-running
-            // against the now-larger message window resolves them.
-            const merged =
-              useAppStore.getState().chatMessages[sessionId] ?? [];
-            const mergedTotal =
-              useAppStore.getState().chatPagination[sessionId]?.totalCount ??
-              page.total_count;
-            const mergedOffset = mergedTotal - merged.length;
-            loadCompletedTurns(sessionId)
-              .then((turnData) => {
-                if (activeSessionIdRef.current !== sessionId) return;
-                const turns = reconstructCompletedTurns(
-                  merged,
-                  turnData,
-                  mergedOffset,
-                );
-                useAppStore
-                  .getState()
-                  .hydrateCompletedTurns(sessionId, turns);
-              })
-              .catch((err) =>
-                console.error(
-                  "Failed to re-hydrate completed turns after prepend:",
-                  err,
-                ),
-              );
-          })
-          .catch((e) => {
-            console.error("Failed to load older messages:", e);
-            // Read fresh pagination state — `addChatMessage` may have
-            // incremented `totalCount` while the fetch was in flight, and
-            // writing back the captured snapshot here would clobber it.
-            const live = useAppStore.getState().chatPagination[sessionId];
-            if (!live) return; // session was cleared
-            useAppStore
-              .getState()
-              .setChatPagination(sessionId, { ...live, isLoadingMore: false });
-          })
-          .finally(() => {
-            // Clear the synchronous gate regardless of outcome so the next
-            // top-of-scroll event can fetch again.
-            isLoadingMoreRef.current = false;
-          });
-      }
-    };
-
-    container.addEventListener("scroll", onScroll, { passive: true });
-    return () => container.removeEventListener("scroll", onScroll);
-    // Re-attach on session switch so the sessionId ref stays in sync.
-  }, [activeSessionId]);
-
-  // Auto-scroll when new content arrives — respects user intent via useStickyScroll.
-  // Only scrolls if the user is already at/near the bottom.
-  const prevMsgCountRef = useRef<Record<string, number>>({});
-  useEffect(() => {
-    const sid = activeSessionId;
-    if (!sid) return;
-    const prev = prevMsgCountRef.current[sid] ?? 0;
-    const cur = messages.length;
-    prevMsgCountRef.current[sid] = cur;
-    // Only trigger on genuinely new messages (count increase), not DB rehydration.
-    if (cur > prev) handleContentChanged();
-  }, [messages.length, activeSessionId, handleContentChanged]);
-
-  useEffect(() => {
-    if (completedTurnsCount > 0 || activitiesCount > 0 || pendingQuestion || pendingPlan || pendingApproval) {
-      handleContentChanged();
-    }
-  }, [completedTurnsCount, activitiesCount, pendingQuestion, pendingPlan, pendingApproval, handleContentChanged]);
-
-  useEffect(() => {
-    if (!activeSessionId) return;
-    debugChat("ChatPanel", "state", {
-      sessionId: activeSessionId,
-      wsId: selectedWorkspaceId,
-      isRunning,
-      messageCount: messages.length,
-      activitiesCount,
-      completedTurnsCount,
-      hasStreaming,
-    });
-  }, [
-    activeSessionId,
-    selectedWorkspaceId,
-    isRunning,
-    messages.length,
-    activitiesCount,
-    completedTurnsCount,
-    hasStreaming,
-  ]);
 
   if (!ws) return null;
 
@@ -1552,377 +849,81 @@ export function ChatPanel() {
         // The tab strip's `+` button stays above for the mouse path.
         <WorkspaceEmptyTabs workspace={ws} repository={repo} />
       ) : (
-      <>
-      <div className={styles.messagesWrapper}>
-        {selectedWorkspaceId && (
-          <ChatSearchBar
-            workspaceId={selectedWorkspaceId}
-            scopeRef={messagesContainerRef}
-          />
-        )}
-        <ScrollContext.Provider value={scrollContextValue}>
-        {/* Custom DOM scrollbar overlay. Mirrors xterm.js / Monaco's
-         * always-visible 8px slider so all three surfaces stay
-         * pixel-identical at every browser zoom (the OS overlay
-         * scrollbar that WKWebView would render on `.messages` instead
-         * doesn't scale with zoom). */}
-        <OverlayScrollbar
-          targetRef={messagesContainerRef}
-          onUserScrollIntent={markUserScrollIntent}
-        />
-        <div className={styles.messages} ref={messagesContainerRef}>
-          <CliInvocationBanner
-            invocation={cliInvocation}
-            sessionId={activeChatSessionRecord?.id}
-          />
-          {workspaceEnvironmentError && (
-            <div className={styles.envErrorBanner} role="alert">
-              <span>{workspaceEnvironmentError}</span>
-              <button
-                type="button"
-                className={styles.envErrorRetry}
-                onClick={handleRetryWorkspaceEnvironment}
-              >
-                {t("retry_environment", "Retry environment setup")}
-              </button>
-            </div>
-          )}
-          {messages.length === 0 && !hasStreaming && !runningSetupScriptSource ? (
-            <ChatEmptyState
-              key={activeSessionId ?? "no-active-session"}
-              workspaceEnvironmentPreparing={workspaceEnvironmentPreparing}
-              workspaceId={selectedWorkspaceId}
-              onRetryEnvironment={
-                workspaceEnvironmentPreparing || workspaceEnvironmentError
-                  ? handleRetryWorkspaceEnvironment
-                  : undefined
-              }
-            />
-          ) : (
-            <>
-              {isLoadingMore && (
-                <div className={styles.loadingOlder}>
-                  <LoaderCircle size={14} className={styles.loadingOlderSpinner} />
-                  Loading older messages…
-                </div>
-              )}
-              {activeSessionId && selectedWorkspaceId && (
-                <MessagesWithTurns
-                  key={activeSessionId}
-                  messages={messages}
-                  workspaceId={selectedWorkspaceId}
-                  sessionId={activeSessionId}
-                  isRunning={isRunning}
-                  onForkTurn={isRemote ? undefined : handleFork}
-                  onAttachmentContextMenu={openAttachmentMenu}
-                  onAttachmentClick={openLightbox}
-                  onOpenFileLink={rememberChatScrollPosition}
-                  searchQuery={searchQuery}
-                  globalOffset={globalOffset}
-                  toolDisplayMode={toolDisplayMode}
-                  liveTaskProgressNode={
-                    activitiesCount > 0 ? (
-                      <CurrentTurnTaskProgress sessionId={activeSessionId} />
-                    ) : null
-                  }
-                  streamingThinkingNode={
-                    hasThinking && showThinkingBlocks ? (
-                      <StreamingThinkingBlock
-                        sessionId={activeSessionId}
-                        isStreaming={isRunning ?? false}
-                        inline={toolDisplayMode === "inline"}
-                        searchQuery={searchQuery}
-                      />
-                    ) : null
-                  }
-                  streamingMessageNode={
-                    hasStreaming || hasPendingTypewriter ? (
-                      <StreamingMessage
-                        sessionId={activeSessionId}
-                        workspaceId={selectedWorkspaceId}
-                        isStreaming={isRunning ?? false}
-                        searchQuery={searchQuery}
-                      />
-                    ) : null
-                  }
-                />
-              )}
-
-              {showChatAuthLoginPanel && (
-                <ChatAuthFailureCallout
-                  autoStartKey={chatAuthLoginRequestId}
-                  autoStartedKey={chatAuthLoginStartedRequestId}
-                  onAutoStarted={setChatAuthLoginStartedRequestId}
-                />
-              )}
-
-              {runningSetupScriptSource && activeSessionId && (
-                <SetupScriptBanner
-                  outcome={{
-                    source: runningSetupScriptSource,
-                    status: "running",
-                    output: "",
-                  }}
-                  messageId={`setup-running:${activeSessionId}`}
-                />
-              )}
-
-              {pendingQuestion && (
-                <AgentQuestionCard
-                  question={pendingQuestion}
-                  onRespond={async (answers) => {
-                    if (!activeSessionId) return;
-                    const sid = activeSessionId;
-                    const toolUseId = pendingQuestion.toolUseId;
-                    try {
-                      await submitAgentAnswer(sid, toolUseId, answers);
-                      clearAgentQuestion(sid);
-                    } catch (e) {
-                      console.error("Failed to submit agent answer:", e);
-                      setError(String(e));
-                    }
-                  }}
-                />
-              )}
-
-              {pendingPlan && selectedWorkspaceId && (
-                <PlanApprovalCard
-                  approval={pendingPlan}
-                  workspaceId={selectedWorkspaceId}
-                  remoteConnectionId={ws?.remote_connection_id ?? undefined}
-                  onRespond={async (approved, reason) => {
-                    if (!activeSessionId) return;
-                    const sid = activeSessionId;
-                    const toolUseId = pendingPlan.toolUseId;
-                    try {
-                      await submitPlanApproval(sid, toolUseId, approved, reason);
-                      clearPlanApproval(sid);
-                      // User action is authoritative for ending the plan
-                      // phase — flip planMode off so the next turn triggers
-                      // drift detection (backend `session_exited_plan` covers
-                      // this already, but clearing the UI state keeps the
-                      // toolbar chip in sync).
-                      setPlanMode(sid, false);
-                    } catch (e) {
-                      console.error("Failed to submit plan approval:", e);
-                      setError(String(e));
-                    }
-                  }}
-                />
-              )}
-
-              {pendingApproval && (
-                <AgentApprovalCard
-                  approval={pendingApproval}
-                  onRespond={async (approved, reason) => {
-                    if (!activeSessionId) return;
-                    const sid = activeSessionId;
-                    const toolUseId = pendingApproval.toolUseId;
-                    try {
-                      await submitAgentApproval(sid, toolUseId, approved, reason);
-                      clearAgentApproval(sid);
-                    } catch (e) {
-                      console.error("Failed to submit agent approval:", e);
-                      setError(String(e));
-                    }
-                  }}
-                />
-              )}
-
-              {isSteeringQueued && (
-                <div className={styles.pendingSteer} aria-live="polite" aria-label={t("steer_pending_aria")}>
-                  <span className={styles.pendingSteerIcon} aria-hidden="true">
-                    <SendHorizontal size={12} />
-                  </span>
-                  <span className={styles.pendingSteerLabel} aria-hidden="true">
-                    {t("steer_pending_label")}
-                  </span>
-                  <span className={styles.pendingSteerContent}>
-                    {pendingSteerContent ?? t("steer_pending_attachment")}
-                  </span>
-                </div>
-              )}
-
-              {isRunning && !pendingQuestion && !pendingPlan && !pendingApproval && (
-                <div
-                  ref={processingRef}
-                  className={styles.processing}
-                  role="status"
-                  aria-label={
-                    ws?.agent_status === "Compacting"
-                      ? t("compacting_aria", { elapsed: formatElapsed(elapsed) })
-                      : t("processing_aria", { elapsed: formatElapsed(elapsed) })
-                  }
-                >
-                  <span className={styles.spinnerWrap} aria-hidden="true">
-                    <span className={styles.spinner} />
-                  </span>
-                  {ws?.agent_status === "Compacting" && (
-                    <span className={styles.compactingLabel}>{t("compacting_label")}</span>
-                  )}
-                  <span className={styles.elapsed}>{formatElapsed(elapsed)}</span>
-                </div>
-              )}
-
-              {error && (
-                <ChatErrorBanner
-                  message={error}
-                  workspaceId={selectedWorkspaceId}
-                  sessionId={activeSessionId}
-                  onRecovered={() => setError(null)}
-                />
-              )}
-            </>
-          )}
-        </div>
-      </ScrollContext.Provider>
-      </div>
-
-      <ScrollToBottomPill
-        visible={!isAtBottom && messages.length > 0}
-        onClick={scrollToBottom}
-      />
-
-      {queuedMessages.length > 0 && activeSessionId && (
-        <QueuedMessagesPopover
-          queuedMessages={queuedMessages}
-          isRemote={!!ws?.remote_connection_id}
+        <ChatPanelSessionView
+          activeChatSessionRecord={activeChatSessionRecord}
+          activeSessionId={activeSessionId}
+          activitiesCount={activitiesCount}
+          chatAuthLoginRequestId={chatAuthLoginRequestId}
+          chatAuthLoginStartedRequestId={chatAuthLoginStartedRequestId}
+          clearAgentApproval={clearAgentApproval}
+          clearAgentQuestion={clearAgentQuestion}
+          clearPlanApproval={clearPlanApproval}
+          clearQueuedMessagesAndCancelEdit={clearQueuedMessagesAndCancelEdit}
+          draftRef={draftRef}
+          elapsed={elapsed}
+          error={error}
+          globalOffset={globalOffset}
+          hasPendingTypewriter={hasPendingTypewriter}
+          hasStreaming={hasStreaming}
+          hasThinking={hasThinking}
+          historyIndexRef={historyIndexRef}
+          historyRef={historyRef}
+          isAtBottom={isAtBottom}
+          isLoadingMore={isLoadingMore}
+          isRemote={isRemote}
           isRunning={isRunning}
           isSteeringQueued={isSteeringQueued}
+          markUserScrollIntent={markUserScrollIntent}
+          messages={messages}
+          messagesContainerRef={messagesContainerRef}
+          onAttachmentClick={openLightbox}
+          onAttachmentContextMenu={openAttachmentMenu}
+          onForkTurn={(checkpointId) => void handleFork(checkpointId)}
+          onRetryWorkspaceEnvironment={handleRetryWorkspaceEnvironment}
+          onRunShellCommand={handleRunShellCommand}
+          onSend={handleSend}
+          onSendSteer={handleSendSteer}
+          onSteerQueuedMessage={handleSteerQueuedMessage}
+          onSteerQueuedTop={handleSteerQueuedTop}
+          onStop={handleStop}
+          pendingApproval={pendingApproval}
+          pendingPlan={pendingPlan}
+          pendingQuestion={pendingQuestion}
+          pendingSteerContent={pendingSteerContent}
+          processingRef={processingRef}
+          queuedMessages={queuedMessages}
+          rememberChatScrollPosition={rememberChatScrollPosition}
+          removeQueuedMessage={removeQueuedMessage}
+          repo={repo}
+          runningSetupScriptSource={runningSetupScriptSource}
+          scrollContextValue={scrollContextValue}
+          scrollToBottom={scrollToBottom}
+          searchQuery={searchQuery}
+          selectedWorkspaceId={selectedWorkspaceId}
+          setChatAuthLoginStartedRequestId={setChatAuthLoginStartedRequestId}
+          setError={setError}
+          setPlanMode={setPlanMode}
+          setQueuedMessageEditing={setQueuedMessageEditing}
+          showChatAuthLoginPanel={showChatAuthLoginPanel}
+          showThinkingBlocks={showThinkingBlocks}
           steerQueuedTooltip={steerQueuedTooltip}
-          onEditingChange={(isEditing) =>
-            setQueuedMessageEditing(activeSessionId, isEditing)
-          }
-          onClearQueue={() => clearQueuedMessagesAndCancelEdit(activeSessionId)}
-          onRemoveMessage={(messageId) => removeQueuedMessage(activeSessionId, messageId)}
-          onSteerMessage={handleSteerQueuedMessage}
-          onUpdateMessage={(messageId, updates) =>
-            updateQueuedMessage(activeSessionId, messageId, updates)
-          }
+          toolDisplayMode={toolDisplayMode}
+          updateQueuedMessage={updateQueuedMessage}
+          workspaceEnvironmentError={workspaceEnvironmentError}
+          workspaceEnvironmentPreparing={workspaceEnvironmentPreparing}
+          ws={ws}
         />
       )}
-
-      <ChatInputArea
-        onSend={handleSend}
-        onSendSteer={handleSendSteer}
-        onSteerQueuedTop={handleSteerQueuedTop}
-        onRunShellCommand={handleRunShellCommand}
-        onStop={handleStop}
-        isRunning={isRunning}
-        workspaceEnvironmentPreparing={workspaceEnvironmentPreparing}
-        isRemote={!!ws?.remote_connection_id}
-        hasQueuedMessages={queuedMessages.length > 0}
-        selectedWorkspaceId={selectedWorkspaceId!}
-        sessionId={activeSessionId!}
-        repoId={repo?.id}
-        projectPath={repo?.path}
-        historyRef={historyRef}
-        historyIndexRef={historyIndexRef}
-        draftRef={draftRef}
-        onAttachmentContextMenu={openAttachmentMenu}
-        onAttachmentClick={openLightbox}
+      <ChatPanelAttachmentOverlays
+        attachmentMenu={attachmentMenu}
+        browseAvailable={browseAvailable}
+        ensureAttachmentBytes={ensureAttachmentBytes}
+        lightbox={lightbox}
+        openAttachmentMenu={openAttachmentMenu}
+        setAttachmentMenu={setAttachmentMenu}
+        setLightbox={setLightbox}
+        shareSupported={shareSupported}
       />
-      </>
-      )}
-      {attachmentMenu && (() => {
-        const mt = attachmentMenu.attachment.media_type;
-        const labels = buildAttachmentMenuLabels(mt);
-        // The browser-wrapper path renders bytes inside <img>, which is
-        // broken for PDFs (and would be broken for any non-image type we
-        // add later). Drop "Open in New Window" for non-images — left-
-        // click already opens the PDF in the system default viewer.
-        const isImage = mt.startsWith("image/");
-        const withBytes = () =>
-          ensureAttachmentBytes(
-            attachmentMenu.attachment,
-            attachmentMenu.attachmentId,
-          );
-        return (
-          <AttachmentContextMenu
-            x={attachmentMenu.x}
-            y={attachmentMenu.y}
-            onClose={() => setAttachmentMenu(null)}
-            items={[
-              // `downloadAttachment` opens a native Save As dialog
-              // via the same plugin path that crashes on portal-less
-              // Linux. Drop the row entirely when no picker is
-              // available — Copy still works for binary attachments
-              // (clipboard write), so the user retains a way to
-              // pull the bytes out.
-              ...(browseAvailable
-                ? [
-                    {
-                      label: labels.download,
-                      onSelect: () => {
-                        withBytes()
-                          .then(downloadAttachment)
-                          .catch((err) => console.error("Download failed:", err));
-                      },
-                    },
-                  ]
-                : []),
-              {
-                label: labels.copy,
-                onSelect: () => {
-                  withBytes()
-                    .then(copyAttachmentToClipboard)
-                    .catch((err) => console.error("Copy failed:", err));
-                },
-              },
-              ...(isImage
-                ? [
-                    {
-                      label: labels.open,
-                      onSelect: () => {
-                        withBytes()
-                          .then(openAttachmentInBrowser)
-                          .catch((err) =>
-                            console.error("Open in browser failed:", err),
-                          );
-                      },
-                    },
-                  ]
-                : [
-                    // Non-image types (PDF + the text-shaped cards)
-                    // route through the OS default-app handler — the
-                    // Rust side stages the bytes to a temp file with
-                    // the right extension and asks the system to open
-                    // it. Same UX as left-clicking a PDF thumbnail.
-                    {
-                      label: "Open with default app",
-                      onSelect: () => {
-                        withBytes()
-                          .then(openAttachmentWithDefaultApp)
-                          .catch((err) =>
-                            console.error("Open with default app failed:", err),
-                          );
-                      },
-                    },
-                  ]),
-              ...(shareSupported
-                ? [
-                    {
-                      label: "Share…",
-                      onSelect: () => {
-                        withBytes()
-                          .then(shareAttachment)
-                          .catch((err) => console.error("Share failed:", err));
-                      },
-                    },
-                  ]
-                : []),
-            ]}
-          />
-        );
-      })()}
-      {lightbox && (
-        <AttachmentLightbox
-          attachment={lightbox.attachment}
-          returnFocusTo={lightbox.returnFocus}
-          onClose={() => setLightbox(null)}
-          onContextMenu={(e) => openAttachmentMenu(e, lightbox.attachment)}
-        />
-      )}
     </div>
   );
 }

--- a/src/ui/src/components/chat/ChatPanelAttachmentOverlays.tsx
+++ b/src/ui/src/components/chat/ChatPanelAttachmentOverlays.tsx
@@ -1,0 +1,135 @@
+import type { Dispatch, MouseEvent, SetStateAction } from "react";
+
+import {
+  copyAttachmentToClipboard,
+  downloadAttachment,
+  openAttachmentInBrowser,
+  openAttachmentWithDefaultApp,
+  shareAttachment,
+  type DownloadableAttachment,
+} from "../../utils/attachmentDownload";
+import { AttachmentContextMenu } from "./AttachmentContextMenu";
+import { AttachmentLightbox } from "./AttachmentLightbox";
+import { buildAttachmentMenuLabels } from "./attachmentContextMenuLabels";
+import type {
+  AttachmentLightboxState,
+  AttachmentMenuState,
+} from "./useChatPanelAttachments";
+
+type ChatPanelAttachmentOverlaysProps = {
+  attachmentMenu: AttachmentMenuState;
+  browseAvailable: boolean;
+  ensureAttachmentBytes: (
+    attachment: DownloadableAttachment,
+    attachmentId?: string,
+  ) => Promise<DownloadableAttachment>;
+  lightbox: AttachmentLightboxState;
+  openAttachmentMenu: (
+    e: MouseEvent,
+    attachment: DownloadableAttachment,
+    attachmentId?: string,
+  ) => void;
+  setAttachmentMenu: Dispatch<SetStateAction<AttachmentMenuState>>;
+  setLightbox: Dispatch<SetStateAction<AttachmentLightboxState>>;
+  shareSupported: boolean;
+};
+
+export function ChatPanelAttachmentOverlays({
+  attachmentMenu,
+  browseAvailable,
+  ensureAttachmentBytes,
+  lightbox,
+  openAttachmentMenu,
+  setAttachmentMenu,
+  setLightbox,
+  shareSupported,
+}: ChatPanelAttachmentOverlaysProps) {
+  return (
+    <>
+      {attachmentMenu && (() => {
+        const mt = attachmentMenu.attachment.media_type;
+        const labels = buildAttachmentMenuLabels(mt);
+        const isImage = mt.startsWith("image/");
+        const withBytes = () =>
+          ensureAttachmentBytes(
+            attachmentMenu.attachment,
+            attachmentMenu.attachmentId,
+          );
+        return (
+          <AttachmentContextMenu
+            x={attachmentMenu.x}
+            y={attachmentMenu.y}
+            onClose={() => setAttachmentMenu(null)}
+            items={[
+              ...(browseAvailable
+                ? [
+                    {
+                      label: labels.download,
+                      onSelect: () => {
+                        withBytes()
+                          .then(downloadAttachment)
+                          .catch((err) => console.error("Download failed:", err));
+                      },
+                    },
+                  ]
+                : []),
+              {
+                label: labels.copy,
+                onSelect: () => {
+                  withBytes()
+                    .then(copyAttachmentToClipboard)
+                    .catch((err) => console.error("Copy failed:", err));
+                },
+              },
+              ...(isImage
+                ? [
+                    {
+                      label: labels.open,
+                      onSelect: () => {
+                        withBytes()
+                          .then(openAttachmentInBrowser)
+                          .catch((err) =>
+                            console.error("Open in browser failed:", err),
+                          );
+                      },
+                    },
+                  ]
+                : [
+                    {
+                      label: "Open with default app",
+                      onSelect: () => {
+                        withBytes()
+                          .then(openAttachmentWithDefaultApp)
+                          .catch((err) =>
+                            console.error("Open with default app failed:", err),
+                          );
+                      },
+                    },
+                  ]),
+              ...(shareSupported
+                ? [
+                    {
+                      label: "Share…",
+                      onSelect: () => {
+                        withBytes()
+                          .then(shareAttachment)
+                          .catch((err) => console.error("Share failed:", err));
+                      },
+                    },
+                  ]
+                : []),
+            ]}
+          />
+        );
+      })()}
+      {lightbox && (
+        <AttachmentLightbox
+          attachment={lightbox.attachment}
+          returnFocusTo={lightbox.returnFocus}
+          onClose={() => setLightbox(null)}
+          onContextMenu={(e) => openAttachmentMenu(e, lightbox.attachment)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/ui/src/components/chat/ChatPanelSessionView.tsx
+++ b/src/ui/src/components/chat/ChatPanelSessionView.tsx
@@ -10,7 +10,6 @@ import { useTranslation } from "react-i18next";
 import { LoaderCircle, SendHorizontal } from "lucide-react";
 
 import type { AttachmentInput } from "../../types/chat";
-import type { QueuedMessage } from "../../stores/useAppStore";
 import type { DownloadableAttachment } from "../../utils/attachmentDownload";
 import {
   submitAgentAnswer,
@@ -425,7 +424,7 @@ export function ChatPanelSessionView({
 
       {queuedMessages.length > 0 && activeSessionId && (
         <QueuedMessagesPopover
-          queuedMessages={queuedMessages as QueuedMessage[]}
+          queuedMessages={queuedMessages}
           isRemote={!!ws?.remote_connection_id}
           isRunning={isRunning}
           isSteeringQueued={isSteeringQueued}
@@ -442,26 +441,28 @@ export function ChatPanelSessionView({
         />
       )}
 
-      <ChatInputArea
-        onSend={onSend}
-        onSendSteer={onSendSteer}
-        onSteerQueuedTop={onSteerQueuedTop}
-        onRunShellCommand={onRunShellCommand}
-        onStop={onStop}
-        isRunning={isRunning}
-        workspaceEnvironmentPreparing={workspaceEnvironmentPreparing}
-        isRemote={!!ws?.remote_connection_id}
-        hasQueuedMessages={queuedMessages.length > 0}
-        selectedWorkspaceId={selectedWorkspaceId!}
-        sessionId={activeSessionId!}
-        repoId={repo?.id}
-        projectPath={repo?.path}
-        historyRef={historyRef}
-        historyIndexRef={historyIndexRef}
-        draftRef={draftRef}
-        onAttachmentContextMenu={onAttachmentContextMenu}
-        onAttachmentClick={onAttachmentClick}
-      />
+      {selectedWorkspaceId && activeSessionId && (
+        <ChatInputArea
+          onSend={onSend}
+          onSendSteer={onSendSteer}
+          onSteerQueuedTop={onSteerQueuedTop}
+          onRunShellCommand={onRunShellCommand}
+          onStop={onStop}
+          isRunning={isRunning}
+          workspaceEnvironmentPreparing={workspaceEnvironmentPreparing}
+          isRemote={!!ws?.remote_connection_id}
+          hasQueuedMessages={queuedMessages.length > 0}
+          selectedWorkspaceId={selectedWorkspaceId}
+          sessionId={activeSessionId}
+          repoId={repo?.id}
+          projectPath={repo?.path}
+          historyRef={historyRef}
+          historyIndexRef={historyIndexRef}
+          draftRef={draftRef}
+          onAttachmentContextMenu={onAttachmentContextMenu}
+          onAttachmentClick={onAttachmentClick}
+        />
+      )}
     </>
   );
 }

--- a/src/ui/src/components/chat/ChatPanelSessionView.tsx
+++ b/src/ui/src/components/chat/ChatPanelSessionView.tsx
@@ -1,0 +1,467 @@
+import type {
+  ContextType,
+  Dispatch,
+  MouseEvent,
+  MutableRefObject,
+  RefObject,
+  SetStateAction,
+} from "react";
+import { useTranslation } from "react-i18next";
+import { LoaderCircle, SendHorizontal } from "lucide-react";
+
+import type { AttachmentInput } from "../../types/chat";
+import type { QueuedMessage } from "../../stores/useAppStore";
+import type { DownloadableAttachment } from "../../utils/attachmentDownload";
+import {
+  submitAgentAnswer,
+  submitAgentApproval,
+  submitPlanApproval,
+} from "../../services/tauri";
+import { ChatAuthFailureCallout } from "../auth/ChatAuthFailureCallout";
+import { AgentApprovalCard } from "./AgentApprovalCard";
+import { AgentQuestionCard } from "./AgentQuestionCard";
+import { ChatEmptyState } from "./ChatEmptyState";
+import { ChatErrorBanner } from "./ChatErrorBanner";
+import { ChatInputArea } from "./ChatInputArea";
+import { ChatSearchBar } from "./ChatSearchBar";
+import { CliInvocationBanner } from "./CliInvocationBanner";
+import { CurrentTurnTaskProgress } from "./CurrentTurnTaskProgress";
+import { MessagesWithTurns } from "./MessagesWithTurns";
+import { OverlayScrollbar } from "./OverlayScrollbar";
+import { PlanApprovalCard } from "./PlanApprovalCard";
+import { QueuedMessagesPopover } from "./QueuedMessagesPopover";
+import { ScrollContext } from "./ScrollContext";
+import { ScrollToBottomPill } from "./ScrollToBottomPill";
+import { SetupScriptBanner } from "./SetupScriptBanner";
+import { StreamingMessage } from "./StreamingMessage";
+import { StreamingThinkingBlock } from "./StreamingThinkingBlock";
+import { formatElapsedSeconds } from "./chatHelpers";
+import styles from "./ChatPanel.module.css";
+import type { useChatPanelStore } from "./useChatPanelStore";
+
+type ChatPanelStore = ReturnType<typeof useChatPanelStore>;
+
+type ChatPanelSessionViewProps = Pick<
+  ChatPanelStore,
+  | "activeChatSessionRecord"
+  | "activeSessionId"
+  | "activitiesCount"
+  | "chatAuthLoginRequestId"
+  | "chatAuthLoginStartedRequestId"
+  | "clearAgentApproval"
+  | "clearAgentQuestion"
+  | "clearPlanApproval"
+  | "globalOffset"
+  | "hasPendingTypewriter"
+  | "hasStreaming"
+  | "hasThinking"
+  | "isLoadingMore"
+  | "isRunning"
+  | "isSteeringQueued"
+  | "messages"
+  | "pendingApproval"
+  | "pendingPlan"
+  | "pendingQuestion"
+  | "pendingSteerContent"
+  | "queuedMessages"
+  | "removeQueuedMessage"
+  | "repo"
+  | "runningSetupScriptSource"
+  | "searchQuery"
+  | "selectedWorkspaceId"
+  | "setChatAuthLoginStartedRequestId"
+  | "setPlanMode"
+  | "setQueuedMessageEditing"
+  | "showChatAuthLoginPanel"
+  | "showThinkingBlocks"
+  | "steerQueuedTooltip"
+  | "toolDisplayMode"
+  | "updateQueuedMessage"
+  | "workspaceEnvironmentError"
+  | "workspaceEnvironmentPreparing"
+  | "ws"
+> & {
+  clearQueuedMessagesAndCancelEdit: (sessionId: string) => void;
+  draftRef: MutableRefObject<string>;
+  elapsed: number;
+  error: string | null;
+  historyIndexRef: MutableRefObject<number>;
+  historyRef: MutableRefObject<Record<string, string[]>>;
+  isAtBottom: boolean;
+  isRemote: boolean;
+  markUserScrollIntent: () => void;
+  messagesContainerRef: RefObject<HTMLDivElement | null>;
+  onAttachmentContextMenu: (
+    e: MouseEvent,
+    attachment: DownloadableAttachment,
+    attachmentId?: string,
+  ) => void;
+  onAttachmentClick: (e: MouseEvent, attachment: DownloadableAttachment) => void;
+  onForkTurn: (checkpointId: string) => void;
+  onRetryWorkspaceEnvironment: () => void;
+  onRunShellCommand: (command: string) => void | Promise<void>;
+  onSend: (
+    content: string,
+    mentionedFiles?: Set<string>,
+    attachments?: AttachmentInput[],
+  ) => Promise<void>;
+  onSendSteer: (
+    content: string,
+    mentionedFiles?: Set<string>,
+    attachments?: AttachmentInput[],
+  ) => Promise<void>;
+  onSteerQueuedMessage: (queuedMessageId: string) => void | Promise<void>;
+  onSteerQueuedTop: () => void;
+  onStop: () => void | Promise<void>;
+  processingRef: RefObject<HTMLDivElement | null>;
+  rememberChatScrollPosition: () => void;
+  scrollContextValue: ContextType<typeof ScrollContext>;
+  scrollToBottom: () => void;
+  setError: Dispatch<SetStateAction<string | null>>;
+};
+
+export function ChatPanelSessionView({
+  activeChatSessionRecord,
+  activeSessionId,
+  activitiesCount,
+  chatAuthLoginRequestId,
+  chatAuthLoginStartedRequestId,
+  clearAgentApproval,
+  clearAgentQuestion,
+  clearPlanApproval,
+  clearQueuedMessagesAndCancelEdit,
+  draftRef,
+  elapsed,
+  error,
+  globalOffset,
+  hasPendingTypewriter,
+  hasStreaming,
+  hasThinking,
+  historyIndexRef,
+  historyRef,
+  isAtBottom,
+  isLoadingMore,
+  isRemote,
+  isRunning,
+  isSteeringQueued,
+  markUserScrollIntent,
+  messages,
+  messagesContainerRef,
+  onAttachmentClick,
+  onAttachmentContextMenu,
+  onForkTurn,
+  onRetryWorkspaceEnvironment,
+  onRunShellCommand,
+  onSend,
+  onSendSteer,
+  onSteerQueuedMessage,
+  onSteerQueuedTop,
+  onStop,
+  pendingApproval,
+  pendingPlan,
+  pendingQuestion,
+  pendingSteerContent,
+  processingRef,
+  queuedMessages,
+  rememberChatScrollPosition,
+  removeQueuedMessage,
+  repo,
+  runningSetupScriptSource,
+  scrollContextValue,
+  scrollToBottom,
+  searchQuery,
+  selectedWorkspaceId,
+  setChatAuthLoginStartedRequestId,
+  setError,
+  setPlanMode,
+  setQueuedMessageEditing,
+  showChatAuthLoginPanel,
+  showThinkingBlocks,
+  steerQueuedTooltip,
+  toolDisplayMode,
+  updateQueuedMessage,
+  workspaceEnvironmentError,
+  workspaceEnvironmentPreparing,
+  ws,
+}: ChatPanelSessionViewProps) {
+  const { t } = useTranslation("chat");
+  const cliInvocation = activeChatSessionRecord?.cli_invocation ?? null;
+  const formatElapsed = formatElapsedSeconds;
+
+  return (
+    <>
+      <div className={styles.messagesWrapper}>
+        {selectedWorkspaceId && (
+          <ChatSearchBar
+            workspaceId={selectedWorkspaceId}
+            scopeRef={messagesContainerRef}
+          />
+        )}
+        <ScrollContext.Provider value={scrollContextValue}>
+          <OverlayScrollbar
+            targetRef={messagesContainerRef}
+            onUserScrollIntent={markUserScrollIntent}
+          />
+          <div className={styles.messages} ref={messagesContainerRef}>
+            <CliInvocationBanner
+              invocation={cliInvocation}
+              sessionId={activeChatSessionRecord?.id}
+            />
+            {workspaceEnvironmentError && (
+              <div className={styles.envErrorBanner} role="alert">
+                <span>{workspaceEnvironmentError}</span>
+                <button
+                  type="button"
+                  className={styles.envErrorRetry}
+                  onClick={onRetryWorkspaceEnvironment}
+                >
+                  {t("retry_environment", "Retry environment setup")}
+                </button>
+              </div>
+            )}
+            {messages.length === 0 && !hasStreaming && !runningSetupScriptSource ? (
+              <ChatEmptyState
+                key={activeSessionId ?? "no-active-session"}
+                workspaceEnvironmentPreparing={workspaceEnvironmentPreparing}
+                workspaceId={selectedWorkspaceId}
+                onRetryEnvironment={
+                  workspaceEnvironmentPreparing || workspaceEnvironmentError
+                    ? onRetryWorkspaceEnvironment
+                    : undefined
+                }
+              />
+            ) : (
+              <>
+                {isLoadingMore && (
+                  <div className={styles.loadingOlder}>
+                    <LoaderCircle
+                      size={14}
+                      className={styles.loadingOlderSpinner}
+                    />
+                    Loading older messages…
+                  </div>
+                )}
+                {activeSessionId && selectedWorkspaceId && (
+                  <MessagesWithTurns
+                    key={activeSessionId}
+                    messages={messages}
+                    workspaceId={selectedWorkspaceId}
+                    sessionId={activeSessionId}
+                    isRunning={isRunning}
+                    onForkTurn={isRemote ? undefined : onForkTurn}
+                    onAttachmentContextMenu={onAttachmentContextMenu}
+                    onAttachmentClick={onAttachmentClick}
+                    onOpenFileLink={rememberChatScrollPosition}
+                    searchQuery={searchQuery}
+                    globalOffset={globalOffset}
+                    toolDisplayMode={toolDisplayMode}
+                    liveTaskProgressNode={
+                      activitiesCount > 0 ? (
+                        <CurrentTurnTaskProgress sessionId={activeSessionId} />
+                      ) : null
+                    }
+                    streamingThinkingNode={
+                      hasThinking && showThinkingBlocks ? (
+                        <StreamingThinkingBlock
+                          sessionId={activeSessionId}
+                          isStreaming={isRunning ?? false}
+                          inline={toolDisplayMode === "inline"}
+                          searchQuery={searchQuery}
+                        />
+                      ) : null
+                    }
+                    streamingMessageNode={
+                      hasStreaming || hasPendingTypewriter ? (
+                        <StreamingMessage
+                          sessionId={activeSessionId}
+                          workspaceId={selectedWorkspaceId}
+                          isStreaming={isRunning ?? false}
+                          searchQuery={searchQuery}
+                        />
+                      ) : null
+                    }
+                  />
+                )}
+
+                {showChatAuthLoginPanel && (
+                  <ChatAuthFailureCallout
+                    autoStartKey={chatAuthLoginRequestId}
+                    autoStartedKey={chatAuthLoginStartedRequestId}
+                    onAutoStarted={setChatAuthLoginStartedRequestId}
+                  />
+                )}
+
+                {runningSetupScriptSource && activeSessionId && (
+                  <SetupScriptBanner
+                    outcome={{
+                      source: runningSetupScriptSource,
+                      status: "running",
+                      output: "",
+                    }}
+                    messageId={`setup-running:${activeSessionId}`}
+                  />
+                )}
+
+                {pendingQuestion && (
+                  <AgentQuestionCard
+                    question={pendingQuestion}
+                    onRespond={async (answers) => {
+                      if (!activeSessionId) return;
+                      const sid = activeSessionId;
+                      const toolUseId = pendingQuestion.toolUseId;
+                      try {
+                        await submitAgentAnswer(sid, toolUseId, answers);
+                        clearAgentQuestion(sid);
+                      } catch (e) {
+                        console.error("Failed to submit agent answer:", e);
+                        setError(String(e));
+                      }
+                    }}
+                  />
+                )}
+
+                {pendingPlan && selectedWorkspaceId && (
+                  <PlanApprovalCard
+                    approval={pendingPlan}
+                    workspaceId={selectedWorkspaceId}
+                    remoteConnectionId={ws?.remote_connection_id ?? undefined}
+                    onRespond={async (approved, reason) => {
+                      if (!activeSessionId) return;
+                      const sid = activeSessionId;
+                      const toolUseId = pendingPlan.toolUseId;
+                      try {
+                        await submitPlanApproval(sid, toolUseId, approved, reason);
+                        clearPlanApproval(sid);
+                        setPlanMode(sid, false);
+                      } catch (e) {
+                        console.error("Failed to submit plan approval:", e);
+                        setError(String(e));
+                      }
+                    }}
+                  />
+                )}
+
+                {pendingApproval && (
+                  <AgentApprovalCard
+                    approval={pendingApproval}
+                    onRespond={async (approved, reason) => {
+                      if (!activeSessionId) return;
+                      const sid = activeSessionId;
+                      const toolUseId = pendingApproval.toolUseId;
+                      try {
+                        await submitAgentApproval(sid, toolUseId, approved, reason);
+                        clearAgentApproval(sid);
+                      } catch (e) {
+                        console.error("Failed to submit agent approval:", e);
+                        setError(String(e));
+                      }
+                    }}
+                  />
+                )}
+
+                {isSteeringQueued && (
+                  <div
+                    className={styles.pendingSteer}
+                    aria-live="polite"
+                    aria-label={t("steer_pending_aria")}
+                  >
+                    <span className={styles.pendingSteerIcon} aria-hidden="true">
+                      <SendHorizontal size={12} />
+                    </span>
+                    <span className={styles.pendingSteerLabel} aria-hidden="true">
+                      {t("steer_pending_label")}
+                    </span>
+                    <span className={styles.pendingSteerContent}>
+                      {pendingSteerContent ?? t("steer_pending_attachment")}
+                    </span>
+                  </div>
+                )}
+
+                {isRunning && !pendingQuestion && !pendingPlan && !pendingApproval && (
+                  <div
+                    ref={processingRef}
+                    className={styles.processing}
+                    role="status"
+                    aria-label={
+                      ws?.agent_status === "Compacting"
+                        ? t("compacting_aria", {
+                            elapsed: formatElapsed(elapsed),
+                          })
+                        : t("processing_aria", {
+                            elapsed: formatElapsed(elapsed),
+                          })
+                    }
+                  >
+                    <span className={styles.spinnerWrap} aria-hidden="true">
+                      <span className={styles.spinner} />
+                    </span>
+                    {ws?.agent_status === "Compacting" && (
+                      <span className={styles.compactingLabel}>
+                        {t("compacting_label")}
+                      </span>
+                    )}
+                    <span className={styles.elapsed}>{formatElapsed(elapsed)}</span>
+                  </div>
+                )}
+
+                {error && (
+                  <ChatErrorBanner
+                    message={error}
+                    workspaceId={selectedWorkspaceId}
+                    sessionId={activeSessionId}
+                    onRecovered={() => setError(null)}
+                  />
+                )}
+              </>
+            )}
+          </div>
+        </ScrollContext.Provider>
+      </div>
+
+      <ScrollToBottomPill
+        visible={!isAtBottom && messages.length > 0}
+        onClick={scrollToBottom}
+      />
+
+      {queuedMessages.length > 0 && activeSessionId && (
+        <QueuedMessagesPopover
+          queuedMessages={queuedMessages as QueuedMessage[]}
+          isRemote={!!ws?.remote_connection_id}
+          isRunning={isRunning}
+          isSteeringQueued={isSteeringQueued}
+          steerQueuedTooltip={steerQueuedTooltip}
+          onEditingChange={(isEditing) =>
+            setQueuedMessageEditing(activeSessionId, isEditing)
+          }
+          onClearQueue={() => clearQueuedMessagesAndCancelEdit(activeSessionId)}
+          onRemoveMessage={(messageId) => removeQueuedMessage(activeSessionId, messageId)}
+          onSteerMessage={onSteerQueuedMessage}
+          onUpdateMessage={(messageId, updates) =>
+            updateQueuedMessage(activeSessionId, messageId, updates)
+          }
+        />
+      )}
+
+      <ChatInputArea
+        onSend={onSend}
+        onSendSteer={onSendSteer}
+        onSteerQueuedTop={onSteerQueuedTop}
+        onRunShellCommand={onRunShellCommand}
+        onStop={onStop}
+        isRunning={isRunning}
+        workspaceEnvironmentPreparing={workspaceEnvironmentPreparing}
+        isRemote={!!ws?.remote_connection_id}
+        hasQueuedMessages={queuedMessages.length > 0}
+        selectedWorkspaceId={selectedWorkspaceId!}
+        sessionId={activeSessionId!}
+        repoId={repo?.id}
+        projectPath={repo?.path}
+        historyRef={historyRef}
+        historyIndexRef={historyIndexRef}
+        draftRef={draftRef}
+        onAttachmentContextMenu={onAttachmentContextMenu}
+        onAttachmentClick={onAttachmentClick}
+      />
+    </>
+  );
+}

--- a/src/ui/src/components/chat/useChatPanelAttachments.ts
+++ b/src/ui/src/components/chat/useChatPanelAttachments.ts
@@ -1,0 +1,81 @@
+import { useCallback, useMemo, useState } from "react";
+import type { MouseEvent } from "react";
+
+import { loadAttachmentData } from "../../services/tauri";
+import {
+  isShareSupported,
+  type DownloadableAttachment,
+} from "../../utils/attachmentDownload";
+
+export type AttachmentMenuState = {
+  x: number;
+  y: number;
+  attachment: DownloadableAttachment;
+  /** Persisted PDFs hydrate without data_base64 (it's stripped to keep the
+   *  initial IPC small). Hold the row id so menu actions can lazy-load bytes. */
+  attachmentId?: string;
+} | null;
+
+export type AttachmentLightboxState = {
+  attachment: DownloadableAttachment;
+  returnFocus: HTMLElement | null;
+} | null;
+
+export function useChatPanelAttachments() {
+  const [attachmentMenu, setAttachmentMenu] =
+    useState<AttachmentMenuState>(null);
+  const [lightbox, setLightbox] = useState<AttachmentLightboxState>(null);
+
+  const openAttachmentMenu = useCallback(
+    (
+      e: MouseEvent,
+      attachment: DownloadableAttachment,
+      attachmentId?: string,
+    ) => {
+      e.preventDefault();
+      setAttachmentMenu({
+        x: e.clientX,
+        y: e.clientY,
+        attachment,
+        attachmentId,
+      });
+    },
+    [],
+  );
+
+  const ensureAttachmentBytes = useCallback(
+    async (
+      attachment: DownloadableAttachment,
+      attachmentId?: string,
+    ): Promise<DownloadableAttachment> => {
+      if (attachment.data_base64 || !attachmentId) return attachment;
+      const data_base64 = await loadAttachmentData(attachmentId);
+      return { ...attachment, data_base64 };
+    },
+    [],
+  );
+
+  const openLightbox = useCallback(
+    (e: MouseEvent, attachment: DownloadableAttachment) => {
+      setLightbox({
+        attachment,
+        returnFocus: (e.currentTarget as HTMLElement) ?? null,
+      });
+    },
+    [],
+  );
+
+  // navigator.canShare({ files: [probe] }) doesn't change across re-renders.
+  const shareSupported = useMemo(() => isShareSupported(), []);
+
+  return {
+    attachmentMenu,
+    ensureAttachmentBytes,
+    lightbox,
+    openAttachmentMenu,
+    openLightbox,
+    setAttachmentMenu,
+    setLightbox,
+    shareSupported,
+  };
+}

--- a/src/ui/src/components/chat/useChatPanelSessionLifecycle.ts
+++ b/src/ui/src/components/chat/useChatPanelSessionLifecycle.ts
@@ -1,0 +1,533 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type Dispatch,
+  type MutableRefObject,
+  type RefObject,
+  type SetStateAction,
+} from "react";
+
+import {
+  getAppSetting,
+  listCheckpoints,
+  loadChatHistoryPage,
+  loadCompletedTurns,
+  sendRemoteCommand,
+} from "../../services/tauri";
+import type { ChatAttachment, ChatMessage, ChatPaginationState } from "../../types";
+import { debugChat } from "../../utils/chatDebug";
+import { extractCompactionEvents } from "../../utils/compactionSentinel";
+import { extractLatestCallUsage } from "../../utils/extractLatestCallUsage";
+import { reconstructCompletedTurns } from "../../utils/reconstructTurns";
+import { usePreventScrollBounce } from "../../hooks/usePreventScrollBounce";
+import { useStickyScroll } from "../../hooks/useStickyScroll";
+import { useAppStore } from "../../stores/useAppStore";
+import type { useChatPanelStore } from "./useChatPanelStore";
+
+type ChatPanelStore = ReturnType<typeof useChatPanelStore>;
+
+type UseChatPanelSessionLifecycleOptions = Pick<
+  ChatPanelStore,
+  | "activeSessionId"
+  | "activeSessionIdsKey"
+  | "activitiesCount"
+  | "completedTurnsCount"
+  | "hasMore"
+  | "hasStreaming"
+  | "hydrateCompletedTurns"
+  | "isLoadingMore"
+  | "isRunning"
+  | "messages"
+  | "oldestMessageId"
+  | "pendingApproval"
+  | "pendingPlan"
+  | "pendingQuestion"
+  | "selectedWorkspaceId"
+  | "setChatMessages"
+  | "setChatPagination"
+  | "setPermissionLevel"
+> & {
+  draftRef: MutableRefObject<string>;
+  historyIndexRef: MutableRefObject<number>;
+  historyRef: MutableRefObject<Record<string, string[]>>;
+  messagesContainerRef: RefObject<HTMLDivElement | null>;
+  restoringChatScrollSessionsRef: MutableRefObject<Set<string>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+};
+
+export function useChatPanelSessionLifecycle({
+  activeSessionId,
+  activeSessionIdsKey,
+  activitiesCount,
+  completedTurnsCount,
+  draftRef,
+  hasMore,
+  hasStreaming,
+  historyIndexRef,
+  historyRef,
+  hydrateCompletedTurns,
+  isLoadingMore,
+  isRunning,
+  messages,
+  messagesContainerRef,
+  oldestMessageId,
+  pendingApproval,
+  pendingPlan,
+  pendingQuestion,
+  restoringChatScrollSessionsRef,
+  selectedWorkspaceId,
+  setChatMessages,
+  setChatPagination,
+  setError,
+  setPermissionLevel,
+}: UseChatPanelSessionLifecycleOptions) {
+  const chatScrollTopBySessionRef = useRef(new Map<string, number>());
+
+  const {
+    isAtBottom,
+    scrollToBottom,
+    restoreScrollPosition,
+    handleContentChanged,
+    markUserScrollIntent,
+    suppressNextAutoScrollRef,
+  } = useStickyScroll(messagesContainerRef);
+  usePreventScrollBounce(messagesContainerRef);
+
+  const scrollContextValue = useMemo(
+    () => ({ handleContentChanged, suppressNextAutoScrollRef }),
+    [handleContentChanged, suppressNextAutoScrollRef],
+  );
+
+  useEffect(() => {
+    const activeSessionIds = new Set(
+      activeSessionIdsKey ? activeSessionIdsKey.split("\0") : [],
+    );
+    for (const sessionId of chatScrollTopBySessionRef.current.keys()) {
+      if (!activeSessionIds.has(sessionId)) {
+        chatScrollTopBySessionRef.current.delete(sessionId);
+      }
+    }
+    for (const sessionId of restoringChatScrollSessionsRef.current.keys()) {
+      if (!activeSessionIds.has(sessionId)) {
+        restoringChatScrollSessionsRef.current.delete(sessionId);
+      }
+    }
+  }, [activeSessionIdsKey, restoringChatScrollSessionsRef]);
+
+  useEffect(() => {
+    if (!activeSessionId) return;
+    let cancelled = false;
+    getAppSetting(`permission_level:${activeSessionId}`)
+      .then((val) => {
+        if (cancelled) return;
+        if (val === "readonly" || val === "standard" || val === "full") {
+          setPermissionLevel(activeSessionId, val);
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to load permission level:", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSessionId, setPermissionLevel]);
+
+  useEffect(() => {
+    if (!activeSessionId || !selectedWorkspaceId) return;
+    let cancelled = false;
+    setError(null);
+    historyIndexRef.current = -1;
+    draftRef.current = "";
+
+    const currentWs = useAppStore
+      .getState()
+      .workspaces.find((w) => w.id === selectedWorkspaceId);
+    const sessionId = activeSessionId;
+    const isLocal = !currentWs?.remote_connection_id;
+    const isCurrentHistoryLoad = () => {
+      const state = useAppStore.getState();
+      return (
+        state.selectedWorkspaceId === selectedWorkspaceId &&
+        state.selectedSessionIdByWorkspaceId[selectedWorkspaceId] === sessionId
+      );
+    };
+
+    debugChat("ChatPanel", "load-history:start", {
+      sessionId,
+      isLocal,
+      agentStatus: currentWs?.agent_status ?? null,
+    });
+
+    const onMessages = (
+      msgs: ChatMessage[],
+      attachments?: ChatAttachment[],
+      pageState?: ChatPaginationState,
+    ) => {
+      if (cancelled || !isCurrentHistoryLoad()) return;
+      const filtered = pageState
+        ? msgs
+        : msgs.filter(
+            (m) => m.role !== "Assistant" || m.content.trim() !== "" || !!m.thinking,
+          );
+      debugChat("ChatPanel", "load-history:success", {
+        sessionId,
+        rawMessageCount: msgs.length,
+        filteredMessageCount: filtered.length,
+        messageIds: filtered.map((msg) => msg.id),
+      });
+      setChatMessages(sessionId, filtered);
+      if (attachments) {
+        useAppStore.getState().setChatAttachments(sessionId, attachments);
+      }
+      if (pageState) {
+        setChatPagination(sessionId, pageState);
+      }
+      const loadGlobalOffset = pageState
+        ? pageState.totalCount - filtered.length
+        : 0;
+      historyRef.current[sessionId] = filtered
+        .filter((m) => m.role === "User")
+        .map((m) => m.content);
+      const callUsage = extractLatestCallUsage(filtered);
+      const store = useAppStore.getState();
+      if (callUsage) store.setLatestTurnUsage(sessionId, callUsage);
+      else store.clearLatestTurnUsage(sessionId);
+      store.setCompactionEvents(sessionId, extractCompactionEvents(filtered));
+
+      if (isLocal) {
+        const sessions =
+          useAppStore.getState().sessionsByWorkspace[selectedWorkspaceId] ?? [];
+        const thisSession = sessions.find((s) => s.id === sessionId);
+        const sessionRunning = thisSession?.agent_status === "Running";
+        debugChat("ChatPanel", "load-completed-turns:gate", {
+          sessionId,
+          isRunning: sessionRunning,
+          currentCompletedTurnIds: (
+            useAppStore.getState().completedTurns[sessionId] || []
+          ).map((turn) => turn.id),
+        });
+        if (!sessionRunning) {
+          loadCompletedTurns(sessionId)
+            .then((turnData) => {
+              if (cancelled || !isCurrentHistoryLoad()) return;
+              const turns = reconstructCompletedTurns(
+                filtered,
+                turnData,
+                loadGlobalOffset,
+              );
+              debugChat("ChatPanel", "load-completed-turns:success", {
+                sessionId,
+                dbTurnIds: turnData.map((turn) => turn.checkpoint_id),
+                reconstructedTurnIds: turns.map((turn) => turn.id),
+              });
+              hydrateCompletedTurns(sessionId, turns);
+            })
+            .catch((e) => console.error("Failed to load completed turns:", e));
+        }
+      }
+    };
+
+    if (isLocal) {
+      const existingPagination = useAppStore.getState().chatPagination[sessionId];
+      if (existingPagination) {
+        debugChat("ChatPanel", "load-history:skip-already-loaded", {
+          sessionId,
+          totalCount: existingPagination.totalCount,
+        });
+      } else {
+        loadChatHistoryPage(sessionId, 50)
+          .then((page) => {
+            onMessages(page.messages, page.attachments, {
+              hasMore: page.has_more,
+              isLoadingMore: false,
+              totalCount: page.total_count,
+              oldestMessageId: page.messages[0]?.id ?? null,
+            });
+          })
+          .catch((e) => console.error("Failed to load chat history:", e));
+      }
+    } else {
+      sendRemoteCommand(currentWs!.remote_connection_id!, "load_chat_history", {
+        chat_session_id: sessionId,
+      })
+        .then((data) => {
+          const msgs =
+            (data as { messages?: ChatMessage[] })?.messages ??
+            (data as ChatMessage[]);
+          onMessages(msgs);
+        })
+        .catch((e) => console.error("Failed to load chat history:", e));
+    }
+
+    if (isLocal) {
+      const setCheckpoints = useAppStore.getState().setCheckpoints;
+      listCheckpoints(sessionId)
+        .then((cps) => {
+          if (cancelled || !isCurrentHistoryLoad()) return;
+          setCheckpoints(sessionId, cps);
+        })
+        .catch((e) => console.error("Failed to load checkpoints:", e));
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeSessionId,
+    draftRef,
+    historyIndexRef,
+    historyRef,
+    hydrateCompletedTurns,
+    selectedWorkspaceId,
+    setChatMessages,
+    setChatPagination,
+    setError,
+  ]);
+
+  useEffect(() => {
+    if (!activeSessionId) return;
+    const savedScrollTop = chatScrollTopBySessionRef.current.get(activeSessionId);
+    if (savedScrollTop == null) {
+      restoringChatScrollSessionsRef.current.delete(activeSessionId);
+      scrollToBottom();
+      return;
+    }
+    const restoringSessions = restoringChatScrollSessionsRef.current;
+    restoringSessions.add(activeSessionId);
+    let cancelled = false;
+    let frameId: number | null = null;
+    let attempts = 0;
+    const restore = () => {
+      if (cancelled) return;
+      restoreScrollPosition(savedScrollTop);
+      attempts += 1;
+      const container = messagesContainerRef.current;
+      const maxScrollTop = container
+        ? Math.max(0, container.scrollHeight - container.clientHeight)
+        : 0;
+      const expectedTop = Math.min(savedScrollTop, maxScrollTop);
+      if (
+        attempts < 8 &&
+        container &&
+        Math.abs(container.scrollTop - expectedTop) > 1
+      ) {
+        frameId = requestAnimationFrame(restore);
+      } else {
+        restoringSessions.delete(activeSessionId);
+      }
+    };
+    frameId = requestAnimationFrame(restore);
+    return () => {
+      cancelled = true;
+      restoringSessions.delete(activeSessionId);
+      if (frameId !== null) cancelAnimationFrame(frameId);
+    };
+  }, [
+    activeSessionId,
+    messagesContainerRef,
+    restoreScrollPosition,
+    restoringChatScrollSessionsRef,
+    scrollToBottom,
+  ]);
+
+  useEffect(() => {
+    if (!activeSessionId) return;
+    const container = messagesContainerRef.current;
+    const scrollPositions = chatScrollTopBySessionRef.current;
+    const restoringSessions = restoringChatScrollSessionsRef.current;
+    return () => {
+      if (container && !restoringSessions.has(activeSessionId)) {
+        scrollPositions.set(activeSessionId, container.scrollTop);
+        restoringSessions.add(activeSessionId);
+      }
+    };
+  }, [activeSessionId, messagesContainerRef, restoringChatScrollSessionsRef]);
+
+  const rememberChatScrollPosition = useCallback(() => {
+    if (!activeSessionId) return;
+    const container = messagesContainerRef.current;
+    if (!container) return;
+    chatScrollTopBySessionRef.current.set(activeSessionId, container.scrollTop);
+    restoringChatScrollSessionsRef.current.add(activeSessionId);
+  }, [activeSessionId, messagesContainerRef, restoringChatScrollSessionsRef]);
+
+  const hasMoreRef = useRef(false);
+  hasMoreRef.current = hasMore;
+  const isLoadingMoreRef = useRef(false);
+  isLoadingMoreRef.current = isLoadingMore;
+  const oldestMessageIdRef = useRef<string | null>(null);
+  oldestMessageIdRef.current = oldestMessageId;
+  const activeSessionIdRef = useRef<string | null>(null);
+  activeSessionIdRef.current = activeSessionId;
+
+  useEffect(() => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+
+    const onScroll = () => {
+      if (
+        activeSessionIdRef.current &&
+        !restoringChatScrollSessionsRef.current.has(activeSessionIdRef.current)
+      ) {
+        chatScrollTopBySessionRef.current.set(
+          activeSessionIdRef.current,
+          container.scrollTop,
+        );
+      }
+      if (
+        container.scrollTop < 200 &&
+        hasMoreRef.current &&
+        !isLoadingMoreRef.current &&
+        activeSessionIdRef.current &&
+        oldestMessageIdRef.current
+      ) {
+        const sessionId = activeSessionIdRef.current;
+        const cursorId = oldestMessageIdRef.current;
+        const store = useAppStore.getState();
+        const pagination = store.chatPagination[sessionId];
+        if (!pagination) return;
+
+        isLoadingMoreRef.current = true;
+        store.setChatPagination(sessionId, { ...pagination, isLoadingMore: true });
+        const prevScrollHeight = container.scrollHeight;
+
+        loadChatHistoryPage(sessionId, 50, cursorId)
+          .then((page) => {
+            const liveStore = useAppStore.getState();
+            const livePagination = liveStore.chatPagination[sessionId];
+            const stillCurrent =
+              activeSessionIdRef.current === sessionId &&
+              livePagination &&
+              livePagination.oldestMessageId === cursorId;
+            if (!stillCurrent) {
+              if (livePagination && livePagination.isLoadingMore) {
+                liveStore.setChatPagination(sessionId, {
+                  ...livePagination,
+                  isLoadingMore: false,
+                });
+              }
+              return;
+            }
+            liveStore.prependChatMessages(sessionId, page.messages);
+            liveStore.prependChatAttachments(sessionId, page.attachments);
+            const liveTotal =
+              useAppStore.getState().chatPagination[sessionId]?.totalCount ?? 0;
+            liveStore.setChatPagination(sessionId, {
+              hasMore: page.has_more,
+              isLoadingMore: false,
+              totalCount: Math.max(page.total_count, liveTotal),
+              oldestMessageId: page.messages[0]?.id ?? cursorId,
+            });
+            const olderUserPrompts = page.messages
+              .filter((m) => m.role === "User")
+              .map((m) => m.content);
+            if (olderUserPrompts.length > 0) {
+              const existing = historyRef.current[sessionId] ?? [];
+              historyRef.current[sessionId] = [
+                ...olderUserPrompts,
+                ...existing,
+              ];
+            }
+            requestAnimationFrame(() => {
+              container.scrollTop += container.scrollHeight - prevScrollHeight;
+            });
+            const merged = useAppStore.getState().chatMessages[sessionId] ?? [];
+            const mergedTotal =
+              useAppStore.getState().chatPagination[sessionId]?.totalCount ??
+              page.total_count;
+            const mergedOffset = mergedTotal - merged.length;
+            loadCompletedTurns(sessionId)
+              .then((turnData) => {
+                if (activeSessionIdRef.current !== sessionId) return;
+                const turns = reconstructCompletedTurns(
+                  merged,
+                  turnData,
+                  mergedOffset,
+                );
+                useAppStore.getState().hydrateCompletedTurns(sessionId, turns);
+              })
+              .catch((err) =>
+                console.error(
+                  "Failed to re-hydrate completed turns after prepend:",
+                  err,
+                ),
+              );
+          })
+          .catch((e) => {
+            console.error("Failed to load older messages:", e);
+            const live = useAppStore.getState().chatPagination[sessionId];
+            if (!live) return;
+            useAppStore
+              .getState()
+              .setChatPagination(sessionId, { ...live, isLoadingMore: false });
+          })
+          .finally(() => {
+            isLoadingMoreRef.current = false;
+          });
+      }
+    };
+
+    container.addEventListener("scroll", onScroll, { passive: true });
+    return () => container.removeEventListener("scroll", onScroll);
+  }, [activeSessionId, historyRef, messagesContainerRef, restoringChatScrollSessionsRef]);
+
+  const prevMsgCountRef = useRef<Record<string, number>>({});
+  useEffect(() => {
+    const sid = activeSessionId;
+    if (!sid) return;
+    const prev = prevMsgCountRef.current[sid] ?? 0;
+    const cur = messages.length;
+    prevMsgCountRef.current[sid] = cur;
+    if (cur > prev) handleContentChanged();
+  }, [messages.length, activeSessionId, handleContentChanged]);
+
+  useEffect(() => {
+    if (
+      completedTurnsCount > 0 ||
+      activitiesCount > 0 ||
+      pendingQuestion ||
+      pendingPlan ||
+      pendingApproval
+    ) {
+      handleContentChanged();
+    }
+  }, [
+    completedTurnsCount,
+    activitiesCount,
+    pendingQuestion,
+    pendingPlan,
+    pendingApproval,
+    handleContentChanged,
+  ]);
+
+  useEffect(() => {
+    if (!activeSessionId) return;
+    debugChat("ChatPanel", "state", {
+      sessionId: activeSessionId,
+      wsId: selectedWorkspaceId,
+      isRunning,
+      messageCount: messages.length,
+      activitiesCount,
+      completedTurnsCount,
+      hasStreaming,
+    });
+  }, [
+    activeSessionId,
+    selectedWorkspaceId,
+    isRunning,
+    messages.length,
+    activitiesCount,
+    completedTurnsCount,
+    hasStreaming,
+  ]);
+
+  return {
+    isAtBottom,
+    markUserScrollIntent,
+    rememberChatScrollPosition,
+    scrollContextValue,
+    scrollToBottom,
+  };
+}

--- a/src/ui/src/components/chat/useChatPanelStore.ts
+++ b/src/ui/src/components/chat/useChatPanelStore.ts
@@ -1,0 +1,293 @@
+import { useTranslation } from "react-i18next";
+
+import { tooltipWithHotkey } from "../../hotkeys/display";
+import { isMacHotkeyPlatform } from "../../hotkeys/platform";
+import type { QueuedMessage } from "../../stores/useAppStore";
+import { useAppStore } from "../../stores/useAppStore";
+import { isWorkspaceEnvironmentPreparing } from "../../utils/workspaceEnvironment";
+import { EMPTY_ACTIVITIES } from "./chatConstants";
+
+const EMPTY_QUEUED_MESSAGES: QueuedMessage[] = [];
+
+export function useChatPanelStore() {
+  const { t } = useTranslation("chat");
+  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const workspaceEnvironmentPreparing = useAppStore((s) =>
+    isWorkspaceEnvironmentPreparing(s, s.selectedWorkspaceId),
+  );
+  const workspaceEnvironmentError = useAppStore((s) =>
+    s.selectedWorkspaceId &&
+    s.workspaceEnvironment[s.selectedWorkspaceId]?.status === "error"
+      ? s.workspaceEnvironment[s.selectedWorkspaceId]?.error ??
+        t("environment_error_fallback", {
+          defaultValue: "Workspace environment setup failed.",
+        })
+      : null,
+  );
+  const activeSessionId = useAppStore((s) =>
+    s.selectedWorkspaceId
+      ? s.selectedSessionIdByWorkspaceId[s.selectedWorkspaceId] ?? null
+      : null,
+  );
+  const activeSessionIdsKey = useAppStore((s) =>
+    selectedWorkspaceId
+      ? (s.sessionsByWorkspace[selectedWorkspaceId] ?? [])
+          .map((session) => session.id)
+          .join("\0")
+      : "",
+  );
+  const workspaces = useAppStore((s) => s.workspaces);
+  const repositories = useAppStore((s) => s.repositories);
+  const chatMessages = useAppStore((s) => s.chatMessages);
+  const setChatMessages = useAppStore((s) => s.setChatMessages);
+  // Treat `null` (probe-in-flight) as available so we don't briefly hide the
+  // Download menu item on a working host.
+  const fileDialogAvailable = useAppStore((s) => s.fileDialogAvailable);
+  const browseAvailable = fileDialogAvailable !== false;
+  const runningSetupScriptSource = useAppStore((s) =>
+    activeSessionId ? s.runningSetupScripts[activeSessionId] : undefined,
+  );
+  const hydrateCompletedTurns = useAppStore((s) => s.hydrateCompletedTurns);
+  const addChatMessage = useAppStore((s) => s.addChatMessage);
+  const enqueueTerminalCommand = useAppStore((s) => s.enqueueTerminalCommand);
+  const setChatPagination = useAppStore((s) => s.setChatPagination);
+  const chatPaginationState = useAppStore((s) =>
+    activeSessionId ? s.chatPagination[activeSessionId] : undefined,
+  );
+  const openPluginSettings = useAppStore((s) => s.openPluginSettings);
+  const usageInsightsEnabled = useAppStore((s) => s.usageInsightsEnabled);
+  const openSettings = useAppStore((s) => s.openSettings);
+  const appVersion = useAppStore((s) => s.appVersion);
+  const keybindings = useAppStore((s) => s.keybindings);
+  const slashCommandsByWorkspace = useAppStore((s) => s.slashCommandsByWorkspace);
+  const setSlashCommandsCache = useAppStore((s) => s.setSlashCommands);
+  const isSteeringQueued = useAppStore((s) =>
+    activeSessionId ? s.queuedMessageSteering[activeSessionId] === true : false,
+  );
+  const pendingSteerContent = useAppStore((s) =>
+    activeSessionId ? s.queuedMessageSteeringContent[activeSessionId] ?? null : null,
+  );
+  const setQueuedMessageEditing = useAppStore((s) => s.setQueuedMessageEditing);
+  const setQueuedMessageSteering = useAppStore((s) => s.setQueuedMessageSteering);
+  const chatSearchOpen = useAppStore((s) =>
+    selectedWorkspaceId ? s.chatSearch[selectedWorkspaceId]?.open ?? false : false,
+  );
+  const chatSearchQuery = useAppStore((s) =>
+    selectedWorkspaceId ? s.chatSearch[selectedWorkspaceId]?.query ?? "" : "",
+  );
+  const defaultBranchesMap = useAppStore((s) => s.defaultBranches);
+
+  const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
+  const repo = repositories.find((r) => r.id === ws?.repository_id);
+  const defaultBranch = repo ? defaultBranchesMap[repo.id] : undefined;
+
+  const pendingForkSourceName = useAppStore((s) => {
+    if (!s.selectedWorkspaceId) return null;
+    const sourceId = s.pendingForks[s.selectedWorkspaceId];
+    if (!sourceId) return null;
+    return s.workspaces.find((w) => w.id === sourceId)?.name ?? null;
+  });
+  const pendingCreateRepoName = useAppStore((s) => {
+    if (!s.selectedWorkspaceId) return null;
+    const repoId = s.pendingCreates[s.selectedWorkspaceId];
+    if (!repoId) return null;
+    return s.repositories.find((r) => r.id === repoId)?.name ?? null;
+  });
+  const pendingCreateWorkspaceName = useAppStore((s) => {
+    if (!s.selectedWorkspaceId) return null;
+    if (!s.pendingCreates[s.selectedWorkspaceId]) return null;
+    return s.workspaces.find((w) => w.id === s.selectedWorkspaceId)?.name ?? null;
+  });
+  const activeSessionCount = useAppStore((s) =>
+    selectedWorkspaceId
+      ? (s.sessionsByWorkspace[selectedWorkspaceId] ?? []).filter(
+          (sess) => sess.status === "Active",
+        ).length
+      : 0,
+  );
+  const diffTabCount = useAppStore((s) =>
+    selectedWorkspaceId
+      ? (s.diffTabsByWorkspace[selectedWorkspaceId] ?? []).length
+      : 0,
+  );
+  const fileTabCount = useAppStore((s) =>
+    selectedWorkspaceId
+      ? (s.fileTabsByWorkspace[selectedWorkspaceId] ?? []).length
+      : 0,
+  );
+  const sessionsLoaded = useAppStore((s) =>
+    selectedWorkspaceId
+      ? s.sessionsLoadedByWorkspace[selectedWorkspaceId] === true
+      : false,
+  );
+  const noOpenTabs =
+    sessionsLoaded &&
+    activeSessionCount === 0 &&
+    diffTabCount === 0 &&
+    fileTabCount === 0;
+  const messages = activeSessionId ? chatMessages[activeSessionId] || [] : [];
+  const hasMore = chatPaginationState?.hasMore ?? false;
+  const isLoadingMore = chatPaginationState?.isLoadingMore ?? false;
+  const paginationTotalCount = chatPaginationState?.totalCount ?? messages.length;
+  const oldestMessageId = chatPaginationState?.oldestMessageId ?? null;
+  const globalOffset = paginationTotalCount - messages.length;
+
+  const hasStreaming = useAppStore(
+    (s) => !!(activeSessionId && s.streamingContent[activeSessionId]),
+  );
+  const hasPendingTypewriter = useAppStore(
+    (s) => !!(activeSessionId && s.pendingTypewriter[activeSessionId]),
+  );
+  const hasThinking = useAppStore(
+    (s) => !!(activeSessionId && s.streamingThinking[activeSessionId]),
+  );
+  const showThinkingBlocks = useAppStore((s) =>
+    activeSessionId ? s.showThinkingBlocks[activeSessionId] === true : false,
+  );
+  const activitiesCount = useAppStore((s) =>
+    activeSessionId
+      ? (s.toolActivities[activeSessionId] ?? EMPTY_ACTIVITIES).length
+      : 0,
+  );
+  const completedTurnsCount = useAppStore((s) =>
+    activeSessionId ? (s.completedTurns[activeSessionId] || []).length : 0,
+  );
+  const setPermissionLevel = useAppStore((s) => s.setPermissionLevel);
+  const pendingQuestion = useAppStore((s) =>
+    activeSessionId ? s.agentQuestions[activeSessionId] ?? null : null,
+  );
+  const clearAgentQuestion = useAppStore((s) => s.clearAgentQuestion);
+  const pendingPlan = useAppStore((s) =>
+    activeSessionId ? s.planApprovals[activeSessionId] ?? null : null,
+  );
+  const clearPlanApproval = useAppStore((s) => s.clearPlanApproval);
+  const pendingApproval = useAppStore((s) =>
+    activeSessionId ? s.agentApprovals[activeSessionId] ?? null : null,
+  );
+  const clearAgentApproval = useAppStore((s) => s.clearAgentApproval);
+  const setPlanMode = useAppStore((s) => s.setPlanMode);
+  const queuedMessages = useAppStore((s) =>
+    activeSessionId
+      ? s.queuedMessages[activeSessionId] ?? EMPTY_QUEUED_MESSAGES
+      : EMPTY_QUEUED_MESSAGES,
+  );
+  const setQueuedMessage = useAppStore((s) => s.setQueuedMessage);
+  const updateQueuedMessage = useAppStore((s) => s.updateQueuedMessage);
+  const removeQueuedMessage = useAppStore((s) => s.removeQueuedMessage);
+  const clearQueuedMessage = useAppStore((s) => s.clearQueuedMessage);
+  const setQueuedMessageAutoDispatchPaused = useAppStore(
+    (s) => s.setQueuedMessageAutoDispatchPaused,
+  );
+  const addCheckpoint = useAppStore((s) => s.addCheckpoint);
+  const beginPendingFork = useAppStore((s) => s.beginPendingFork);
+  const commitPendingFork = useAppStore((s) => s.commitPendingFork);
+  const cancelPendingFork = useAppStore((s) => s.cancelPendingFork);
+  const toolDisplayMode = useAppStore((s) => s.toolDisplayMode);
+  const activeSessionStatus = useAppStore((s) => {
+    if (!activeSessionId || !selectedWorkspaceId) return "Idle" as const;
+    const sessions = s.sessionsByWorkspace[selectedWorkspaceId];
+    return (
+      sessions?.find((sess) => sess.id === activeSessionId)?.agent_status ??
+      ("Idle" as const)
+    );
+  });
+  const activeChatSessionRecord = useAppStore((s) =>
+    selectedWorkspaceId
+      ? (s.sessionsByWorkspace[selectedWorkspaceId] ?? []).find(
+          (cs) => cs.id === activeSessionId,
+        ) ?? null
+      : null,
+  );
+  const showChatAuthLoginPanel = useAppStore((s) => s.chatAuthLoginPanelOpen);
+  const chatAuthLoginRequestId = useAppStore((s) => s.chatAuthLoginRequestId);
+  const chatAuthLoginStartedRequestId = useAppStore(
+    (s) => s.chatAuthLoginStartedRequestId,
+  );
+  const openChatAuthLoginPanel = useAppStore((s) => s.openChatAuthLoginPanel);
+  const setChatAuthLoginStartedRequestId = useAppStore(
+    (s) => s.setChatAuthLoginStartedRequestId,
+  );
+
+  const isMac = isMacHotkeyPlatform();
+  const isRunning = activeSessionStatus === "Running";
+  const searchQuery = chatSearchOpen ? chatSearchQuery : "";
+  const steerQueuedTooltip = tooltipWithHotkey(
+    t("steer_queued"),
+    "chat.steer-immediate",
+    keybindings,
+    isMac,
+  );
+
+  return {
+    activeChatSessionRecord,
+    activeSessionId,
+    activeSessionIdsKey,
+    activeSessionStatus,
+    addChatMessage,
+    addCheckpoint,
+    appVersion,
+    beginPendingFork,
+    browseAvailable,
+    cancelPendingFork,
+    chatAuthLoginRequestId,
+    chatAuthLoginStartedRequestId,
+    clearAgentApproval,
+    clearAgentQuestion,
+    clearPlanApproval,
+    clearQueuedMessage,
+    commitPendingFork,
+    completedTurnsCount,
+    defaultBranch,
+    enqueueTerminalCommand,
+    globalOffset,
+    hasMore,
+    hasPendingTypewriter,
+    hasStreaming,
+    hasThinking,
+    hydrateCompletedTurns,
+    isLoadingMore,
+    isRunning,
+    isSteeringQueued,
+    messages,
+    noOpenTabs,
+    oldestMessageId,
+    openChatAuthLoginPanel,
+    openPluginSettings,
+    openSettings,
+    pendingApproval,
+    pendingCreateRepoName,
+    pendingCreateWorkspaceName,
+    pendingForkSourceName,
+    pendingPlan,
+    pendingQuestion,
+    pendingSteerContent,
+    queuedMessages,
+    removeQueuedMessage,
+    repo,
+    runningSetupScriptSource,
+    searchQuery,
+    selectedWorkspaceId,
+    sessionsLoaded,
+    setChatAuthLoginStartedRequestId,
+    setChatMessages,
+    setChatPagination,
+    setPermissionLevel,
+    setPlanMode,
+    setQueuedMessage,
+    setQueuedMessageAutoDispatchPaused,
+    setQueuedMessageEditing,
+    setQueuedMessageSteering,
+    setSlashCommandsCache,
+    showChatAuthLoginPanel,
+    showThinkingBlocks,
+    slashCommandsByWorkspace,
+    steerQueuedTooltip,
+    toolDisplayMode,
+    updateQueuedMessage,
+    usageInsightsEnabled,
+    workspaceEnvironmentError,
+    workspaceEnvironmentPreparing,
+    ws,
+    activitiesCount,
+  };
+}


### PR DESCRIPTION
## Summary

- Split the 1,928-line `ChatPanel.tsx` into focused hooks/components for store selection, session lifecycle, attachment overlays, and session rendering.
- Kept the main send/slash-command dispatch path in `ChatPanel.tsx` to avoid behavior churn in the highest-risk flow.
- Reduced `ChatPanel.tsx` to 929 lines while preserving the existing transcript, pagination, approval, queued-message, and attachment behavior.

## What changed

- Added `useChatPanelStore` for the consecutive Zustand subscriptions and derived chat-panel state.
- Added `useChatPanelSessionLifecycle` for persisted permission loading, chat history hydration, completed-turn reconstruction, scroll restoration, sticky scroll, pagination, and debug state logging.
- Added `useChatPanelAttachments` plus `ChatPanelAttachmentOverlays` for attachment context-menu/lightbox state and lazy byte hydration.
- Added `ChatPanelSessionView` for the transcript/search surface, agent question/plan/approval cards, queued-message popover, processing indicator, and composer wiring.

## Regression safety

- Preserved stable selector fallbacks and primitive selectors while moving the store subscription block.
- Preserved the stale-history-load guards, pagination monotonicity, scroll restoration, and completed-turn rehydration logic while lifting it into the lifecycle hook.
- Preserved the existing plan/agent approval submission order and explicit plan-mode clear after plan approval.
- No docs update: this is an internal refactor with no user-facing behavior, settings, commands, or UI copy changes.

## Validation

- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run test src/components/chat/ChatPanel.staleTranscript.test.tsx src/components/chat/nativeSlashCommands.test.ts`
- `cd src/ui && bun run lint` (passes with existing unrelated warnings)
- `cd src/ui && bun run lint:css`
- `cd src/ui && bun run build`
- `git diff --check`
