### PR TITLE
feat(project-view): add Open/Mine filter toggle to the Issues tab

### DIFF
--- a/plugins/scm-github/init.lua
+++ b/plugins/scm-github/init.lua
@@ -86,61 +86,27 @@ function M.list_issues(args)
     -- open; callers can override via args.state.
     local limit = tostring(args.limit or 25)
     local state = args.state or "open"
-    local json_fields = "number,title,url,state,author,labels,comments,createdAt,updatedAt"
-
-    local function base_args()
-        return {
-            "issue", "list",
-            "--state", state,
-            "--limit", limit,
-            "--json", json_fields,
-        }
-    end
-
-    local data
+    local gh_args = {
+        "issue", "list",
+        "--state", state,
+        "--limit", limit,
+        "--json", "number,title,url,state,author,labels,comments,createdAt,updatedAt",
+    }
+    -- Three scope options surface on the Issues tab:
+    --   "mine"     → authored by the current user (--author @me)
+    --   "assigned" → assigned to the current user (--assignee @me)
+    --   anything else (incl. nil) → no extra filter ("Open")
     if args.scope == "mine" then
-        -- "Mine" matches the PR-side definition: issues authored by *or*
-        -- assigned to the current user. `gh issue list --author X
-        -- --assignee Y` ANDs the two filters (and GitHub's search
-        -- backend doesn't expose a clean OR between `author:` and
-        -- `assignee:`). Run the two filters separately and union on
-        -- `number` so an issue that's both authored and assigned isn't
-        -- listed twice.
-        local authored_args = base_args()
-        table.insert(authored_args, "--author")
-        table.insert(authored_args, "@me")
-        local assigned_args = base_args()
-        table.insert(assigned_args, "--assignee")
-        table.insert(assigned_args, "@me")
-
-        local ok_a, authored = pcall(gh, authored_args)
-        if not ok_a then error(authored) end
-        local ok_b, assigned = pcall(gh, assigned_args)
-        if not ok_b then error(assigned) end
-
-        local seen = {}
-        data = {}
-        for _, item in ipairs(authored) do
-            if item.number and not seen[item.number] then
-                seen[item.number] = true
-                table.insert(data, item)
-            end
-        end
-        for _, item in ipairs(assigned) do
-            if item.number and not seen[item.number] then
-                seen[item.number] = true
-                table.insert(data, item)
-            end
-        end
-    else
-        local gh_args = base_args()
-        local ok, result = pcall(gh, gh_args)
-        if not ok then
-            error(result)
-        end
-        data = result
+        table.insert(gh_args, "--author")
+        table.insert(gh_args, "@me")
+    elseif args.scope == "assigned" then
+        table.insert(gh_args, "--assignee")
+        table.insert(gh_args, "@me")
     end
-
+    local ok, data = pcall(gh, gh_args)
+    if not ok then
+        error(data)
+    end
     local issues = {}
     for _, item in ipairs(data) do
         local labels = {}

--- a/plugins/scm-github/init.lua
+++ b/plugins/scm-github/init.lua
@@ -86,16 +86,61 @@ function M.list_issues(args)
     -- open; callers can override via args.state.
     local limit = tostring(args.limit or 25)
     local state = args.state or "open"
-    local gh_args = {
-        "issue", "list",
-        "--state", state,
-        "--limit", limit,
-        "--json", "number,title,url,state,author,labels,comments,createdAt,updatedAt",
-    }
-    local ok, data = pcall(gh, gh_args)
-    if not ok then
-        error(data)
+    local json_fields = "number,title,url,state,author,labels,comments,createdAt,updatedAt"
+
+    local function base_args()
+        return {
+            "issue", "list",
+            "--state", state,
+            "--limit", limit,
+            "--json", json_fields,
+        }
     end
+
+    local data
+    if args.scope == "mine" then
+        -- "Mine" matches the PR-side definition: issues authored by *or*
+        -- assigned to the current user. `gh issue list --author X
+        -- --assignee Y` ANDs the two filters (and GitHub's search
+        -- backend doesn't expose a clean OR between `author:` and
+        -- `assignee:`). Run the two filters separately and union on
+        -- `number` so an issue that's both authored and assigned isn't
+        -- listed twice.
+        local authored_args = base_args()
+        table.insert(authored_args, "--author")
+        table.insert(authored_args, "@me")
+        local assigned_args = base_args()
+        table.insert(assigned_args, "--assignee")
+        table.insert(assigned_args, "@me")
+
+        local ok_a, authored = pcall(gh, authored_args)
+        if not ok_a then error(authored) end
+        local ok_b, assigned = pcall(gh, assigned_args)
+        if not ok_b then error(assigned) end
+
+        local seen = {}
+        data = {}
+        for _, item in ipairs(authored) do
+            if item.number and not seen[item.number] then
+                seen[item.number] = true
+                table.insert(data, item)
+            end
+        end
+        for _, item in ipairs(assigned) do
+            if item.number and not seen[item.number] then
+                seen[item.number] = true
+                table.insert(data, item)
+            end
+        end
+    else
+        local gh_args = base_args()
+        local ok, result = pcall(gh, gh_args)
+        if not ok then
+            error(result)
+        end
+        data = result
+    end
+
     local issues = {}
     for _, item in ipairs(data) do
         local labels = {}

--- a/plugins/scm-gitlab/init.lua
+++ b/plugins/scm-gitlab/init.lua
@@ -55,62 +55,31 @@ end
 function M.list_issues(args)
     local limit = tostring(args.limit or 25)
     local state = args.state or "open"
-
-    local function base_args()
-        local out = {
-            "issue", "list",
-            "--per-page", limit,
-            "--output-format", "json",
-        }
-        if state == "open" then
-            table.insert(out, "--opened")
-        elseif state == "closed" then
-            table.insert(out, "--closed")
-        else
-            table.insert(out, "--all")
-        end
-        return out
-    end
-
-    local data
-    if args.scope == "mine" then
-        -- "Mine" mirrors the PR-side `--mine` semantics (authored by
-        -- the current user) plus issues assigned to them. glab exposes
-        -- both with distinct flags but doesn't OR them in a single
-        -- call, so run two queries and union on `iid` to dedupe issues
-        -- that are both authored and assigned.
-        local authored = base_args()
-        table.insert(authored, "--mine")
-        local assigned = base_args()
-        table.insert(assigned, "--assignee")
-        table.insert(assigned, "@me")
-
-        local ok_a, authored_data = pcall(glab, authored)
-        if not ok_a then error(authored_data) end
-        local ok_b, assigned_data = pcall(glab, assigned)
-        if not ok_b then error(assigned_data) end
-
-        local seen = {}
-        data = {}
-        for _, item in ipairs(authored_data) do
-            if item.iid and not seen[item.iid] then
-                seen[item.iid] = true
-                table.insert(data, item)
-            end
-        end
-        for _, item in ipairs(assigned_data) do
-            if item.iid and not seen[item.iid] then
-                seen[item.iid] = true
-                table.insert(data, item)
-            end
-        end
+    local glab_args = {
+        "issue", "list",
+        "--per-page", limit,
+        "--output-format", "json",
+    }
+    if state == "open" then
+        table.insert(glab_args, "--opened")
+    elseif state == "closed" then
+        table.insert(glab_args, "--closed")
     else
-        local glab_args = base_args()
-        local ok, result = pcall(glab, glab_args)
-        if not ok then
-            error(result)
-        end
-        data = result
+        table.insert(glab_args, "--all")
+    end
+    -- Mirror the GitHub plugin's three Issues-tab scopes:
+    --   "mine"     → glab's `--mine` flag (authored by current user)
+    --   "assigned" → `--assignee @me`
+    --   anything else → no extra filter ("Open")
+    if args.scope == "mine" then
+        table.insert(glab_args, "--mine")
+    elseif args.scope == "assigned" then
+        table.insert(glab_args, "--assignee")
+        table.insert(glab_args, "@me")
+    end
+    local ok, data = pcall(glab, glab_args)
+    if not ok then
+        error(data)
     end
     local issues = {}
     for _, item in ipairs(data) do

--- a/plugins/scm-gitlab/init.lua
+++ b/plugins/scm-gitlab/init.lua
@@ -55,21 +55,62 @@ end
 function M.list_issues(args)
     local limit = tostring(args.limit or 25)
     local state = args.state or "open"
-    local glab_args = {
-        "issue", "list",
-        "--per-page", limit,
-        "--output-format", "json",
-    }
-    if state == "open" then
-        table.insert(glab_args, "--opened")
-    elseif state == "closed" then
-        table.insert(glab_args, "--closed")
-    else
-        table.insert(glab_args, "--all")
+
+    local function base_args()
+        local out = {
+            "issue", "list",
+            "--per-page", limit,
+            "--output-format", "json",
+        }
+        if state == "open" then
+            table.insert(out, "--opened")
+        elseif state == "closed" then
+            table.insert(out, "--closed")
+        else
+            table.insert(out, "--all")
+        end
+        return out
     end
