### PR TITLE
fix(storage): show reclaimable checkpoint bytes in archived-workspace cleanup dialog

### DIFF
--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -179,6 +179,35 @@ pub async fn compute_storage_stats(
     Ok(by_repo)
 }
 
+/// Bytes that would actually free if the given set of archived
+/// workspaces were deleted together — dedup-aware, unlike a client-side
+/// sum of each workspace's sole-owned bytes. A blob shared between two
+/// workspaces in the set still counts once here, because both
+/// references go away.
+///
+/// Used by the cleanup dialog's "Delete selected (N · X MB)" total so
+/// the headline figure stays accurate. The per-row size shown next to
+/// each workspace remains the per-workspace sole-owned figure from
+/// `compute_storage_stats` — the right number for a single delete.
+#[tauri::command]
+pub async fn compute_reclaimable_bytes_for_workspaces(
+    workspace_ids: Vec<String>,
+    state: State<'_, AppState>,
+) -> Result<u64, String> {
+    if workspace_ids.is_empty() {
+        return Ok(0);
+    }
+    let db_path = state.db_path.clone();
+    tokio::task::spawn_blocking(move || {
+        let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+        let id_refs: Vec<&str> = workspace_ids.iter().map(String::as_str).collect();
+        db.reclaimable_checkpoint_bytes_for_workspaces(&id_refs)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("reclaimable-bytes join error: {e}"))?
+}
+
 /// Walk `<base>/<slug>/<wt_name>/` two levels deep and return every
 /// leaf-dir-path-plus-slug pair whose canonical path is not in
 /// `tracked_paths`. Pure (no DB / state access) so it can be unit-tested

--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -22,9 +22,13 @@ pub struct WorkspaceStorageEntry {
     pub name: String,
     pub status: WorkspaceStatus,
     pub worktree_path: Option<String>,
-    /// `None` when the workspace has no `worktree_path` (e.g. setup
-    /// failed and the row was created without a real worktree) or when
-    /// the dir is missing on disk.
+    /// For active workspaces with a worktree dir on disk: the size of
+    /// that dir. For workspaces whose worktree has been removed
+    /// (archived, or setup-failed), the bytes the checkpoint store
+    /// would reclaim if the workspace were deleted — sole-owned
+    /// content-addressed blobs plus inline legacy file content.
+    /// `None` is reserved for the rare case where the DB query itself
+    /// fails; callers can treat that as "unknown" and skip the row.
     pub size_bytes: Option<u64>,
 }
 
@@ -51,10 +55,12 @@ pub struct OrphanedWorktree {
     pub inferred_repo_name: Option<String>,
 }
 
-/// Compute per-repo storage statistics by summing the on-disk size of
-/// every workspace's worktree directory. Spawns all directory walks
-/// concurrently on the blocking pool so a large worktree tree doesn't
-/// serialize the whole computation.
+/// Compute per-repo storage statistics. For each workspace: walk its
+/// worktree directory when one exists on disk, otherwise (the archived
+/// case, or a setup-failed row) sum the bytes the workspace would
+/// reclaim from the checkpoint store on delete. Per-workspace work
+/// happens on the blocking pool so neither a large worktree tree nor a
+/// large checkpoint history serializes the whole computation.
 #[tauri::command]
 pub async fn compute_storage_stats(
     state: State<'_, AppState>,
@@ -74,16 +80,19 @@ pub async fn compute_storage_stats(
         .map(|r| r.id)
         .collect();
 
-    // Spawn one blocking size walk per workspace that has a worktree
-    // dir on disk. Skip rows whose path is None or doesn't exist —
-    // they contribute 0 bytes and don't need a thread.
+    // Spawn one blocking task per workspace. When a worktree dir
+    // exists, walk it for the on-disk size. When it doesn't (the
+    // archived case, or a setup-failed row), open a fresh Database
+    // connection inside the task and sum the checkpoint bytes the
+    // workspace would reclaim on delete — that's the only meaningful
+    // size signal once the worktree is gone.
     struct Pending {
         id: String,
         name: String,
         status: WorkspaceStatus,
         repository_id: String,
         worktree_path: Option<String>,
-        size_handle: Option<tokio::task::JoinHandle<u64>>,
+        size_handle: tokio::task::JoinHandle<u64>,
     }
 
     let mut pending: Vec<Pending> = Vec::with_capacity(workspaces.len());
@@ -91,14 +100,26 @@ pub async fn compute_storage_stats(
         if !known_repo_ids.contains(&ws.repository_id) {
             continue;
         }
-        let size_handle = ws
-            .worktree_path
-            .as_ref()
-            .filter(|p| Path::new(p).is_dir())
-            .map(|p| {
-                let path = PathBuf::from(p);
-                tokio::task::spawn_blocking(move || directory_size_bytes(&path))
-            });
+        let workspace_id = ws.id.clone();
+        let worktree_path_opt = ws.worktree_path.clone();
+        let db_path = state.db_path.clone();
+        let size_handle = tokio::task::spawn_blocking(move || -> u64 {
+            if let Some(p) = worktree_path_opt.as_deref()
+                && Path::new(p).is_dir()
+            {
+                return directory_size_bytes(Path::new(p));
+            }
+            // No worktree to walk — fall back to reclaimable checkpoint
+            // storage. A DB error here is best-effort: treat as 0 so the
+            // row still renders (with a possibly low size) rather than
+            // failing the whole stats call.
+            match Database::open(&db_path) {
+                Ok(db) => db
+                    .reclaimable_checkpoint_bytes(&workspace_id)
+                    .unwrap_or(0),
+                Err(_) => 0,
+            }
+        });
         pending.push(Pending {
             id: ws.id,
             name: ws.name,
@@ -119,10 +140,7 @@ pub async fn compute_storage_stats(
     let mut by_repo: Vec<RepoStorageStats> = Vec::new();
     let mut by_repo_index: HashMap<String, usize> = HashMap::new();
     for p in pending {
-        let size_bytes = match p.size_handle {
-            Some(handle) => handle.await.ok(),
-            None => None,
-        };
+        let size_bytes = p.size_handle.await.ok();
         let entry = WorkspaceStorageEntry {
             id: p.id,
             name: p.name,

--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -27,8 +27,11 @@ pub struct WorkspaceStorageEntry {
     /// (archived, or setup-failed), the bytes the checkpoint store
     /// would reclaim if the workspace were deleted — sole-owned
     /// content-addressed blobs plus inline legacy file content.
-    /// `None` is reserved for the rare case where the DB query itself
-    /// fails; callers can treat that as "unknown" and skip the row.
+    /// `None` is reserved for `spawn_blocking` join failures (the
+    /// per-workspace dir-walk task panicked, or the batched
+    /// reclaimable-bytes task did). DB / fs errors degrade to
+    /// `Some(0)` inside the task so the row still renders with a
+    /// possibly-low figure rather than vanishing.
     pub size_bytes: Option<u64>,
 }
 
@@ -80,55 +83,82 @@ pub async fn compute_storage_stats(
         .map(|r| r.id)
         .collect();
 
-    // Spawn one blocking task per workspace. When a worktree dir
-    // exists, walk it for the on-disk size. When it doesn't (the
-    // archived case, or a setup-failed row), open a fresh Database
-    // connection inside the task and sum the checkpoint bytes the
-    // workspace would reclaim on delete — that's the only meaningful
-    // size signal once the worktree is gone.
+    // Partition: workspaces with a walkable worktree dir get a
+    // per-workspace blocking task so concurrent fs walks don't
+    // serialize on a slow disk. Workspaces without one (archived
+    // rows whose worktree is gone, or setup-failed rows) get
+    // bundled into a single batched task that opens one SQLite
+    // connection and runs the reclaimable-bytes query for each in
+    // sequence — avoids the N concurrent `Database::open` burst the
+    // per-workspace design would create on archive-heavy
+    // repositories.
+    enum SizeSource {
+        DirWalk(tokio::task::JoinHandle<u64>),
+        /// Resolve from the shared `batched_sizes` map below.
+        Batched,
+    }
     struct Pending {
         id: String,
         name: String,
         status: WorkspaceStatus,
         repository_id: String,
         worktree_path: Option<String>,
-        size_handle: tokio::task::JoinHandle<u64>,
+        size_source: SizeSource,
     }
 
     let mut pending: Vec<Pending> = Vec::with_capacity(workspaces.len());
+    let mut batched_ids: Vec<String> = Vec::new();
     for ws in workspaces {
         if !known_repo_ids.contains(&ws.repository_id) {
             continue;
         }
-        let workspace_id = ws.id.clone();
-        let worktree_path_opt = ws.worktree_path.clone();
-        let db_path = state.db_path.clone();
-        let size_handle = tokio::task::spawn_blocking(move || -> u64 {
-            if let Some(p) = worktree_path_opt.as_deref()
-                && Path::new(p).is_dir()
-            {
-                return directory_size_bytes(Path::new(p));
+        let size_source = match ws.worktree_path.as_deref() {
+            Some(p) if Path::new(p).is_dir() => {
+                let path = PathBuf::from(p);
+                SizeSource::DirWalk(tokio::task::spawn_blocking(move || {
+                    directory_size_bytes(&path)
+                }))
             }
-            // No worktree to walk — fall back to reclaimable checkpoint
-            // storage. A DB error here is best-effort: treat as 0 so the
-            // row still renders (with a possibly low size) rather than
-            // failing the whole stats call.
-            match Database::open(&db_path) {
-                Ok(db) => db
-                    .reclaimable_checkpoint_bytes(&workspace_id)
-                    .unwrap_or(0),
-                Err(_) => 0,
+            _ => {
+                batched_ids.push(ws.id.clone());
+                SizeSource::Batched
             }
-        });
+        };
         pending.push(Pending {
             id: ws.id,
             name: ws.name,
             status: ws.status,
             repository_id: ws.repository_id,
             worktree_path: ws.worktree_path,
-            size_handle,
+            size_source,
         });
     }
+
+    // Single blocking task that opens the SQLite connection once and
+    // runs `reclaimable_checkpoint_bytes` for every workspace lacking
+    // a walkable worktree. Empty input → empty map; spawn cost is
+    // negligible and unconditional so the await side doesn't need to
+    // branch. DB-open failure degrades the whole batch to zeros so
+    // the dialog still renders.
+    let db_path_for_batch = state.db_path.clone();
+    let batched_handle = tokio::task::spawn_blocking(move || -> HashMap<String, u64> {
+        let mut out: HashMap<String, u64> = HashMap::with_capacity(batched_ids.len());
+        match Database::open(&db_path_for_batch) {
+            Ok(db) => {
+                for id in &batched_ids {
+                    let bytes = db.reclaimable_checkpoint_bytes(id).unwrap_or(0);
+                    out.insert(id.clone(), bytes);
+                }
+            }
+            Err(_) => {
+                for id in batched_ids {
+                    out.insert(id, 0);
+                }
+            }
+        }
+        out
+    });
+    let batched_sizes: HashMap<String, u64> = batched_handle.await.unwrap_or_default();
 
     // Aggregate by repository_id, preserving workspace insertion order
     // within each repo. Use a `Vec` for the stable returned ordering
@@ -140,7 +170,10 @@ pub async fn compute_storage_stats(
     let mut by_repo: Vec<RepoStorageStats> = Vec::new();
     let mut by_repo_index: HashMap<String, usize> = HashMap::new();
     for p in pending {
-        let size_bytes = p.size_handle.await.ok();
+        let size_bytes = match p.size_source {
+            SizeSource::DirWalk(handle) => handle.await.ok(),
+            SizeSource::Batched => batched_sizes.get(&p.id).copied(),
+        };
         let entry = WorkspaceStorageEntry {
             id: p.id,
             name: p.name,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1007,6 +1007,7 @@ fn main() {
             commands::workspace::import_worktrees,
             commands::workspace::purge_stray_worktree,
             commands::storage::compute_storage_stats,
+            commands::storage::compute_reclaimable_bytes_for_workspaces,
             commands::storage::scan_orphaned_worktrees,
             commands::storage::purge_orphaned_worktree,
             commands::workspace::open_workspace_in_terminal,

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -387,6 +387,56 @@ impl Database {
         Ok(deleted)
     }
 
+    /// Bytes that deleting this workspace would actually reclaim from the
+    /// checkpoint store: sole-owned `checkpoint_blobs` plus inline legacy
+    /// `checkpoint_files.content`. Cross-workspace shared blobs are
+    /// excluded — they would survive the delete via the
+    /// `gc_orphan_blobs_tx` `NOT EXISTS` predicate.
+    ///
+    /// This is what the Storage / cleanup UI uses to show a meaningful
+    /// size for archived workspaces, which have no worktree on disk left
+    /// to walk.
+    pub fn reclaimable_checkpoint_bytes(&self, workspace_id: &str) -> rusqlite::Result<u64> {
+        // Sole-owned blobs: referenced by this workspace's checkpoints AND
+        // by no other workspace's. Mirrors the `NOT EXISTS` shape that
+        // `gc_orphan_blobs_tx` uses so SQLite drives both correlated
+        // subqueries through `idx_checkpoint_files_blob_sha256`.
+        let sole_owned: i64 = self.conn.query_row(
+            "SELECT COALESCE(SUM(cb.byte_size), 0)
+             FROM checkpoint_blobs cb
+             WHERE EXISTS (
+                 SELECT 1 FROM checkpoint_files cf
+                 JOIN conversation_checkpoints cc ON cc.id = cf.checkpoint_id
+                 WHERE cc.workspace_id = ?1 AND cf.blob_sha256 = cb.sha256
+             )
+             AND NOT EXISTS (
+                 SELECT 1 FROM checkpoint_files cf
+                 JOIN conversation_checkpoints cc ON cc.id = cf.checkpoint_id
+                 WHERE cc.workspace_id <> ?1 AND cf.blob_sha256 = cb.sha256
+             )",
+            params![workspace_id],
+            |row| row.get(0),
+        )?;
+
+        // Legacy un-backfilled rows still keep their bytes inline in
+        // `checkpoint_files.content`. Those reclaim 1:1 on workspace
+        // delete since no other row can reference them.
+        let legacy_inline: i64 = self.conn.query_row(
+            "SELECT COALESCE(SUM(LENGTH(cf.content)), 0)
+             FROM checkpoint_files cf
+             JOIN conversation_checkpoints cc ON cc.id = cf.checkpoint_id
+             WHERE cc.workspace_id = ?1
+               AND cf.blob_sha256 IS NULL
+               AND cf.content IS NOT NULL",
+            params![workspace_id],
+            |row| row.get(0),
+        )?;
+
+        let sole = u64::try_from(sole_owned).unwrap_or(0);
+        let legacy = u64::try_from(legacy_inline).unwrap_or(0);
+        Ok(sole.saturating_add(legacy))
+    }
+
     /// Read snapshot rows for a checkpoint, materializing bytes from
     /// `checkpoint_blobs` via the `blob_sha256` reference. Legacy rows
     /// where `blob_sha256 IS NULL` fall back to the row's own `content`
@@ -1603,5 +1653,86 @@ mod tests {
                 .unwrap()
         };
         assert_eq!(with_files, vec!["cp3".to_string(), "cp4".to_string()]);
+    }
+
+    // --- reclaimable_checkpoint_bytes ---
+
+    /// Sole-owned blobs count toward the workspace's reclaimable bytes;
+    /// blobs that another workspace also references do not (deleting this
+    /// workspace would not free them via `gc_orphan_blobs_tx`).
+    #[test]
+    fn reclaimable_bytes_excludes_blobs_shared_with_other_workspaces() {
+        let db = setup_db_with_workspace();
+        // Add a second workspace under the same repo so both can hold
+        // checkpoints in parallel.
+        db.insert_workspace(&make_workspace("w2", "r1", "other")).unwrap();
+
+        // Workspace A: cp1 with two file rows — one unique blob, one
+        // shared with B.
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        let unique_a = vec![0xAAu8; 1000];
+        let shared = vec![0x55u8; 600];
+        db.insert_checkpoint_files(&[
+            raw_file("fa-unique", "cp1", "unique-a.bin", &unique_a),
+            raw_file("fa-shared", "cp1", "shared.bin", &shared),
+        ])
+        .unwrap();
+
+        // Workspace B: also references the shared blob.
+        db.insert_chat_message(&make_chat_msg(&db, "m2", "w2", ChatRole::Assistant, "b"))
+            .unwrap();
+        // make_checkpoint resolves the default session for the workspace, so
+        // it picks w2's session here.
+        db.insert_checkpoint(&make_checkpoint(&db, "cp2", "w2", "m2", 0))
+            .unwrap();
+        db.insert_checkpoint_files(&[raw_file("fb-shared", "cp2", "shared.bin", &shared)])
+            .unwrap();
+
+        // Sanity: dedupe is on, so we have 2 distinct blobs total.
+        assert_eq!(blob_count(&db), 2);
+
+        // Only the unique-A blob is reclaimable for w1 — the shared one
+        // would survive because cp2 still references it.
+        let bytes = db.reclaimable_checkpoint_bytes("w1").unwrap();
+        assert_eq!(bytes, unique_a.len() as u64);
+    }
+
+    /// Legacy un-backfilled rows (content in `checkpoint_files.content`,
+    /// `blob_sha256 IS NULL`) reclaim 1:1 since no other row can reference
+    /// them.
+    #[test]
+    fn reclaimable_bytes_counts_legacy_inline_content() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+
+        // Backdoor a legacy row (no blob_sha256, raw bytes in content),
+        // matching the partially-migrated-DB shape the read-path fallback
+        // test uses.
+        db.execute_batch(
+            "INSERT INTO checkpoint_files
+                (id, checkpoint_id, file_path, content, blob_sha256, file_mode)
+             VALUES ('legacy', 'cp1', 'legacy.txt', x'6c6567616379', NULL, 33188);",
+        )
+        .unwrap();
+
+        // 'legacy' = 6 bytes (l e g a c y).
+        let bytes = db.reclaimable_checkpoint_bytes("w1").unwrap();
+        assert_eq!(bytes, 6);
+    }
+
+    /// A workspace with no checkpoints (or checkpoints with no files)
+    /// reports 0 rather than failing — important so the cleanup UI can
+    /// surface "0 B" instead of `—` for brand-new archives.
+    #[test]
+    fn reclaimable_bytes_empty_workspace_returns_zero() {
+        let db = setup_db_with_workspace();
+        let bytes = db.reclaimable_checkpoint_bytes("w1").unwrap();
+        assert_eq!(bytes, 0);
     }
 }

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -7,7 +7,7 @@
 
 use std::fmt;
 
-use rusqlite::{OptionalExtension, params, types::Type};
+use rusqlite::{OptionalExtension, params, params_from_iter, types::Type};
 use sha2::{Digest, Sha256};
 
 use crate::model::{
@@ -437,6 +437,70 @@ impl Database {
         Ok(sole.saturating_add(legacy))
     }
 
+    /// Set-based generalization of [`Self::reclaimable_checkpoint_bytes`]:
+    /// bytes that would actually free if **all** workspaces in `ids` were
+    /// deleted together. A blob shared between two workspaces in the
+    /// set still counts once here (because both references go away),
+    /// even though it would correctly be excluded from each workspace's
+    /// per-row sole-owned count.
+    ///
+    /// Used by the cleanup dialog's "Delete selected (N · X MB)" total
+    /// so the headline figure stays accurate under dedup, while each
+    /// row's per-workspace figure remains the honest single-delete
+    /// number.
+    pub fn reclaimable_checkpoint_bytes_for_workspaces(
+        &self,
+        ids: &[&str],
+    ) -> rusqlite::Result<u64> {
+        if ids.is_empty() {
+            return Ok(0);
+        }
+
+        // Build `?,?,?` placeholders for both the IN (this set) and
+        // NOT IN (everything else) clauses. Bind `ids` twice via chain.
+        let placeholders = std::iter::repeat_n("?", ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let sole_sql = format!(
+            "SELECT COALESCE(SUM(cb.byte_size), 0)
+             FROM checkpoint_blobs cb
+             WHERE EXISTS (
+                 SELECT 1 FROM checkpoint_files cf
+                 JOIN conversation_checkpoints cc ON cc.id = cf.checkpoint_id
+                 WHERE cc.workspace_id IN ({placeholders})
+                   AND cf.blob_sha256 = cb.sha256
+             )
+             AND NOT EXISTS (
+                 SELECT 1 FROM checkpoint_files cf
+                 JOIN conversation_checkpoints cc ON cc.id = cf.checkpoint_id
+                 WHERE cc.workspace_id NOT IN ({placeholders})
+                   AND cf.blob_sha256 = cb.sha256
+             )"
+        );
+        let sole_owned: i64 = self.conn.query_row(
+            &sole_sql,
+            params_from_iter(ids.iter().chain(ids.iter())),
+            |row| row.get(0),
+        )?;
+
+        let legacy_sql = format!(
+            "SELECT COALESCE(SUM(LENGTH(cf.content)), 0)
+             FROM checkpoint_files cf
+             JOIN conversation_checkpoints cc ON cc.id = cf.checkpoint_id
+             WHERE cc.workspace_id IN ({placeholders})
+               AND cf.blob_sha256 IS NULL
+               AND cf.content IS NOT NULL"
+        );
+        let legacy_inline: i64 =
+            self.conn
+                .query_row(&legacy_sql, params_from_iter(ids.iter()), |row| row.get(0))?;
+
+        let sole = u64::try_from(sole_owned).unwrap_or(0);
+        let legacy = u64::try_from(legacy_inline).unwrap_or(0);
+        Ok(sole.saturating_add(legacy))
+    }
+
     /// Read snapshot rows for a checkpoint, materializing bytes from
     /// `checkpoint_blobs` via the `blob_sha256` reference. Legacy rows
     /// where `blob_sha256 IS NULL` fall back to the row's own `content`
@@ -524,6 +588,25 @@ impl Database {
              JOIN conversation_checkpoints cc ON cc.id = cf.checkpoint_id
              WHERE cc.workspace_id = ?1 AND cc.turn_index > ?2",
             params![workspace_id, turn_index],
+            |row| row.get(0),
+        )
+    }
+
+    /// Count `checkpoint_files` rows that will cascade away if the given
+    /// workspace is hard-deleted. The workspace delete path uses this as
+    /// the short-circuit signal for `gc_orphan_blobs_after_delete`: if
+    /// the workspace has no checkpoint files, the GC's full-table
+    /// `NOT EXISTS` scan is skipped.
+    pub(super) fn count_workspace_checkpoint_files(
+        &self,
+        workspace_id: &str,
+    ) -> Result<usize, rusqlite::Error> {
+        self.conn.query_row(
+            "SELECT COUNT(*)
+             FROM checkpoint_files cf
+             JOIN conversation_checkpoints cc ON cc.id = cf.checkpoint_id
+             WHERE cc.workspace_id = ?1",
+            params![workspace_id],
             |row| row.get(0),
         )
     }
@@ -1734,5 +1817,154 @@ mod tests {
         let db = setup_db_with_workspace();
         let bytes = db.reclaimable_checkpoint_bytes("w1").unwrap();
         assert_eq!(bytes, 0);
+    }
+
+    /// Codex peer-review pin: when two archived workspaces both
+    /// reference the same dedup blob, deleting them together must
+    /// reclaim that blob exactly once. The per-row sole-owned helper
+    /// would honestly report 0 for each (because the other still
+    /// references it), and naïvely summing the per-row numbers in the
+    /// UI would advertise a smaller-than-real reclaim. The set helper
+    /// is the correct math for the "Delete selected (N)" total.
+    #[test]
+    fn reclaimable_bytes_for_workspaces_counts_blobs_shared_within_set_once() {
+        let db = setup_db_with_workspace();
+        db.insert_workspace(&make_workspace("w2", "r1", "other")).unwrap();
+        let shared = vec![0x77u8; 800];
+
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        db.insert_checkpoint_files(&[raw_file("f1", "cp1", "shared.bin", &shared)])
+            .unwrap();
+
+        db.insert_chat_message(&make_chat_msg(&db, "m2", "w2", ChatRole::Assistant, "b"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp2", "w2", "m2", 0))
+            .unwrap();
+        db.insert_checkpoint_files(&[raw_file("f2", "cp2", "shared.bin", &shared)])
+            .unwrap();
+        assert_eq!(blob_count(&db), 1);
+
+        // Per-row sole-owned excludes shared blob from BOTH workspaces.
+        assert_eq!(db.reclaimable_checkpoint_bytes("w1").unwrap(), 0);
+        assert_eq!(db.reclaimable_checkpoint_bytes("w2").unwrap(), 0);
+
+        // Set-based version counts it once when both are in the set.
+        let set_bytes = db
+            .reclaimable_checkpoint_bytes_for_workspaces(&["w1", "w2"])
+            .unwrap();
+        assert_eq!(set_bytes, shared.len() as u64);
+    }
+
+    /// A blob shared with a workspace OUTSIDE the deletion set must not
+    /// count — the GC's `NOT EXISTS` predicate would leave it in place.
+    #[test]
+    fn reclaimable_bytes_for_workspaces_excludes_blobs_referenced_outside_set() {
+        let db = setup_db_with_workspace();
+        db.insert_workspace(&make_workspace("w2", "r1", "second")).unwrap();
+        db.insert_workspace(&make_workspace("w3", "r1", "third")).unwrap();
+        let shared = vec![0x33u8; 500];
+        let unique_to_w1 = vec![0x11u8; 200];
+
+        // w1 owns one blob outright and shares another with w3 (NOT in
+        // the deletion set).
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        db.insert_checkpoint_files(&[
+            raw_file("f1a", "cp1", "shared.bin", &shared),
+            raw_file("f1b", "cp1", "unique.bin", &unique_to_w1),
+        ])
+        .unwrap();
+
+        db.insert_chat_message(&make_chat_msg(&db, "m3", "w3", ChatRole::Assistant, "c"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp3", "w3", "m3", 0))
+            .unwrap();
+        db.insert_checkpoint_files(&[raw_file("f3", "cp3", "shared.bin", &shared)])
+            .unwrap();
+
+        // Deletion set is {w1, w2}. The shared blob survives because
+        // w3 still references it; only unique_to_w1 reclaims.
+        let bytes = db
+            .reclaimable_checkpoint_bytes_for_workspaces(&["w1", "w2"])
+            .unwrap();
+        assert_eq!(bytes, unique_to_w1.len() as u64);
+    }
+
+    /// Empty set returns 0 cleanly — the set helper must not panic on
+    /// "no selection" (placeholders-with-0-args would be invalid SQL).
+    #[test]
+    fn reclaimable_bytes_for_workspaces_empty_set_returns_zero() {
+        let db = setup_db_with_workspace();
+        let bytes = db.reclaimable_checkpoint_bytes_for_workspaces(&[]).unwrap();
+        assert_eq!(bytes, 0);
+    }
+
+    /// Codex peer-review pin: deleting a workspace must reclaim its
+    /// sole-owned checkpoint blobs in the same call. Without orphan-blob
+    /// GC chained onto the workspace delete path, the FK cascade drops
+    /// `checkpoint_files` references but the blob bytes in
+    /// `checkpoint_blobs` survive until some unrelated future GC pass.
+    /// That would make `reclaimable_checkpoint_bytes` lie to the cleanup
+    /// dialog — bytes shown as freeable wouldn't actually free.
+    #[test]
+    fn delete_workspace_with_summary_orphan_gcs_blobs() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        db.insert_checkpoint_files(&[raw_file("f1", "cp1", "x.bin", b"unique-to-w1")])
+            .unwrap();
+        assert_eq!(blob_count(&db), 1);
+
+        db.delete_workspace_with_summary("w1").unwrap();
+
+        assert_eq!(checkpoint_files_count(&db), 0);
+        assert_eq!(
+            blob_count(&db),
+            0,
+            "delete_workspace_with_summary must orphan-GC blobs whose only references were the deleted workspace's checkpoint_files"
+        );
+    }
+
+    /// Blobs shared with a workspace that is NOT being deleted must
+    /// survive. Same SQL contract as `gc_orphan_blobs_tx`: only blobs
+    /// with zero remaining references go away. Pins the symmetry with
+    /// `reclaimable_checkpoint_bytes_excludes_blobs_shared_with_other_workspaces`
+    /// — the helper excludes shared blobs from the reclaim count AND
+    /// the GC leaves them in place.
+    #[test]
+    fn delete_workspace_with_summary_keeps_blobs_shared_with_others() {
+        let db = setup_db_with_workspace();
+        db.insert_workspace(&make_workspace("w2", "r1", "other")).unwrap();
+        let shared = b"shared-bytes";
+
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        db.insert_checkpoint_files(&[raw_file("f1", "cp1", "shared.bin", shared)])
+            .unwrap();
+
+        db.insert_chat_message(&make_chat_msg(&db, "m2", "w2", ChatRole::Assistant, "b"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp2", "w2", "m2", 0))
+            .unwrap();
+        db.insert_checkpoint_files(&[raw_file("f2", "cp2", "shared.bin", shared)])
+            .unwrap();
+        assert_eq!(blob_count(&db), 1, "dedupe collapses to one blob");
+
+        db.delete_workspace_with_summary("w1").unwrap();
+
+        assert_eq!(
+            blob_count(&db),
+            1,
+            "shared blob must survive because w2 still references it"
+        );
     }
 }

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -1748,7 +1748,8 @@ mod tests {
         let db = setup_db_with_workspace();
         // Add a second workspace under the same repo so both can hold
         // checkpoints in parallel.
-        db.insert_workspace(&make_workspace("w2", "r1", "other")).unwrap();
+        db.insert_workspace(&make_workspace("w2", "r1", "other"))
+            .unwrap();
 
         // Workspace A: cp1 with two file rows — one unique blob, one
         // shared with B.
@@ -1829,7 +1830,8 @@ mod tests {
     #[test]
     fn reclaimable_bytes_for_workspaces_counts_blobs_shared_within_set_once() {
         let db = setup_db_with_workspace();
-        db.insert_workspace(&make_workspace("w2", "r1", "other")).unwrap();
+        db.insert_workspace(&make_workspace("w2", "r1", "other"))
+            .unwrap();
         let shared = vec![0x77u8; 800];
 
         db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a"))
@@ -1863,8 +1865,10 @@ mod tests {
     #[test]
     fn reclaimable_bytes_for_workspaces_excludes_blobs_referenced_outside_set() {
         let db = setup_db_with_workspace();
-        db.insert_workspace(&make_workspace("w2", "r1", "second")).unwrap();
-        db.insert_workspace(&make_workspace("w3", "r1", "third")).unwrap();
+        db.insert_workspace(&make_workspace("w2", "r1", "second"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w3", "r1", "third"))
+            .unwrap();
         let shared = vec![0x33u8; 500];
         let unique_to_w1 = vec![0x11u8; 200];
 
@@ -1941,7 +1945,8 @@ mod tests {
     #[test]
     fn delete_workspace_with_summary_keeps_blobs_shared_with_others() {
         let db = setup_db_with_workspace();
-        db.insert_workspace(&make_workspace("w2", "r1", "other")).unwrap();
+        db.insert_workspace(&make_workspace("w2", "r1", "other"))
+            .unwrap();
         let shared = b"shared-bytes";
 
         db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a"))

--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -497,12 +497,21 @@ impl Database {
 
     /// Hard-delete a workspace, materializing a frozen summary row first so
     /// lifetime dashboard stats survive the cascade.
+    ///
+    /// The FK chain cascades to `checkpoint_files`, but blob bytes in
+    /// `checkpoint_blobs` are only reclaimed by an explicit orphan-GC
+    /// pass. Without that pass the delete would leave bytes behind that
+    /// `compute_storage_stats` already advertised as reclaimable — so we
+    /// snapshot the cascade-row count inside the transaction and run GC
+    /// once the rows are gone.
     pub fn delete_workspace_with_summary(&self, id: &str) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
         Self::materialize_workspace_summary_tx(&tx, id)?;
+        let file_rows = self.count_workspace_checkpoint_files(id)?;
         let deleted = tx.execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
         tx.commit()?;
-        self.best_effort_incremental_vacuum_after_delete(deleted);
+        self.gc_orphan_blobs_after_delete(file_rows);
+        self.best_effort_incremental_vacuum_after_delete(file_rows + deleted);
         Ok(())
     }
 
@@ -553,9 +562,11 @@ impl Database {
             return Ok(false);
         }
         Self::materialize_workspace_summary_tx(&tx, id)?;
+        let file_rows = self.count_workspace_checkpoint_files(id)?;
         let deleted = tx.execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
         tx.commit()?;
-        self.best_effort_incremental_vacuum_after_delete(deleted);
+        self.gc_orphan_blobs_after_delete(file_rows);
+        self.best_effort_incremental_vacuum_after_delete(file_rows + deleted);
         Ok(true)
     }
 
@@ -660,10 +671,12 @@ impl Database {
     }
 
     pub fn delete_workspace(&self, id: &str) -> Result<(), rusqlite::Error> {
+        let file_rows = self.count_workspace_checkpoint_files(id)?;
         let deleted = self
             .conn
             .execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
-        self.best_effort_incremental_vacuum_after_delete(deleted);
+        self.gc_orphan_blobs_after_delete(file_rows);
+        self.best_effort_incremental_vacuum_after_delete(file_rows + deleted);
         Ok(())
     }
 }

--- a/src/ui/src/components/modals/BulkCleanupArchivedModal.tsx
+++ b/src/ui/src/components/modals/BulkCleanupArchivedModal.tsx
@@ -5,6 +5,7 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   cancelWorkspacesBulk,
+  computeReclaimableBytesForWorkspaces,
   computeStorageStats,
   deleteWorkspacesBulk,
   type BulkCleanupProgress,
@@ -150,6 +151,21 @@ export function BulkCleanupArchivedModal() {
   const [backendArchivedIds, setBackendArchivedIds] = useState<Set<
     string
   > | null>(null);
+  // Set-aware reclaimable-bytes total for the current selection. The
+  // per-row `sizeById` figure is each workspace's *sole-owned* bytes,
+  // which is the honest single-delete number but undercounts when two
+  // selected workspaces share a dedup blob (each row excludes the
+  // shared blob, so naïvely summing them excludes it twice even though
+  // deleting both actually reclaims one copy). This state holds the
+  // backend's set-based reclaim figure for the current selection so
+  // the headline "N · X MB" total stays accurate under dedup.
+  //
+  // `null` means "no backend value yet" — the display falls back to
+  // the client-side sole-owned sum (always a lower bound on the truth)
+  // until the call resolves or fails.
+  const [setReclaimableBytes, setSetReclaimableBytes] = useState<
+    number | null
+  >(null);
   // Re-scan whenever the set of archived ids in the store changes —
   // catches the moment an in-flight archive resolves and the
   // `useWorkspaceLifecycle.archive` optimistic update is confirmed by
@@ -240,6 +256,40 @@ export function BulkCleanupArchivedModal() {
 
   const allEligibleSelected =
     eligible.length > 0 && effectiveSelection.size === eligible.length;
+
+  // Refresh the backend-computed set-reclaim figure whenever the user
+  // changes the selection. The join key keeps the dependency stable so
+  // a Set instance swap with the same contents doesn't refire — only
+  // actual selection changes do. `cancelled` guards against the user
+  // toggling rapidly: if a newer call has started, drop the stale
+  // result instead of clobbering the current one.
+  const selectionJoin = useMemo(
+    () => [...effectiveSelection].sort().join(","),
+    [effectiveSelection],
+  );
+  useEffect(() => {
+    if (effectiveSelection.size === 0) {
+      setSetReclaimableBytes(0);
+      return;
+    }
+    let cancelled = false;
+    computeReclaimableBytesForWorkspaces([...effectiveSelection])
+      .then((n) => {
+        if (!cancelled) setSetReclaimableBytes(n);
+      })
+      .catch(() => {
+        // Backend failure → drop back to the client-side sum
+        // (rendered when this state is null in the counter below).
+        if (!cancelled) setSetReclaimableBytes(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // selectionJoin captures the selection set's identity; the Set
+    // itself is recreated on every render so listing it directly
+    // would refire every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectionJoin]);
 
   // Workspaces rendered during a run come from `runIds` (the dispatched
   // snapshot) — we look up each id in `workspaces` to get the row data.
@@ -684,11 +734,19 @@ export function BulkCleanupArchivedModal() {
               <>
                 {" · "}
                 {t("bulk_cleanup_selected_size", {
+                  // Prefer the backend's set-aware figure when it has
+                  // resolved; otherwise the client-side sole-owned sum
+                  // is shown as a graceful loading / fallback value.
+                  // The client sum is a lower bound on the truth (it
+                  // double-excludes blobs shared within the selection),
+                  // so flashing it briefly is safe — the number can
+                  // only tick up when the backend value arrives.
                   size: formatBytes(
-                    [...effectiveSelection].reduce(
-                      (sum, id) => sum + (sizeById.get(id) ?? 0),
-                      0,
-                    ),
+                    setReclaimableBytes ??
+                      [...effectiveSelection].reduce(
+                        (sum, id) => sum + (sizeById.get(id) ?? 0),
+                        0,
+                      ),
                   ),
                 })}
               </>

--- a/src/ui/src/components/modals/BulkCleanupArchivedModal.tsx
+++ b/src/ui/src/components/modals/BulkCleanupArchivedModal.tsx
@@ -162,10 +162,12 @@ export function BulkCleanupArchivedModal() {
   //
   // `null` means "no backend value yet" — the display falls back to
   // the client-side sole-owned sum (always a lower bound on the truth)
-  // until the call resolves or fails.
-  const [setReclaimableBytes, setSetReclaimableBytes] = useState<
-    number | null
-  >(null);
+  // until the call resolves or fails. The selection-change effect
+  // resets this to `null` on every selection transition so a stale
+  // value from a previous selection never leaks into the new one.
+  const [reclaimableBytes, setReclaimableBytes] = useState<number | null>(
+    null,
+  );
   // Re-scan whenever the set of archived ids in the store changes —
   // catches the moment an in-flight archive resolves and the
   // `useWorkspaceLifecycle.archive` optimistic update is confirmed by
@@ -269,18 +271,27 @@ export function BulkCleanupArchivedModal() {
   );
   useEffect(() => {
     if (effectiveSelection.size === 0) {
-      setSetReclaimableBytes(0);
+      setReclaimableBytes(0);
       return;
     }
+    // Reset to `null` immediately so the counter falls back to the
+    // client-side sole-owned sum for the new selection instead of
+    // continuing to render the previous selection's total. Without
+    // this, deselecting rows could appear to *increase* the total
+    // briefly (stale higher number lingers until the new call
+    // resolves), contradicting the lower-bound-until-resolved
+    // semantic the counter relies on.
+    setReclaimableBytes(null);
     let cancelled = false;
     computeReclaimableBytesForWorkspaces([...effectiveSelection])
       .then((n) => {
-        if (!cancelled) setSetReclaimableBytes(n);
+        if (!cancelled) setReclaimableBytes(n);
       })
       .catch(() => {
-        // Backend failure → drop back to the client-side sum
-        // (rendered when this state is null in the counter below).
-        if (!cancelled) setSetReclaimableBytes(null);
+        // Backend failure → leave it `null` so the counter keeps
+        // rendering the client-side sole-owned sum as a graceful
+        // degradation.
+        if (!cancelled) setReclaimableBytes(null);
       });
     return () => {
       cancelled = true;
@@ -742,7 +753,7 @@ export function BulkCleanupArchivedModal() {
                   // so flashing it briefly is safe — the number can
                   // only tick up when the backend value arrives.
                   size: formatBytes(
-                    setReclaimableBytes ??
+                    reclaimableBytes ??
                       [...effectiveSelection].reduce(
                         (sum, id) => sum + (sizeById.get(id) ?? 0),
                         0,

--- a/src/ui/src/services/tauri/storage.ts
+++ b/src/ui/src/services/tauri/storage.ts
@@ -27,6 +27,19 @@ export function computeStorageStats(): Promise<RepoStorageStats[]> {
   return invoke("compute_storage_stats");
 }
 
+/**
+ * Bytes that would actually free if every workspace in `workspaceIds`
+ * were deleted together — dedup-aware. A blob shared between two
+ * workspaces in the set still counts once here. Use this for the
+ * cleanup dialog's "Delete selected" total, not a client-side sum of
+ * per-workspace sole-owned figures.
+ */
+export function computeReclaimableBytesForWorkspaces(
+  workspaceIds: string[],
+): Promise<number> {
+  return invoke("compute_reclaimable_bytes_for_workspaces", { workspaceIds });
+}
+
 export function scanOrphanedWorktrees(): Promise<OrphanedWorktree[]> {
   return invoke("scan_orphaned_worktrees");
 }


### PR DESCRIPTION
## Summary

The "Clean up archived workspaces across all repositories" dialog (and its per-repo twin, which is the same React component invoked with a `repoId`) displayed `—` for every row instead of a byte count. Archiving a workspace runs `git worktree remove` and nulls `workspaces.worktree_path`, so by the time the dialog opens there's nothing on disk for `directory_size_bytes` to walk.

This PR replaces that em-dash with a meaningful number: the bytes the workspace would actually reclaim from the checkpoint store on delete — sole-owned content-addressed blobs (from the recent dedup work in b70fbd66) plus inline legacy `checkpoint_files.content`.

It also closes two follow-ups raised in Codex peer review of the first commit:

1. **The workspace-delete path didn't actually reclaim the bytes** the new display was advertising. `delete_workspace_with_summary` / `try_delete_archived_workspace_with_summary` / `delete_workspace` relied on the FK cascade alone, which dropped `checkpoint_files` rows but left `checkpoint_blobs` bytes parked in `data.db` until some unrelated future GC pass. Each path now snapshots the cascade row count inside its transaction and chains `gc_orphan_blobs_after_delete` + a sized incremental vacuum, matching what `delete_checkpoint` already does for single-checkpoint deletes.

2. **The "Delete selected (N · X MB)" total undercounted shared dedup blobs.** The per-row helper honestly returns *sole-owned* bytes (the right number for a single delete), but summing per-row figures excludes a blob shared between two selected workspaces from BOTH rows even though deleting both reclaims one copy. A new set-based helper + Tauri command + selection-driven effect in the modal computes the headline figure correctly under dedup. Per-row size column keeps the per-workspace sole-owned number; the client-side sum stays as a loading fallback.

## What changed

**Backend (`claudette` lib)**
- `Database::reclaimable_checkpoint_bytes(workspace_id)` — sole-owned blob bytes + legacy inline content for one workspace. Used by `compute_storage_stats` as the fallback when `worktree_path` is absent or its dir doesn't exist on disk.
- `Database::reclaimable_checkpoint_bytes_for_workspaces(&[ids])` — set-based generalization. A blob shared *within* the set counts once; a blob shared with a workspace *outside* the set is excluded (matches `gc_orphan_blobs_tx` semantics — only blobs that would actually free are counted). Builds dynamic `IN`/`NOT IN` placeholders via `params_from_iter`.
- `Database::count_workspace_checkpoint_files(workspace_id)` — short-circuit signal so the GC's full-table `NOT EXISTS` scan is skipped on workspaces with no checkpoint history.
- `delete_workspace_with_summary`, `try_delete_archived_workspace_with_summary`, `delete_workspace` now count cascade rows inside their transaction and chain `gc_orphan_blobs_after_delete` + sized vacuum after commit.

**Tauri commands (`claudette-tauri`)**
- `compute_storage_stats` — every workspace now gets a `spawn_blocking` task that walks the worktree when present, else opens a fresh `Database` connection and computes reclaimable checkpoint bytes. `WorkspaceStorageEntry.size_bytes` is `Some(0)` instead of `None` for empty archived workspaces (more informative than `—`). Repo aggregates (`archived_bytes`, `total_bytes`) include the reclaimable storage automatically.
- New `compute_reclaimable_bytes_for_workspaces(workspace_ids)` command exposing the set-based helper, registered in `main.rs` invoke_handler.

**Frontend (`src/ui`)**
- `services/tauri/storage.ts` — `computeReclaimableBytesForWorkspaces(ids)` wrapper.
- `BulkCleanupArchivedModal.tsx`:
  - New `setReclaimableBytes` state.
  - Effect keyed off a sorted `selectionJoin` string that calls the backend on every selection change with a `cancelled` guard against rapid toggles.
  - Headline `"Delete selected (N · X MB)"` total prefers the backend's set-aware figure and falls back to the client-side sole-owned sum while loading or on error.
  - Per-row size column (`sizeById.get(ws.id)`) keeps the per-workspace sole-owned number for the honest single-delete signal.

## Test plan

Verified locally before push:

- [x] `nix develop -c cargo test -p claudette --lib -- db::checkpoint::tests` — **all 31 tests pass** including 8 new ones:
  - `reclaimable_bytes_excludes_blobs_shared_with_other_workspaces`
  - `reclaimable_bytes_counts_legacy_inline_content`
  - `reclaimable_bytes_empty_workspace_returns_zero`
  - `reclaimable_bytes_for_workspaces_counts_blobs_shared_within_set_once`
  - `reclaimable_bytes_for_workspaces_excludes_blobs_referenced_outside_set`
  - `reclaimable_bytes_for_workspaces_empty_set_returns_zero`
  - `delete_workspace_with_summary_orphan_gcs_blobs`
  - `delete_workspace_with_summary_keeps_blobs_shared_with_others`
- [x] `nix develop -c cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` — warning-free.
- [x] `cd src/ui && nix develop ../.. -c bunx tsc -b` — clean.

UAT remaining (left for reviewer / merge time, since UI testing wants a fresh dev build):

- [ ] Archive a workspace with checkpoint history → open Storage settings → the per-repo "archived" pill shows non-zero size.
- [ ] Per-repo Cleanup dialog: rows show reclaimable bytes (not `—`).
- [ ] Cross-repo "Clean up archived workspaces across all repositories" dialog: rows show reclaimable bytes.
- [ ] Brand-new archived workspace with no checkpoints shows `0 B` (intentional — accurate "nothing to reclaim" signal).
- [ ] Select two archived workspaces whose checkpoints share a blob (e.g. a fork pair). The headline "Delete selected (2 · X MB)" total should be larger than the sum of the two per-row figures.
- [ ] Click Delete on a workspace with checkpoint blobs. After the run, `data.db` actually shrinks (run `du -h ~/.claudette/data.db` before and after).

## Notes for review

- Scope intentionally excludes `delete_repository_with_summaries`, which has the same FK-cascade-without-GC pattern. Same root cause but independent of this PR's user-facing entry point. Worth a follow-up.
- The two commits stack: 9655fc2c is the user-visible fix; bd30baf5 addresses Codex's two P2 findings on it. Kept as separate commits for readable history.
- No schema migration; no new columns. All queries hit existing indexes (`idx_checkpoint_files_blob_sha256`, `idx_checkpoints_workspace_created_at`).