### PR TITLE
feat(composer): support fuzzy file mention matching

### DIFF
--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -160,7 +160,7 @@ If you switch between build channels (e.g. nightly → stable, or run two builds
 
 ## File References (@-mentions)
 
-Type `@` in the chat input to reference specific files in your workspace. A file picker appears showing matching files — select one to include it as context for the agent.
+Type `@` in the chat input to reference specific files in your workspace. A file picker appears showing matching files — select one to include it as context for the agent. Exact filename and path substrings rank first, and abbreviations or skipped-character queries can still match as ordered subsequences (for example, `cpanel` can find `ChatPanel.tsx`).
 
 This is useful for directing the agent's attention to specific files:
 

--- a/src/ui/src/components/chat/FileMentionPicker.test.ts
+++ b/src/ui/src/components/chat/FileMentionPicker.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import type { FileEntry } from "../../services/tauri";
+import { matchFiles } from "./FileMentionPicker";
+
+function file(path: string, isDirectory = false): FileEntry {
+  return {
+    path,
+    is_directory: isDirectory,
+  };
+}
+
+describe("matchFiles", () => {
+  const files = [
+    file("src/ui/src/components/chat/ChatPanel.tsx"),
+    file("src/ui/src/components/chat/ChatInputArea.tsx"),
+    file("src/ui/src/stores/useAppStore.ts"),
+    file("src/ui/src/components/settings/PluginsSettings.tsx"),
+    file("src-tauri/src/commands/settings.rs"),
+    file("site/src/content/docs/features/settings.mdx"),
+  ];
+
+  it("keeps substring matches ranked above fuzzy matches", () => {
+    const results = matchFiles(
+      [
+        file("src/ui/src/components/chat/ChatPanel.tsx"),
+        file("src/ui/src/components/CoolHarnessTool.tsx"),
+      ],
+      "chat",
+    );
+
+    expect(results.map((result) => result.file.path)).toEqual([
+      "src/ui/src/components/chat/ChatPanel.tsx",
+      "src/ui/src/components/CoolHarnessTool.tsx",
+    ]);
+  });
+
+  it("matches skipped characters in a filename", () => {
+    expect(
+      matchFiles(files, "chatpanl").map((result) => result.file.path),
+    ).toContain("src/ui/src/components/chat/ChatPanel.tsx");
+  });
+
+  it("matches filename abbreviations as subsequences", () => {
+    expect(
+      matchFiles(files, "cpanel").map((result) => result.file.path),
+    ).toContain("src/ui/src/components/chat/ChatPanel.tsx");
+  });
+
+  it("matches subsequences across path segments", () => {
+    expect(
+      matchFiles(files, "uiappstore").map((result) => result.file.path),
+    ).toContain("src/ui/src/stores/useAppStore.ts");
+  });
+
+  it("does not match characters that only appear out of order", () => {
+    expect(matchFiles(files, "storeappui")).toEqual([]);
+  });
+
+  it("keeps directory results ahead at equal substring relevance", () => {
+    const results = matchFiles(
+      [file("src/ui/example", false), file("src/ui/example", true)],
+      "example",
+    );
+
+    expect(results[0]?.file.is_directory).toBe(true);
+  });
+});

--- a/src/ui/src/components/chat/FileMentionPicker.test.ts
+++ b/src/ui/src/components/chat/FileMentionPicker.test.ts
@@ -35,6 +35,15 @@ describe("matchFiles", () => {
     ]);
   });
 