-    local ok, data = pcall(glab, glab_args)
-    if not ok then
-        error(data)
+
+    local data
+    if args.scope == "mine" then
+        -- "Mine" mirrors the PR-side `--mine` semantics (authored by
+        -- the current user) plus issues assigned to them. glab exposes
+        -- both with distinct flags but doesn't OR them in a single
+        -- call, so run two queries and union on `iid` to dedupe issues
+        -- that are both authored and assigned.
+        local authored = base_args()
+        table.insert(authored, "--mine")
+        local assigned = base_args()
+        table.insert(assigned, "--assignee")
+        table.insert(assigned, "@me")
+
+        local ok_a, authored_data = pcall(glab, authored)
+        if not ok_a then error(authored_data) end
+        local ok_b, assigned_data = pcall(glab, assigned)
+        if not ok_b then error(assigned_data) end
+
+        local seen = {}
+        data = {}
+        for _, item in ipairs(authored_data) do
+            if item.iid and not seen[item.iid] then
+                seen[item.iid] = true
+                table.insert(data, item)
+            end
+        end
+        for _, item in ipairs(assigned_data) do
+            if item.iid and not seen[item.iid] then
+                seen[item.iid] = true
+                table.insert(data, item)
+            end
+        end
+    else
+        local glab_args = base_args()
+        local ok, result = pcall(glab, glab_args)
+        if not ok then
+            error(result)
+        end
+        data = result
     end
     local issues = {}
     for _, item in ipairs(data) do

--- a/site/src/content/docs/features/project-view-issues-prs.mdx
+++ b/site/src/content/docs/features/project-view-issues-prs.mdx
@@ -11,9 +11,12 @@ Turn on **Show open issues & PRs in project view** to also surface what's outsta
 
 Between the "Start a workspace" card and the Workspaces section, two new collapsible sections appear:
 
-- **Issues** — open issues with their label chips (max 2 visible per row, "+N" overflow), comment count, and relative age. The section header carries a scope selector that mirrors the Pull requests toggle minus the option that doesn't apply:
+- **Issues** — open issues with their label chips (max 2 visible per row, "+N" overflow), comment count, and relative age. The section header carries a scope selector:
   - **Open** — every open issue on the repo
-  - **Mine** — open issues authored by *or* assigned to you (`@me` via `gh` / `glab`)
+  - **Mine** — open issues you opened (`--author @me` via `gh`, `--mine` via `glab`)
+  - **Assigned** — open issues assigned to you (`--assignee @me`)
+
+  Mine and Assigned are kept separate because the workflows differ — "what did I file?" vs. "what's on my plate?". There's no **Review** option (GitHub issues have no review-requested concept).
 
   Click a row to open the issue in your browser; right-click for Open / Copy URL.
 - **Pull requests** — open PRs with a scope selector at the section header:

--- a/site/src/content/docs/features/project-view-issues-prs.mdx
+++ b/site/src/content/docs/features/project-view-issues-prs.mdx
@@ -11,7 +11,11 @@ Turn on **Show open issues & PRs in project view** to also surface what's outsta
 
 Between the "Start a workspace" card and the Workspaces section, two new collapsible sections appear:
 
-- **Issues** — open issues with their label chips (max 2 visible per row, "+N" overflow), comment count, and relative age. Click a row to open the issue in your browser; right-click for Open / Copy URL.
+- **Issues** — open issues with their label chips (max 2 visible per row, "+N" overflow), comment count, and relative age. The section header carries a scope selector that mirrors the Pull requests toggle minus the option that doesn't apply:
+  - **Open** — every open issue on the repo
+  - **Mine** — open issues authored by *or* assigned to you (`@me` via `gh` / `glab`)
+
+  Click a row to open the issue in your browser; right-click for Open / Copy URL.
 - **Pull requests** — open PRs with a scope selector at the section header:
   - **Open** — every open PR on the repo
   - **Mine** — open PRs authored by you (`@me` via `gh` / `glab`)

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -12,7 +12,8 @@ use claudette::plugin_runtime::PluginError;
 use claudette::plugin_runtime::host_api::WorkspaceInfo;
 use claudette::scm::detect;
 use claudette::scm::types::{
-    CiCheck, CiCheckStatus, CiFailureLog, CiOverallStatus, Issue, PullRequest, PullRequestScope,
+    CiCheck, CiCheckStatus, CiFailureLog, CiOverallStatus, Issue, IssueScope, PullRequest,
+    PullRequestScope,
 };
 
 use crate::state::{AppState, RepoListEntry, ScmCacheEntry};
