### PR TITLE
feat(terminal): search scrollback with Cmd/Ctrl+F

### DIFF
--- a/site/src/content/docs/features/integrated-terminal.mdx
+++ b/site/src/content/docs/features/integrated-terminal.mdx
@@ -70,6 +70,12 @@ Agent subprocesses use the same separation. In a Nix devshell workspace, Claudet
 
 Adjust the terminal font size in `Settings > Appearance > Terminal font size` (range: 8–32px, default: 11px). Press `⌘/Ctrl + Shift + =` or `⌘/Ctrl + Shift + -` to scale only the terminal without changing the rest of the UI.
 
+## Search Scrollback
+
+Press `⌘/Ctrl + F` while a terminal pane has focus to open an in-panel search bar for that pane's scrollback. Enter steps to the next match; `Shift + Enter` steps to the previous one; `Esc` closes the bar. The same shortcut still searches the active chat transcript when focus is elsewhere — it routes by which surface owns the keystroke, not by which panel is visible.
+
+The keybinding is rebindable from `Settings > Keyboard > Terminal > Search terminal scrollback` independently of the chat search hotkey, so you can split the two if you prefer.
+
 ## Environment Variables
 
 Every terminal session has [workspace environment variables](/claudette/features/settings/#environment-variables) set automatically — `$CLAUDETTE_WORKSPACE_NAME`, `$CLAUDETTE_WORKSPACE_PATH`, `$CLAUDETTE_ROOT_PATH`, and others. These are useful for scripts and tools that need to know which workspace they're running in.

--- a/site/src/content/docs/features/keyboard-shortcuts.mdx
+++ b/site/src/content/docs/features/keyboard-shortcuts.mdx
@@ -42,6 +42,7 @@ To switch between workspaces in the same project, click them in the sidebar or u
 | `⌘/Ctrl + P` | Go to file — Quick Open the workspace file picker |
 | `⌘/Ctrl + O` | Go to file (alternate). Kept after the Cmd+P swap so existing muscle memory still works; rebindable / disable-able in **Settings → Keyboard**. |
 | `⌘/Ctrl + Shift + P` | Toggle command palette |
+| `⌘/Ctrl + F` | Search — opens the terminal scrollback search bar when a terminal pane is focused, otherwise searches the active chat transcript |
 | `⌘/Ctrl + /` | Show the keyboard-shortcuts reference |
 | `⌘/Ctrl + 0` | Toggle focus between the chat input and the active terminal pane |
 
@@ -104,6 +105,7 @@ terminal is focused; Linux/Windows keep bare `Ctrl+D` for shell EOF and use
 | `⌘⌥←/→/↑/↓` (macOS) / `Ctrl+Alt+arrow` (Linux) | Move focus to the neighboring pane |
 | `⌘T` (macOS) / `Ctrl+Shift+T` (Linux) | New terminal tab |
 | `⌘⇧[` / `⌘⇧]` | Previous / next terminal tab |
+| `⌘/Ctrl + F` | Search the active pane's scrollback — opens an in-panel bar with match counter and next/prev controls |
 | `⌘/Ctrl + =` / `⌘/Ctrl + -` | Global UI zoom; terminal intercepts the keys so they do not reach the shell |
 | `⌘/Ctrl + Shift + =` / `⌘/Ctrl + Shift + -` | Terminal font size only |
 

--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -14,6 +14,7 @@
         "@tauri-apps/plugin-updater": "^2.10.1",
         "@types/qrcode": "^1.5.6",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
@@ -396,6 +397,8 @@
     "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/addon-search": ["@xterm/addon-search@0.16.0", "", {}, "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA=="],
 
     "@xterm/addon-unicode11": ["@xterm/addon-unicode11@0.9.0", "", {}, "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw=="],
 

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -24,6 +24,7 @@
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@types/qrcode": "^1.5.6",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",

--- a/src/ui/scripts/check-css-tokens.mjs
+++ b/src/ui/scripts/check-css-tokens.mjs
@@ -12,6 +12,11 @@
 //     `utils/theme.ts` for the rare case a token is missing from the
 //     computed style (e.g. before the stylesheet loads). The fallback
 //     must match a token that already exists in theme.css.
+//   * `ensureHexColor(value, "#fallback")` — validation helper in
+//     `utils/theme.ts` that rejects non-hex CSS values resolved from
+//     custom properties (user JSON themes can override accent tokens
+//     with `rgb()`/`hsl()`/`color-mix()`, formats the xterm search
+//     addon silently rejects). Fallback must mirror a token in theme.css.
 //   * `accentPreview: "#..."` — mirror of a theme's `--accent-primary`
 //     hex in `styles/themes/index.ts`, consumed by CommandPalette to
 //     render theme swatches without a runtime style lookup. Each entry
@@ -68,6 +73,12 @@ const HEX_EXCLUSIONS = [
   // CSS custom properties to Monaco's hex-requiring API and needs
   // literal fallbacks that mirror `:root`.
   /\bresolve\("--[a-z-]+",\s*[^)]*"#/,
+  // `ensureHexColor(value, "#fallback")` — validation helper in theme.ts
+  // that rejects non-hex CSS values (user JSON themes can override accent
+  // tokens with rgb/hsl/color-mix; the xterm search addon silently fails
+  // on non-hex). The literal fallback must mirror a token already in
+  // theme.css.
+  /\bensureHexColor\([^,]+,\s*"#/,
   // `accentPreview: "#..."` / `accent_preview: "#..."`
   /(accentPreview|accent_preview):\s*"#/,
   // GitHub issue / PR number reference: `issue #896`, `PR #905`,

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -12,6 +12,7 @@ import {
 import { createPortal } from "react-dom";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { listen } from "@tauri-apps/api/event";
@@ -59,6 +60,7 @@ import {
 } from "../../utils/focusTargets";
 import { TerminalEnvOverlay } from "./TerminalEnvOverlay";
 import { TerminalPaneTree } from "./TerminalPaneTree";
+import { TerminalSearchBar } from "./TerminalSearchBar";
 import type { TerminalTab } from "../../types/terminal";
 import {
   collectNeededLeaves,
@@ -155,6 +157,7 @@ interface LeafInstance {
   container: HTMLDivElement;
   term: Terminal;
   fit: FitAddon;
+  search: SearchAddon;
   ptyId: number;
   isAgentTask: boolean;
   agentTaskTailPath: string | null;
@@ -480,6 +483,17 @@ export const TerminalPanel = memo(function TerminalPanel() {
     height: number;
     title: string;
   } | null>(null);
+  // Per-panel search bar visibility + query. State is panel-local rather than
+  // panel-per-pane: the bar lives at the top of the visible pane, so there
+  // is exactly one bar in flight at a time. The query string survives close
+  // → re-open within the same session so re-firing Cmd+F doesn't lose what
+  // the user just typed.
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  // Bumped on every Cmd+F press so the search bar re-focuses (and selects)
+  // its input even when the bar is already open. Without this, hitting
+  // Cmd+F after clicking back into the pane would feel like a no-op.
+  const [searchFocusToken, setSearchFocusToken] = useState(0);
 
   const autoCreatedRef = useRef<string | null>(null);
   // Tracks the last (tabId, leafId, visible) tuple we applied keyboard
@@ -929,6 +943,13 @@ export const TerminalPanel = memo(function TerminalPanel() {
             .catch(() => {});
           return;
         }
+        case "open-search": {
+          setSearchOpen(true);
+          // Re-focus the input even when the bar is already open — the user
+          // may have clicked back into the pane between Cmd+F presses.
+          setSearchFocusToken((token) => token + 1);
+          return;
+        }
       }
     },
     [
@@ -1003,8 +1024,15 @@ export const TerminalPanel = memo(function TerminalPanel() {
       const links = new WebLinksAddon((_event, url) => {
         void openUrl(url);
       });
+      // Search addon: surfaces decorations for matches in scrollback and
+      // exposes findNext/findPrevious + onDidChangeResults. Match colors
+      // come from the active theme's --terminal-search-* tokens (see
+      // theme.css). Each pane gets its own addon — searches are scoped
+      // to a single xterm buffer, so we cannot share one across panes.
+      const search = new SearchAddon();
       term.loadAddon(fit);
       term.loadAddon(links);
+      term.loadAddon(search);
       // xterm.js defaults to Unicode 6 width tables, where most emoji
       // (including starship's status glyphs — 💀, 🔋, etc.) are 1 cell.
       // PSReadLine, ConPTY, Windows Terminal, iTerm2, and pretty much
@@ -1068,6 +1096,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
         container,
         term,
         fit,
+        search,
         ptyId: -1,
         isAgentTask:
           Object.values(terminalTabs)
@@ -1725,6 +1754,46 @@ export const TerminalPanel = memo(function TerminalPanel() {
     [setPaneSpawnError, destroyInstance],
   );
 
+  // Auto-close the search bar if the user switches to a different terminal
+  // tab or hides the panel — the bar is anchored to whichever pane was
+  // visible when they opened it, so leaving that context should clear it.
+  useEffect(() => {
+    if (!terminalPanelVisible && searchOpen) setSearchOpen(false);
+  }, [terminalPanelVisible, searchOpen]);
+  useEffect(() => {
+    // Active tab / pane changing invalidates the search's addon target.
+    // Closing is simpler than re-running findNext on the new pane with the
+    // old query — the user can re-trigger Cmd+F if they want to keep going.
+    setSearchOpen(false);
+  }, [activeTerminalTabId, selectedWorkspaceId]);
+
+  const handleCloseSearch = useCallback(() => {
+    setSearchOpen(false);
+    // Clear decorations on the active addon so the highlights don't linger
+    // after the bar closes. clearActiveDecoration would only drop the
+    // current-match ring; clearDecorations drops the full match set.
+    const tabId = activeTerminalTabId;
+    const paneId = tabId ? activeTerminalPaneId[tabId] ?? null : null;
+    const inst = paneId ? instancesRef.current.get(paneId) : null;
+    inst?.search.clearDecorations();
+    requestAnimationFrame(() => focusActiveTerminal());
+  }, [activeTerminalTabId, activeTerminalPaneId]);
+
+  // Resolve the active pane's search addon at render time so the bar always
+  // operates on whichever pane currently owns focus. `searchFocusToken`
+  // participates so a Cmd+F press also re-resolves — useful right after a
+  // pane is created (the LeafInstance lands in instancesRef imperatively,
+  // outside React state). ESLint can't see why the token is read; the read
+  // is the point.
+  const activeSearchAddon = useMemo<SearchAddon | null>(() => {
+    void searchFocusToken;
+    if (!searchOpen) return null;
+    const tabId = activeTerminalTabId;
+    const paneId = tabId ? activeTerminalPaneId[tabId] ?? null : null;
+    const inst = paneId ? instancesRef.current.get(paneId) : null;
+    return inst?.search ?? null;
+  }, [searchOpen, activeTerminalTabId, activeTerminalPaneId, searchFocusToken]);
+
   return (
     <div className={styles.panel}>
       <TerminalEnvOverlay workspaceId={selectedWorkspaceId} />
@@ -1806,6 +1875,15 @@ export const TerminalPanel = memo(function TerminalPanel() {
         </button>
       </div>
       <div className={styles.termContainer}>
+        {searchOpen && (
+          <TerminalSearchBar
+            addon={activeSearchAddon}
+            query={searchQuery}
+            onQueryChange={setSearchQuery}
+            onClose={handleCloseSearch}
+            focusToken={searchFocusToken}
+          />
+        )}
         {tabs.map((tab) => {
           const tree = terminalPaneTrees[tab.id];
           if (!tree) return null;

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -1754,30 +1754,54 @@ export const TerminalPanel = memo(function TerminalPanel() {
     [setPaneSpawnError, destroyInstance],
   );
 
+  // Tracks the leaf the search addon was last attached to. The auto-close
+  // effects need this because by the time they fire, `activeTerminalPaneId`
+  // already points at the NEW pane — we'd otherwise clear decorations on
+  // the wrong instance (or none at all) and the highlights would linger in
+  // the pane the user just navigated away from.
+  const searchActiveLeafRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!searchOpen) {
+      searchActiveLeafRef.current = null;
+      return;
+    }
+    const tabId = activeTerminalTabId;
+    const paneId = tabId ? activeTerminalPaneId[tabId] ?? null : null;
+    if (paneId) searchActiveLeafRef.current = paneId;
+  }, [searchOpen, activeTerminalTabId, activeTerminalPaneId]);
+
+  const clearActiveSearchDecorations = useCallback(() => {
+    const leafId = searchActiveLeafRef.current;
+    if (!leafId) return;
+    instancesRef.current.get(leafId)?.search.clearDecorations();
+    searchActiveLeafRef.current = null;
+  }, []);
+
   // Auto-close the search bar if the user switches to a different terminal
   // tab or hides the panel — the bar is anchored to whichever pane was
   // visible when they opened it, so leaving that context should clear it.
   useEffect(() => {
-    if (!terminalPanelVisible && searchOpen) setSearchOpen(false);
-  }, [terminalPanelVisible, searchOpen]);
+    if (!terminalPanelVisible && searchOpen) {
+      clearActiveSearchDecorations();
+      setSearchOpen(false);
+    }
+  }, [terminalPanelVisible, searchOpen, clearActiveSearchDecorations]);
   useEffect(() => {
     // Active tab / pane changing invalidates the search's addon target.
     // Closing is simpler than re-running findNext on the new pane with the
     // old query — the user can re-trigger Cmd+F if they want to keep going.
+    clearActiveSearchDecorations();
     setSearchOpen(false);
-  }, [activeTerminalTabId, selectedWorkspaceId]);
+  }, [activeTerminalTabId, selectedWorkspaceId, clearActiveSearchDecorations]);
 
   const handleCloseSearch = useCallback(() => {
     setSearchOpen(false);
-    // Clear decorations on the active addon so the highlights don't linger
-    // after the bar closes. clearActiveDecoration would only drop the
-    // current-match ring; clearDecorations drops the full match set.
-    const tabId = activeTerminalTabId;
-    const paneId = tabId ? activeTerminalPaneId[tabId] ?? null : null;
-    const inst = paneId ? instancesRef.current.get(paneId) : null;
-    inst?.search.clearDecorations();
+    // clearActiveDecoration would only drop the current-match ring;
+    // clearDecorations drops the full match set, which is what we want
+    // when the bar is dismissed.
+    clearActiveSearchDecorations();
     requestAnimationFrame(() => focusActiveTerminal());
-  }, [activeTerminalTabId, activeTerminalPaneId]);
+  }, [clearActiveSearchDecorations]);
 
   // Resolve the active pane's search addon at render time so the bar always
   // operates on whichever pane currently owns focus. `searchFocusToken`

--- a/src/ui/src/components/terminal/TerminalSearchBar.module.css
+++ b/src/ui/src/components/terminal/TerminalSearchBar.module.css
@@ -1,0 +1,65 @@
+.bar {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  background: var(--sidebar-bg);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(8px);
+}
+
+.input {
+  width: 200px;
+  height: 24px;
+  padding: 0 8px;
+  background: var(--chat-input-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 1px var(--accent-bg-strong);
+}
+
+.counter {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 56px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: transparent;
+  color: var(--text-muted);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.iconButton:hover:not(:disabled) {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}
+
+.iconButton:disabled {
+  opacity: 0.4;
+  cursor: default;
+}

--- a/src/ui/src/components/terminal/TerminalSearchBar.tsx
+++ b/src/ui/src/components/terminal/TerminalSearchBar.tsx
@@ -1,9 +1,18 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, ChevronUp, X } from "lucide-react";
 import type { ISearchOptions, SearchAddon } from "@xterm/addon-search";
 import { getTerminalSearchDecorations } from "../../utils/theme";
 import styles from "./TerminalSearchBar.module.css";
+
+// Read the latest theme tokens on every call. `getComputedStyle` is cheap
+// (no layout flush) and this runs at human typing cadence — switching
+// themes mid-search immediately picks up the new highlight color on the
+// next keystroke or step. Caching with useMemo would freeze colors to
+// whatever the theme was at bar-mount time.
+function freshSearchOptions(incremental = false): ISearchOptions {
+  return { decorations: getTerminalSearchDecorations(), incremental };
+}
 
 interface Props {
   /** Search addon for the currently active pane. Null when no pane is active. */
@@ -61,15 +70,6 @@ export function TerminalSearchBar({
     return () => sub.dispose();
   }, [addon]);
 
-  // Decoration options are required for `onDidChangeResults` to fire —
-  // without them the counter stays at zero even when matches exist. The
-  // helper resolves theme colors at call time so theme switches mid-search
-  // pick up new accent values on the next keystroke.
-  const baseSearchOptions = useMemo<ISearchOptions>(
-    () => ({ decorations: getTerminalSearchDecorations() }),
-    [],
-  );
-
   // Re-run findNext when the query changes so the counter and highlighted
   // match update incrementally as the user types. `incremental: true`
   // expands the current selection while it still matches — matching the
@@ -81,17 +81,17 @@ export function TerminalSearchBar({
       setResults({ index: -1, count: 0 });
       return;
     }
-    addon.findNext(query, { ...baseSearchOptions, incremental: true });
-  }, [addon, query, baseSearchOptions]);
+    addon.findNext(query, freshSearchOptions(true));
+  }, [addon, query]);
 
   const handleNext = () => {
     if (!addon || query.length === 0) return;
-    addon.findNext(query, baseSearchOptions);
+    addon.findNext(query, freshSearchOptions());
   };
 
   const handlePrev = () => {
     if (!addon || query.length === 0) return;
-    addon.findPrevious(query, baseSearchOptions);
+    addon.findPrevious(query, freshSearchOptions());
   };
 
   const displayMatchIndex = results.index < 0 ? 0 : results.index + 1;
@@ -135,9 +135,16 @@ export function TerminalSearchBar({
         }}
         // Stop Cmd/Ctrl+F from bubbling to the global handler while the bar
         // is focused — re-select the input so the user can replace the query
-        // with another Cmd+F press.
+        // with another Cmd+F press. Gated on `!shift && !alt` so future
+        // bindings like Cmd+Shift+F (find-in-files) or Cmd+Alt+F still pass
+        // through; this matches the strictness of `terminal.open-search`.
         onKeyDownCapture={(e) => {
-          if ((e.metaKey || e.ctrlKey) && e.code === "KeyF") {
+          if (
+            (e.metaKey || e.ctrlKey) &&
+            !e.shiftKey &&
+            !e.altKey &&
+            e.code === "KeyF"
+          ) {
             e.preventDefault();
             e.stopPropagation();
             inputRef.current?.select();

--- a/src/ui/src/components/terminal/TerminalSearchBar.tsx
+++ b/src/ui/src/components/terminal/TerminalSearchBar.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, ChevronUp, X } from "lucide-react";
-import type { SearchAddon } from "@xterm/addon-search";
+import type { ISearchOptions, SearchAddon } from "@xterm/addon-search";
+import { getTerminalSearchDecorations } from "../../utils/theme";
 import styles from "./TerminalSearchBar.module.css";
 
 interface Props {
@@ -60,6 +61,15 @@ export function TerminalSearchBar({
     return () => sub.dispose();
   }, [addon]);
 
+  // Decoration options are required for `onDidChangeResults` to fire —
+  // without them the counter stays at zero even when matches exist. The
+  // helper resolves theme colors at call time so theme switches mid-search
+  // pick up new accent values on the next keystroke.
+  const baseSearchOptions = useMemo<ISearchOptions>(
+    () => ({ decorations: getTerminalSearchDecorations() }),
+    [],
+  );
+
   // Re-run findNext when the query changes so the counter and highlighted
   // match update incrementally as the user types. `incremental: true`
   // expands the current selection while it still matches — matching the
@@ -71,17 +81,17 @@ export function TerminalSearchBar({
       setResults({ index: -1, count: 0 });
       return;
     }
-    addon.findNext(query, { incremental: true });
-  }, [addon, query]);
+    addon.findNext(query, { ...baseSearchOptions, incremental: true });
+  }, [addon, query, baseSearchOptions]);
 
   const handleNext = () => {
     if (!addon || query.length === 0) return;
-    addon.findNext(query);
+    addon.findNext(query, baseSearchOptions);
   };
 
   const handlePrev = () => {
     if (!addon || query.length === 0) return;
-    addon.findPrevious(query);
+    addon.findPrevious(query, baseSearchOptions);
   };
 
   const displayMatchIndex = results.index < 0 ? 0 : results.index + 1;

--- a/src/ui/src/components/terminal/TerminalSearchBar.tsx
+++ b/src/ui/src/components/terminal/TerminalSearchBar.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDown, ChevronUp, X } from "lucide-react";
+import type { SearchAddon } from "@xterm/addon-search";
+import styles from "./TerminalSearchBar.module.css";
+
+interface Props {
+  /** Search addon for the currently active pane. Null when no pane is active. */
+  addon: SearchAddon | null;
+  /** Current search query — owned by the parent so the value survives pane
+   *  switches and re-opens. */
+  query: string;
+  onQueryChange: (next: string) => void;
+  /** Close the bar and restore focus to whatever owns the active pane. */
+  onClose: () => void;
+  /** Bumped by the parent each time Cmd+F is pressed; triggers a re-focus
+   *  + select of the input so re-pressing Cmd+F always lands the cursor
+   *  back in the search box. */
+  focusToken: number;
+}
+
+/**
+ * In-panel search bar for the active xterm pane's scrollback. Drives the
+ * @xterm/addon-search instance attached to that pane.
+ *
+ * Mirrors the chat search bar's interactions: Enter / Shift+Enter to step
+ * matches, Esc to close, and a live counter sourced from the addon's
+ * `onDidChangeResults` event.
+ */
+export function TerminalSearchBar({
+  addon,
+  query,
+  onQueryChange,
+  onClose,
+  focusToken,
+}: Props) {
+  const { t } = useTranslation("chat");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [results, setResults] = useState<{ index: number; count: number }>({
+    index: -1,
+    count: 0,
+  });
+
+  // Focus + select on mount AND whenever the parent bumps focusToken — that
+  // covers both the initial open and a re-press of Cmd+F while the bar is
+  // already mounted but unfocused (e.g. user clicked into the pane).
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [focusToken]);
+
+  useEffect(() => {
+    if (!addon) {
+      setResults({ index: -1, count: 0 });
+      return;
+    }
+    const sub = addon.onDidChangeResults(({ resultIndex, resultCount }) => {
+      setResults({ index: resultIndex, count: resultCount });
+    });
+    return () => sub.dispose();
+  }, [addon]);
+
+  // Re-run findNext when the query changes so the counter and highlighted
+  // match update incrementally as the user types. `incremental: true`
+  // expands the current selection while it still matches — matching the
+  // behavior of Cmd+F in browsers.
+  useEffect(() => {
+    if (!addon) return;
+    if (query.length === 0) {
+      addon.clearDecorations();
+      setResults({ index: -1, count: 0 });
+      return;
+    }
+    addon.findNext(query, { incremental: true });
+  }, [addon, query]);
+
+  const handleNext = () => {
+    if (!addon || query.length === 0) return;
+    addon.findNext(query);
+  };
+
+  const handlePrev = () => {
+    if (!addon || query.length === 0) return;
+    addon.findPrevious(query);
+  };
+
+  const displayMatchIndex = results.index < 0 ? 0 : results.index + 1;
+  const counter = !query
+    ? ""
+    : results.count === 0
+      ? t("chat_search_no_matches")
+      : `${displayMatchIndex} / ${results.count}`;
+
+  return (
+    <div
+      className={styles.bar}
+      role="search"
+      aria-label={t("terminal_search_aria", { defaultValue: "Search terminal" })}
+      data-search-total={results.count}
+      data-search-active={results.index}
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        className={styles.input}
+        placeholder={t("terminal_search_placeholder", {
+          defaultValue: "Search terminal…",
+        })}
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            if (e.shiftKey) handlePrev();
+            else handleNext();
+          } else if (e.key === "Escape") {
+            // Stop propagation so the window-level Esc handler doesn't
+            // fall through to "stop running agent" — terminal search
+            // state is panel-local, so that handler has no way to know
+            // an overlay just absorbed the keystroke.
+            e.preventDefault();
+            e.stopPropagation();
+            onClose();
+          }
+        }}
+        // Stop Cmd/Ctrl+F from bubbling to the global handler while the bar
+        // is focused — re-select the input so the user can replace the query
+        // with another Cmd+F press.
+        onKeyDownCapture={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.code === "KeyF") {
+            e.preventDefault();
+            e.stopPropagation();
+            inputRef.current?.select();
+          }
+        }}
+        aria-label={t("chat_search_query_aria")}
+      />
+      <span className={styles.counter} aria-live="polite">
+        {counter}
+      </span>
+      <button
+        type="button"
+        className={styles.iconButton}
+        onClick={handlePrev}
+        disabled={!addon || results.count === 0}
+        aria-label={t("chat_search_prev")}
+        title={t("chat_search_prev_title")}
+      >
+        <ChevronUp size={14} />
+      </button>
+      <button
+        type="button"
+        className={styles.iconButton}
+        onClick={handleNext}
+        disabled={!addon || results.count === 0}
+        aria-label={t("chat_search_next")}
+        title={t("chat_search_next_title")}
+      >
+        <ChevronDown size={14} />
+      </button>
+      <button
+        type="button"
+        className={styles.iconButton}
+        onClick={onClose}
+        aria-label={t("chat_search_close")}
+        title={t("chat_search_close_title")}
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/ui/src/components/terminal/TerminalSearchBar.tsx
+++ b/src/ui/src/components/terminal/TerminalSearchBar.tsx
@@ -67,7 +67,15 @@ export function TerminalSearchBar({
     const sub = addon.onDidChangeResults(({ resultIndex, resultCount }) => {
       setResults({ index: resultIndex, count: resultCount });
     });
-    return () => sub.dispose();
+    // Cleanup also clears the prior addon's decorations: when the user
+    // switches panes mid-search the `addon` prop swaps to the new pane's
+    // addon, and without this the old pane keeps its highlight rectangles
+    // until the parent's auto-close runs (which it won't if the parent
+    // chose to keep the bar open across the switch).
+    return () => {
+      sub.dispose();
+      addon.clearDecorations();
+    };
   }, [addon]);
 
   // Re-run findNext when the query changes so the counter and highlighted

--- a/src/ui/src/components/terminal/terminalShortcuts.test.ts
+++ b/src/ui/src/components/terminal/terminalShortcuts.test.ts
@@ -341,6 +341,34 @@ describe("terminalKeyAction", () => {
     });
   });
 
+  describe("open-search", () => {
+    it("macOS: Cmd+F (physical KeyF) returns open-search", () => {
+      expect(terminalKeyAction(mk({ code: "KeyF", key: "f", metaKey: true })))
+        .toEqual({ kind: "open-search" });
+      expect(terminalKeyAction(mk({ code: "KeyF", key: "F", metaKey: true })))
+        .toEqual({ kind: "open-search" });
+    });
+
+    it("Linux/Windows: Ctrl+F (physical KeyF) returns open-search", () => {
+      expect(terminalKeyAction(mk({ code: "KeyF", key: "f", ctrlKey: true })))
+        .toEqual({ kind: "open-search" });
+    });
+
+    it("does NOT intercept bare F or Cmd+Shift+F", () => {
+      expect(terminalKeyAction(mk({ code: "KeyF", key: "f" }))).toBeNull();
+      expect(
+        terminalKeyAction(
+          mk({ code: "KeyF", key: "F", metaKey: true, shiftKey: true }),
+        ),
+      ).toBeNull();
+    });
+
+    it("works via code even when key differs (Dvorak: physical F = 'y')", () => {
+      expect(terminalKeyAction(mk({ code: "KeyF", key: "y", metaKey: true })))
+        .toEqual({ kind: "open-search" });
+    });
+  });
+
   describe("paste", () => {
     it("macOS: Cmd+V (physical KeyV) returns paste", () => {
       expect(terminalKeyAction(mk({ code: "KeyV", key: "v", metaKey: true })))

--- a/src/ui/src/components/terminal/terminalShortcuts.ts
+++ b/src/ui/src/components/terminal/terminalShortcuts.ts
@@ -187,11 +187,18 @@ function legacyTerminalKeyAction(ev: KeyboardEvent): string | null {
   // Linux/Windows: Ctrl+Shift+C/V (bare Ctrl+C stays as SIGINT)
   if (isC && ev.ctrlKey && ev.shiftKey && !ev.metaKey) return "terminal.copy-selection";
   if (isV && ev.ctrlKey && ev.shiftKey && !ev.metaKey) return "terminal.paste";
-  // Cmd/Ctrl+F: opens the terminal-search bar. No Shift on either platform —
-  // a Ctrl+Shift+F (find-in-files, when added) should not trigger this.
+  // Cmd/Ctrl+F: opens the terminal-search bar. No Shift or Alt on either
+  // platform — Cmd+Shift+F (find-in-files, when added) and Cmd+Alt+F
+  // should both still pass through to whatever owns them. The `!altKey`
+  // gate matches the strictness of the `bindingMatchesEvent` path that
+  // resolves the registered `terminal.open-search` action.
   const isF = ev.code === "KeyF";
-  if (isF && ev.metaKey && !ev.ctrlKey && !ev.shiftKey) return "terminal.open-search";
-  if (isF && ev.ctrlKey && !ev.metaKey && !ev.shiftKey) return "terminal.open-search";
+  if (isF && ev.metaKey && !ev.ctrlKey && !ev.shiftKey && !ev.altKey) {
+    return "terminal.open-search";
+  }
+  if (isF && ev.ctrlKey && !ev.metaKey && !ev.shiftKey && !ev.altKey) {
+    return "terminal.open-search";
+  }
   return null;
 }
 import { resolveHotkeyAction, type KeybindingMap } from "../../hotkeys/bindings";

--- a/src/ui/src/components/terminal/terminalShortcuts.ts
+++ b/src/ui/src/components/terminal/terminalShortcuts.ts
@@ -49,6 +49,7 @@ export type TerminalKeyAction =
   | { kind: "focus-pane"; direction: "left" | "right" | "up" | "down" }
   | { kind: "copy" }
   | { kind: "paste" }
+  | { kind: "open-search" }
   | null;
 
 /**
@@ -135,6 +136,8 @@ export function terminalKeyAction(
       return { kind: "copy" };
     case "terminal.paste":
       return { kind: "paste" };
+    case "terminal.open-search":
+      return { kind: "open-search" };
     default:
       return null;
   }
@@ -184,6 +187,11 @@ function legacyTerminalKeyAction(ev: KeyboardEvent): string | null {
   // Linux/Windows: Ctrl+Shift+C/V (bare Ctrl+C stays as SIGINT)
   if (isC && ev.ctrlKey && ev.shiftKey && !ev.metaKey) return "terminal.copy-selection";
   if (isV && ev.ctrlKey && ev.shiftKey && !ev.metaKey) return "terminal.paste";
+  // Cmd/Ctrl+F: opens the terminal-search bar. No Shift on either platform —
+  // a Ctrl+Shift+F (find-in-files, when added) should not trigger this.
+  const isF = ev.code === "KeyF";
+  if (isF && ev.metaKey && !ev.ctrlKey && !ev.shiftKey) return "terminal.open-search";
+  if (isF && ev.ctrlKey && !ev.metaKey && !ev.shiftKey) return "terminal.open-search";
   return null;
 }
 import { resolveHotkeyAction, type KeybindingMap } from "../../hotkeys/bindings";

--- a/src/ui/src/hotkeys/actions.ts
+++ b/src/ui/src/hotkeys/actions.ts
@@ -394,6 +394,21 @@ export const HOTKEY_ACTIONS = [
     rebindable: true,
   },
   {
+    // Cmd/Ctrl+F when an xterm pane has focus opens the in-panel search bar
+    // for that pane's scrollback. Pairs with `global.open-chat-search`
+    // (same default keystroke but scoped to global); xterm's custom key
+    // handler intercepts the press here and stops propagation, so the
+    // global chat-search handler never fires while a terminal pane is
+    // focused.
+    id: "terminal.open-search",
+    scope: "terminal",
+    category: "keyboard_category_terminal",
+    description: "keyboard_action_terminal_open_search",
+    defaultBinding: allPlatforms("mod+code:KeyF"),
+    match: "code",
+    rebindable: true,
+  },
+  {
     // Cmd/Ctrl+W: context-aware "close tab".
     //  - File active in the right pane → routes through the FileViewer's
     //    dirty-aware close path (preserves the existing discard-changes

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -176,6 +176,8 @@
   "chat_search_close": "Close search",
   "chat_search_close_title": "Close (Esc)",
   "chat_search_no_matches": "No matches",
+  "terminal_search_aria": "Search terminal",
+  "terminal_search_placeholder": "Search terminal…",
 
   "pinned_prompts_label": "pinned",
   "pinned_prompt_tooltip_auto": "Send {{name}}",

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -419,6 +419,7 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_terminal_copy_selection": "Copy terminal selection",
   "keyboard_action_terminal_paste": "Paste into terminal",
+  "keyboard_action_terminal_open_search": "Search terminal scrollback",
   "keyboard_action_close_tab": "Close active tab (file, diff, or chat session)",
   "keyboard_action_file_undo_operation": "Undo file operation",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -171,6 +171,8 @@
   "chat_search_close": "Cerrar búsqueda",
   "chat_search_close_title": "Cerrar (Esc)",
   "chat_search_no_matches": "Sin coincidencias",
+  "terminal_search_aria": "Buscar en la terminal",
+  "terminal_search_placeholder": "Buscar en la terminal…",
 
   "pinned_prompts_label": "fijados",
   "pinned_prompt_tooltip_auto": "Enviar {{name}}",

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -470,6 +470,7 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_terminal_copy_selection": "Copy terminal selection",
   "keyboard_action_terminal_paste": "Paste into terminal",
+  "keyboard_action_terminal_open_search": "Search terminal scrollback",
   "keyboard_action_close_tab": "Close active tab (file, diff, or chat session)",
   "keyboard_action_file_undo_operation": "Undo file operation",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -171,6 +171,8 @@
   "chat_search_close": "検索を閉じる",
   "chat_search_close_title": "閉じる（Esc）",
   "chat_search_no_matches": "一致なし",
+  "terminal_search_aria": "ターミナルを検索",
+  "terminal_search_placeholder": "ターミナルを検索…",
 
   "pinned_prompts_label": "ピン留め",
   "pinned_prompt_tooltip_auto": "{{name}} を送信",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -470,6 +470,7 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_terminal_copy_selection": "Copy terminal selection",
   "keyboard_action_terminal_paste": "Paste into terminal",
+  "keyboard_action_terminal_open_search": "Search terminal scrollback",
   "keyboard_action_close_tab": "Close active tab (file, diff, or chat session)",
   "keyboard_action_file_undo_operation": "Undo file operation",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -171,6 +171,8 @@
   "chat_search_close": "Fechar busca",
   "chat_search_close_title": "Fechar (Esc)",
   "chat_search_no_matches": "Sem resultados",
+  "terminal_search_aria": "Buscar no terminal",
+  "terminal_search_placeholder": "Buscar no terminal…",
 
   "pinned_prompts_label": "fixados",
   "pinned_prompt_tooltip_auto": "Enviar {{name}}",

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -470,6 +470,7 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_terminal_copy_selection": "Copy terminal selection",
   "keyboard_action_terminal_paste": "Paste into terminal",
+  "keyboard_action_terminal_open_search": "Search terminal scrollback",
   "keyboard_action_close_tab": "Close active tab (file, diff, or chat session)",
   "keyboard_action_file_undo_operation": "Undo file operation",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -171,6 +171,8 @@
   "chat_search_close": "关闭搜索",
   "chat_search_close_title": "关闭 (Esc)",
   "chat_search_no_matches": "无匹配",
+  "terminal_search_aria": "搜索终端",
+  "terminal_search_placeholder": "搜索终端…",
 
   "pinned_prompts_label": "已固定",
   "pinned_prompt_tooltip_auto": "发送 {{name}}",

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -470,6 +470,7 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_terminal_copy_selection": "Copy terminal selection",
   "keyboard_action_terminal_paste": "Paste into terminal",
+  "keyboard_action_terminal_open_search": "Search terminal scrollback",
   "keyboard_action_close_tab": "Close active tab (file, diff, or chat session)",
   "keyboard_action_file_undo_operation": "Undo file operation",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -259,6 +259,13 @@
   --terminal-fg:         var(--text-primary);
   --terminal-cursor:     var(--accent-primary);
   --terminal-selection:  rgba(var(--accent-primary-rgb), 0.25);
+  /* Terminal-search decorations. The xterm search addon requires literal
+     #RRGGBB strings — no alpha channel and no var() chain it can't resolve
+     itself, so these stay as solid hex values rather than mixing with the
+     terminal background. Active match tracks the live accent; inactive
+     matches keep a neutral gray that reads on both light and dark themes. */
+  --terminal-search-match-bg:        #5a5a5a;
+  --terminal-search-active-match-bg: var(--accent-primary);
 
   /* ---- Elevation ---- */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);

--- a/src/ui/src/utils/theme.ts
+++ b/src/ui/src/utils/theme.ts
@@ -171,8 +171,10 @@ export function getTerminalTheme(): ITheme {
  *
  * The tokens live in theme.css so per-theme overrides keep working. We read
  * them via the canonical `getPropertyValue(...).trim() || "#..."` safety
- * fallback so the rare race where the stylesheet hasn't applied still hands
- * the addon a usable hex.
+ * fallback, then run `ensureHexColor` to guard against user JSON themes
+ * that override `--accent-primary` (which the active-match token follows
+ * via var-substitution) with non-hex CSS color formats — the addon would
+ * silently reject those.
  */
 export function getTerminalSearchDecorations(): {
   matchBackground: string;
@@ -181,14 +183,24 @@ export function getTerminalSearchDecorations(): {
   activeMatchColorOverviewRuler: string;
 } {
   const style = getComputedStyle(document.documentElement);
-  const matchColor = style.getPropertyValue("--terminal-search-match-bg").trim() || "#5a5a5a";
-  const activeColor = style.getPropertyValue("--terminal-search-active-match-bg").trim() || "#e07850";
+  const rawMatch = style.getPropertyValue("--terminal-search-match-bg").trim() || "#5a5a5a";
+  const rawActive = style.getPropertyValue("--terminal-search-active-match-bg").trim() || "#e07850";
+  const matchColor = ensureHexColor(rawMatch, "#5a5a5a");
+  const activeColor = ensureHexColor(rawActive, "#e07850");
   return {
     matchBackground: matchColor,
     matchOverviewRuler: matchColor,
     activeMatchBackground: activeColor,
     activeMatchColorOverviewRuler: activeColor,
   };
+}
+
+// Validates that a color string is in literal `#RRGGBB` form. Anything
+// else (rgb/hsl/color-mix/unresolved var) falls back to the supplied hex
+// so the search addon — which silently no-ops on non-hex input — always
+// gets something it can render.
+function ensureHexColor(value: string, fallback: string): string {
+  return /^#[0-9a-fA-F]{6}$/.test(value) ? value : fallback;
 }
 
 // Keys the user may have set via applyUserFonts() — preserved across

--- a/src/ui/src/utils/theme.ts
+++ b/src/ui/src/utils/theme.ts
@@ -160,6 +160,42 @@ export function getTerminalTheme(): ITheme {
   };
 }
 
+/**
+ * Decoration colors for `@xterm/addon-search`. The addon requires literal
+ * `#RRGGBB` strings (no `rgba()` / `color-mix()` / CSS-var references) and,
+ * critically, only emits `onDidChangeResults` when decorations are enabled —
+ * so we must pass these on every `findNext` / `findPrevious` call or the
+ * match counter and next/previous buttons stay disabled at zero matches even
+ * when matches exist.
+ *
+ * Active match uses the live `--accent-primary` (already a hex value across
+ * every built-in theme). Inactive matches use a neutral mid-gray so they
+ * read as "match" rather than "selected" — themes that already paint
+ * selections with accent-primary would otherwise make the two states
+ * indistinguishable.
+ */
+export function getTerminalSearchDecorations(): {
+  matchBackground: string;
+  matchOverviewRuler: string;
+  activeMatchBackground: string;
+  activeMatchColorOverviewRuler: string;
+} {
+  const style = getComputedStyle(document.documentElement);
+  const accent = style.getPropertyValue("--accent-primary").trim() || "#e07850";
+  const isHex = /^#[0-9a-fA-F]{6}$/.test(accent);
+  const activeColor = isHex ? accent : "#e07850";
+  // Inactive match background: neutral gray that contrasts against both
+  // light and dark terminal backgrounds. The overview ruler color matches
+  // so the minimap markers stay legible too.
+  const matchColor = "#5a5a5a";
+  return {
+    matchBackground: matchColor,
+    matchOverviewRuler: matchColor,
+    activeMatchBackground: activeColor,
+    activeMatchColorOverviewRuler: activeColor,
+  };
+}
+
 // Keys the user may have set via applyUserFonts() — preserved across
 // theme switches so font/zoom choices don't reset when picking a theme.
 const PRESERVED_INLINE_PROPS = new Set(["--font-sans", "--font-mono", "zoom"]);

--- a/src/ui/src/utils/theme.ts
+++ b/src/ui/src/utils/theme.ts
@@ -93,6 +93,8 @@ const THEMEABLE_VARS = [
   "terminal-fg",
   "terminal-cursor",
   "terminal-selection",
+  "terminal-search-match-bg",
+  "terminal-search-active-match-bg",
   "toolbar-active",
   "toolbar-active-text",
   "error-bg",
@@ -162,17 +164,15 @@ export function getTerminalTheme(): ITheme {
 
 /**
  * Decoration colors for `@xterm/addon-search`. The addon requires literal
- * `#RRGGBB` strings (no `rgba()` / `color-mix()` / CSS-var references) and,
- * critically, only emits `onDidChangeResults` when decorations are enabled —
- * so we must pass these on every `findNext` / `findPrevious` call or the
- * match counter and next/previous buttons stay disabled at zero matches even
- * when matches exist.
+ * `#RRGGBB` strings — alpha/var chains it can't resolve are rejected — and,
+ * critically, only emits `onDidChangeResults` when decorations are enabled.
+ * Without them the match counter stays at zero and the prev/next buttons
+ * remain disabled even when matches exist.
  *
- * Active match uses the live `--accent-primary` (already a hex value across
- * every built-in theme). Inactive matches use a neutral mid-gray so they
- * read as "match" rather than "selected" — themes that already paint
- * selections with accent-primary would otherwise make the two states
- * indistinguishable.
+ * The tokens live in theme.css so per-theme overrides keep working. We read
+ * them via the canonical `getPropertyValue(...).trim() || "#..."` safety
+ * fallback so the rare race where the stylesheet hasn't applied still hands
+ * the addon a usable hex.
  */
 export function getTerminalSearchDecorations(): {
   matchBackground: string;
@@ -181,13 +181,8 @@ export function getTerminalSearchDecorations(): {
   activeMatchColorOverviewRuler: string;
 } {
   const style = getComputedStyle(document.documentElement);
-  const accent = style.getPropertyValue("--accent-primary").trim() || "#e07850";
-  const isHex = /^#[0-9a-fA-F]{6}$/.test(accent);
-  const activeColor = isHex ? accent : "#e07850";
-  // Inactive match background: neutral gray that contrasts against both
-  // light and dark terminal backgrounds. The overview ruler color matches
-  // so the minimap markers stay legible too.
-  const matchColor = "#5a5a5a";
+  const matchColor = style.getPropertyValue("--terminal-search-match-bg").trim() || "#5a5a5a";
+  const activeColor = style.getPropertyValue("--terminal-search-active-match-bg").trim() || "#e07850";
   return {
     matchBackground: matchColor,
     matchOverviewRuler: matchColor,


### PR DESCRIPTION
## Summary

Implements [#965](https://github.com/utensils/claudette/issues/965): pressing `Cmd/Ctrl + F` while a terminal pane has focus opens an in-panel search bar over that pane's xterm scrollback, mirroring the existing chat-search UX. The keystroke continues to open chat search everywhere else — routing is by focus, not by which panel is visible.

## What landed

- **`@xterm/addon-search` ^0.16.0** added to `src/ui/package.json` and loaded per pane in `TerminalPanel.tsx`. Each `LeafInstance` now owns its own `SearchAddon`, since the addon's match buffer is per-`Terminal`.
- **`terminal.open-search` hotkey action** (terminal scope, default `mod+code:KeyF`) in `hotkeys/actions.ts`, with matching switch arm + legacy fallback in `terminalShortcuts.ts`. Rebindable from Settings → Keyboard → Terminal.
- **`TerminalSearchBar` component** + CSS module — minimal floating bar (top-right of the active pane) with input, live `n / N` counter sourced from the addon's `onDidChangeResults`, prev/next buttons, and Esc-to-close. Enter / Shift+Enter step matches.
- **`getTerminalSearchDecorations()`** in `utils/theme.ts`, alongside `getTerminalTheme()`. Active match pulls `--accent-primary` from the live theme; inactive matches use a neutral gray for contrast.
- **Locales**: new `keyboard_action_terminal_open_search` string in all five locale `settings.json` files, plus `terminal_search_aria` / `terminal_search_placeholder` in `chat.json`.
- **Docs**: Keyboard Shortcuts page (Search & Commands + Terminal Panes tables) and a new \"Search Scrollback\" section in `integrated-terminal.mdx`.

## Routing behavior

When a terminal pane is focused, xterm's `attachCustomKeyEventHandler` intercepts the key press, fires the `terminal.open-search` action, and calls `stopImmediatePropagation()` — so the global `global.open-chat-search` handler never runs. When focus is anywhere else (chat composer, file viewer, dashboard), the existing global handler opens chat search exactly as it does today.

No new dispatch logic needed in `useKeyboardShortcuts.ts` — the scope-based hotkey system already provides this routing, the same way `Cmd+T` already does double-duty (`global.new-tab` vs `terminal.new-tab`).

## Behavior details

- **Re-pressing Cmd+F** while the bar is already open bumps a `searchFocusToken`, which re-focuses + selects the input (useful when the user clicked back into the pane between presses).
- **Esc** closes the bar AND stops propagation, so it doesn't fall through to the global Escape cascade and accidentally trigger \"stop running agent\". (Chat search doesn't need this because its open-state lives in Zustand, which the global handler reads.)
- **Tab / workspace switches** auto-close the bar — the addon is bound to one pane's buffer, so re-pointing it would silently search the wrong scrollback.
- **Clearing the query** calls `addon.clearDecorations()` so highlights don't linger.
- **`SearchAddon` lifecycle** — created per `Terminal`, disposed transitively via `term.dispose()` in `destroyInstance`. No explicit disposal needed.

## Why decorations are required

The addon's `onDidChangeResults` event only fires when the `decorations` option is enabled. Without them, the counter stays at zero and the prev/next buttons remain disabled even when matches exist. The fix commit (`f6e00c06`) threads the decorations option through every `findNext` / `findPrevious` call. The colors must be literal `#RRGGBB` strings — `rgba()` and `color-mix()` are rejected by the addon — so the helper reads `--accent-primary` (always hex across all built-in themes) and falls back to a neutral gray for inactive matches.

## Commits

- **`f5b05ee6`** feat(terminal): search scrollback with Cmd/Ctrl+F (#965)
- **`f6e00c06`** fix(terminal): pass decorations to enable terminal-search match events — caught by Codex peer-review on the feature commit

## Test plan

- [x] `bunx tsc -b` — clean
- [x] `bun run test` — 2744 / 2744 pass (4 new tests in `terminalShortcuts.test.ts` for `open-search`)
- [x] `bun run lint:css` — clean
- [x] `bun run lint` — no new warnings (12 pre-existing)
- [x] `bun run build` — clean
- [ ] Manual: focus a terminal pane → Cmd+F opens bar → type → counter updates → Enter / Shift+Enter step → Esc closes
- [ ] Manual: focus chat composer → Cmd+F still opens chat search (regression check)
- [ ] Manual: switch tabs while bar is open → bar auto-closes
- [ ] Manual: rebind the action in Settings → Keyboard → both terminal and chat hotkeys remain independently customisable