+  it("preserves contiguous highlights for substring matches", () => {
+    const [result] = matchFiles(files, "panel");
+    const path = "src/ui/src/components/chat/ChatPanel.tsx";
+
+    expect(result?.file.path).toBe(path);
+    expect(result?.matchStart).toBe(path.indexOf("Panel"));
+    expect(result?.matchEnd).toBe(path.indexOf("Panel") + "panel".length);
+  });
+
   it("matches skipped characters in a filename", () => {
     expect(
       matchFiles(files, "chatpanl").map((result) => result.file.path),
@@ -47,6 +56,14 @@ describe("matchFiles", () => {
     ).toContain("src/ui/src/components/chat/ChatPanel.tsx");
   });
 
+  it("does not highlight a contiguous block for fuzzy matches", () => {
+    const result = matchFiles(files, "cpanel").find(
+      (match) => match.file.path === "src/ui/src/components/chat/ChatPanel.tsx",
+    );
+
+    expect(result?.matchStart).toBe(result?.matchEnd);
+  });
+
   it("matches subsequences across path segments", () => {
     expect(
       matchFiles(files, "uiappstore").map((result) => result.file.path),
@@ -55,6 +72,10 @@ describe("matchFiles", () => {
 
   it("does not match characters that only appear out of order", () => {
     expect(matchFiles(files, "storeappui")).toEqual([]);
+  });
+
+  it("does not scan impossible subsequence matches longer than the path", () => {
+    expect(matchFiles([file("short.ts")], "short-ts-but-longer")).toEqual([]);
   });
 
   it("keeps directory results ahead at equal substring relevance", () => {

--- a/src/ui/src/components/chat/FileMentionPicker.tsx
+++ b/src/ui/src/components/chat/FileMentionPicker.tsx
@@ -115,11 +115,12 @@ export function matchFiles(
       q,
     );
     if (filenameMatch) {
+      const matchPosition = filenameOffset + filenameMatch.matchStart;
       scored.push({
         file,
         score: 20 + filenameMatch.score + directoryBoost(file),
-        matchStart: filenameOffset + filenameMatch.matchStart,
-        matchEnd: filenameOffset + filenameMatch.matchEnd,
+        matchStart: matchPosition,
+        matchEnd: matchPosition,
       });
       continue;
     }
@@ -130,7 +131,7 @@ export function matchFiles(
         file,
         score: 5 + pathMatch.score + directoryBoost(file),
         matchStart: pathMatch.matchStart,
-        matchEnd: pathMatch.matchEnd,
+        matchEnd: pathMatch.matchStart,
       });
     }
   }
@@ -149,6 +150,10 @@ function scoreSubsequence(
   target: string,
   queryLower: string,
 ): SubsequenceMatch | null {
+  if (queryLower.length > target.length) {
+    return null;
+  }
+
   const targetLower = target.toLowerCase();
   const positions: number[] = [];
   let queryIndex = 0;

--- a/src/ui/src/components/chat/FileMentionPicker.tsx
+++ b/src/ui/src/components/chat/FileMentionPicker.tsx
@@ -16,6 +16,16 @@ interface FileMentionPickerProps {
   onHover: (index: number) => void;
 }
 
+interface ScoredFileMatch extends FileMatchResult {
+  score: number;
+}
+
+interface SubsequenceMatch {
+  score: number;
+  matchStart: number;
+  matchEnd: number;
+}
+
 export function FileMentionPicker({
   results,
   selectedIndex,
@@ -67,7 +77,7 @@ export function matchFiles(
   }
 
   const q = query.toLowerCase();
-  const scored: { file: FileEntry; score: number; matchStart: number; matchEnd: number }[] = [];
+  const scored: ScoredFileMatch[] = [];
 
   for (const file of files) {
     const pathLower = file.path.toLowerCase();
@@ -78,11 +88,9 @@ export function matchFiles(
     const fnIdx = filename.indexOf(q);
     if (fnIdx >= 0) {
       const score = 100 + (q.length / filename.length) * 50;
-      // Boost directories so they sort before files at equal relevance
-      const dirBoost = file.is_directory ? 0.5 : 0;
       scored.push({
         file,
-        score: score + dirBoost,
+        score: score + directoryBoost(file),
         matchStart: filenameOffset + fnIdx,
         matchEnd: filenameOffset + fnIdx + q.length,
       });
@@ -93,21 +101,123 @@ export function matchFiles(
     const pathIdx = pathLower.indexOf(q);
     if (pathIdx >= 0) {
       const score = 50 + (q.length / pathLower.length) * 25;
-      const dirBoost = file.is_directory ? 0.5 : 0;
       scored.push({
         file,
-        score: score + dirBoost,
+        score: score + directoryBoost(file),
         matchStart: pathIdx,
         matchEnd: pathIdx + q.length,
       });
       continue;
     }
 
-    // No fuzzy fallback — only substring matches
+    const filenameMatch = scoreSubsequence(
+      file.path.slice(filenameOffset),
+      q,
+    );
+    if (filenameMatch) {
+      scored.push({
+        file,
+        score: 20 + filenameMatch.score + directoryBoost(file),
+        matchStart: filenameOffset + filenameMatch.matchStart,
+        matchEnd: filenameOffset + filenameMatch.matchEnd,
+      });
+      continue;
+    }
+
+    const pathMatch = scoreSubsequence(file.path, q);
+    if (pathMatch) {
+      scored.push({
+        file,
+        score: 5 + pathMatch.score + directoryBoost(file),
+        matchStart: pathMatch.matchStart,
+        matchEnd: pathMatch.matchEnd,
+      });
+    }
   }
 
   return scored
     .sort((a, b) => b.score - a.score)
     .slice(0, MAX_RESULTS)
     .map(({ file, matchStart, matchEnd }) => ({ file, matchStart, matchEnd }));
+}
+
+function directoryBoost(file: FileEntry): number {
+  return file.is_directory ? 0.5 : 0;
+}
+
+function scoreSubsequence(
+  target: string,
+  queryLower: string,
+): SubsequenceMatch | null {
+  const targetLower = target.toLowerCase();
+  const positions: number[] = [];
+  let queryIndex = 0;
+
+  for (
+    let i = 0;
+    i < targetLower.length && queryIndex < queryLower.length;
+    i += 1
+  ) {
+    if (targetLower[i] === queryLower[queryIndex]) {
+      positions.push(i);
+      queryIndex += 1;
+    }
+  }
+
+  if (queryIndex !== queryLower.length || positions.length === 0) {
+    return null;
+  }
+
+  const matchStart = positions[0] ?? 0;
+  const lastPosition = positions[positions.length - 1] ?? matchStart;
+  const matchEnd = lastPosition + 1;
+  const spanLength = matchEnd - matchStart;
+  const density = queryLower.length / spanLength;
+  const boundaryHits = positions.filter((position) =>
+    isWordBoundary(target, position),
+  ).length;
+  const boundaryRatio = boundaryHits / positions.length;
+  const contiguousPairs = positions.slice(1).filter((position, index) => {
+    return position === positions[index] + 1;
+  }).length;
+  const contiguityRatio =
+    positions.length > 1 ? contiguousPairs / (positions.length - 1) : 1;
+  const startRatio =
+    target.length > 0 ? 1 - matchStart / Math.max(target.length, 1) : 1;
+
+  return {
+    score:
+      density * 10 +
+      contiguityRatio * 8 +
+      boundaryRatio * 6 +
+      startRatio * 3,
+    matchStart,
+    matchEnd,
+  };
+}
+
+function isWordBoundary(target: string, index: number): boolean {
+  if (index === 0) {
+    return true;
+  }
+
+  const previous = target[index - 1] ?? "";
+  const current = target[index] ?? "";
+
+  return (
+    previous === "/" ||
+    previous === "-" ||
+    previous === "_" ||
+    previous === "." ||
+    previous === " " ||
+    (isLowercaseAscii(previous) && isUppercaseAscii(current))
+  );
+}
+
+function isLowercaseAscii(value: string): boolean {
+  return value >= "a" && value <= "z";
+}
+
+function isUppercaseAscii(value: string): boolean {
+  return value >= "A" && value <= "Z";
 }


### PR DESCRIPTION
## Summary

Closes #964.

This updates the chat composer file mention picker so `@` file searches are no longer limited to strict contiguous substrings. Existing substring matches against the filename and full path still rank above fuzzy matches, so exact typing keeps the current behavior. Below those tiers, the picker now accepts ordered subsequence matches for abbreviations, skipped characters, and cross-segment queries like `uiappstore`.

## What changed

- Added a hand-rolled subsequence scorer in `FileMentionPicker.tsx` with no new dependency.
- Preserved the existing filename-over-path priority and directory relevance boost.
- Ranked fuzzy matches using match density, contiguous character runs, word/path boundary hits, and earlier match position.
- Added focused Vitest coverage for the issue examples: `chatpanl`, `cpanel`, and `uiappstore`.
- Documented the fuzzier `@` file reference behavior in the Agent Configuration docs.

## User impact

Users can type shorter or imperfect file queries in the chat composer and still find the intended workspace file. Exact filename/path substring searches continue to win over fuzzy matches, keeping predictable results for normal typing.

## Validation

- `cd src/ui && bun run test FileMentionPicker.test.ts`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bunx eslint src/components/chat/FileMentionPicker.tsx src/components/chat/FileMentionPicker.test.ts`
- `git diff --check`