### PR TITLE
fix(files): retain Monaco scroll state across tab switches

### DIFF
--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -20,7 +20,10 @@ import {
 } from "../../hotkeys/bindings";
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
 import { tooltipWithHotkey } from "../../hotkeys/display";
-import { fileBufferKey } from "../../stores/slices/fileTreeSlice";
+import {
+  fileBufferKey,
+  type FileEditorViewState,
+} from "../../stores/slices/fileTreeSlice";
 import {
   loadDiffFiles,
   readAgentManagedFile,
@@ -90,6 +93,7 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
   const setFileBufferSaved = useAppStore((s) => s.setFileBufferSaved);
   const setDiffFiles = useAppStore((s) => s.setDiffFiles);
   const setFileTabPreview = useAppStore((s) => s.setFileTabPreview);
+  const setFileEditorViewState = useAppStore((s) => s.setFileEditorViewState);
   const closeFileTab = useAppStore((s) => s.closeFileTab);
   const clearFileRevealTarget = useAppStore((s) => s.clearFileRevealTarget);
   const requestFileTreeRefresh = useAppStore((s) => s.requestFileTreeRefresh);
@@ -248,6 +252,12 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
       clearFileRevealTarget(workspaceId, nonce);
     },
     [clearFileRevealTarget, workspaceId],
