### PR TITLE
fix: keep non-Claude usage meters ungated

### DIFF
--- a/src/ui/src/components/chat/composer/UsageIndicator.test.tsx
+++ b/src/ui/src/components/chat/composer/UsageIndicator.test.tsx
@@ -15,6 +15,7 @@ import type { UsageSnapshot } from "../../../types/usage";
 const appStore = vi.hoisted(() => ({
   usageInsightsEnabled: false,
   agentBackends: [] as AgentBackendConfig[],
+  defaultAgentBackendId: "anthropic",
   selectedModel: {} as Record<string, string>,
   selectedModelProvider: {} as Record<string, string>,
   sessionUsage: {} as Record<string, UsageSnapshot>,
@@ -126,6 +127,7 @@ function makeSnapshot(overrides: Partial<UsageSnapshot> = {}): UsageSnapshot {
 beforeEach(() => {
   appStore.usageInsightsEnabled = false;
   appStore.agentBackends = [];
+  appStore.defaultAgentBackendId = "anthropic";
   appStore.selectedModel = {};
   appStore.selectedModelProvider = {};
   appStore.sessionUsage = {};
@@ -150,25 +152,92 @@ describe("UsageIndicator", () => {
     expect(container.querySelector("button")).toBeNull();
   });
 
-  it("hides when no backend matches and there's no Anthropic default", async () => {
-    // No entry in agentBackends matches either an explicit provider or
-    // the implicit "anthropic" fallback — defensive: shouldn't paint.
+  it("falls back to the first loaded backend when the configured default is absent", async () => {
+    // Mirrors the send/runtime fallback chain. If the loaded backend
+    // list contains only Codex (or a remote/default-only backend),
+    // the usage meter should not silently fall back to Claude and show
+    // the Claude Code Usage-off affordance.
     appStore.agentBackends = [makeBackend("codex_native", "codex")];
-    appStore.selectedModelProvider = {}; // no entry for s1
+    appStore.defaultAgentBackendId = "anthropic";
+    appStore.selectedModelProvider = {};
+    appStore.sessionUsage = { s1: makeSnapshot() };
     const container = await render();
-    expect(container.querySelector("button")).toBeNull();
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.className).not.toContain("disabled");
+    expect(pollerMock.useSessionUsagePoller).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: expect.objectContaining({ id: "codex", kind: "codex_native" }),
+        mode: "active",
+        usageInsightsEnabled: false,
+      }),
+    );
   });
 
-  it("defaults to Anthropic when the session has no saved provider", async () => {
-    // selectedModelProvider has no entry for s1 — the indicator should
-    // resolve to the built-in "anthropic" backend and render the
-    // greyed-out disabled state (flag is off in beforeEach), matching
-    // ComposerToolbar / ChatToolbar / ChatPanel's default behavior.
+  it("uses the configured default backend when the session has no saved provider", async () => {
     appStore.agentBackends = [makeBackend("anthropic", "anthropic")];
     const container = await render();
     const button = container.querySelector("button");
     expect(button).not.toBeNull();
     expect(button?.className).toContain("disabled");
+  });
+
+  it("does not gate a default Codex backend behind Claude Code Usage", async () => {
+    appStore.agentBackends = [
+      makeBackend("anthropic", "anthropic"),
+      makeBackend("codex_native", "codex"),
+    ];
+    appStore.defaultAgentBackendId = "codex";
+    appStore.selectedModelProvider = {};
+    appStore.sessionUsage = { s1: makeSnapshot() };
+
+    const container = await render();
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.className).not.toContain("disabled");
+    expect(pollerMock.useSessionUsagePoller).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: expect.objectContaining({ id: "codex", kind: "codex_native" }),
+        mode: "active",
+        usageInsightsEnabled: false,
+      }),
+    );
+  });
+
+  it("does not gate a default OpenRouter backend behind Claude Code Usage", async () => {
+    const openrouter = {
+      ...makeBackend("custom_openai", "openrouter"),
+      label: "OpenRouter",
+      base_url: "https://openrouter.ai/api/v1",
+    };
+    appStore.agentBackends = [
+      makeBackend("anthropic", "anthropic"),
+      openrouter,
+    ];
+    appStore.defaultAgentBackendId = "openrouter";
+    appStore.selectedModelProvider = {};
+    appStore.sessionUsage = {
+      s1: makeSnapshot({
+        provider_kind: "custom_openai",
+        source_label: "OpenRouter",
+      }),
+    };
+
+    const container = await render();
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.className).not.toContain("disabled");
+    expect(pollerMock.useSessionUsagePoller).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: expect.objectContaining({
+          id: "openrouter",
+          kind: "custom_openai",
+          base_url: "https://openrouter.ai/api/v1",
+        }),
+        mode: "active",
+        usageInsightsEnabled: false,
+      }),
+    );
   });
 
   it("renders disabled state for Claude family when flag is off", async () => {

--- a/src/ui/src/components/chat/composer/UsageIndicator.tsx
+++ b/src/ui/src/components/chat/composer/UsageIndicator.tsx
@@ -9,11 +9,6 @@ import { resolveIndicatorMode } from "./usageIndicatorMode";
 import { UsagePopover } from "./UsagePopover";
 import styles from "./UsageIndicator.module.css";
 
-/** Matches the convention used elsewhere in the chat UI
- *  (ComposerToolbar, ChatToolbar, ChatPanel, OverflowMenu, applySelectedModel)
- *  for sessions that haven't explicitly saved a provider yet. */
-const DEFAULT_BACKEND_ID = "anthropic";
-
 interface UsageIndicatorProps {
   workspaceId: string | null;
   sessionId: string | null;
@@ -57,6 +52,7 @@ export function UsageIndicator({ workspaceId, sessionId }: UsageIndicatorProps) 
 
   const usageInsightsEnabled = useAppStore((s) => s.usageInsightsEnabled);
   const agentBackends = useAppStore((s) => s.agentBackends);
+  const defaultAgentBackendId = useAppStore((s) => s.defaultAgentBackendId);
   const selectedModel = useAppStore((s) => s.selectedModel);
   const selectedModelProvider = useAppStore((s) => s.selectedModelProvider);
   const sessionUsage = useAppStore((s) => s.sessionUsage);
@@ -64,13 +60,18 @@ export function UsageIndicator({ workspaceId, sessionId }: UsageIndicatorProps) 
 
   const backend = useMemo(() => {
     if (!sessionId) return null;
-    // Default to "anthropic" when no explicit provider has been saved
-    // for this session — matches the convention every other chat
-    // composer surface uses, so a brand-new default-Claude session
-    // gets the greyed-out enable affordance instead of nothing.
-    const backendId = selectedModelProvider[sessionId] ?? DEFAULT_BACKEND_ID;
-    return agentBackends.find((b) => b.id === backendId) ?? null;
-  }, [agentBackends, selectedModelProvider, sessionId]);
+    // Match the backend resolution used by the send/runtime path:
+    // per-session provider -> configured default backend -> first
+    // loaded backend. A hardcoded "anthropic" fallback makes Codex or
+    // OpenRouter defaults look gated by the Claude Code Usage toggle.
+    const backendId = selectedModelProvider[sessionId] ?? defaultAgentBackendId;
+    return (
+      agentBackends.find((b) => b.id === backendId) ??
+      agentBackends.find((b) => b.id === defaultAgentBackendId) ??
+      agentBackends[0] ??
+      null
+    );
+  }, [agentBackends, defaultAgentBackendId, selectedModelProvider, sessionId]);
 
   const usageBackend = useMemo(() => {
     if (!backend || !sessionId) return backend;

--- a/src/ui/src/components/chat/composer/UsageIndicator.tsx
+++ b/src/ui/src/components/chat/composer/UsageIndicator.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../../stores/useAppStore";
 import { useSessionUsagePoller } from "../../../hooks/useSessionUsagePoller";
 import type { UsageBucket } from "../../../types/usage";
+import { resolveSessionBackend } from "../resolveSessionBackend";
 import { CLAUDE_CODE_USAGE_FOCUS } from "../../settings/focusKeys";
 import { resolveIndicatorMode } from "./usageIndicatorMode";
 import { UsagePopover } from "./UsagePopover";
@@ -60,17 +61,12 @@ export function UsageIndicator({ workspaceId, sessionId }: UsageIndicatorProps) 
 
   const backend = useMemo(() => {
     if (!sessionId) return null;
-    // Match the backend resolution used by the send/runtime path:
-    // per-session provider -> configured default backend -> first
-    // loaded backend. A hardcoded "anthropic" fallback makes Codex or
-    // OpenRouter defaults look gated by the Claude Code Usage toggle.
-    const backendId = selectedModelProvider[sessionId] ?? defaultAgentBackendId;
-    return (
-      agentBackends.find((b) => b.id === backendId) ??
-      agentBackends.find((b) => b.id === defaultAgentBackendId) ??
-      agentBackends[0] ??
-      null
-    );
+    return resolveSessionBackend({
+      sessionId,
+      selectedModelProvider,
+      agentBackends,
+      defaultAgentBackendId,
+    });
   }, [agentBackends, defaultAgentBackendId, selectedModelProvider, sessionId]);
 
   const usageBackend = useMemo(() => {

--- a/src/ui/src/components/chat/resolveSessionBackend.test.ts
+++ b/src/ui/src/components/chat/resolveSessionBackend.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  AgentBackendConfig,
+  AgentBackendKind,
+} from "../../services/tauri/agentBackends";
+import { resolveSessionBackend } from "./resolveSessionBackend";
+
+function backend(kind: AgentBackendKind, id: string = kind): AgentBackendConfig {
+  return {
+    id,
+    label: id,
+    kind,
+    base_url: null,
+    enabled: true,
+    default_model: null,
+    manual_models: [],
+    discovered_models: [],
+    auth_ref: null,
+    capabilities: {
+      thinking: false,
+      effort: false,
+      fast_mode: false,
+      one_m_context: false,
+      tools: true,
+      vision: false,
+    },
+    context_window_default: 0,
+    model_discovery: false,
+    has_secret: false,
+    runtime_harness: null,
+  };
+}
+
+describe("resolveSessionBackend", () => {
+  it("prefers the explicit per-session provider", () => {
+    const anthropic = backend("anthropic", "anthropic");
+    const codex = backend("codex_native", "codex");
+
+    expect(
+      resolveSessionBackend({
+        sessionId: "s1",
+        selectedModelProvider: { s1: "codex" },
+        agentBackends: [anthropic, codex],
+        defaultAgentBackendId: "anthropic",
+      }),
+    ).toBe(codex);
+  });
+
+  it("falls back to the configured default backend", () => {
+    const anthropic = backend("anthropic", "anthropic");
+    const openrouter = backend("custom_openai", "openrouter");
+
+    expect(
+      resolveSessionBackend({
+        sessionId: "s1",
+        selectedModelProvider: {},
+        agentBackends: [anthropic, openrouter],
+        defaultAgentBackendId: "openrouter",
+      }),
+    ).toBe(openrouter);
+  });
+
+  it("falls back to the first loaded backend when the configured default is absent", () => {
+    const codex = backend("codex_native", "codex");
+
+    expect(
+      resolveSessionBackend({
+        sessionId: "s1",
+        selectedModelProvider: {},
+        agentBackends: [codex],
+        defaultAgentBackendId: "anthropic",
+      }),
+    ).toBe(codex);
+  });
+
+  it("returns null before backends load", () => {
+    expect(
+      resolveSessionBackend({
+        sessionId: "s1",
+        selectedModelProvider: {},
+        agentBackends: [],
+        defaultAgentBackendId: "anthropic",
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/ui/src/components/chat/resolveSessionBackend.ts
+++ b/src/ui/src/components/chat/resolveSessionBackend.ts
@@ -1,0 +1,29 @@
+import type { AgentBackendConfig } from "../../services/tauri/agentBackends";
+
+export interface ResolveSessionBackendArgs {
+  sessionId: string;
+  selectedModelProvider: Record<string, string | undefined>;
+  agentBackends: readonly AgentBackendConfig[];
+  defaultAgentBackendId: string;
+}
+
+/**
+ * Resolve the backend for a chat session using the same fallback chain
+ * the send/runtime path applies: explicit per-session provider,
+ * configured default backend, then first loaded backend.
+ */
+export function resolveSessionBackend({
+  sessionId,
+  selectedModelProvider,
+  agentBackends,
+  defaultAgentBackendId,
+}: ResolveSessionBackendArgs): AgentBackendConfig | null {
+  if (agentBackends.length === 0) return null;
+  const providerId = selectedModelProvider[sessionId] ?? defaultAgentBackendId;
+  return (
+    agentBackends.find((backend) => backend.id === providerId) ??
+    agentBackends.find((backend) => backend.id === defaultAgentBackendId) ??
+    agentBackends[0] ??
+    null
+  );
+}

--- a/src/ui/src/components/chat/resolveSessionHarness.ts
+++ b/src/ui/src/components/chat/resolveSessionHarness.ts
@@ -7,6 +7,7 @@ import {
   defaultHarnessForKind,
   effectiveHarness,
 } from "../../services/tauri/agentBackends";
+import { resolveSessionBackend } from "./resolveSessionBackend";
 
 /**
  * Resolve the runtime harness for a chat session using the same fallback
@@ -36,13 +37,12 @@ export function resolveSessionHarness(args: {
   defaultAgentBackendId: string;
 }): AgentBackendRuntimeHarness | null {
   const { sessionId, selectedModelProvider, agentBackends, defaultAgentBackendId } = args;
-  if (agentBackends.length === 0) return null;
-  const providerId =
-    selectedModelProvider[sessionId] ?? defaultAgentBackendId;
-  const backend =
-    agentBackends.find((b) => b.id === providerId) ??
-    agentBackends.find((b) => b.id === defaultAgentBackendId) ??
-    agentBackends[0];
+  const backend = resolveSessionBackend({
+    sessionId,
+    selectedModelProvider,
+    agentBackends,
+    defaultAgentBackendId,
+  });
   if (!backend) return null;
   const harness = effectiveHarness(backend);
   if (harness !== "pi_sdk") return harness;


### PR DESCRIPTION
## Summary
- Resolve the composer usage indicator backend with the same fallback chain used by chat send/runtime dispatch: session provider, configured default backend, then first loaded backend.
- Prevent sessions without a saved provider from hardcoding Anthropic and incorrectly showing the Claude Code Usage disabled state for Codex or OpenRouter defaults.
- Add regression coverage for default Codex, default OpenRouter, and first-loaded backend fallback while Claude Code Usage is disabled.

## Root Cause
The usage indicator had its own fallback constant set to `anthropic`. When a session did not yet have an explicit `selectedModelProvider`, the meter ignored the configured default backend. That made Codex and OpenRouter sessions look gated by the Claude Code Usage experimental toggle even though their usage sources are local/Codex/OpenRouter-specific and should remain active.

## User Impact
Switching to Codex or an OpenRouter provider now keeps the usage meter live regardless of the Claude Code Usage toggle. Claude-family backends remain gated as intended.

## Validation
- `cd src/ui && bun run test -- src/components/chat/composer/UsageIndicator.test.tsx src/components/chat/composer/usageIndicatorMode.test.ts`
- `cd src/ui && bunx tsc -b`
- `git diff --check`
- `cd src/ui && bun run lint -- src/components/chat/composer/UsageIndicator.tsx src/components/chat/composer/UsageIndicator.test.tsx` exited 0; it reported existing unrelated repo warnings outside the touched files.
