### PR TITLE
fix(chat): drop env retry button from preparing empty state

### DIFF
--- a/src/ui/src/components/chat/ChatEmptyState.test.tsx
+++ b/src/ui/src/components/chat/ChatEmptyState.test.tsx
@@ -124,23 +124,21 @@ describe("ChatEmptyState", () => {
       .toBe("Preparing direnv…");
   });
 
-  it("offers an in-place retry while the environment is still preparing", async () => {
-    const onRetry = vi.fn();
+  it("does not offer a retry while the environment is still preparing", async () => {
+    hookMocks.useEnvElapsedSeconds.mockReturnValueOnce({
+      plugin: "env-direnv",
+      seconds: 0,
+    });
     const container = await render(
       <ChatEmptyState
         workspaceEnvironmentPreparing
         workspaceId="ws-1"
-        onRetryEnvironment={onRetry}
       />,
     );
 
-    const button = container.querySelector("button");
-    expect(button?.textContent).toBe("Retry environment setup");
-
-    await act(async () => {
-      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    expect(onRetry).toHaveBeenCalledTimes(1);
+    // A genuinely stuck workspace is surfaced by the env-prep timeout,
+    // which flips the workspace to "error" and shows the chat error
+    // banner's retry. The preparing empty state must never flash one.
+    expect(container.querySelector("button")).toBeNull();
   });
 });

--- a/src/ui/src/components/chat/ChatEmptyState.tsx
+++ b/src/ui/src/components/chat/ChatEmptyState.tsx
@@ -8,13 +8,11 @@ import styles from "./ChatPanel.module.css";
 interface ChatEmptyStateProps {
   workspaceEnvironmentPreparing: boolean;
   workspaceId: string | null;
-  onRetryEnvironment?: () => void;
 }
 
 export function ChatEmptyState({
   workspaceEnvironmentPreparing,
   workspaceId,
-  onRetryEnvironment,
 }: ChatEmptyStateProps) {
   const { t } = useTranslation("chat");
   const { plugin: envPlugin, seconds: envSeconds } = useEnvElapsedSeconds(
@@ -51,15 +49,6 @@ export function ChatEmptyState({
         {title}
       </div>
       <div className={styles.emptySub}>{t("empty_preparing_env_subtitle")}</div>
-      {onRetryEnvironment && (
-        <button
-          type="button"
-          className={styles.emptyRetry}
-          onClick={onRetryEnvironment}
-        >
-          {t("retry_environment", "Retry environment setup")}
-        </button>
-      )}
     </div>
   );
 }

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -171,22 +171,6 @@
   color: var(--text-faint);
 }
 
-.emptyRetry {
-  margin-top: 4px;
-  border: 1px solid var(--divider);
-  border-radius: 6px;
-  background: var(--chat-input-bg);
-  color: var(--text-primary);
-  font: inherit;
-  font-size: 12px;
-  padding: 5px 10px;
-  cursor: pointer;
-}
-
-.emptyRetry:hover {
-  background: var(--hover-bg);
-}
-
 .errorBanner {
   background: var(--accent-error-bg);
   border: 1px solid var(--accent-error-border);

--- a/src/ui/src/components/chat/ChatPanelSessionView.tsx
+++ b/src/ui/src/components/chat/ChatPanelSessionView.tsx
@@ -223,11 +223,6 @@ export function ChatPanelSessionView({
                 key={activeSessionId ?? "no-active-session"}
                 workspaceEnvironmentPreparing={workspaceEnvironmentPreparing}
                 workspaceId={selectedWorkspaceId}
-                onRetryEnvironment={
-                  workspaceEnvironmentPreparing || workspaceEnvironmentError
-                    ? onRetryWorkspaceEnvironment
-                    : undefined
-                }
               />
             ) : (
               <>


### PR DESCRIPTION
## Summary

- The "Retry environment setup" button added to the chat empty state in #946 rendered from the **first frame** of env preparation, so every normal cold export flashed the button for ~1s before resolving.
- A genuinely stuck workspace is already handled by the env-prep timeout (`ENV_PREPARATION_TIMEOUT_MS`, 5 min): it flips the workspace to `error`, which surfaces the `envErrorBanner` with its own retry. `envPreparationTimeoutMessage()` even tells the user to "retry environment setup from the chat banner" — that banner.
- The in-place preparing-state retry was therefore redundant; it only produced the flash. Removed it (prop, JSX, orphaned `.emptyRetry` CSS). `ChatEmptyState.tsx` reverts exactly to its pre-#946 state.

The error-state retry banner is untouched — stuck/failed workspaces still get a retry.

## Test plan

- [x] `tsc -b` passes
- [x] `vitest` — `ChatEmptyState` suite passes (4/4); the old "offers an in-place retry while preparing" test is replaced with one pinning that no button renders during preparation
- [ ] Manual: open a workspace with a cold env export — spinner shows, no retry button flashes
- [ ] Manual: let env prep time out (or fail) — `error` banner appears with a working "Retry environment setup"