+  );
+  const handleEditorViewStateChange = useCallback(
+    (viewState: FileEditorViewState | null) => {
+      setFileEditorViewState(workspaceId, path, viewState);
+    },
+    [path, setFileEditorViewState, workspaceId],
   );
 
   const handleSave = useCallback(async () => {
@@ -602,6 +612,8 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
               filename={path}
               revealTarget={revealTarget}
               onRevealTargetApplied={handleRevealTargetApplied}
+              editorViewState={bufferState.editorViewState}
+              onEditorViewStateChange={handleEditorViewStateChange}
               isSymlink={bufferState.isSymlink}
               disableGitGutter={!!agentFile}
               readOnly={editDisabled}

--- a/src/ui/src/components/file-viewer/MonacoEditor.test.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { FileEditorViewState } from "../../stores/slices/fileTreeSlice";
+import { MonacoEditor } from "./MonacoEditor";
+
+const monacoMock = vi.hoisted(() => {
+  const savedViewState = {
+    cursorState: [],
+    viewState: {
+      scrollTop: 720,
+      scrollTopWithoutViewZones: 720,
+      scrollLeft: 0,
+      firstPosition: { lineNumber: 24, column: 1 },
+      firstPositionDeltaTop: 0,
+    },
+    contributionsState: {},
+  } satisfies FileEditorViewState;
+
+  const editor = {
+    addCommand: vi.fn(),
+    createDecorationsCollection: vi.fn(() => ({ clear: vi.fn(), set: vi.fn() })),
+    restoreViewState: vi.fn(),
+    saveViewState: vi.fn(() => savedViewState),
+    updateOptions: vi.fn(),
+  };
+
+  const monaco = {
+    KeyCode: {
+      KeyP: 1,
+      KeyS: 2,
+      KeyT: 3,
+      KeyW: 4,
+    },
+    KeyMod: {
+      CtrlCmd: 1 << 8,
+      Shift: 1 << 9,
+    },
+    editor: {
+      OverviewRulerLane: { Center: 2 },
+    },
+  };
+
+  return { editor, monaco, savedViewState };
+});
+
+vi.mock("./monacoSetup", () => ({}));
+vi.mock("./monacoTheme", () => ({
+  applyMonacoTheme: vi.fn(),
+  initMonacoThemeSync: vi.fn(() => vi.fn()),
+}));
+vi.mock("./useGitGutter", () => ({
+  useGitGutter: vi.fn(),
+}));
+vi.mock("../../hotkeys/contextActions", () => ({
+  executeCloseTab: vi.fn(),
+  executeNewTab: vi.fn(),
+}));
+vi.mock("@monaco-editor/react", () => ({
+  default: ({
+    beforeMount,
+    onMount,
+  }: {
+    beforeMount?: (monaco: typeof monacoMock.monaco) => void;
+    onMount?: (
+      editor: typeof monacoMock.editor,
+      monaco: typeof monacoMock.monaco,
+    ) => void;
+  }) => {
+    beforeMount?.(monacoMock.monaco);
+    onMount?.(monacoMock.editor, monacoMock.monaco);
+    return <div data-testid="monaco-editor" />;
+  },
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const roots: Root[] = [];
+const containers: HTMLElement[] = [];
+
+async function render(node: ReactNode): Promise<Root> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  containers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return root;
+}
+
+afterEach(async () => {
+  for (const root of roots.splice(0).reverse()) {
+    await act(async () => root.unmount());
+  }
+  for (const container of containers.splice(0)) container.remove();
+  vi.clearAllMocks();
+});
+
+describe("MonacoEditor view state", () => {
+  it("restores saved view state on mount and captures the next state on unmount", async () => {
+    const previousViewState = {
+      cursorState: [],
+      viewState: {
+        scrollTop: 360,
+        scrollTopWithoutViewZones: 360,
+        scrollLeft: 0,
+        firstPosition: { lineNumber: 12, column: 1 },
+        firstPositionDeltaTop: 0,
+      },
+      contributionsState: {},
+    } satisfies FileEditorViewState;
+    const onEditorViewStateChange = vi.fn();
+
+    const root = await render(
+      <MonacoEditor
+        workspaceId="ws-1"
+        value={"one\ntwo\nthree"}
+        filename="src/app.ts"
+        isSymlink={false}
+        readOnly={false}
+        editorViewState={previousViewState}
+        onChange={vi.fn()}
+        onEditorViewStateChange={onEditorViewStateChange}
+      />,
+    );
+
+    expect(monacoMock.editor.restoreViewState).toHaveBeenCalledWith(
+      previousViewState,
+    );
+
+    await act(async () => root.unmount());
+    roots.splice(roots.indexOf(root), 1);
+
+    expect(monacoMock.editor.saveViewState).toHaveBeenCalled();
+    expect(onEditorViewStateChange).toHaveBeenCalledWith(
+      monacoMock.savedViewState,
+    );
+  });
+});

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -5,7 +5,10 @@ import { applyMonacoTheme, initMonacoThemeSync } from "./monacoTheme";
 import { DEFAULT_MONO_STACK } from "../../styles/fonts";
 import { useAppStore } from "../../stores/useAppStore";
 import { executeCloseTab, executeNewTab } from "../../hotkeys/contextActions";
-import type { FileRevealTarget } from "../../stores/slices/fileTreeSlice";
+import type {
+  FileEditorViewState,
+  FileRevealTarget,
+} from "../../stores/slices/fileTreeSlice";
 import { EDITOR_BASE_FONT_SIZE } from "./editorConstants";
 import {
   useGitGutter,
@@ -47,6 +50,10 @@ interface MonacoEditorProps {
   /** Optional one-shot reveal target from chat file links. */
   revealTarget?: FileRevealTarget | null;
   onRevealTargetApplied?: (nonce: number) => void;
+  /** Monaco cursor + scroll snapshot from the last time this file tab
+   *  unmounted. */
+  editorViewState?: FileEditorViewState | null;
+  onEditorViewStateChange?: (viewState: FileEditorViewState | null) => void;
   /** Fired on every document change. The parent compares against the
    *  baseline to update the per-tab dirty flag. The `@monaco-editor/react`
    *  wrapper internally suppresses this callback while it's applying a
@@ -73,6 +80,8 @@ export const MonacoEditor = memo(function MonacoEditor({
   disableGitGutter = false,
   revealTarget,
   onRevealTargetApplied,
+  editorViewState,
+  onEditorViewStateChange,
   readOnly,
   onChange,
   onSave,
@@ -85,6 +94,7 @@ export const MonacoEditor = memo(function MonacoEditor({
   const onChangeRef = useRef(onChange);
   const onSaveRef = useRef(onSave);
   const onEditorReadyRef = useRef(onEditorReady);
+  const onEditorViewStateChangeRef = useRef(onEditorViewStateChange);
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
@@ -94,6 +104,9 @@ export const MonacoEditor = memo(function MonacoEditor({
   useEffect(() => {
     onEditorReadyRef.current = onEditorReady;
   }, [onEditorReady]);
+  useEffect(() => {
+    onEditorViewStateChangeRef.current = onEditorViewStateChange;
+  }, [onEditorViewStateChange]);
 
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
   const monacoRef = useRef<Parameters<OnMount>[1] | null>(null);
@@ -156,6 +169,9 @@ export const MonacoEditor = memo(function MonacoEditor({
   // editor reference so handlers don't fire against a disposed editor.
   useEffect(
     () => () => {
+      onEditorViewStateChangeRef.current?.(
+        editorRef.current?.saveViewState() ?? null,
+      );
       cleanupThemeSyncRef.current?.();
       gutterCollectionRef.current?.clear();
       revealCollectionRef.current?.clear();
@@ -208,6 +224,9 @@ export const MonacoEditor = memo(function MonacoEditor({
   const handleMount: OnMount = (editor, monacoInstance) => {
     editorRef.current = editor;
     monacoRef.current = monacoInstance;
+    if (editorViewState) {
+      editor.restoreViewState(editorViewState);
+    }
     // Initialize the gutter decoration collection now that Monaco has
     // handed us a live editor. The collection survives buffer/file
     // changes within the same mount; the parent remounts on file

--- a/src/ui/src/hooks/useViewTogglePersistence.test.ts
+++ b/src/ui/src/hooks/useViewTogglePersistence.test.ts
@@ -119,6 +119,7 @@ describe("view state persistence", () => {
           loaded: true,
           loadError: null,
           preview: "source",
+          editorViewState: null,
           externallyChanged: false,
         },
       },

--- a/src/ui/src/stores/slices/fileTreeSlice.ts
+++ b/src/ui/src/stores/slices/fileTreeSlice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from "zustand";
+import type { editor as MonacoEditorNs } from "monaco-editor";
 import type { AppState } from "../useAppStore";
 import type { UnifiedTabEntry } from "../../components/chat/sessionTabsLogic";
 
@@ -12,6 +13,8 @@ export interface FileRevealTarget {
   endColumn?: number;
   nonce: number;
 }
+
+export type FileEditorViewState = MonacoEditorNs.ICodeEditorViewState;
 
 /** Per-tab buffer + UI state. Lives in the store keyed by `${wsId}:${path}`
  *  so that switching tabs preserves unsaved edits across the FileViewer's
@@ -39,6 +42,9 @@ export interface FileBufferState {
   loaded: boolean;
   loadError: string | null;
   preview: FileViewerPreviewMode;
+  /** Monaco cursor + scroll snapshot. Captured before the editor unmounts
+   *  so switching to chat/diff and back restores the user's place. */
+  editorViewState: FileEditorViewState | null;
   /** Set by `applyExternalFileChange` when an external write (agent edit,
    *  manual save in another editor, `git checkout`, …) lands on disk while
    *  the buffer was dirty. Drives the tab strip's "external change" badge:
@@ -100,6 +106,7 @@ export function makeUnloadedBuffer(): FileBufferState {
     loaded: false,
     loadError: null,
     preview: "source",
+    editorViewState: null,
     externallyChanged: false,
   };
 }
@@ -355,6 +362,11 @@ export interface FileTreeSlice {
     workspaceId: string,
     path: string,
     preview: FileViewerPreviewMode,
+  ) => void;
+  setFileEditorViewState: (
+    workspaceId: string,
+    path: string,
+    editorViewState: FileEditorViewState | null,
   ) => void;
   renameFilePathInWorkspace: (
     workspaceId: string,
@@ -743,6 +755,20 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
         fileBuffers: {
           ...s.fileBuffers,
           [key]: { ...prev, preview },
+        },
+      };
+    }),
+
+  setFileEditorViewState: (workspaceId, path, editorViewState) =>
+    set((s) => {
+      const key = fileBufferKey(workspaceId, path);
+      const prev = s.fileBuffers[key];
+      if (!prev) return s;
+      if (prev.editorViewState === editorViewState) return s;
+      return {
+        fileBuffers: {
+          ...s.fileBuffers,
+          [key]: { ...prev, editorViewState },
         },
       };
     }),

--- a/src/ui/src/stores/useAppStore.fileTree.test.ts
+++ b/src/ui/src/stores/useAppStore.fileTree.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { useAppStore } from "./useAppStore";
 import {
+  type FileEditorViewState,
   getRevealAncestorDirs,
   snapshotRemovedFilePath,
 } from "./slices/fileTreeSlice";
@@ -31,6 +32,23 @@ function openLoadedFile(path: string, content = "saved") {
     truncated: false,
     imageBytesB64: null,
   });
+}
+
+function makeEditorViewState(scrollTop: number): FileEditorViewState {
+  return {
+    cursorState: [],
+    viewState: {
+      scrollTop,
+      scrollTopWithoutViewZones: scrollTop,
+      scrollLeft: 0,
+      firstPosition: {
+        lineNumber: 1,
+        column: 1,
+      },
+      firstPositionDeltaTop: 0,
+    },
+    contributionsState: {},
+  };
 }
 
 describe("file path store updates", () => {
@@ -89,6 +107,10 @@ describe("file path store updates", () => {
   it("renames an open file tab and preserves its buffer", () => {
     openLoadedFile("src/app.ts");
     useAppStore.getState().setFileBufferContent(WS, "src/app.ts", "dirty");
+    const editorViewState = makeEditorViewState(320);
+    useAppStore
+      .getState()
+      .setFileEditorViewState(WS, "src/app.ts", editorViewState);
     useAppStore.setState({
       tabOrderByWorkspace: { [WS]: [{ kind: "file", path: "src/app.ts" }] },
     });
@@ -102,9 +124,25 @@ describe("file path store updates", () => {
     expect(state.activeFileTabByWorkspace[WS]).toBe("src/main.ts");
     expect(state.fileBuffers[`${WS}:src/app.ts`]).toBeUndefined();
     expect(state.fileBuffers[`${WS}:src/main.ts`].buffer).toBe("dirty");
+    expect(state.fileBuffers[`${WS}:src/main.ts`].editorViewState).toBe(
+      editorViewState,
+    );
     expect(state.tabOrderByWorkspace[WS]).toEqual([
       { kind: "file", path: "src/main.ts" },
     ]);
+  });
+
+  it("stores Monaco view state per file tab", () => {
+    openLoadedFile("src/app.ts");
+    const editorViewState = makeEditorViewState(640);
+
+    useAppStore
+      .getState()
+      .setFileEditorViewState(WS, "src/app.ts", editorViewState);
+
+    expect(
+      useAppStore.getState().fileBuffers[`${WS}:src/app.ts`].editorViewState,
+    ).toBe(editorViewState);
   });
 
   it("stores a one-shot reveal target when opening a file tab with a line range", () => {


### PR DESCRIPTION
## Summary

- Store Monaco's native editor view state with each open file tab so cursor and scroll position survive switching away to chat or diff tabs.
- Restore that view state when the Monaco editor remounts for the same file, while continuing to drop it naturally when the file tab closes with its buffer state.
- Add regression coverage for both the Monaco save/restore wiring and the file-tab store state that carries the snapshot.

## Root Cause

File tabs already preserved their text buffer and dirty state in the Zustand file buffer map, but the Monaco editor instance itself is unmounted when the user switches back to the workspace chat or another right-pane surface. Because we were not saving Monaco's `ICodeEditorViewState`, remounting the file recreated the editor at the default top-of-file position.

## User Impact

Users can now scroll deep into a file, switch to the workspace chat, then return to the file without losing their place.

## Docs

No docs update: this restores expected file editor behavior and does not add or change a user-facing setting, command, shortcut, or documented workflow.

## Verification

- `cd src/ui && bun run test -- MonacoEditor.test.tsx useAppStore.fileTree.test.ts FileViewer.test.tsx`
- `cd src/ui && bunx tsc -b`
- `git diff --check`
