### PR TITLE
fix: cap mdns_sd logs for diagnostics debug level

### DIFF
--- a/site/src/content/docs/features/diagnostics.mdx
+++ b/site/src/content/docs/features/diagnostics.mdx
@@ -25,11 +25,13 @@ Restart-required filter applied to the file log when `RUST_LOG` is unset. Choose
 
 | Level | Captures |
 |-------|----------|
-| `default` | `info` overall plus `debug` for Claudette's own crates — the shipping default |
+| `default` | `info` overall plus `debug` for Claudette's own crates, with `mdns_sd` capped at `warn` — the shipping default |
 | `warn` | warnings and errors only |
 | `info` | startup, shutdown, every Tauri command lifecycle event |
-| `debug` | the above plus span timings for slow ops (DB migrations, git fetches, diff parsing, agent spawns) |
-| `trace` | maximum detail; not recommended for normal use |
+| `debug` | the above plus Claudette debug events and span timings for slow ops (DB migrations, git fetches, diff parsing, agent spawns) |
+| `trace` | maximum Claudette detail; not recommended for normal use |
+
+The in-app selector scopes coarse levels to Claudette's own crates and keeps dependencies below debug/trace. It also caps `mdns_sd` at `warn` so mDNS packet chatter does not flood the daily log.
 
 If `RUST_LOG` is set in the process's environment, this select is locked and a banner explains why — `RUST_LOG` always wins so the env var workflow is preserved.
 