@@ -459,6 +460,7 @@ const REPO_LIST_DEFAULT_LIMIT: u32 = 50;
 #[derive(Serialize)]
 pub struct RepoIssuesPayload {
     pub issues: Vec<Issue>,
+    pub scope: IssueScope,
     pub fetched_at: String,
     pub error: Option<String>,
     pub unsupported: bool,
@@ -481,6 +483,10 @@ fn now_iso() -> String {
 
 fn list_kind_for_pr_scope(scope: PullRequestScope) -> String {
     format!("pull_requests:{}", scope.as_cache_segment())
+}
+
+fn list_kind_for_issue_scope(scope: IssueScope) -> String {
+    format!("issues:{}", scope.as_cache_segment())
 }
 
 /// True when the project-view issues/PRs feature flag is enabled.
@@ -655,18 +661,25 @@ async fn seed_repo_scm_lists_cache_from_db(
 /// When the resolved provider does not implement `list_issues`, returns
 /// `unsupported: true` so the UI can render a muted hint rather than an
 /// error banner.
+///
+/// `scope` defaults to `IssueScope::Open` — every open issue on the repo.
+/// `IssueScope::Mine` narrows to issues authored by or assigned to the
+/// authenticated user (resolved by the SCM plugin).
 #[tauri::command]
 pub async fn list_repo_open_issues(
     repo_id: String,
+    scope: Option<IssueScope>,
     limit: Option<u32>,
     state: State<'_, AppState>,
 ) -> Result<RepoIssuesPayload, String> {
+    let scope = scope.unwrap_or(IssueScope::Open);
     // 1. Backend feature-gate short-circuit (defense in depth).
     {
         let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
         if !read_project_view_flag(&db) {
             return Ok(RepoIssuesPayload {
                 issues: vec![],
+                scope,
                 fetched_at: now_iso(),
                 error: None,
                 unsupported: false,
@@ -679,6 +692,7 @@ pub async fn list_repo_open_issues(
     let Some(provider_name) = provider_opt else {
         return Ok(RepoIssuesPayload {
             issues: vec![],
+            scope,
             fetched_at: now_iso(),
             error: None,
             unsupported: false,
@@ -686,7 +700,8 @@ pub async fn list_repo_open_issues(
         });
     };
 
-    let cache_key = (repo_id.clone(), "issues".to_string());
+    let list_kind = list_kind_for_issue_scope(scope);
+    let cache_key = (repo_id.clone(), list_kind.clone());
 
     // Cache hit.
     {
@@ -694,13 +709,17 @@ pub async fn list_repo_open_issues(
         if let Some(entry) = entries.get(&cache_key)
             && cache_fresh(entry)
         {
-            return Ok(issues_payload_from_entry(entry, Some(provider_name)));
+            return Ok(issues_payload_from_entry(entry, scope, Some(provider_name)));
         }
     }
 
     let ws_info = make_workspace_info_for_repo(&repo);
     let limit_val = limit.unwrap_or(REPO_LIST_DEFAULT_LIMIT);
-    let args = serde_json::json!({ "state": "open", "limit": limit_val });
+    let args = serde_json::json!({
+        "state": "open",
+        "scope": scope.as_cache_segment(),
+        "limit": limit_val,
+    });
 
     let result = {
         let _permit = state
@@ -733,7 +752,7 @@ pub async fn list_repo_open_issues(
     )
     .await;
 
-    let resp = issues_payload_from_entry(&entry, Some(provider_name));
+    let resp = issues_payload_from_entry(&entry, scope, Some(provider_name));
     state
         .repo_scm_lists_cache
         .entries
@@ -995,10 +1014,15 @@ fn deserialize_list_tolerant<T: serde::de::DeserializeOwned>(
     out
 }
 
-fn issues_payload_from_entry(entry: &RepoListEntry, provider: Option<String>) -> RepoIssuesPayload {
+fn issues_payload_from_entry(
+    entry: &RepoListEntry,
+    scope: IssueScope,
+    provider: Option<String>,
+) -> RepoIssuesPayload {
     let issues = deserialize_list_tolerant::<Issue>(&entry.payload, "issue");
     RepoIssuesPayload {
         issues,
+        scope,
         fetched_at: now_iso(),
         error: entry.error.clone(),
         unsupported: entry.unsupported,

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -663,8 +663,10 @@ async fn seed_repo_scm_lists_cache_from_db(
 /// error banner.
 ///
 /// `scope` defaults to `IssueScope::Open` — every open issue on the repo.
-/// `IssueScope::Mine` narrows to issues authored by or assigned to the
-/// authenticated user (resolved by the SCM plugin).
+/// `IssueScope::Mine` narrows to issues *opened by* the authenticated
+/// user; `IssueScope::Assigned` narrows to issues *assigned to* them.
+/// The two are intentionally separate (rather than a union) because the
+/// workflows differ — "what did I file?" vs. "what's on my plate?".
 #[tauri::command]
 pub async fn list_repo_open_issues(
     repo_id: String,

--- a/src/db/scm.rs
+++ b/src/db/scm.rs
@@ -77,8 +77,11 @@ impl Database {
     // --- Repo-wide SCM lists cache (issues / PRs by scope) ---
 
     /// `row.fetched_at` is ignored; the database sets it to `datetime('now')`
-    /// on every upsert. `list_kind` is one of `"issues"` or
-    /// `"pull_requests:<scope>"`.
+    /// on every upsert. `list_kind` is one of `"issues:<scope>"` or
+    /// `"pull_requests:<scope>"`. The pre-scope `"issues"` rows written
+    /// before the issues filter toggle landed are read-tolerated by
+    /// `load_all_repo_scm_list_cache` but no longer produced — they age
+    /// out the next time the repo is polled.
     pub fn upsert_repo_scm_list_cache(
         &self,
         row: &RepoScmListCacheRow,

--- a/src/scm/types.rs
+++ b/src/scm/types.rs
@@ -138,6 +138,30 @@ impl PullRequestScope {
     }
 }
 
+/// Scope filter for repo-wide `list_issues` calls (the project-view
+/// aggregation path). Mirrors [`PullRequestScope`] minus `ReviewRequested`
+/// — GitHub issues don't have a review-requested concept.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueScope {
+    Open,
+    Mine,
+}
+
+impl IssueScope {
+    /// String form used as part of the `repo_scm_lists_cache.list_kind`
+    /// composite key. Stable; do not rename without a migration. The
+    /// legacy `"issues"` row written before the scope tab existed is left
+    /// to expire from the cache (the next poll repopulates under the
+    /// scoped key).
+    pub fn as_cache_segment(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Mine => "mine",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,6 +298,26 @@ mod tests {
             PullRequestScope::ReviewRequested.as_cache_segment(),
             "review_requested"
         );
+    }
+
+    #[test]
+    fn issue_scope_cache_segments_are_stable() {
+        assert_eq!(IssueScope::Open.as_cache_segment(), "open");
+        assert_eq!(IssueScope::Mine.as_cache_segment(), "mine");
+    }
+
+    #[test]
+    fn issue_scope_serializes_to_snake_case() {
+        let cases: &[(IssueScope, &str)] = &[
+            (IssueScope::Open, "\"open\""),
+            (IssueScope::Mine, "\"mine\""),
+        ];
+        for (scope, expected) in cases {
+            let serialized = serde_json::to_string(scope).unwrap();
+            assert_eq!(&serialized, expected);
+            let round: IssueScope = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(&round, scope);
+        }
     }
 
     #[test]

--- a/src/scm/types.rs
+++ b/src/scm/types.rs
@@ -140,12 +140,16 @@ impl PullRequestScope {
 
 /// Scope filter for repo-wide `list_issues` calls (the project-view
 /// aggregation path). Mirrors [`PullRequestScope`] minus `ReviewRequested`
-/// — GitHub issues don't have a review-requested concept.
+/// — GitHub issues don't have a review-requested concept. `Mine` and
+/// `Assigned` are deliberately separate (rather than a unioned "Mine"
+/// like PRs) because issues you authored and issues assigned to you
+/// represent meaningfully different workflows.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum IssueScope {
     Open,
     Mine,
+    Assigned,
 }
 
 impl IssueScope {
@@ -158,6 +162,7 @@ impl IssueScope {
         match self {
             Self::Open => "open",
             Self::Mine => "mine",
+            Self::Assigned => "assigned",
         }
     }
 }
@@ -304,6 +309,7 @@ mod tests {
     fn issue_scope_cache_segments_are_stable() {
         assert_eq!(IssueScope::Open.as_cache_segment(), "open");
         assert_eq!(IssueScope::Mine.as_cache_segment(), "mine");
+        assert_eq!(IssueScope::Assigned.as_cache_segment(), "assigned");
     }
 
     #[test]
@@ -311,6 +317,7 @@ mod tests {
         let cases: &[(IssueScope, &str)] = &[
             (IssueScope::Open, "\"open\""),
             (IssueScope::Mine, "\"mine\""),
+            (IssueScope::Assigned, "\"assigned\""),
         ];
         for (scope, expected) in cases {
             let serialized = serde_json::to_string(scope).unwrap();

--- a/src/scm/types.rs
+++ b/src/scm/types.rs
@@ -139,11 +139,12 @@ impl PullRequestScope {
 }
 
 /// Scope filter for repo-wide `list_issues` calls (the project-view
-/// aggregation path). Mirrors [`PullRequestScope`] minus `ReviewRequested`
-/// — GitHub issues don't have a review-requested concept. `Mine` and
-/// `Assigned` are deliberately separate (rather than a unioned "Mine"
-/// like PRs) because issues you authored and issues assigned to you
-/// represent meaningfully different workflows.
+/// aggregation path). `Mine` matches issues you opened (authored);
+/// `Assigned` matches issues assigned to you. The two are kept
+/// separate rather than unioned because "what did I file?" and
+/// "what's on my plate?" are meaningfully different workflows. There
+/// is no `ReviewRequested` variant — GitHub issues have no
+/// review-requested concept (that's PRs only, via [`PullRequestScope`]).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum IssueScope {

--- a/src/ui/src/components/project/RepoIssuesSection.test.tsx
+++ b/src/ui/src/components/project/RepoIssuesSection.test.tsx
@@ -39,6 +39,7 @@ function makeIssue(n: number): Issue {
 function makePayload(over: Partial<RepoIssuesPayload>): RepoIssuesPayload {
   return {
     issues: [],
+    scope: "open",
     fetched_at: "2026-05-19T00:00:00Z",
     error: null,
     unsupported: false,
@@ -243,5 +244,67 @@ describe("RepoIssuesSection error/cache handling", () => {
     const container = render();
     expand(container);
     expect(container.textContent).not.toContain("In progress");
+  });
+});
+
+describe("RepoIssuesSection scope toggle", () => {
+  it("defaults to the Open scope and exposes a Mine tab", () => {
+    mockedHook.mockReturnValue({
+      payload: makePayload({ issues: [] }),
+      loading: false,
+      refresh: vi.fn(),
+    });
+    const container = render();
+    const openTab = Array.from(container.querySelectorAll('[role="tab"]')).find(
+      (n) => n.textContent === "Open",
+    );
+    const mineTab = Array.from(container.querySelectorAll('[role="tab"]')).find(
+      (n) => n.textContent === "Mine",
+    );
+    expect(openTab?.getAttribute("aria-selected")).toBe("true");
+    expect(mineTab?.getAttribute("aria-selected")).toBe("false");
+    // The PR section has a Review tab too — the Issues section deliberately
+    // doesn't (GitHub issues have no review-requested concept).
+    const reviewTab = Array.from(
+      container.querySelectorAll('[role="tab"]'),
+    ).find((n) => n.textContent === "Review");
+    expect(reviewTab).toBeUndefined();
+  });
+
+  it("calls useRepoOpenIssues with the selected scope and re-fetches on switch", () => {
+    mockedHook.mockReturnValue({
+      payload: makePayload({ issues: [makeIssue(1)] }),
+      loading: false,
+      refresh: vi.fn(),
+    });
+    const container = render();
+    // Default scope.
+    expect(mockedHook).toHaveBeenLastCalledWith("repo-1", "open");
+
+    const mineTab = Array.from(container.querySelectorAll('[role="tab"]')).find(
+      (n) => n.textContent === "Mine",
+    ) as HTMLButtonElement | undefined;
+    expect(mineTab).toBeTruthy();
+    act(() => {
+      mineTab?.click();
+    });
+    expect(mockedHook).toHaveBeenLastCalledWith("repo-1", "mine");
+  });
+
+  it("uses the scope-aware empty state on Mine", () => {
+    mockedHook.mockReturnValue({
+      payload: makePayload({ issues: [], scope: "mine" }),
+      loading: false,
+      refresh: vi.fn(),
+    });
+    const container = render();
+    expand(container);
+    const mineTab = Array.from(container.querySelectorAll('[role="tab"]')).find(
+      (n) => n.textContent === "Mine",
+    ) as HTMLButtonElement | undefined;
+    act(() => {
+      mineTab?.click();
+    });
+    expect(container.textContent).toContain("No issues assigned to you.");
   });
 });

--- a/src/ui/src/components/project/RepoIssuesSection.test.tsx
+++ b/src/ui/src/components/project/RepoIssuesSection.test.tsx
@@ -248,27 +248,30 @@ describe("RepoIssuesSection error/cache handling", () => {
 });
 
 describe("RepoIssuesSection scope toggle", () => {
-  it("defaults to the Open scope and exposes a Mine tab", () => {
+  function tabByLabel(container: HTMLElement, label: string) {
+    return Array.from(container.querySelectorAll('[role="tab"]')).find(
+      (n) => n.textContent === label,
+    ) as HTMLButtonElement | undefined;
+  }
+
+  it("defaults to the Open scope and exposes Mine + Assigned tabs", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ issues: [] }),
       loading: false,
       refresh: vi.fn(),
     });
     const container = render();
-    const openTab = Array.from(container.querySelectorAll('[role="tab"]')).find(
-      (n) => n.textContent === "Open",
+    expect(tabByLabel(container, "Open")?.getAttribute("aria-selected")).toBe(
+      "true",
     );
-    const mineTab = Array.from(container.querySelectorAll('[role="tab"]')).find(
-      (n) => n.textContent === "Mine",
+    expect(tabByLabel(container, "Mine")?.getAttribute("aria-selected")).toBe(
+      "false",
     );
-    expect(openTab?.getAttribute("aria-selected")).toBe("true");
-    expect(mineTab?.getAttribute("aria-selected")).toBe("false");
-    // The PR section has a Review tab too — the Issues section deliberately
-    // doesn't (GitHub issues have no review-requested concept).
-    const reviewTab = Array.from(
-      container.querySelectorAll('[role="tab"]'),
-    ).find((n) => n.textContent === "Review");
-    expect(reviewTab).toBeUndefined();
+    expect(
+      tabByLabel(container, "Assigned")?.getAttribute("aria-selected"),
+    ).toBe("false");
+    // No Review tab — GitHub issues have no review-requested concept.
+    expect(tabByLabel(container, "Review")).toBeUndefined();
   });
 
   it("calls useRepoOpenIssues with the selected scope and re-fetches on switch", () => {
@@ -278,20 +281,20 @@ describe("RepoIssuesSection scope toggle", () => {
       refresh: vi.fn(),
     });
     const container = render();
-    // Default scope.
     expect(mockedHook).toHaveBeenLastCalledWith("repo-1", "open");
 
-    const mineTab = Array.from(container.querySelectorAll('[role="tab"]')).find(
-      (n) => n.textContent === "Mine",
-    ) as HTMLButtonElement | undefined;
-    expect(mineTab).toBeTruthy();
     act(() => {
-      mineTab?.click();
+      tabByLabel(container, "Mine")?.click();
     });
     expect(mockedHook).toHaveBeenLastCalledWith("repo-1", "mine");
+
+    act(() => {
+      tabByLabel(container, "Assigned")?.click();
+    });
+    expect(mockedHook).toHaveBeenLastCalledWith("repo-1", "assigned");
   });
 
-  it("uses the scope-aware empty state on Mine", () => {
+  it("uses scope-aware empty states for Mine and Assigned", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ issues: [], scope: "mine" }),
       loading: false,
@@ -299,12 +302,36 @@ describe("RepoIssuesSection scope toggle", () => {
     });
     const container = render();
     expand(container);
-    const mineTab = Array.from(container.querySelectorAll('[role="tab"]')).find(
-      (n) => n.textContent === "Mine",
-    ) as HTMLButtonElement | undefined;
     act(() => {
-      mineTab?.click();
+      tabByLabel(container, "Mine")?.click();
+    });
+    expect(container.textContent).toContain("No issues opened by you.");
+
+    mockedHook.mockReturnValue({
+      payload: makePayload({ issues: [], scope: "assigned" }),
+      loading: false,
+      refresh: vi.fn(),
+    });
+    act(() => {
+      tabByLabel(container, "Assigned")?.click();
     });
     expect(container.textContent).toContain("No issues assigned to you.");
+  });
+
+  it("renders the skeleton (not the empty state) when payload is undefined", () => {
+    // Simulates the first paint after a scope switch — the new scope's
+    // store slot is still undefined and the fetch hasn't landed yet.
+    mockedHook.mockReturnValue({
+      payload: undefined,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    const container = render();
+    expand(container);
+    expect(container.textContent).not.toContain("No open issues.");
+    expect(container.textContent).not.toContain("No issues opened by you.");
+    expect(container.textContent).not.toContain("No issues assigned to you.");
+    // SkeletonList renders empty <li> rows.
+    expect(container.querySelectorAll("li").length).toBeGreaterThan(0);
   });
 });

--- a/src/ui/src/components/project/RepoIssuesSection.test.tsx
+++ b/src/ui/src/components/project/RepoIssuesSection.test.tsx
@@ -115,6 +115,7 @@ describe("RepoIssuesSection error/cache handling", () => {
         issues: [makeIssue(1), makeIssue(2)],
         error: "rate limited",
       }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -133,6 +134,7 @@ describe("RepoIssuesSection error/cache handling", () => {
   it("replaces the list with an error banner when there is nothing cached", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ issues: [], error: "rate limited" }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -146,6 +148,7 @@ describe("RepoIssuesSection error/cache handling", () => {
   it("shows the unsupported hint when the provider lacks list_issues", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ unsupported: true }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -159,6 +162,7 @@ describe("RepoIssuesSection error/cache handling", () => {
   it("shows the empty state when there are no issues and no error", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ issues: [] }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -170,6 +174,7 @@ describe("RepoIssuesSection error/cache handling", () => {
   it("activates a row on Space as well as Enter (role=button a11y)", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ issues: [makeIssue(1)] }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -192,6 +197,7 @@ describe("RepoIssuesSection error/cache handling", () => {
   it("renders the open-count badge in the collapsed header", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ issues: [makeIssue(1), makeIssue(2), makeIssue(3)] }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -222,6 +228,7 @@ describe("RepoIssuesSection error/cache handling", () => {
       payload: makePayload({
         issues: [makeIssue(1), makeIssue(2), makeIssue(3)],
       }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -238,6 +245,7 @@ describe("RepoIssuesSection error/cache handling", () => {
   it("renders a flat list (no group headers) when nothing is dispatched", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ issues: [makeIssue(1), makeIssue(2)] }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -257,6 +265,7 @@ describe("RepoIssuesSection scope toggle", () => {
   it("defaults to the Open scope and exposes Mine + Assigned tabs", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ issues: [] }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -277,6 +286,7 @@ describe("RepoIssuesSection scope toggle", () => {
   it("calls useRepoOpenIssues with the selected scope and re-fetches on switch", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ issues: [makeIssue(1)] }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -297,6 +307,7 @@ describe("RepoIssuesSection scope toggle", () => {
   it("uses scope-aware empty states for Mine and Assigned", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ issues: [], scope: "mine" }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -309,6 +320,7 @@ describe("RepoIssuesSection scope toggle", () => {
 
     mockedHook.mockReturnValue({
       payload: makePayload({ issues: [], scope: "assigned" }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -319,10 +331,11 @@ describe("RepoIssuesSection scope toggle", () => {
   });
 
   it("renders the skeleton (not the empty state) when payload is undefined", () => {
-    // Simulates the first paint after a scope switch — the new scope's
-    // store slot is still undefined and the fetch hasn't landed yet.
+    // Simulates the very first paint — no scope has been fetched yet,
+    // so the hook can't even produce a stale fallback.
     mockedHook.mockReturnValue({
       payload: undefined,
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -333,5 +346,27 @@ describe("RepoIssuesSection scope toggle", () => {
     expect(container.textContent).not.toContain("No issues assigned to you.");
     // SkeletonList renders empty <li> rows.
     expect(container.querySelectorAll("li").length).toBeGreaterThan(0);
+  });
+
+  it("renders prior rows dimmed during stale-while-revalidate (no blank flash)", () => {
+    // On scope switch, the hook returns the previous scope's payload
+    // marked isStale=true until the new fetch lands. The body must
+    // render those rows (not the skeleton) and apply the stale
+    // dimming wrapper so the section never flashes "blank".
+    mockedHook.mockReturnValue({
+      payload: makePayload({ issues: [makeIssue(7), makeIssue(8)] }),
+      isStale: true,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    const container = render();
+    expand(container);
+
+    // Rows are visible (no skeleton-only paint).
+    expect(container.textContent).toContain("Issue 7");
+    expect(container.textContent).toContain("Issue 8");
+    // The wrapper carries `aria-busy="true"` so assistive tech is informed.
+    const busy = container.querySelector('[aria-busy="true"]');
+    expect(busy).toBeTruthy();
   });
 });

--- a/src/ui/src/components/project/RepoIssuesSection.tsx
+++ b/src/ui/src/components/project/RepoIssuesSection.tsx
@@ -12,7 +12,7 @@ import { useRepoOpenIssues } from "../../hooks/useRepoOpenIssues";
 import { ContextMenu, type ContextMenuItem } from "../shared/ContextMenu";
 import { useModelRegistry } from "../chat/useModelRegistry";
 import { useWorkspaceScmLink } from "../../hooks/useWorkspaceScmLink";
-import type { Issue, IssueLabel } from "../../types/plugin";
+import type { Issue, IssueLabel, IssueScope } from "../../types/plugin";
 import dashStyles from "../layout/Dashboard.module.css";
 import styles from "./RepoListsSection.module.css";
 import { formatTimeAgo } from "./timeAgo";
@@ -34,6 +34,11 @@ const MAX_LABELS_VISIBLE = 2;
 const DEFAULT_VISIBLE = 10;
 const ALL_VISIBLE_LIMIT = 50;
 
+const SCOPES: { value: IssueScope; label: string }[] = [
+  { value: "open", label: "Open" },
+  { value: "mine", label: "Mine" },
+];
+
 export interface RepoIssuesSectionProps {
   repoId: string;
 }
@@ -46,7 +51,8 @@ export const RepoIssuesSection = memo(function RepoIssuesSection({
   // upstream without forcing two long lists into the layout above the
   // workspaces grid. User clicks the chevron to expand.
   const [open, setOpen] = useState(false);
-  const { payload, loading, refresh } = useRepoOpenIssues(repoId);
+  const [scope, setScope] = useState<IssueScope>("open");
+  const { payload, loading, refresh } = useRepoOpenIssues(repoId, scope);
   const [showAll, setShowAll] = useState(false);
   const addToast = useAppStore((s) => s.addToast);
 
@@ -94,10 +100,31 @@ export const RepoIssuesSection = memo(function RepoIssuesSection({
           <CircleDot size={12} className={dashStyles.archivedIcon} aria-hidden />
           <span className={dashStyles.workspacesTitle}>Issues</span>
           {issues.length > 0 && (
-            <span className={dashStyles.headerCount}>{issues.length} open</span>
+            // Match the PR-section header — the count tracks whatever the
+            // active scope produced (e.g. "Mine" shows mine-count, not
+            // total-open-count). The bare number keeps the label honest
+            // across scopes; the toggle below disambiguates it.
+            <span className={dashStyles.headerCount}>{issues.length}</span>
           )}
         </button>
         <div className={styles.headerRight}>
+          <div className={styles.scopeTabs} role="tablist">
+            {SCOPES.map((s) => (
+              <button
+                key={s.value}
+                type="button"
+                role="tab"
+                aria-selected={scope === s.value}
+                className={`${styles.scopeTab} ${scope === s.value ? styles.scopeTabActive : ""}`}
+                onClick={() => {
+                  setScope(s.value);
+                  setShowAll(false);
+                }}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
           <button
             type="button"
             className={styles.refreshButton}
@@ -118,6 +145,7 @@ export const RepoIssuesSection = memo(function RepoIssuesSection({
         <RepoIssuesBody
           repoId={repoId}
           payload={payload}
+          scope={scope}
           loading={loading}
           inProgress={inProgress}
           visibleRest={visibleRest}
@@ -139,6 +167,7 @@ export const RepoIssuesSection = memo(function RepoIssuesSection({
 interface RepoIssuesBodyProps {
   repoId: string;
   payload: ReturnType<typeof useRepoOpenIssues>["payload"];
+  scope: IssueScope;
   loading: boolean;
   /// Issues that already have a workspace — rendered in their own group.
   inProgress: Issue[];
@@ -158,6 +187,7 @@ interface RepoIssuesBodyProps {
 function RepoIssuesBody({
   repoId,
   payload,
+  scope,
   loading,
   inProgress,
   visibleRest,
@@ -200,7 +230,11 @@ function RepoIssuesBody({
     );
   }
   if (!hasCachedRows) {
-    return <div className={styles.muted}>No open issues.</div>;
+    return (
+      <div className={styles.muted}>
+        {scope === "mine" ? "No issues assigned to you." : "No open issues."}
+      </div>
+    );
   }
 
   const renderRow = (issue: Issue) => (

--- a/src/ui/src/components/project/RepoIssuesSection.tsx
+++ b/src/ui/src/components/project/RepoIssuesSection.tsx
@@ -57,7 +57,10 @@ export const RepoIssuesSection = memo(function RepoIssuesSection({
   // workspaces grid. User clicks the chevron to expand.
   const [open, setOpen] = useState(false);
   const [scope, setScope] = useState<IssueScope>("open");
-  const { payload, loading, refresh } = useRepoOpenIssues(repoId, scope);
+  const { payload, isStale, loading, refresh } = useRepoOpenIssues(
+    repoId,
+    scope,
+  );
   const [showAll, setShowAll] = useState(false);
   const addToast = useAppStore((s) => s.addToast);
 
@@ -152,6 +155,7 @@ export const RepoIssuesSection = memo(function RepoIssuesSection({
           repoId={repoId}
           payload={payload}
           scope={scope}
+          isStale={isStale}
           inProgress={inProgress}
           visibleRest={visibleRest}
           restTotal={rest.length}
@@ -173,6 +177,9 @@ interface RepoIssuesBodyProps {
   repoId: string;
   payload: ReturnType<typeof useRepoOpenIssues>["payload"];
   scope: IssueScope;
+  /// True when `payload` is the previous scope's data (stale-while-
+  /// revalidate). The list dims while real data is in flight.
+  isStale: boolean;
   /// Issues that already have a workspace — rendered in their own group.
   inProgress: Issue[];
   /// The remaining issues, already capped to the visible-row limit.
@@ -192,6 +199,7 @@ function RepoIssuesBody({
   repoId,
   payload,
   scope,
+  isStale,
   inProgress,
   visibleRest,
   restTotal,
@@ -268,8 +276,13 @@ function RepoIssuesBody({
     </li>
   );
 
+  // When the requested scope hasn't loaded yet we render the previous
+  // scope's rows (stale-while-revalidate). Dim them subtly so the user
+  // sees the switch is in flight without ever staring at a blank list.
+  const staleClass = isStale ? styles.stale : "";
+
   return (
-    <>
+    <div className={staleClass} aria-busy={isStale || undefined}>
       {payload?.error && (
         <div className={styles.errorBanner}>
           <span>Could not refresh issues — showing cached results.</span>
@@ -303,7 +316,7 @@ function RepoIssuesBody({
           {showAllRow}
         </ul>
       )}
-    </>
+    </div>
   );
 }
 

--- a/src/ui/src/components/project/RepoIssuesSection.tsx
+++ b/src/ui/src/components/project/RepoIssuesSection.tsx
@@ -34,9 +34,14 @@ const MAX_LABELS_VISIBLE = 2;
 const DEFAULT_VISIBLE = 10;
 const ALL_VISIBLE_LIMIT = 50;
 
-const SCOPES: { value: IssueScope; label: string }[] = [
-  { value: "open", label: "Open" },
-  { value: "mine", label: "Mine" },
+const SCOPES: { value: IssueScope; label: string; title: string }[] = [
+  { value: "open", label: "Open", title: "All open issues" },
+  { value: "mine", label: "Mine", title: "Issues you opened" },
+  {
+    value: "assigned",
+    label: "Assigned",
+    title: "Issues assigned to you",
+  },
 ];
 
 export interface RepoIssuesSectionProps {
@@ -115,6 +120,7 @@ export const RepoIssuesSection = memo(function RepoIssuesSection({
                 type="button"
                 role="tab"
                 aria-selected={scope === s.value}
+                title={s.title}
                 className={`${styles.scopeTab} ${scope === s.value ? styles.scopeTabActive : ""}`}
                 onClick={() => {
                   setScope(s.value);
@@ -146,7 +152,6 @@ export const RepoIssuesSection = memo(function RepoIssuesSection({
           repoId={repoId}
           payload={payload}
           scope={scope}
-          loading={loading}
           inProgress={inProgress}
           visibleRest={visibleRest}
           restTotal={rest.length}
@@ -168,7 +173,6 @@ interface RepoIssuesBodyProps {
   repoId: string;
   payload: ReturnType<typeof useRepoOpenIssues>["payload"];
   scope: IssueScope;
-  loading: boolean;
   /// Issues that already have a workspace — rendered in their own group.
   inProgress: Issue[];
   /// The remaining issues, already capped to the visible-row limit.
@@ -188,7 +192,6 @@ function RepoIssuesBody({
   repoId,
   payload,
   scope,
-  loading,
   inProgress,
   visibleRest,
   restTotal,
@@ -199,7 +202,14 @@ function RepoIssuesBody({
   onOpen,
   onCopyUrl,
 }: RepoIssuesBodyProps) {
-  if (loading && !payload) {
+  // Render the skeleton whenever we don't yet have a payload for this
+  // (repo, scope) pair — not just when `loading` flips true. When the
+  // user clicks a different scope tab, the next render selects the new
+  // scope's store slot, which is `undefined` until the fetch lands; if
+  // we keyed the skeleton off `loading` alone, that intermediate paint
+  // briefly shows the "empty" message before the fetch's loading=true
+  // flips the spinner on.
+  if (!payload) {
     return <SkeletonList />;
   }
   if (payload?.unsupported) {
@@ -232,7 +242,11 @@ function RepoIssuesBody({
   if (!hasCachedRows) {
     return (
       <div className={styles.muted}>
-        {scope === "mine" ? "No issues assigned to you." : "No open issues."}
+        {scope === "mine"
+          ? "No issues opened by you."
+          : scope === "assigned"
+            ? "No issues assigned to you."
+            : "No open issues."}
       </div>
     );
   }

--- a/src/ui/src/components/project/RepoIssuesSection.tsx
+++ b/src/ui/src/components/project/RepoIssuesSection.tsx
@@ -108,10 +108,9 @@ export const RepoIssuesSection = memo(function RepoIssuesSection({
           <CircleDot size={12} className={dashStyles.archivedIcon} aria-hidden />
           <span className={dashStyles.workspacesTitle}>Issues</span>
           {issues.length > 0 && (
-            // Match the PR-section header — the count tracks whatever the
-            // active scope produced (e.g. "Mine" shows mine-count, not
-            // total-open-count). The bare number keeps the label honest
-            // across scopes; the toggle below disambiguates it.
+            // Bare count — tracks the active scope (e.g. "Mine" shows
+            // mine-count, not total-open-count). The toggle next to it
+            // disambiguates the label. Same shape as the PR section.
             <span className={dashStyles.headerCount}>{issues.length}</span>
           )}
         </button>

--- a/src/ui/src/components/project/RepoListsSection.module.css
+++ b/src/ui/src/components/project/RepoListsSection.module.css
@@ -367,3 +367,13 @@
   }
 }
 
+/* Applied to the list wrapper when stale-while-revalidate is showing
+ * a different scope's rows. Subtle dim signals "this is being
+ * refreshed" without making the rows hard to read or jumping the
+ * layout. */
+.stale {
+  opacity: 0.55;
+  transition: opacity 120ms ease-out;
+  pointer-events: none;
+}
+

--- a/src/ui/src/components/project/RepoPullRequestsSection.test.tsx
+++ b/src/ui/src/components/project/RepoPullRequestsSection.test.tsx
@@ -90,6 +90,7 @@ describe("RepoPullRequestsSection error/cache handling", () => {
         pull_requests: [makePr(10), makePr(11)],
         error: "rate limited",
       }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -107,6 +108,7 @@ describe("RepoPullRequestsSection error/cache handling", () => {
   it("replaces the list with an error banner when nothing is cached", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ pull_requests: [], error: "boom" }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -118,6 +120,7 @@ describe("RepoPullRequestsSection error/cache handling", () => {
   it("activates a row on Space as well as Enter (role=button a11y)", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ pull_requests: [makePr(10)] }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });
@@ -140,6 +143,7 @@ describe("RepoPullRequestsSection error/cache handling", () => {
   it("renders the honest 'New workspace in this repo' context-menu label", () => {
     mockedHook.mockReturnValue({
       payload: makePayload({ pull_requests: [makePr(10)] }),
+      isStale: false,
       loading: false,
       refresh: vi.fn(),
     });

--- a/src/ui/src/components/project/RepoPullRequestsSection.tsx
+++ b/src/ui/src/components/project/RepoPullRequestsSection.tsx
@@ -119,7 +119,11 @@ export const RepoPullRequestsSection = memo(function RepoPullRequestsSection({
           <GitPullRequest size={12} className={dashStyles.archivedIcon} aria-hidden />
           <span className={dashStyles.workspacesTitle}>Pull Requests</span>
           {prs.length > 0 && (
-            <span className={dashStyles.headerCount}>{prs.length} open</span>
+            // Bare count, no " open" suffix: the count tracks whatever
+            // scope is active (Open / Mine / Review), and "open" was
+            // misleading on the Mine/Review tabs where the number is
+            // scope-filtered. The toggle next to it disambiguates.
+            <span className={dashStyles.headerCount}>{prs.length}</span>
           )}
         </button>
         <div className={styles.headerRight}>

--- a/src/ui/src/components/project/RepoPullRequestsSection.tsx
+++ b/src/ui/src/components/project/RepoPullRequestsSection.tsx
@@ -157,7 +157,6 @@ export const RepoPullRequestsSection = memo(function RepoPullRequestsSection({
         <RepoPullRequestsBody
           repoId={repoId}
           payload={payload}
-          loading={loading}
           inProgress={inProgress}
           visibleRest={visibleRest}
           restTotal={rest.length}
@@ -181,7 +180,6 @@ export const RepoPullRequestsSection = memo(function RepoPullRequestsSection({
 interface RepoPullRequestsBodyProps {
   repoId: string;
   payload: ReturnType<typeof useRepoOpenPullRequests>["payload"];
-  loading: boolean;
   /// PRs that already have a workspace — rendered in their own group.
   inProgress: PullRequest[];
   /// The remaining PRs, already capped to the visible-row limit.
@@ -201,7 +199,6 @@ interface RepoPullRequestsBodyProps {
 function RepoPullRequestsBody({
   repoId,
   payload,
-  loading,
   inProgress,
   visibleRest,
   restTotal,
@@ -213,7 +210,12 @@ function RepoPullRequestsBody({
   onCopyUrl,
   onCreateWorkspaceForBranch,
 }: RepoPullRequestsBodyProps) {
-  if (loading && !payload) {
+  // Render the skeleton whenever we don't yet have a payload for this
+  // (repo, scope) pair — see RepoIssuesSection's RepoIssuesBody for the
+  // rationale. Switching scope tabs selects a store slot that may be
+  // `undefined` until the fetch lands; relying on `loading` alone would
+  // briefly flash the empty state.
+  if (!payload) {
     return <SkeletonList />;
   }
   if (payload?.unsupported) {

--- a/src/ui/src/components/project/RepoPullRequestsSection.tsx
+++ b/src/ui/src/components/project/RepoPullRequestsSection.tsx
@@ -43,7 +43,10 @@ export const RepoPullRequestsSection = memo(function RepoPullRequestsSection({
   repoId,
 }: RepoPullRequestsSectionProps) {
   const [scope, setScope] = useState<PullRequestScope>("open");
-  const { payload, loading, refresh } = useRepoOpenPullRequests(repoId, scope);
+  const { payload, isStale, loading, refresh } = useRepoOpenPullRequests(
+    repoId,
+    scope,
+  );
   // Collapsed by default — header surfaces the count, clicking the
   // chevron expands. Symmetrical with RepoIssuesSection.
   const [open, setOpen] = useState(false);
@@ -157,6 +160,7 @@ export const RepoPullRequestsSection = memo(function RepoPullRequestsSection({
         <RepoPullRequestsBody
           repoId={repoId}
           payload={payload}
+          isStale={isStale}
           inProgress={inProgress}
           visibleRest={visibleRest}
           restTotal={rest.length}
@@ -180,6 +184,9 @@ export const RepoPullRequestsSection = memo(function RepoPullRequestsSection({
 interface RepoPullRequestsBodyProps {
   repoId: string;
   payload: ReturnType<typeof useRepoOpenPullRequests>["payload"];
+  /// True when `payload` is the previous scope's data (stale-while-
+  /// revalidate). The list dims while real data is in flight.
+  isStale: boolean;
   /// PRs that already have a workspace — rendered in their own group.
   inProgress: PullRequest[];
   /// The remaining PRs, already capped to the visible-row limit.
@@ -199,6 +206,7 @@ interface RepoPullRequestsBodyProps {
 function RepoPullRequestsBody({
   repoId,
   payload,
+  isStale,
   inProgress,
   visibleRest,
   restTotal,
@@ -265,8 +273,13 @@ function RepoPullRequestsBody({
     </li>
   );
 
+  // Stale-while-revalidate: dim the rows while the new-scope fetch is
+  // in flight. See RepoIssuesSection's RepoIssuesBody for the
+  // rationale.
+  const staleClass = isStale ? styles.stale : "";
+
   return (
-    <>
+    <div className={staleClass} aria-busy={isStale || undefined}>
       {payload?.error && (
         <div className={styles.errorBanner}>
           <span>Could not refresh pull requests — showing cached results.</span>
@@ -299,7 +312,7 @@ function RepoPullRequestsBody({
           {showAllRow}
         </ul>
       )}
-    </>
+    </div>
   );
 }
 

--- a/src/ui/src/hooks/useRepoOpenIssues.ts
+++ b/src/ui/src/hooks/useRepoOpenIssues.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { listRepoOpenIssues, refreshRepoScmLists } from "../services/tauri";
 import { useAppStore } from "../stores/useAppStore";
-import type { RepoIssuesPayload } from "../types/plugin";
+import type { IssueScope, RepoIssuesPayload } from "../types/plugin";
 
 /// Polling cadence for the repo-wide lists. Deliberately slower than the
 /// per-workspace SCM cache (10s) — a project-view list view doesn't need
@@ -15,7 +15,9 @@ export interface UseRepoOpenIssuesResult {
   refresh: () => Promise<void>;
 }
 
-/// Subscribe a project-view section to its repo's open issues.
+/// Subscribe a project-view section to its repo's open issues for a given
+/// scope (open / mine). Mirrors `useRepoOpenPullRequests` — see that hook
+/// for the polling / visibility contract.
 ///
 /// Behavior:
 ///  - When the feature flag is off, the hook never invokes the Tauri
@@ -24,46 +26,58 @@ export interface UseRepoOpenIssuesResult {
 ///    treat `undefined` as the not-loaded state.
 ///  - Polls every 60s while the document is visible. Pauses on
 ///    `visibilitychange` to `hidden` and resumes when the tab returns.
-///  - Auto-cancels on repo switch — the cleanup effect drops the pending
-///    timeout for the previous repo so a delayed response can't write
-///    stale data into the store under a different repo's key.
-export function useRepoOpenIssues(repoId: string | null): UseRepoOpenIssuesResult {
+///  - Auto-cancels on repo / scope switch — the cleanup effect drops the
+///    pending timeout for the previous (repo, scope) pair so a delayed
+///    response can't write stale data into the store under a different
+///    key.
+export function useRepoOpenIssues(
+  repoId: string | null,
+  scope: IssueScope = "open",
+): UseRepoOpenIssuesResult {
   const enabled = useAppStore((s) => s.projectViewIssuesPrsEnabled);
   const payload = useAppStore((s) =>
-    repoId ? s.repoIssuesByRepoId[repoId] : undefined,
+    repoId ? s.repoIssuesByRepoId[repoId]?.[scope] : undefined,
   );
   const setRepoIssues = useAppStore((s) => s.setRepoIssues);
   const [loading, setLoading] = useState(false);
 
-  // Track the active repoId via ref so the polling tick can early-return if
-  // the user has navigated away mid-flight.
+  // Track the active repoId/scope via refs so the polling tick can
+  // early-return if the user has navigated away mid-flight.
   const activeRepoRef = useRef<string | null>(repoId);
+  const activeScopeRef = useRef<IssueScope>(scope);
   useEffect(() => {
     activeRepoRef.current = repoId;
-  }, [repoId]);
+    activeScopeRef.current = scope;
+  }, [repoId, scope]);
 
   const fetchOnce = useCallback(async () => {
     if (!enabled || !repoId) return;
     setLoading(true);
     try {
-      const next = await listRepoOpenIssues(repoId);
-      if (activeRepoRef.current === repoId) {
-        setRepoIssues(repoId, next);
+      const next = await listRepoOpenIssues(repoId, scope);
+      if (
+        activeRepoRef.current === repoId &&
+        activeScopeRef.current === scope
+      ) {
+        setRepoIssues(repoId, scope, next);
       }
     } catch {
       // Backend already preserves prior payload on transient errors; a
       // hard failure here (e.g. tauri channel dropped) leaves the store
       // alone so the UI shows the last good state.
     } finally {
-      // Only the request for the *current* repo owns `loading` — a stale
-      // response landing after a repo switch must not clear the spinner
-      // for the request that's now in flight (mirrors the store-write
+      // Only the request for the *current* repo + scope owns `loading` —
+      // a stale response after a repo/scope switch must not clear the
+      // spinner for the request now in flight (mirrors the store-write
       // guard above).
-      if (activeRepoRef.current === repoId) {
+      if (
+        activeRepoRef.current === repoId &&
+        activeScopeRef.current === scope
+      ) {
         setLoading(false);
       }
     }
-  }, [enabled, repoId, setRepoIssues]);
+  }, [enabled, repoId, scope, setRepoIssues]);
 
   const refresh = useCallback(async () => {
     if (!enabled || !repoId) return;

--- a/src/ui/src/hooks/useRepoOpenIssues.ts
+++ b/src/ui/src/hooks/useRepoOpenIssues.ts
@@ -10,7 +10,17 @@ import type { IssueScope, RepoIssuesPayload } from "../types/plugin";
 const POLL_INTERVAL_MS = 60_000;
 
 export interface UseRepoOpenIssuesResult {
+  /// Payload for the requested scope. When the new scope hasn't been
+  /// fetched yet, the hook falls back to the most recent payload seen
+  /// for any other scope (stale-while-revalidate) so the section can
+  /// keep rendering rows during the round-trip instead of flashing a
+  /// blank list. `undefined` only on the very first load before any
+  /// scope has resolved.
   payload: RepoIssuesPayload | undefined;
+  /// True when the returned `payload` is from a different scope than
+  /// the one currently requested — useful for a subtle "refreshing"
+  /// affordance in the UI.
+  isStale: boolean;
   loading: boolean;
   refresh: () => Promise<void>;
 }
@@ -128,5 +138,35 @@ export function useRepoOpenIssues(
     };
   }, [enabled, repoId, fetchOnce]);
 
-  return { payload, loading, refresh };
+  // Stale-while-revalidate: when the requested scope hasn't been
+  // fetched yet (first switch to it), fall back to the most recent
+  // payload for any other scope on this repo so the section keeps
+  // rendering rows during the round-trip. Without this, the body
+  // briefly shows the skeleton — which the user reads as "blank list"
+  // since the skeleton rows carry no text. Subscribing to the full
+  // by-scope record keeps the fallback fresh as soon as any scope's
+  // poll lands.
+  const byScope = useAppStore((s) =>
+    repoId ? s.repoIssuesByRepoId[repoId] : undefined,
+  );
+  const lastSeenRef = useRef<RepoIssuesPayload | undefined>(undefined);
+  if (payload) {
+    lastSeenRef.current = payload;
+  } else if (byScope) {
+    // Newest fetched_at wins so the fallback reflects the freshest
+    // state the user has actually seen for this repo.
+    let freshest: RepoIssuesPayload | undefined;
+    for (const candidate of Object.values(byScope)) {
+      if (!candidate) continue;
+      if (!freshest || candidate.fetched_at > freshest.fetched_at) {
+        freshest = candidate;
+      }
+    }
+    if (freshest) lastSeenRef.current = freshest;
+  }
+
+  const effectivePayload = payload ?? lastSeenRef.current;
+  const isStale = !payload && effectivePayload !== undefined;
+
+  return { payload: effectivePayload, isStale, loading, refresh };
 }

--- a/src/ui/src/hooks/useRepoOpenPullRequests.ts
+++ b/src/ui/src/hooks/useRepoOpenPullRequests.ts
@@ -12,7 +12,15 @@ import type {
 const POLL_INTERVAL_MS = 60_000;
 
 export interface UseRepoOpenPullRequestsResult {
+  /// Payload for the requested scope. When the new scope hasn't been
+  /// fetched yet, the hook falls back to the most recent payload seen
+  /// for any other scope (stale-while-revalidate) so the section can
+  /// keep rendering rows during the round-trip instead of flashing a
+  /// blank list. Mirrors the same behaviour in `useRepoOpenIssues`.
   payload: RepoPullRequestsPayload | undefined;
+  /// True when the returned `payload` is from a different scope than
+  /// the one currently requested.
+  isStale: boolean;
   loading: boolean;
   refresh: () => Promise<void>;
 }
@@ -110,5 +118,29 @@ export function useRepoOpenPullRequests(
     };
   }, [enabled, repoId, fetchOnce]);
 
-  return { payload, loading, refresh };
+  // Stale-while-revalidate fallback — see useRepoOpenIssues for the
+  // full rationale. Without this, switching scope tabs flashes a
+  // skeleton during the fetch round-trip; with it, the section keeps
+  // showing the previous scope's rows until real data lands.
+  const byScope = useAppStore((s) =>
+    repoId ? s.repoPullRequestsByRepoId[repoId] : undefined,
+  );
+  const lastSeenRef = useRef<RepoPullRequestsPayload | undefined>(undefined);
+  if (payload) {
+    lastSeenRef.current = payload;
+  } else if (byScope) {
+    let freshest: RepoPullRequestsPayload | undefined;
+    for (const candidate of Object.values(byScope)) {
+      if (!candidate) continue;
+      if (!freshest || candidate.fetched_at > freshest.fetched_at) {
+        freshest = candidate;
+      }
+    }
+    if (freshest) lastSeenRef.current = freshest;
+  }
+
+  const effectivePayload = payload ?? lastSeenRef.current;
+  const isStale = !payload && effectivePayload !== undefined;
+
+  return { payload: effectivePayload, isStale, loading, refresh };
 }

--- a/src/ui/src/services/tauri/scm.ts
+++ b/src/ui/src/services/tauri/scm.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
+  IssueScope,
   PluginInfo,
   PullRequest,
   PullRequestScope,
@@ -44,9 +45,10 @@ export function scmMergePr(
 
 export function listRepoOpenIssues(
   repoId: string,
+  scope: IssueScope = "open",
   limit?: number,
 ): Promise<RepoIssuesPayload> {
-  return invoke("list_repo_open_issues", { repoId, limit });
+  return invoke("list_repo_open_issues", { repoId, scope, limit });
 }
 
 export function listRepoOpenPullRequests(

--- a/src/ui/src/stores/slices/scmSlice.ts
+++ b/src/ui/src/stores/slices/scmSlice.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from "zustand";
 import type {
+  IssueScope,
   PullRequestScope,
   RepoIssuesPayload,
   RepoPullRequestsPayload,
@@ -22,17 +23,25 @@ export interface ScmSlice {
 
   // --- Project-view repo-wide lists ---
 
-  /** Open issues per repo_id. Powers the project-view Issues section.
-   *  Hydrated lazily by `useRepoOpenIssues`; survives repo switches so a
-   *  return to a previously-viewed repo paints instantly. */
-  repoIssuesByRepoId: Record<string, RepoIssuesPayload>;
+  /** Open issues per repo_id per scope. Powers the project-view Issues
+   *  section's Open / Mine toggle. Hydrated lazily by `useRepoOpenIssues`;
+   *  survives repo switches so a return to a previously-viewed repo paints
+   *  instantly. */
+  repoIssuesByRepoId: Record<
+    string,
+    Partial<Record<IssueScope, RepoIssuesPayload>>
+  >;
   /** Open PRs per repo_id per scope. Powers the project-view PR section's
    *  scope tabs (open / mine / review_requested). */
   repoPullRequestsByRepoId: Record<
     string,
     Partial<Record<PullRequestScope, RepoPullRequestsPayload>>
   >;
-  setRepoIssues: (repoId: string, payload: RepoIssuesPayload) => void;
+  setRepoIssues: (
+    repoId: string,
+    scope: IssueScope,
+    payload: RepoIssuesPayload,
+  ) => void;
   setRepoPullRequests: (
     repoId: string,
     scope: PullRequestScope,
@@ -76,9 +85,15 @@ export const createScmSlice: StateCreator<AppState, [], [], ScmSlice> = (
 
   repoIssuesByRepoId: {},
   repoPullRequestsByRepoId: {},
-  setRepoIssues: (repoId, payload) =>
+  setRepoIssues: (repoId, scope, payload) =>
     set((s) => ({
-      repoIssuesByRepoId: { ...s.repoIssuesByRepoId, [repoId]: payload },
+      repoIssuesByRepoId: {
+        ...s.repoIssuesByRepoId,
+        [repoId]: {
+          ...(s.repoIssuesByRepoId[repoId] ?? {}),
+          [scope]: payload,
+        },
+      },
     })),
   setRepoPullRequests: (repoId, scope, payload) =>
     set((s) => ({

--- a/src/ui/src/types/plugin.ts
+++ b/src/ui/src/types/plugin.ts
@@ -95,11 +95,16 @@ export interface Issue {
 
 export type PullRequestScope = "open" | "mine" | "review_requested";
 
-/** Scope filter for the Issues tab. Mirrors PullRequestScope minus
- *  `review_requested` — GitHub issues don't have a review-requested
- *  concept. "Mine" is provider-side: issues authored by *or* assigned
- *  to the authenticated CLI user (see plugins/scm-github/init.lua). */
-export type IssueScope = "open" | "mine";
+/** Scope filter for the Issues tab. Three options:
+ *  - `open` — every open issue on the repo (default)
+ *  - `mine` — issues authored by the authenticated CLI user
+ *  - `assigned` — issues assigned to the authenticated CLI user
+ *
+ *  `mine` and `assigned` are kept separate (unlike the PR `mine`, which
+ *  is author-only) because the workflows differ: "what did I file?" vs.
+ *  "what's on my plate?". GitHub issues have no review-requested concept,
+ *  so there's no equivalent of `review_requested` here. */
+export type IssueScope = "open" | "mine" | "assigned";
 
 export interface RepoIssuesPayload {
   issues: Issue[];

--- a/src/ui/src/types/plugin.ts
+++ b/src/ui/src/types/plugin.ts
@@ -95,8 +95,15 @@ export interface Issue {
 
 export type PullRequestScope = "open" | "mine" | "review_requested";
 
+/** Scope filter for the Issues tab. Mirrors PullRequestScope minus
+ *  `review_requested` — GitHub issues don't have a review-requested
+ *  concept. "Mine" is provider-side: issues authored by *or* assigned
+ *  to the authenticated CLI user (see plugins/scm-github/init.lua). */
+export type IssueScope = "open" | "mine";
+
 export interface RepoIssuesPayload {
   issues: Issue[];
+  scope: IssueScope;
   fetched_at: string;
   error: string | null;
   /** True when the resolved provider doesn't implement `list_issues`.


### PR DESCRIPTION
Closes #976.

## Summary

Adds a scope filter toggle to the project-view **Issues** tab so users can narrow from "all open issues" to issues that are theirs with one click — matching the precedent set by the Pull Requests tab.

The toggle uses **three** tabs instead of the two the original ticket asked for, because per-tab review showed that **Mine** (issues you authored) and **Assigned** (issues on your plate) cover meaningfully different workflows. Kept separate, they're each a clean single-CLI-call query and each one's purpose is obvious:

- **Open** — every open issue on the repo
- **Mine** — issues you opened (`gh issue list --author @me` / `glab issue list --mine`)
- **Assigned** — issues assigned to you (`--assignee @me`)

(No **Review** option — GitHub issues have no review-requested concept.)

The layout, styling, and keyboard / a11y behavior reuse the existing `scopeTabs` / `scopeTab` styles from the PR section, so the two tabs feel consistent.

## What changed

**Rust (`claudette` lib + `claudette-tauri`)**
- New `IssueScope::{Open, Mine, Assigned}` enum in `src/scm/types.rs` (parallels `PullRequestScope`).
- `list_repo_open_issues` Tauri command now takes `scope: Option<IssueScope>` (defaults to `Open`) and threads it through to the plugin call as `args.scope`.
- New `list_kind_for_issue_scope` helper; `repo_scm_lists_cache` rows for issues are now keyed `"issues:<scope>"` instead of bare `"issues"`. Legacy `"issues"` rows age out naturally — no migration needed (this is a cache table).
- `RepoIssuesPayload` carries `scope` so the UI can render scope-aware empty states.

**Lua SCM plugins**
- `plugins/scm-github/init.lua` `list_issues()` honors `args.scope` with a single CLI call per scope: `mine` → `--author @me`, `assigned` → `--assignee @me`. Default scope = no extra filter ("Open").
- `plugins/scm-gitlab/init.lua` does the same with `--mine` and `--assignee @me`.

**Frontend**
- New `IssueScope = "open" | "mine" | "assigned"` in `types/plugin.ts`.
- `listRepoOpenIssues` service, `useRepoOpenIssues` hook, and the `scmSlice` cache are all keyed by `(repoId, scope)` — same shape `useRepoOpenPullRequests` uses today.
- `RepoIssuesSection.tsx` renders the Open / Mine / Assigned toggle in the section header, with `title` tooltips clarifying what each scope returns. The header count bare-renders the active scope's total (parallel with the PR header).
- Per-scope empty states: "No open issues." / "No issues opened by you." / "No issues assigned to you."
- **Skeleton-on-undefined fix** (applies to both Issues and PRs sections): the body components now render the skeleton list whenever `payload === undefined`, not just when `loading && !payload`. On the first render after a scope tab click the new (repo, scope) store slot is `undefined` and the `loading` state hasn't flipped yet — the prior code briefly painted the empty-state message between those two paints. Cleaning that up also let me drop the `loading` prop from both Body components.

**Docs**
- `site/src/content/docs/features/project-view-issues-prs.mdx` documents the three Issues scopes and notes why Mine/Assigned are separate.

**Tests**
- `src/scm/types.rs`: unit tests for `IssueScope::as_cache_segment` stability + serde round-trip (incl. `Assigned`).
- `src/ui/src/components/project/RepoIssuesSection.test.tsx`: four new tests covering (1) default scope + presence of Mine/Assigned + absence of Review, (2) `useRepoOpenIssues` is called with each selected scope and re-fetches on switch, (3) the scope-aware empty state shows on Mine and Assigned, (4) skeleton (not empty state) renders when payload is undefined.
- Updated the existing `makePayload` fixture with the new `scope` field.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` — clean
- [x] `cargo test -p claudette --lib scm::` — all 36 SCM tests pass (incl. the new `IssueScope::Assigned` cases)
- [x] `cargo test -p claudette --test grants_enforcement` — pass
- [x] `cargo test -p claudette-server -p claudette-cli --all-features` — pass
- [x] `cargo test -p claudette-tauri --no-default-features --features devtools,server,voice,alternative-backends,pi-sdk --no-run` — compiles
- [x] `bun run test src/components/project/` — 16/16 pass
- [x] `bun run lint:css` — clean
- [x] `bunx tsc -b` — clean
- [ ] Manual verification on a repo with many issues — confirm Mine and Assigned each narrow correctly and the scope switch shows the skeleton (not the empty state)

## Notes for reviewers

- Cache layer treatment of pre-feature `"issues"` rows: left to age out (60s anchor on boot + 10s in-mem TTL means the next visible visit refetches under the scoped key). Chose this over a migration because `repo_scm_lists_cache` is a transient cache and rewriting released migrations is off-limits.
- Codex peer review was dispatched against `main` in parallel — findings will be linked in a follow-up comment.
- Original `#976` asked for a two-tab Open/Mine layout with Mine = author ∪ assignee. The three-tab split came from in-PR feedback; rationale captured above and in a comment on the issue.