### PR TITLE
fix(windows): import GlobalFree from Win32::Foundation

### DIFF
--- a/src-tauri/src/commands/files/clipboard.rs
+++ b/src-tauri/src/commands/files/clipboard.rs
@@ -117,9 +117,7 @@ fn copy_file_path(path: &Path) -> Result<(), String> {
     use windows_sys::Win32::System::DataExchange::{
         CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
     };
-    use windows_sys::Win32::System::Memory::{
-        GHND, GlobalAlloc, GlobalLock, GlobalUnlock,
-    };
+    use windows_sys::Win32::System::Memory::{GHND, GlobalAlloc, GlobalLock, GlobalUnlock};
     use windows_sys::Win32::System::Ole::CF_HDROP;
     use windows_sys::Win32::UI::Shell::DROPFILES;
 

--- a/src-tauri/src/commands/files/clipboard.rs
+++ b/src-tauri/src/commands/files/clipboard.rs
@@ -113,12 +113,12 @@ fn pipe_to_command(program: &str, args: &[&str], input: &[u8]) -> Result<(), Str
 #[cfg(windows)]
 fn copy_file_path(path: &Path) -> Result<(), String> {
     use std::os::windows::ffi::OsStrExt as _;
-    use windows_sys::Win32::Foundation::HGLOBAL;
+    use windows_sys::Win32::Foundation::{GlobalFree, HGLOBAL};
     use windows_sys::Win32::System::DataExchange::{
         CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
     };
     use windows_sys::Win32::System::Memory::{
-        GHND, GlobalAlloc, GlobalFree, GlobalLock, GlobalUnlock,
+        GHND, GlobalAlloc, GlobalLock, GlobalUnlock,
     };
     use windows_sys::Win32::System::Ole::CF_HDROP;
     use windows_sys::Win32::UI::Shell::DROPFILES;


### PR DESCRIPTION
## Summary

Both Windows nightly builds (`windows-x86_64`, `windows-aarch64`) have been failing since #958 with:

```
error[E0432]: unresolved import `windows_sys::Win32::System::Memory::GlobalFree`
  --> src-tauri/src/commands/files/clipboard.rs:121:28
   |
   | no `GlobalFree` in `Win32::System::Memory`
   | help: a similar name exists in the module: `GlobalSize`
```

**Root cause:** `clipboard.rs` (added by the files-command split in #958) imports `GlobalFree` from `Win32::System::Memory`. In `windows-sys` 0.61 that function lives in `Win32::Foundation` — only `GlobalAlloc` / `GlobalLock` / `GlobalUnlock` / `GHND` remain under `System::Memory`. Verified against the crate source (`windows-sys-0.61.2/src/Windows/Win32/Foundation/mod.rs`).

**Why PR CI missed it:** PR CI only compiles Windows... it doesn't — Windows is built solely by the nightly/release workflows. A Windows-only import error therefore passes PR CI and only surfaces in the nightly.

## Fix

Move `GlobalFree` to the `Win32::Foundation` import line. One line each way, no behavior change.

## Test plan

- [x] `cargo xwin check --target x86_64-pc-windows-msvc -p claudette-tauri` — all Rust source (incl. `clipboard.rs`) type-checks for the Windows target; no `E0432` / unresolved-import errors remain. (A macOS-host xwin link-step artifact — `library kind 'framework' is only supported on Apple targets` — is unrelated and does not occur on CI's native Windows runner.)
- [ ] Nightly Windows builds (`windows-x86_64` + `windows-aarch64`) go green