@@ -51,7 +53,7 @@ Two buttons. The first reveals the log directory in your file manager (Finder on
 
 ## Filtering verbosity by domain
 
-When investigating a specific subsystem, use a per-domain `RUST_LOG` filter rather than turning every domain up to `trace`. Every event in Claudette is emitted under a `claudette::<domain>` target:
+When investigating a specific subsystem, use a per-domain `RUST_LOG` filter rather than turning every domain up to `trace`. `RUST_LOG` is honored verbatim, so it can still enable dependency targets when you deliberately need them. Every event in Claudette is emitted under a `claudette::<domain>` target:
 
 ```bash
 # Only chat lifecycle events

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -171,7 +171,7 @@ When the workspace is checked out on the base branch itself, "Workspace branch b
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| Log level | File-log filter applied when `RUST_LOG` is unset. Restart required for changes to take effect. | `default` (`info,claudette=debug,claudette_tauri=debug,claudette_server=debug`) |
+| Log level | File-log filter applied when `RUST_LOG` is unset. Bare levels are scoped to Claudette's crates so dependencies stay below debug/trace, with `mdns_sd` capped at `warn`. Restart required for changes to take effect. | `default` (`info,claudette=debug,claudette_tauri=debug,claudette_server=debug,mdns_sd=warn`) |
 | Frontend log verbosity | How much of the React side's `console.*` output is mirrored into the daily log. Live — no restart needed. | Errors only |
 | Reveal in file manager | Opens `~/.claudette/logs/` in the host file manager. | — |
 | Copy path | Copies the log directory path to the clipboard. | — |

--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -32,9 +32,11 @@ use claudette::db::Database;
 use crate::state::AppState;
 
 /// Settings key that persists the user's chosen log filter.
-/// Read once at startup by `main.rs`. The value is any valid
-/// `EnvFilter` directive (see `claudette::logging` doc-comment for the
-/// syntax). `RUST_LOG`, if set, still wins.
+/// Read once at startup by `main.rs`. Bare levels such as `debug` are
+/// scoped to Claudette's own crates by `claudette::logging` before the
+/// `EnvFilter` is built, with noisy dependency caps such as
+/// `mdns_sd=warn`; custom directives are preserved as written. `RUST_LOG`,
+/// if set, still wins.
 pub const LOG_LEVEL_SETTING: &str = "diagnostics.log_level";
 
 /// Settings key that persists the frontend bridge verbosity. The

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -24,7 +24,8 @@
 //! ## Filtering
 //!
 //! Defaults to
-//! `info,claudette=debug,claudette_tauri=debug,claudette_server=debug`
+//! `info,claudette=debug,claudette_tauri=debug,claudette_server=debug,`
+//! `mdns_sd=warn`
 //! (see [`DEFAULT_FILTER`]). Override with the standard `RUST_LOG` env
 //! var (e.g.
 //! `RUST_LOG=claudette::commands::chat=trace`). For users who don't
@@ -66,6 +67,7 @@
 //! Use these targets verbatim; new domains are added here first so the
 //! convention stays one filterable axis.
 
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{Duration, SystemTime};
@@ -89,8 +91,20 @@ const LOG_FILE_PREFIX: &str = "claudette";
 /// Default subscriber filter when `RUST_LOG` is unset. Library and
 /// binary crate names go to `debug`; the rest of the dep tree stays
 /// at `info` so reqwest / hyper / mio chatter doesn't drown out our
-/// own events.
-const DEFAULT_FILTER: &str = "info,claudette=debug,claudette_tauri=debug,claudette_server=debug";
+/// own events. `mdns_sd` is capped further because it can log one
+/// event per mDNS packet observed on the LAN.
+const DEFAULT_FILTER: &str =
+    "info,claudette=debug,claudette_tauri=debug,claudette_server=debug,mdns_sd=warn";
+
+/// Coarse levels selected in Settings are scoped to our crates instead
+/// of applied globally. A bare `debug`/`trace` would also raise noisy
+/// dependencies such as `mdns_sd`, which logs every LAN mDNS packet at
+/// debug level and can grow the daily log by hundreds of MB.
+const CLAUDETTE_CRATES: &[&str] = &["claudette", "claudette_tauri", "claudette_server"];
+
+/// Dependencies that are too noisy for coarse in-app levels. `RUST_LOG`
+/// remains the escape hatch for deliberately enabling these targets.
+const NOISY_DEPENDENCY_CAPS: &[(&str, &str)] = &[("mdns_sd", "warn")];
 
 /// Holds the appender's worker thread alive for the lifetime of the
 /// process. `init` returns a `LogHandle` to `main`, which drops it on
@@ -165,10 +179,10 @@ pub fn init_stderr_only() -> Option<LogHandle> {
 ///
 /// `runtime_override` is parsed as an `EnvFilter` directive (e.g.
 /// `info`, `debug`, `claudette::chat=trace,info`). It is used **only**
-/// when `RUST_LOG` is unset, so an explicit env var still wins. The GUI
-/// reads `app_settings["diagnostics.log_level"]` and passes it through
-/// here so users who don't want to set env vars can change verbosity
-/// from Settings → Diagnostics.
+/// when `RUST_LOG` is unset, so an explicit env var still wins. Bare
+/// coarse levels from Settings are scoped to Claudette's crates before
+/// parsing so dependencies stay below debug/trace unless the user opts
+/// into a custom directive.
 ///
 /// Errors here are logged to stderr only and downgrade gracefully:
 /// if the file appender can't be created, stderr-only logging still
@@ -195,12 +209,15 @@ pub fn init_with_override(runtime_override: Option<&str>) -> Option<LogHandle> {
             let trimmed = s.trim();
             (!trimmed.is_empty()).then_some(trimmed)
         }) {
-            Some(directive) => EnvFilter::try_new(directive).unwrap_or_else(|e| {
-                eprintln!(
-                    "[logging] invalid runtime override {directive:?}: {e} — using default filter"
-                );
-                EnvFilter::new(DEFAULT_FILTER)
-            }),
+            Some(directive) => {
+                let normalized = normalize_runtime_override(directive);
+                EnvFilter::try_new(normalized.as_ref()).unwrap_or_else(|e| {
+                    eprintln!(
+                        "[logging] invalid runtime override {directive:?}: {e} — using default filter"
+                    );
+                    EnvFilter::new(DEFAULT_FILTER)
+                })
+            }
             None => EnvFilter::new(DEFAULT_FILTER),
         },
     };
@@ -277,6 +294,37 @@ pub fn init_with_override(runtime_override: Option<&str>) -> Option<LogHandle> {
         _file_guard: guard,
         log_dir,
     })
+}
+
+/// Convert simple Settings selections (`debug`, `trace`, etc.) into a
+/// scoped filter that changes Claudette's own crates without raising
+/// the whole dependency tree. Custom `EnvFilter` directives are returned
+/// verbatim so power users can persist targeted filters if needed.
+fn normalize_runtime_override(directive: &str) -> Cow<'_, str> {
+    let trimmed = directive.trim();
+    if matches!(trimmed, "trace" | "debug" | "info" | "warn" | "error") {
+        let dependency_floor = if matches!(trimmed, "trace" | "debug") {
+            "info"
+        } else {
+            trimmed
+        };
+        let mut scoped = String::from(dependency_floor);
+        for target in CLAUDETTE_CRATES {
+            scoped.push(',');
+            scoped.push_str(target);
+            scoped.push('=');
+            scoped.push_str(trimmed);
+        }
+        for (target, level) in NOISY_DEPENDENCY_CAPS {
+            scoped.push(',');
+            scoped.push_str(target);
+            scoped.push('=');
+            scoped.push_str(level);
+        }
+        Cow::Owned(scoped)
+    } else {
+        Cow::Borrowed(trimmed)
+    }
 }
 
 /// Resolve the directory rolled log files are written to. Order:
@@ -488,11 +536,11 @@ mod tests {
 
     /// The Settings UI writes one of these strings into
     /// `app_settings["diagnostics.log_level"]` and we thread it into
-    /// `init_with_override`. Verify each parses as a real `EnvFilter`
-    /// directive so a typo in the Settings select can't silently brick
-    /// the subscriber. We can't easily install a global subscriber
-    /// from a test (it's process-wide and other tests may have set it),
-    /// so we exercise the parsing path directly — the same call
+    /// `init_with_override`. Verify each parses after the runtime
+    /// normalization that keeps coarse selections scoped to Claudette's
+    /// own crates. We can't easily install a global subscriber from a
+    /// test (it's process-wide and other tests may have set it), so we
+    /// exercise the parsing path directly — the same call
     /// `init_with_override` makes when `RUST_LOG` is unset.
     #[test]
     fn supported_log_level_directives_parse() {
@@ -505,8 +553,36 @@ mod tests {
             "claudette::chat=trace",
             DEFAULT_FILTER,
         ] {
-            assert!(EnvFilter::try_new(ok).is_ok(), "expected {ok:?} to parse");
+            let normalized = normalize_runtime_override(ok);
+            assert!(
+                EnvFilter::try_new(normalized.as_ref()).is_ok(),
+                "expected {ok:?} to parse after normalization to {normalized:?}"
+            );
         }
+    }
+
+    #[test]
+    fn coarse_runtime_overrides_scope_claudette_crates_only() {
+        assert_eq!(
+            normalize_runtime_override("debug"),
+            "info,claudette=debug,claudette_tauri=debug,claudette_server=debug,mdns_sd=warn"
+        );
+        assert_eq!(
+            normalize_runtime_override("trace"),
+            "info,claudette=trace,claudette_tauri=trace,claudette_server=trace,mdns_sd=warn"
+        );
+        assert_eq!(
+            normalize_runtime_override("warn"),
+            "warn,claudette=warn,claudette_tauri=warn,claudette_server=warn,mdns_sd=warn"
+        );
+    }
+
+    #[test]
+    fn targeted_runtime_overrides_remain_verbatim() {
+        assert_eq!(
+            normalize_runtime_override("claudette::chat=trace,mdns_sd=debug"),
+            "claudette::chat=trace,mdns_sd=debug"
+        );
     }
 
     /// Validate the env override path. We guard the env mutation so

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -23,9 +23,11 @@
 //!
 //! ## Filtering
 //!
-//! Defaults to
-//! `info,claudette=debug,claudette_tauri=debug,claudette_server=debug,`
-//! `mdns_sd=warn`
+//! Defaults to:
+//!
+//! ```text
+//! info,claudette=debug,claudette_tauri=debug,claudette_server=debug,mdns_sd=warn
+//! ```
 //! (see [`DEFAULT_FILTER`]). Override with the standard `RUST_LOG` env
 //! var (e.g.
 //! `RUST_LOG=claudette::commands::chat=trace`). For users who don't
@@ -319,11 +321,30 @@ fn normalize_runtime_override(directive: &str) -> Cow<'_, str> {
             scoped.push(',');
             scoped.push_str(target);
             scoped.push('=');
-            scoped.push_str(level);
+            scoped.push_str(less_verbose_level(trimmed, level));
         }
         Cow::Owned(scoped)
     } else {
         Cow::Borrowed(trimmed)
+    }
+}
+
+fn less_verbose_level<'a>(selected_level: &'a str, cap_level: &'a str) -> &'a str {
+    if level_severity_rank(selected_level) >= level_severity_rank(cap_level) {
+        selected_level
+    } else {
+        cap_level
+    }
+}
+
+fn level_severity_rank(level: &str) -> u8 {
+    match level {
+        "trace" => 0,
+        "debug" => 1,
+        "info" => 2,
+        "warn" => 3,
+        "error" => 4,
+        _ => 2,
     }
 }
 
