### PR TITLE
fix(chat): stop duplicating AskUserQuestion cards after user answers

### DIFF
--- a/src/ui/src/hooks/useAgentStream.sessionRenamed.test.tsx
+++ b/src/ui/src/hooks/useAgentStream.sessionRenamed.test.tsx
@@ -315,7 +315,14 @@ describe("useAgentStream — session-renamed listener", () => {
     expect(useAppStore.getState().promptStartTime["ws-1"]).toBeUndefined();
   });
 
-  it("falls back to rendering AskUserQuestion from the streamed tool block", async () => {
+  it("does NOT re-show an AskUserQuestion card from the streamed tool block", async () => {
+    // Regression guard for the PR-939 fallback. The prior implementation
+    // re-created the question card from `content_block_stop` if the user
+    // had already answered the original (control_request-driven) card.
+    // The Rust side had cleared the matching pending_permissions entry,
+    // so the second answer failed with "No pending permission request for
+    // tool_use_id ...". The card must only ever come from the Rust-side
+    // `agent-permission-prompt` event.
     vi.useFakeTimers();
     await mountHook();
     const handlers = registeredHandlers.get("agent-stream") ?? [];
@@ -373,28 +380,9 @@ describe("useAgentStream — session-renamed listener", () => {
           },
         });
       }
-      vi.advanceTimersByTime(500);
+      vi.advanceTimersByTime(5_000);
     });
 
-    const question = useAppStore.getState().agentQuestions["session-1"];
-    expect(question).toMatchObject({
-      sessionId: "session-1",
-      toolUseId: "toolu-question-1",
-      questions: [
-        {
-          header: "Next step",
-          question: "How should I proceed?",
-          options: [
-            { label: "Implement the fix", description: "Patch and test it." },
-            { label: "Stop here" },
-          ],
-        },
-      ],
-    });
-    const session = useAppStore
-      .getState()
-      .sessionsByWorkspace["ws-1"]?.find((item) => item.id === "session-1");
-    expect(session?.needs_attention).toBe(true);
-    expect(session?.attention_kind).toBe("Ask");
+    expect(useAppStore.getState().agentQuestions["session-1"]).toBeUndefined();
   });
 });

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -41,7 +41,6 @@ import {
 } from "../components/chat/chatTurnLifecycle";
 
 const ASK_USER_QUESTION_TOOL = "AskUserQuestion";
-const ASK_USER_QUESTION_FALLBACK_DELAY_MS = 500;
 const CODEX_COMMAND_APPROVAL_TOOL = "CodexCommandApproval";
 const CODEX_FILE_CHANGE_APPROVAL_TOOL = "CodexFileChangeApproval";
 const CODEX_PERMISSIONS_APPROVAL_TOOL = "CodexPermissionsApproval";
@@ -151,16 +150,6 @@ function stringArrayFromUnknown(value: unknown): string[] {
     .filter((item) => item.length > 0);
 }
 
-function parseJsonRecord(inputJson: string): Record<string, unknown> | null {
-  try {
-    const parsed = JSON.parse(inputJson);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-    return parsed as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-}
-
 interface AgentHookEventPayload {
   workspace_id: string;
   chat_session_id: string;
@@ -215,9 +204,6 @@ export function useAgentStream() {
   const planFilePathRef = useRef<Record<string, string>>({});
   const thinkingBlocksRef = useRef<Record<string, Set<number>>>({});
   const pendingAgentToolCallsRef = useRef<Record<string, AgentToolCall[]>>({});
-  const askQuestionFallbackTimersRef = useRef<
-    Record<string, ReturnType<typeof setTimeout>>
-  >({});
 
   // Recompute the workspace-level `agent_status` from the current
   // per-session statuses plus active background tasks. Priority:
@@ -600,39 +586,14 @@ export function useAgentStream() {
                     }
                   }
 
-                  // The control_request path below is the primary source of
-                  // truth because it means the Rust side has populated
-                  // pending_permissions and can receive the answer. Keep a
-                  // delayed fallback from the streamed tool_use input, though:
-                  // if the prompt event is dropped or missed, the user must
-                  // still get the picker instead of a generic raw JSON tool
-                  // block.
-                  if (
-                    entry.toolName === ASK_USER_QUESTION_TOOL &&
-                    activity?.inputJson
-                  ) {
-                    const parsed = parseJsonRecord(activity.inputJson);
-                    const questions = parsed ? parseAskUserQuestion(parsed) : [];
-                    if (questions.length > 0) {
-                      const key = `${sessionId}:${entry.toolUseId}`;
-                      clearTimeout(askQuestionFallbackTimersRef.current[key]);
-                      askQuestionFallbackTimersRef.current[key] = setTimeout(() => {
-                        delete askQuestionFallbackTimersRef.current[key];
-                        const existing =
-                          useAppStore.getState().agentQuestions[sessionId];
-                        if (existing) return;
-                        setAgentQuestion({
-                          sessionId,
-                          toolUseId: entry.toolUseId,
-                          questions,
-                        });
-                        updateChatSession(sessionId, {
-                          needs_attention: true,
-                          attention_kind: "Ask",
-                        });
-                      }, ASK_USER_QUESTION_FALLBACK_DELAY_MS);
-                    }
-                  }
+                  // AskUserQuestion / ExitPlanMode card-showing is NOT driven
+                  // by content_block_stop. The Rust bridge emits an
+                  // `agent-permission-prompt` event the moment the CLI's
+                  // `control_request` is captured (and pending_permissions is
+                  // populated). The listener below handles those tools — that
+                  // way the card cannot be clicked before the Rust side is
+                  // ready to receive the answer, and a card never gets
+                  // re-shown after the user has already answered it.
                   break;
                 }
               }