@@ -574,6 +595,10 @@ mod tests {
         assert_eq!(
             normalize_runtime_override("warn"),
             "warn,claudette=warn,claudette_tauri=warn,claudette_server=warn,mdns_sd=warn"
+        );
+        assert_eq!(
+            normalize_runtime_override("error"),
+            "error,claudette=error,claudette_tauri=error,claudette_server=error,mdns_sd=error"
         );
     }
 

--- a/src/ui/src/components/settings/sections/DiagnosticsSettings.tsx
+++ b/src/ui/src/components/settings/sections/DiagnosticsSettings.tsx
@@ -19,9 +19,9 @@ interface DiagnosticsSettingsPayload {
   rust_log_active: boolean;
 }
 
-// EnvFilter directives the select offers. Anything more exotic (e.g.
-// per-target overrides) belongs in the RUST_LOG path — the select is
-// for users who don't want to know what an EnvFilter is.
+// Coarse log levels the select offers. The Rust logging bootstrap
+// scopes these to Claudette's own crates and caps noisy dependency
+// targets like mdns_sd. Anything more exotic belongs in RUST_LOG.
 const LOG_LEVELS = [
   { value: "", label: "default" },
   { value: "warn", label: "warn" },


### PR DESCRIPTION
## Summary

- cap the default file-log filter with `mdns_sd=warn` so mDNS packet parsing never floods normal Claudette logs
- normalize coarse Settings > Diagnostics log-level selections to Claudette-scoped filters while preserving dependency caps
- keep custom persisted `EnvFilter` directives and `RUST_LOG` as explicit power-user escape hatches
- update Diagnostics and Settings docs to explain the scoped behavior

## Root Cause

The Diagnostics log-level selector persisted bare `EnvFilter` directives such as `debug`. On restart, that bare directive raised every crate in the process to DEBUG, including the `mdns_sd` dependency. Because Claudette starts mDNS discovery at launch, `mdns_sd` logged packet and DNS record details continuously on busy LANs, inflating daily log files.

## Fix

`init_with_override` now normalizes simple persisted levels (`warn`, `info`, `debug`, `trace`, `error`) into a filter that applies the selected level to Claudette crates only. The default filter and all normalized coarse levels append `mdns_sd=warn`, so the in-app `debug` setting still captures app debug detail without dependency packet spam. Custom directives remain verbatim, and `RUST_LOG` still wins when set.

Closes #967

## Validation

- `cargo fmt --all --check`
- `cargo test -p claudette logging::tests:: --lib`
- `cd src/ui && bunx tsc -b`
- `git diff --check`