@@ -752,10 +713,6 @@ export function useAgentStream() {
     return () => {
       active = false;
       unlisten.then((fn) => fn());
-      for (const timeout of Object.values(askQuestionFallbackTimersRef.current)) {
-        clearTimeout(timeout);
-      }
-      askQuestionFallbackTimersRef.current = {};
     };
   }, [
     appendStreamingContent,
@@ -893,9 +850,6 @@ export function useAgentStream() {
         input,
       } = event.payload;
       if (toolName === ASK_USER_QUESTION_TOOL) {
-        const fallbackKey = `${sessionId}:${toolUseId}`;
-        clearTimeout(askQuestionFallbackTimersRef.current[fallbackKey]);
-        delete askQuestionFallbackTimersRef.current[fallbackKey];
         // The CLI guarantees `input` is the validated tool-input object —
         // narrow before handing it to the parser.
         if (input && typeof input === "object") {


### PR DESCRIPTION
## Summary

Revert the 500ms streamed-tool fallback added in #939. It re-shows the AskUserQuestion picker after the user has already answered, causing the second answer to fail with `No pending permission request for tool_use_id <id> (pending: [])`.

## The bug

Reported in chat. Symptom: the first AskUserQuestion picker works fine, the agent acknowledges the answer, then an **identical** picker pops up and any answer on it errors:

```
No pending permission request for tool_use_id toolu_… (pending: [])
```

## Root cause

PR #939 added a 500ms timer that re-rendered the picker from the streamed `content_block_stop` event in case the Rust-side `agent-permission-prompt` event was missed. In practice the order is almost always:

1. `agent-permission-prompt` arrives (Rust has populated `pending_permissions`) → card shown.
2. User answers → frontend clears `agentQuestions[sessionId]`, Rust drops `pending_permissions[tool_use_id]`.
3. `content_block_stop` arrives a few hundred ms later carrying the same tool input → fallback timer queued.
4. After 500ms the timer fires, sees the question slot empty, and re-creates a card with the **same `tool_use_id`**.
5. User answers the duplicate → Rust has no matching pending entry → rejected.

The pre-#939 architecture comment in `useAgentStream.ts` documented this directly:

> AskUserQuestion / ExitPlanMode card-showing is no longer driven by `content_block_stop`. The Rust bridge emits an `agent-permission-prompt` event the moment the CLI's `control_request` is captured (and `pending_permissions` is populated). The listener below handles those tools — that way the card cannot be clicked before the Rust side is ready to receive the answer.

The fallback violated exactly that invariant. The webview has no way of knowing whether a given `tool_use_id` is still answerable on the Rust side, so driving the card from the stream is unsafe by construction.

## Changes

### `src/ui/src/hooks/useAgentStream.ts`
- Remove `ASK_USER_QUESTION_FALLBACK_DELAY_MS` constant.
- Remove `parseJsonRecord` helper (only used by the fallback).
- Remove `askQuestionFallbackTimersRef` and its cleanup in the listener-unmount path.
- Remove the `setTimeout` block in `content_block_stop`.
- Remove the now-dead `clearTimeout` call in the `agent-permission-prompt` handler.
- Restore the original architecture comment explaining why the stream path does not set the card.

### `src/ui/src/hooks/useAgentStream.sessionRenamed.test.tsx`
- Replace the test that pinned the buggy fallback (it asserted the card *should* be created after 500ms of fake timers) with a regression guard that asserts a streamed `content_block_stop` for AskUserQuestion does **not** surface a card even after 5s of fake-timer advancement. Also remove the `vi.useRealTimers()` afterEach hook setup that was added to support it — kept as a no-op safety since other tests in the file use fake timers too.

### Kept from #939 (independent, harmless)
- The readable-YAML render of AskUserQuestion details in `ToolActivityRow` (useful in transcript history when reviewing answered questions).
- The stuck-turn cancel affordance in `ChatPanel`.

## If the Rust event is ever genuinely dropped

The right fix is on the Rust side — make sure the `agent-permission-prompt` emitter cannot drop the event for tool_use_ids that have a corresponding pending_permissions slot. The webview cannot safely paper over a missed event because it can't distinguish "missed" from "already answered".

## Test plan

- [x] `bun run test -- useAgentStream.sessionRenamed` — 8/8 passing, including the new regression guard
- [x] `bun run test -- ToolActivityRow` — 11/11 passing
- [x] `bunx tsc -b` — clean
- [x] `bun run lint:css` — clean
- [ ] Manual: run a Claude agent, ask it to call `AskUserQuestion`, answer the picker, confirm only one card is shown and no `No pending permission request` error is logged.
- [ ] Manual: same as above but with two questions in rapid succession across turns, verifying each renders exactly once.