### PR TITLE
feat(scheduler): expose scheduling tools to Codex and Pi agents

### DIFF
--- a/site/src/content/docs/features/agent-scheduling.mdx
+++ b/site/src/content/docs/features/agent-scheduling.mdx
@@ -7,15 +7,17 @@ Claudette can persist agent wakeups and recurring routines in its app database. 
 
 ## Agent Tools
 
-When the built-in Claudette MCP bridge is available, agents can use these native tools:
+Agents can schedule their own wakeups and routines through native tools:
 
-| Tool | Purpose |
-|---|---|
-| `ScheduleWakeup` | Schedule a one-shot wakeup with `delaySeconds` or `fireAt`, plus a prompt and optional reason. |
-| `CronCreate` | Create a routine from a standard 5-field cron expression in local time. |
-| `CronList` | List persisted wakeups and routines. |
-| `CronDelete` | Delete a routine by id or name. |
-| `Monitor` | Subscribe to future output lines from a background Bash task instead of polling. |
+| Tool | Purpose | Backends |
+|---|---|---|
+| `ScheduleWakeup` | Schedule a one-shot wakeup with `delaySeconds` or `fireAt`, plus a prompt and optional reason. | Claude, Codex, Pi |
+| `CronCreate` | Create a routine from a standard 5-field cron expression in local time. | Claude, Codex, Pi |
+| `CronList` | List persisted wakeups and routines. | Claude, Codex, Pi |
+| `CronDelete` | Delete a routine by id or name. | Claude, Codex, Pi |
+| `Monitor` | Subscribe to future output lines from a background Bash task instead of polling. | Claude, Codex |
+
+Claude and Codex agents reach these tools over the built-in Claudette MCP bridge. The Pi backend has no MCP bridge, so its scheduling tools are registered natively in the Pi sidecar — `Monitor` is unavailable there. Scheduling stays available regardless of the **Agent Attachments** plugin toggle.
 
 Wakeups and routines survive app restarts. If a fire time passes while Claudette is closed, the scheduler fires the overdue task when the app starts again.
 

--- a/src-pi-harness/src/main.ts
+++ b/src-pi-harness/src/main.ts
@@ -39,12 +39,29 @@ type PendingTool = {
   resolve: (approved: boolean) => void;
 };
 
+// Result of a `host_tool` round-trip — mirrors the Rust `BridgeResponse`
+// shape the Claudette host writes back in `host_tool_result`.
+type HostToolResult = {
+  ok: boolean;
+  message?: string;
+  data?: unknown;
+  error?: string;
+};
+
+type PendingHostTool = {
+  resolve: (result: HostToolResult) => void;
+  reject: (error: Error) => void;
+};
+
 type HarnessState = {
   cwd: string;
   session?: AgentSession;
   authStorage: AuthStorage;
   modelRegistry: ModelRegistry;
   pendingTools: Map<string, PendingTool>;
+  // In-flight `host_tool` round-trips, keyed by the originating tool
+  // call id. Resolved by a matching `host_tool_result` from the host.
+  pendingHostTools: Map<string, PendingHostTool>;
   activeTurnStartedAt?: number;
   // True when Claudette's permission level is `full` — i.e. the user
   // ran `/permissions full` and Claudette's tools-for-level resolver
@@ -66,6 +83,7 @@ const state: HarnessState = {
   authStorage: AuthStorage.create(),
   modelRegistry: ModelRegistry.create(AuthStorage.create()),
   pendingTools: new Map(),
+  pendingHostTools: new Map(),
   bypassPermissions: false,
 };
 
@@ -278,6 +296,36 @@ function textResult(text: string, details: Record<string, unknown> = {}) {
     content: [{ type: "text" as const, text }],
     details,
   };
+}
+
+/** Round-trip a request to the Claudette host and await its result.
+ *  Pi has no MCP bridge, so this generic `host_tool` channel is how a
+ *  native sidecar tool reaches host-only services (currently the
+ *  `agent_scheduled_tasks` DB). The channel is intentionally not
+ *  scheduling-specific — a future user Pi extension that needs host
+ *  services can reuse it. `toolCallId` doubles as the correlation id:
+ *  it is unique per tool call and a scheduling tool never also runs an
+ *  `approval()` round-trip, so the two pending maps can't collide. */
+function hostTool(toolCallId: string, name: string, args: unknown): Promise<HostToolResult> {
+  send({ type: "host_tool", requestId: toolCallId, name, args });
+  return new Promise<HostToolResult>((resolve, reject) => {
+    state.pendingHostTools.set(toolCallId, { resolve, reject });
+  });
+}
+
+/** Render a `HostToolResult` as a Pi tool result. A failed host call
+ *  throws so the SDK marks the tool call `isError`. */
+function hostToolResult(result: HostToolResult) {
+  if (!result.ok) {
+    throw new Error(result.error ?? "Scheduling request failed.");
+  }
+  const text = result.message ?? "Done.";
+  if (result.data === undefined || result.data === null) {
+    return textResult(text);
+  }
+  return textResult(`${text}\n${JSON.stringify(result.data, null, 2)}`, {
+    data: result.data,
+  });
 }
 
 function buildTools(cwd: string, enabledTools: readonly string[]): ToolDefinition[] {
@@ -502,6 +550,58 @@ function buildTools(cwd: string, enabledTools: readonly string[]): ToolDefinitio
         await writeFile(path, before.replace(params.oldText, params.newText), "utf8");
         return textResult(`Edited ${path}`, { path });
       },
+    }),
+    // Native scheduling tools. These carry no local side effect — each
+    // `execute` round-trips through `hostTool` to the Claudette host,
+    // which writes the `agent_scheduled_tasks` DB and re-enters the
+    // chat when the task is due. Parameter keys mirror the Claudette
+    // MCP server's scheduling tools so the surfaces stay interchangeable.
+    defineTool({
+      name: "ScheduleWakeup",
+      label: "Schedule wakeup",
+      description:
+        "Schedule a one-shot wakeup that re-enters this chat later with a prompt. " +
+        "Provide either delaySeconds or fireAt (an RFC3339 timestamp).",
+      parameters: Type.Object({
+        prompt: Type.String(),
+        delaySeconds: Type.Optional(Type.Number()),
+        fireAt: Type.Optional(Type.String()),
+        reason: Type.Optional(Type.String()),
+      }),
+      execute: async (toolCallId, params) =>
+        hostToolResult(await hostTool(toolCallId, "ScheduleWakeup", params)),
+    }),
+    defineTool({
+      name: "CronCreate",
+      label: "Create routine",
+      description:
+        "Create a scheduled routine from a standard 5-field cron expression in local time.",
+      parameters: Type.Object({
+        cron: Type.String(),
+        prompt: Type.String(),
+        name: Type.Optional(Type.String()),
+        recurring: Type.Optional(Type.Boolean()),
+      }),
+      execute: async (toolCallId, params) =>
+        hostToolResult(await hostTool(toolCallId, "CronCreate", params)),
+    }),
+    defineTool({
+      name: "CronList",
+      label: "List routines",
+      description: "List scheduled wakeups and routines for this chat session.",
+      parameters: Type.Object({}),
+      execute: async (toolCallId, params) =>
+        hostToolResult(await hostTool(toolCallId, "CronList", params)),
+    }),
+    defineTool({
+      name: "CronDelete",
+      label: "Delete routine",
+      description: "Delete a scheduled wakeup or routine by its id or name.",
+      parameters: Type.Object({
+        id: Type.String(),
+      }),
+      execute: async (toolCallId, params) =>
+        hostToolResult(await hostTool(toolCallId, "CronDelete", params)),
     }),
   ];
   return tools.filter((tool) => enabled.has(tool.name));
@@ -734,10 +834,18 @@ async function grepFallback(root: string, query: string): Promise<string> {
   return matches.join("\n");
 }
 
+// Native scheduling tools — always enabled, no approval round-trip,
+// present in every Pi session regardless of Claudette's permission
+// level (they only schedule prompts; they mutate nothing locally).
+const SCHEDULING_TOOLS = ["ScheduleWakeup", "CronCreate", "CronList", "CronDelete"];
+
 function mapPermissionTools(value: unknown): { tools: string[]; bypass: boolean } {
   const tools = asStringArray(value);
   if (tools.includes("*")) {
-    return { tools: ["read", "ls", "find", "grep", "bash", "write", "edit"], bypass: true };
+    return {
+      tools: ["read", "ls", "find", "grep", "bash", "write", "edit", ...SCHEDULING_TOOLS],
+      bypass: true,
+    };
   }
   const out = new Set<string>();
   for (const tool of tools) {
@@ -750,6 +858,7 @@ function mapPermissionTools(value: unknown): { tools: string[]; bypass: boolean 
     if (normalized === "bash") out.add("bash");
   }
   out.add("ls");
+  for (const name of SCHEDULING_TOOLS) out.add(name);
   return { tools: [...out], bypass: false };
 }
 
@@ -1434,6 +1543,12 @@ async function handle(message: RequestMessage): Promise<void> {
         pending.resolve(false);
       }
       state.pendingTools.clear();
+      // Likewise release in-flight host-tool round-trips so a
+      // scheduling tool's `execute()` doesn't dangle past the abort.
+      for (const pending of state.pendingHostTools.values()) {
+        pending.reject(new Error("aborted"));
+      }
+      state.pendingHostTools.clear();
       await state.session?.abort();
       respond(message.id, message.type, true);
       break;
@@ -1506,6 +1621,20 @@ async function handle(message: RequestMessage): Promise<void> {
       if (requestId) state.pendingTools.delete(requestId);
       pending?.resolve(false);
       respond(message.id, message.type, true);
+      break;
+    }
+    case "host_tool_result": {
+      // Result of a `host_tool` round-trip. A notification, not a
+      // request — it carries no `id`, so we send no `response` back.
+      const requestId = asString(message.requestId);
+      const pending = requestId ? state.pendingHostTools.get(requestId) : undefined;
+      if (requestId) state.pendingHostTools.delete(requestId);
+      pending?.resolve({
+        ok: message.ok === true,
+        message: typeof message.message === "string" ? message.message : undefined,
+        data: message.data,
+        error: typeof message.error === "string" ? message.error : undefined,
+      });
       break;
     }
     case "dispose":

--- a/src-tauri/src/agent_mcp_sink.rs
+++ b/src-tauri/src/agent_mcp_sink.rs
@@ -107,6 +107,30 @@ async fn handle_payload(
             media_type,
             caption,
         } => {
+            // The Claudette MCP server is now injected unconditionally so
+            // its always-on scheduling tools reach every agent (see the
+            // wiring in commands/chat/send.rs + remote_control.rs). The
+            // "Agent Attachments" plugin toggle therefore can't gate the
+            // server's mere presence anymore — it has to gate the
+            // send_to_user call itself, here. Without this check,
+            // disabling the plugin would still let attachments through,
+            // breaking the Settings contract that turning it off removes
+            // the tool. Reusing the same `is_builtin_plugin_enabled` read
+            // the system-prompt nudge already consults.
+            let db_for_gate = match Database::open(&db_path) {
+                Ok(db) => db,
+                Err(err) => {
+                    return BridgeResponse::err(format!("open db: {err}"));
+                }
+            };
+            if !claudette::agent_mcp::is_builtin_plugin_enabled(&db_for_gate, "send_to_user") {
+                return BridgeResponse::err(
+                    "The Agent Attachments plugin is disabled. Enable it in Settings → \
+                     Plugins to deliver files inline."
+                        .to_string(),
+                );
+            }
+            drop(db_for_gate);
             send_attachment(
                 app,
                 db_path,

--- a/src-tauri/src/agent_mcp_sink.rs
+++ b/src-tauri/src/agent_mcp_sink.rs
@@ -213,7 +213,19 @@ fn schedule_wakeup(
         Ok(db) => db,
         Err(err) => return BridgeResponse::err(format!("open db: {err}")),
     };
-    match db.create_agent_wakeup(&chat_session_id, fire_at, &prompt, reason.as_deref()) {
+    // Agent-callable scheduling doesn't pin a backend — the cron inherits
+    // the global default when it fires. Backend pinning is a frontend
+    // concern (toolbar choice via `/loop` / `/schedule`); the agent itself
+    // is already running on a backend and doesn't get to choose for the
+    // fired turn.
+    match db.create_agent_wakeup(
+        &chat_session_id,
+        fire_at,
+        &prompt,
+        reason.as_deref(),
+        None,
+        None,
+    ) {
         Ok(task) => {
             app.state::<AppState>().scheduler_notify.notify_waiters();
             BridgeResponse::data(
@@ -244,6 +256,8 @@ fn create_cron(
         &cron_expr,
         &prompt,
         recurring,
+        None,
+        None,
     ) {
         Ok(task) => {
             app.state::<AppState>().scheduler_notify.notify_waiters();

--- a/src-tauri/src/commands/chat/remote_control.rs
+++ b/src-tauri/src/commands/chat/remote_control.rs
@@ -20,10 +20,7 @@ use crate::state::{
     AgentSessionState, AppState, ClaudeRemoteControlLifecycle, ClaudeRemoteControlStatus,
 };
 
-use super::{
-    AgentStreamPayload, build_agent_hook_bridge, now_iso, start_bridge_and_inject_mcp,
-    start_chat_bridge,
-};
+use super::{AgentStreamPayload, build_agent_hook_bridge, now_iso, start_bridge_and_inject_mcp};
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -569,7 +566,13 @@ async fn ensure_persistent_session_for_remote_control(
         hook_bridge: None,
         extra_claude_flags,
     };
-    let bridge = if send_to_user_enabled {
+    // Inject the Claudette MCP server unconditionally — it carries the
+    // always-on scheduling tools (ScheduleWakeup / Cron*) and `Monitor`.
+    // The `send_to_user_enabled` toggle gates only that tool's nudge
+    // (above) and the call itself (in `agent_mcp_sink::handle_payload`),
+    // not the whole server. Same wiring as the spawn / respawn blocks in
+    // `chat::send::send_chat_message`.
+    let bridge = {
         let (bridge, mcp_with_claudette) = start_bridge_and_inject_mcp(
             app,
             &state.db_path,
@@ -580,8 +583,6 @@ async fn ensure_persistent_session_for_remote_control(
         .await?;
         agent_settings.mcp_config = mcp_with_claudette;
         bridge
-    } else {
-        start_chat_bridge(app, &state.db_path, &workspace_id, &chat_session_id).await?
     };
     agent_settings.hook_bridge = Some(build_agent_hook_bridge(&bridge)?);
 

--- a/src-tauri/src/commands/chat/remote_control.rs
+++ b/src-tauri/src/commands/chat/remote_control.rs
@@ -477,13 +477,18 @@ async fn ensure_persistent_session_for_remote_control(
         });
         from_config.or_else(|| repo.as_ref().and_then(|r| r.custom_instructions.clone()))
     };
-    let nudge = send_to_user_enabled.then_some(claudette::agent_mcp::SYSTEM_PROMPT_NUDGE);
+    // Scheduling/Monitor nudge is always on (the MCP server is injected
+    // unconditionally). `send_to_user` nudge is gated on the Agent
+    // Attachments plugin toggle. Mirrors the spawn path in
+    // `commands/chat/send.rs` so the remote-control entry point stays in
+    // lockstep with normal chat spawns.
+    let nudge_owned = claudette::agent_mcp::mcp_system_prompt_nudge(send_to_user_enabled);
     // Remote-control sessions always launch through Claude CLI, so the
     // Claude-Code MCP rule block applies (AskUserQuestion / ExitPlanMode
     // exist via the Claudette MCP bridge).
     let custom_instructions = claudette::global_prompt::compose_system_prompt(
         instructions.as_deref(),
-        nudge,
+        nudge_owned.as_deref(),
         Some(claudette::agent_mcp::CLAUDE_CODE_MCP_RULES),
     );
     let level = launch_options.permission_level.as_deref().unwrap_or("full");

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -37,7 +37,7 @@ use super::naming::{try_auto_rename, try_generate_session_name};
 use super::{
     ATTENTION_NOTIFY_DELAY_MS, AgentStreamPayload, AttachmentInput, AttachmentResponse,
     ChatHistoryPage, build_agent_hook_bridge, fire_completion_notification, now_iso,
-    start_bridge_and_inject_mcp, start_chat_bridge,
+    start_bridge_and_inject_mcp,
 };
 
 mod background_tasks;
@@ -1479,15 +1479,16 @@ pub async fn send_chat_message(
         // Claudette MCP bridge, so those rules apply here.
         Some(claudette::agent_mcp::CLAUDE_CODE_MCP_RULES),
     );
-    // Pi runs without the Claudette MCP bridge, so we strip both the
-    // send_to_user nudge *and* the AskUserQuestion / ExitPlanMode
-    // rules. Pointing a qwen / llama / GPT model at MCP tools that
-    // aren't registered with its runtime confuses the model's tool
-    // self-model and is part of why "what LLM are you?" used to come
-    // back with "Claude Code agent" answers on Pi sessions.
+    // Pi runs without the Claudette MCP bridge, so we strip the
+    // send_to_user nudge and the AskUserQuestion / ExitPlanMode rules:
+    // those name MCP tools the Pi sidecar doesn't register, and
+    // pointing a qwen / llama / GPT model at tools that aren't in its
+    // runtime confuses the model's tool self-model. Pi *does* get the
+    // native scheduling tools (registered directly in the sidecar), so
+    // the send_to_user slot carries the MCP-free PI_SCHEDULING_NUDGE.
     let pi_custom_instructions = claudette::global_prompt::compose_system_prompt(
         session.custom_instructions.as_deref(),
-        None,
+        Some(claudette::agent_mcp::PI_SCHEDULING_NUDGE),
         None,
     );
     session.turn_count += 1;
@@ -1965,6 +1966,17 @@ pub async fn send_chat_message(
     let pi_custom_instructions_for_persistent = pi_custom_instructions.clone();
     #[cfg(not(feature = "pi-sdk"))]
     let _ = &pi_custom_instructions;
+    // Pi has no MCP server, so its native scheduling tools round-trip
+    // `host_tool` messages straight through this `ChatBridgeSink` — the
+    // same sink Claude/Codex reach over their MCP socket.
+    #[cfg(feature = "pi-sdk")]
+    let pi_sink_for_persistent: Arc<dyn claudette::agent_mcp::bridge::Sink> =
+        Arc::new(crate::agent_mcp_sink::ChatBridgeSink {
+            app: app.clone(),
+            db_path: state.db_path.clone(),
+            workspace_id: workspace_id.clone(),
+            chat_session_id: chat_session_id.clone(),
+        });
     let start_persistent = move |worktree: String,
                                  sid: String,
                                  is_resume: bool,
@@ -1978,6 +1990,8 @@ pub async fn send_chat_message(
         let pi_sessions_root = pi_sessions_root.clone();
         #[cfg(feature = "pi-sdk")]
         let pi_instructions = pi_custom_instructions_for_persistent.clone();
+        #[cfg(feature = "pi-sdk")]
+        let pi_sink = pi_sink_for_persistent.clone();
         async move {
             // Note: do NOT route the error through `crate::missing_cli::handle_err`
             // here. The caller's resume-fallback arm needs to inspect the raw
@@ -2110,6 +2124,7 @@ pub async fn send_chat_message(
                                 .clone(),
                             pi_provider_env:
                                 crate::commands::agent_backends::pi_auth::pi_local_secret_env()?,
+                            sink: Some(pi_sink),
                         },
                     )
                     .await?;
@@ -2161,22 +2176,10 @@ pub async fn send_chat_message(
 
                 let mut respawn_settings = agent_settings.clone();
                 let bridge = match respawn_settings.backend_runtime.harness {
-                    AgentBackendRuntimeHarness::ClaudeCode => Some(if send_to_user_enabled {
-                        let (b, mcp_with_claudette) = start_bridge_and_inject_mcp(
-                            &app,
-                            &state.db_path,
-                            &workspace_id,
-                            &chat_session_id,
-                            agent_settings.mcp_config.clone(),
-                        )
-                        .await?;
-                        respawn_settings.mcp_config = mcp_with_claudette;
-                        b
-                    } else {
-                        start_chat_bridge(&app, &state.db_path, &workspace_id, &chat_session_id)
-                            .await?
-                    }),
-                    AgentBackendRuntimeHarness::CodexAppServer if send_to_user_enabled => {
+                    // Injected unconditionally for the same reason as the
+                    // spawn path above — scheduling tools ride this server.
+                    AgentBackendRuntimeHarness::ClaudeCode
+                    | AgentBackendRuntimeHarness::CodexAppServer => {
                         let (b, mcp_with_claudette) = start_bridge_and_inject_mcp(
                             &app,
                             &state.db_path,
@@ -2188,7 +2191,6 @@ pub async fn send_chat_message(
                         respawn_settings.mcp_config = mcp_with_claudette;
                         Some(b)
                     }
-                    AgentBackendRuntimeHarness::CodexAppServer => None,
                     #[cfg(feature = "pi-sdk")]
                     AgentBackendRuntimeHarness::PiSdk => None,
                 };
@@ -2349,21 +2351,12 @@ pub async fn send_chat_message(
         // persistent CLI process.
         let mut spawn_settings = agent_settings.clone();
         let bridge = match spawn_settings.backend_runtime.harness {
-            AgentBackendRuntimeHarness::ClaudeCode => Some(if send_to_user_enabled {
-                let (b, mcp_with_claudette) = start_bridge_and_inject_mcp(
-                    &app,
-                    &state.db_path,
-                    &workspace_id,
-                    &chat_session_id,
-                    agent_settings.mcp_config.clone(),
-                )
-                .await?;
-                spawn_settings.mcp_config = mcp_with_claudette;
-                b
-            } else {
-                start_chat_bridge(&app, &state.db_path, &workspace_id, &chat_session_id).await?
-            }),
-            AgentBackendRuntimeHarness::CodexAppServer if send_to_user_enabled => {
+            // The Claudette MCP server carries always-on scheduling tools
+            // (ScheduleWakeup / Cron*) alongside the toggleable send_to_user
+            // tool, so it is injected unconditionally — the send_to_user
+            // plugin toggle gates that tool's prompt nudge (above), not the
+            // whole server. Codex consumes the same MCP server as Claude.
+            AgentBackendRuntimeHarness::ClaudeCode | AgentBackendRuntimeHarness::CodexAppServer => {
                 let (b, mcp_with_claudette) = start_bridge_and_inject_mcp(
                     &app,
                     &state.db_path,
@@ -2375,7 +2368,6 @@ pub async fn send_chat_message(
                 spawn_settings.mcp_config = mcp_with_claudette;
                 Some(b)
             }
-            AgentBackendRuntimeHarness::CodexAppServer => None,
             #[cfg(feature = "pi-sdk")]
             AgentBackendRuntimeHarness::PiSdk => None,
         };

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -1468,13 +1468,18 @@ pub async fn send_chat_message(
     let send_to_user_enabled = claudette::agent_mcp::is_builtin_plugin_enabled(&db, "send_to_user");
 
     // Compose the system prompt for fresh spawns: bundled global prompt →
-    // MCP nudge (so the model reaches for `mcp__claudette__send_to_user`
-    // when asked to deliver a file) → per-repo instructions. Resume turns
-    // reuse the persistent CLI process and never re-pass the prompt.
-    let nudge = send_to_user_enabled.then_some(claudette::agent_mcp::SYSTEM_PROMPT_NUDGE);
+    // MCP nudge → per-repo instructions. Resume turns reuse the persistent
+    // CLI process and never re-pass the prompt.
+    //
+    // `mcp_system_prompt_nudge` always includes the scheduling/Monitor
+    // guidance (those tools are MCP-served via the unconditional bridge
+    // injection above) and only appends the `send_to_user` guidance when
+    // the Agent Attachments plugin is enabled. Splitting these keeps the
+    // toggle gating only the tool it owns.
+    let nudge_owned = claudette::agent_mcp::mcp_system_prompt_nudge(send_to_user_enabled);
     let custom_instructions = claudette::global_prompt::compose_system_prompt(
         session.custom_instructions.as_deref(),
-        nudge,
+        nudge_owned.as_deref(),
         // Claude CLI exposes `AskUserQuestion` / `ExitPlanMode` via the
         // Claudette MCP bridge, so those rules apply here.
         Some(claudette::agent_mcp::CLAUDE_CODE_MCP_RULES),
@@ -2345,10 +2350,15 @@ pub async fn send_chat_message(
         drop(agents);
 
         // Start the agent-MCP bridge and merge the synthetic `claudette`
-        // server entry into the spawn-time `--mcp-config` JSON when the
-        // built-in `send_to_user` plugin is enabled. The bridge is stored
-        // on the session below so it lives exactly as long as the
-        // persistent CLI process.
+        // server entry into the spawn-time `--mcp-config` JSON
+        // unconditionally for Claude / Codex — the server carries the
+        // always-on scheduling tools (ScheduleWakeup / Cron*) alongside
+        // the toggleable `send_to_user` tool, so injection cannot be
+        // gated on the Agent Attachments plugin without taking
+        // scheduling offline. The toggle now gates only that tool's
+        // call-time policy + prompt nudge, not the whole server. The
+        // bridge is stored on the session below so it lives exactly as
+        // long as the persistent CLI process.
         let mut spawn_settings = agent_settings.clone();
         let bridge = match spawn_settings.backend_runtime.harness {
             // The Claudette MCP server carries always-on scheduling tools

--- a/src-tauri/src/commands/scheduling.rs
+++ b/src-tauri/src/commands/scheduling.rs
@@ -294,7 +294,10 @@ fn post_creation_note(
         content,
         cost_usd: None,
         duration_ms: None,
-        created_at: Utc::now().to_rfc3339(),
+        // Match the format every other Tauri-emitted chat message uses
+        // (Unix-seconds string from `now_iso()`). Mixing formats breaks
+        // the frontend's string-sort over `created_at`.
+        created_at: crate::commands::chat::now_iso(),
         thinking: None,
         input_tokens: None,
         output_tokens: None,

--- a/src-tauri/src/commands/scheduling.rs
+++ b/src-tauri/src/commands/scheduling.rs
@@ -2,9 +2,10 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use serde::Serialize;
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::db::Database;
+use claudette::model::{ChatMessage, ChatRole};
 use claudette::scheduling::{ScheduledTask, ScheduledTaskKind, cron_to_human};
 
 use crate::state::AppState;
@@ -27,12 +28,16 @@ impl From<ScheduledTask> for ScheduledTaskView {
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn schedule_wakeup(
     session_id: String,
     delay_seconds: Option<i64>,
     fire_at: Option<String>,
     prompt: String,
     reason: Option<String>,
+    backend_id: Option<String>,
+    model: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<ScheduledTaskView, String> {
     if prompt.trim().is_empty() {
@@ -41,35 +46,69 @@ pub async fn schedule_wakeup(
     let fire_at = resolve_fire_at(delay_seconds, fire_at.as_deref())?;
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let task = db
-        .create_agent_wakeup(&session_id, fire_at, prompt.trim(), reason.as_deref())
+        .create_agent_wakeup(
+            &session_id,
+            fire_at,
+            prompt.trim(),
+            reason.as_deref(),
+            backend_id.as_deref(),
+            model.as_deref(),
+        )
         .map_err(|e| e.to_string())?;
     state.scheduler_notify.notify_waiters();
+    post_creation_note(
+        &app,
+        &state.db_path,
+        &task.workspace_id,
+        &task.chat_session_id,
+        format!(
+            "Scheduled wakeup for {}. Manage it from the scheduler (clock icon in the sidebar).",
+            fire_at.to_rfc3339()
+        ),
+    );
     Ok(task.into())
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn create_cron_routine(
     session_id: String,
     name: Option<String>,
     cron_expr: String,
     prompt: String,
     recurring: Option<bool>,
+    backend_id: Option<String>,
+    model: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<ScheduledTaskView, String> {
     if prompt.trim().is_empty() {
         return Err("prompt is required".to_string());
     }
+    let cron_expr = cron_expr.trim().to_string();
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let task = db
         .create_agent_cron_task(
             &session_id,
             name.as_deref(),
-            cron_expr.trim(),
+            &cron_expr,
             prompt.trim(),
             recurring.unwrap_or(true),
+            backend_id.as_deref(),
+            model.as_deref(),
         )
         .map_err(|e| e.to_string())?;
     state.scheduler_notify.notify_waiters();
+    post_creation_note(
+        &app,
+        &state.db_path,
+        &task.workspace_id,
+        &task.chat_session_id,
+        format!(
+            "Looping (`{cron_expr}` — {}). Manage it from the scheduler (clock icon in the sidebar).",
+            cron_to_human(&cron_expr)
+        ),
+    );
     Ok(task.into())
 }
 
@@ -183,13 +222,34 @@ pub async fn dispatch_task_prompt(
     source: &str,
 ) -> Result<(), String> {
     let prompt = build_dispatch_prompt(&task, source);
-    dispatch_prompt_to_session(app, task.chat_session_id, prompt).await
+    // Forward the row's pinned backend / model so a cron created from a
+    // Codex or Pi chat fires on the same runtime it was scheduled under.
+    // Either being `None` keeps the existing global-default fallback (the
+    // case for agent-callable rows and pre-migration rows).
+    dispatch_prompt_to_session_with_backend(
+        app,
+        task.chat_session_id,
+        prompt,
+        task.backend_id,
+        task.model,
+    )
+    .await
 }
 
 pub async fn dispatch_prompt_to_session(
     app: AppHandle,
     chat_session_id: String,
     prompt: String,
+) -> Result<(), String> {
+    dispatch_prompt_to_session_with_backend(app, chat_session_id, prompt, None, None).await
+}
+
+async fn dispatch_prompt_to_session_with_backend(
+    app: AppHandle,
+    chat_session_id: String,
+    prompt: String,
+    backend_id: Option<String>,
+    model: Option<String>,
 ) -> Result<(), String> {
     let state = app.state::<AppState>();
     crate::commands::chat::send::send_chat_message(
@@ -198,19 +258,61 @@ pub async fn dispatch_prompt_to_session(
         prompt,
         None,
         None,
+        model,
         None,
         None,
         None,
         None,
         None,
         None,
-        None,
-        None,
+        backend_id,
         None,
         app.clone(),
         state,
     )
     .await
+}
+
+/// Append a system-role chat message announcing that a wakeup / cron was
+/// scheduled, and emit `chat-system-message` so the chat panel renders it
+/// inline. Persisted to the DB so it survives reloads (and is visible
+/// across all backends without any frontend per-backend code) — replaces
+/// the prior frontend `addLocalMessage` which evaporated on refresh.
+/// Best-effort: a failure here doesn't unwind the scheduling itself.
+fn post_creation_note(
+    app: &AppHandle,
+    db_path: &std::path::Path,
+    workspace_id: &str,
+    chat_session_id: &str,
+    content: String,
+) {
+    let message = ChatMessage {
+        id: uuid::Uuid::new_v4().to_string(),
+        workspace_id: workspace_id.to_string(),
+        chat_session_id: chat_session_id.to_string(),
+        role: ChatRole::System,
+        content,
+        cost_usd: None,
+        duration_ms: None,
+        created_at: Utc::now().to_rfc3339(),
+        thinking: None,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: None,
+        cache_creation_tokens: None,
+    };
+    match Database::open(db_path).and_then(|db| db.insert_chat_message(&message)) {
+        Ok(()) => {
+            let _ = app.emit("chat-system-message", &message);
+        }
+        Err(err) => {
+            tracing::warn!(
+                target: "claudette::scheduling",
+                error = %err,
+                "failed to persist schedule confirmation message"
+            );
+        }
+    }
 }
 
 fn build_dispatch_prompt(task: &ScheduledTask, source: &str) -> String {
@@ -268,6 +370,8 @@ mod tests {
             updated_at: "now".into(),
             last_fired_at: None,
             next_fire_at: None,
+            backend_id: None,
+            model: None,
         }
     }
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -941,6 +941,15 @@ async fn handle_schedule_wakeup(
         .get("reason")
         .and_then(|v| v.as_str())
         .map(ToOwned::to_owned);
+    let backend_id = params
+        .get("backend_id")
+        .or_else(|| params.get("backendId"))
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned);
+    let model = params
+        .get("model")
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned);
     let state = app_state(app)?;
     let value = crate::commands::scheduling::schedule_wakeup(
         session_id,
@@ -948,6 +957,9 @@ async fn handle_schedule_wakeup(
         fire_at,
         prompt,
         reason,
+        backend_id,
+        model,
+        app.clone(),
         state,
     )
     .await?;
@@ -968,9 +980,26 @@ async fn handle_routine_create(
         .and_then(|v| v.as_str())
         .map(ToOwned::to_owned);
     let recurring = params.get("recurring").and_then(|v| v.as_bool());
+    let backend_id = params
+        .get("backend_id")
+        .or_else(|| params.get("backendId"))
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned);
+    let model = params
+        .get("model")
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned);
     let state = app_state(app)?;
     let value = crate::commands::scheduling::create_cron_routine(
-        session_id, name, cron_expr, prompt, recurring, state,
+        session_id,
+        name,
+        cron_expr,
+        prompt,
+        recurring,
+        backend_id,
+        model,
+        app.clone(),
+        state,
     )
     .await?;
     serde_json::to_value(value).map_err(|e| e.to_string())

--- a/src/agent/pi_sdk.rs
+++ b/src/agent/pi_sdk.rs
@@ -17,8 +17,14 @@ use super::{
     InnerStreamEvent, StartContentBlock, StreamEvent, TokenUsage, TokenUsageIteration, TurnHandle,
     UserContentBlock, UserEventMessage, UserMessageContent,
 };
+use crate::agent_mcp::bridge::Sink;
+use crate::agent_mcp::protocol::{BridgePayload, BridgeResponse};
 
 type PiStdin = Arc<tokio::sync::Mutex<ChildStdin>>;
+/// Shared host-side tool sink. Pi has no MCP bridge, so a `host_tool`
+/// sidecar message is routed straight through this `Sink` (the same
+/// `ChatBridgeSink` Claude/Codex reach over their MCP socket).
+type PiSink = Arc<dyn Sink>;
 type PendingRequests = Arc<tokio::sync::Mutex<BTreeMap<String, PendingPiRequest>>>;
 type TurnOutput = Arc<tokio::sync::Mutex<PiTurnOutput>>;
 type InitCacheHandle = Arc<tokio::sync::Mutex<InitCache>>;
@@ -86,7 +92,9 @@ struct InitCache {
     init: Option<AgentEvent>,
 }
 
-#[derive(Debug, Clone)]
+// No `Debug` derive: `sink` is a `dyn Sink` trait object, which is not
+// `Debug`. `PiSdkOptions` is built once and consumed, never formatted.
+#[derive(Clone)]
 pub struct PiSdkOptions {
     pub model: Option<String>,
     pub thinking_level: Option<String>,
@@ -106,6 +114,10 @@ pub struct PiSdkOptions {
     /// in the provider auth UI. Maps a Pi-recognized env var name
     /// (e.g. `OPENROUTER_API_KEY`) to its value. Empty by default.
     pub pi_provider_env: Vec<(String, String)>,
+    /// Host-side tool sink for `host_tool` round-trips from the sidecar
+    /// (native scheduling tools). `None` disables them — the sidecar's
+    /// scheduling tools then report "scheduling unavailable".
+    pub sink: Option<PiSink>,
 }
 
 pub struct PiSdkSession {
@@ -122,6 +134,9 @@ pub struct PiSdkSession {
     working_dir: PathBuf,
     turn_output: TurnOutput,
     init_cache: InitCacheHandle,
+    /// Host-side tool sink for `host_tool` sidecar round-trips. Cloned
+    /// into the stdout reader task at spawn time.
+    sink: Option<PiSink>,
 }
 
 /// Setup knobs for `PiSdkSession::spawn_initialized`. `start` and
@@ -141,6 +156,10 @@ struct PiSpawnConfig<'a> {
     /// touching `~/.pi/agent/auth.json`.
     extra_env: Option<&'a [(String, String)]>,
     cache_command_line: bool,
+    /// Host-side tool sink, forwarded to the stdout reader so `host_tool`
+    /// messages can be served the moment the sidecar starts. `None` for
+    /// control-plane sessions, which never run agent tools.
+    sink: Option<PiSink>,
 }
 
 impl PiSdkSession {
@@ -159,6 +178,7 @@ impl PiSdkSession {
                 Some(&options.pi_provider_env)
             },
             cache_command_line: true,
+            sink: options.sink.clone(),
         })
         .await?;
         if let Err(err) = session.start_session(session_id, options).await {
@@ -220,6 +240,7 @@ impl PiSdkSession {
             workspace_env: None,
             extra_env,
             cache_command_line: false,
+            sink: None,
         })
         .await
     }
@@ -312,6 +333,7 @@ impl PiSdkSession {
             working_dir: config.working_dir.to_path_buf(),
             turn_output: Arc::new(tokio::sync::Mutex::new(PiTurnOutput::default())),
             init_cache: Arc::new(tokio::sync::Mutex::new(InitCache::default())),
+            sink: config.sink,
         };
 
         session.spawn_stdout_reader(stdout);
@@ -350,6 +372,7 @@ impl PiSdkSession {
             working_dir: PathBuf::from("/tmp"),
             turn_output: Arc::new(tokio::sync::Mutex::new(PiTurnOutput::default())),
             init_cache: Arc::new(tokio::sync::Mutex::new(InitCache::default())),
+            sink: None,
         }
     }
 
@@ -632,6 +655,8 @@ impl PiSdkSession {
         let pending = self.pending.clone();
         let turn_output = self.turn_output.clone();
         let init_cache = self.init_cache.clone();
+        let stdin = self.stdin.clone();
+        let sink = self.sink.clone();
         tokio::spawn(async move {
             let reader = tokio::io::BufReader::new(stdout);
             let mut lines = reader.lines();
@@ -640,6 +665,17 @@ impl PiSdkSession {
                     continue;
                 }
                 match serde_json::from_str::<PiHarnessMessage>(&line) {
+                    Ok(PiHarnessMessage::HostTool {
+                        request_id,
+                        name,
+                        args,
+                    }) => {
+                        // Served off the reader loop so a slow DB write
+                        // never stalls stdout draining. Intercepted here
+                        // because this is the only place that holds the
+                        // live `stdin` + `sink`.
+                        handle_host_tool(stdin.clone(), sink.clone(), request_id, name, args);
+                    }
                     Ok(message) => {
                         route_pi_message(
                             &event_tx,
@@ -773,6 +809,18 @@ enum PiHarnessMessage {
         tool_call_id: String,
         kind: String,
         input: Value,
+    },
+    /// A native scheduling tool in the Pi sidecar wants the host to run a
+    /// `BridgePayload` and return the result. Intercepted in the stdout
+    /// reader loop (which holds `stdin` + `sink`) — never reaches
+    /// [`route_pi_message`].
+    #[serde(rename = "host_tool")]
+    HostTool {
+        #[serde(rename = "requestId")]
+        request_id: String,
+        name: String,
+        #[serde(default)]
+        args: Value,
     },
     #[serde(rename = "tool_update")]
     ToolUpdate {
@@ -1490,7 +1538,108 @@ async fn route_pi_message(
                 error,
             });
         }
+        // Intercepted in `spawn_stdout_reader`'s loop before this routes —
+        // listed only to keep the match exhaustive.
+        PiHarnessMessage::HostTool { .. } => {}
         PiHarnessMessage::Unknown => {}
+    }
+}
+
+/// Serve a `host_tool` sidecar request: run its `BridgePayload` through
+/// the host `Sink` and write a `host_tool_result` line back to the
+/// sidecar. Spawned as a detached task so the stdout reader keeps
+/// draining while the (blocking-ish) DB write runs.
+fn handle_host_tool(
+    stdin: Option<PiStdin>,
+    sink: Option<PiSink>,
+    request_id: String,
+    name: String,
+    args: Value,
+) {
+    tokio::spawn(async move {
+        let response = run_host_tool(sink, &name, args).await;
+        let Some(stdin) = stdin else {
+            tracing::warn!(
+                target: "claudette::agent",
+                subsystem = "pi-sdk",
+                tool = %name,
+                "host_tool result dropped — sidecar stdin unavailable"
+            );
+            return;
+        };
+        let line = json!({
+            "type": "host_tool_result",
+            "requestId": request_id,
+            "ok": response.ok,
+            "message": response.message,
+            "data": response.data,
+            "error": response.error,
+        });
+        let Ok(mut bytes) = serde_json::to_vec(&line) else {
+            return;
+        };
+        bytes.push(b'\n');
+        let mut guard = stdin.lock().await;
+        if let Err(err) = guard.write_all(&bytes).await {
+            tracing::warn!(
+                target: "claudette::agent",
+                subsystem = "pi-sdk",
+                error = %err,
+                "failed to write host_tool_result to sidecar"
+            );
+        }
+    });
+}
+
+/// Map a `host_tool` request to a `BridgePayload` and run it through the
+/// sink. A missing sink (control session, or a build without scheduling)
+/// degrades to an error result rather than panicking.
+async fn run_host_tool(sink: Option<PiSink>, name: &str, args: Value) -> BridgeResponse {
+    let payload = match bridge_payload_for(name, args) {
+        Ok(payload) => payload,
+        Err(err) => return BridgeResponse::err(err),
+    };
+    match sink {
+        Some(sink) => sink.handle(payload).await,
+        None => BridgeResponse::err("scheduling is unavailable for this session"),
+    }
+}
+
+/// Translate a native Pi scheduling tool name + arguments into the
+/// shared [`BridgePayload`]. Accepts both the camelCase keys the sidecar
+/// sends and the snake_case aliases the MCP server tolerates, so the two
+/// tool surfaces stay interchangeable. An unknown name is an error, not
+/// a panic — a future user Pi extension can add tools without this
+/// dispatch table needing to recognize them.
+fn bridge_payload_for(name: &str, args: Value) -> Result<BridgePayload, String> {
+    let str_arg = |keys: &[&str]| -> Option<String> {
+        keys.iter()
+            .find_map(|k| args.get(*k).and_then(Value::as_str))
+            .map(ToOwned::to_owned)
+    };
+    match name {
+        "ScheduleWakeup" => Ok(BridgePayload::ScheduleWakeup {
+            delay_seconds: ["delaySeconds", "delay_seconds"]
+                .iter()
+                .find_map(|k| args.get(*k).and_then(Value::as_i64)),
+            fire_at: str_arg(&["fireAt", "fire_at"]),
+            prompt: str_arg(&["prompt"]).ok_or("prompt is required")?,
+            reason: str_arg(&["reason"]),
+        }),
+        "CronCreate" => Ok(BridgePayload::CronCreate {
+            name: str_arg(&["name"]),
+            cron_expr: str_arg(&["cron", "cron_expr"]).ok_or("cron is required")?,
+            prompt: str_arg(&["prompt"]).ok_or("prompt is required")?,
+            recurring: args
+                .get("recurring")
+                .and_then(Value::as_bool)
+                .unwrap_or(true),
+        }),
+        "CronList" => Ok(BridgePayload::CronList),
+        "CronDelete" => Ok(BridgePayload::CronDelete {
+            id: str_arg(&["id", "name"]).ok_or("id is required")?,
+        }),
+        other => Err(format!("unknown host tool: {other}")),
     }
 }
 
@@ -1822,6 +1971,142 @@ mod tests {
         let value = r#"{"type":"tool_request","requestId":"r1","toolCallId":"t1","kind":"commandExecution","input":{"command":"echo hi"}}"#;
         let msg: PiHarnessMessage = serde_json::from_str(value).unwrap();
         assert!(matches!(msg, PiHarnessMessage::ToolRequest { .. }));
+    }
+
+    #[test]
+    fn parses_host_tool() {
+        let value = r#"{"type":"host_tool","requestId":"t1","name":"CronCreate","args":{"cron":"0 9 * * *"}}"#;
+        match serde_json::from_str::<PiHarnessMessage>(value).unwrap() {
+            PiHarnessMessage::HostTool {
+                request_id,
+                name,
+                args,
+            } => {
+                assert_eq!(request_id, "t1");
+                assert_eq!(name, "CronCreate");
+                assert_eq!(args["cron"], "0 9 * * *");
+            }
+            other => panic!("expected HostTool, got {other:?}"),
+        }
+        // Zero-parameter tools omit `args`; the field must still parse.
+        let no_args = r#"{"type":"host_tool","requestId":"t2","name":"CronList"}"#;
+        assert!(matches!(
+            serde_json::from_str::<PiHarnessMessage>(no_args).unwrap(),
+            PiHarnessMessage::HostTool { .. }
+        ));
+    }
+
+    #[test]
+    fn bridge_payload_for_maps_each_scheduling_tool() {
+        // camelCase keys (what the sidecar sends).
+        match bridge_payload_for(
+            "ScheduleWakeup",
+            json!({ "prompt": "ping", "delaySeconds": 60, "reason": "later" }),
+        )
+        .unwrap()
+        {
+            BridgePayload::ScheduleWakeup {
+                delay_seconds,
+                prompt,
+                reason,
+                ..
+            } => {
+                assert_eq!(delay_seconds, Some(60));
+                assert_eq!(prompt, "ping");
+                assert_eq!(reason.as_deref(), Some("later"));
+            }
+            other => panic!("expected ScheduleWakeup, got {other:?}"),
+        }
+        // snake_case aliases still work — parity with the MCP server.
+        assert!(matches!(
+            bridge_payload_for(
+                "ScheduleWakeup",
+                json!({ "prompt": "p", "delay_seconds": 5 })
+            )
+            .unwrap(),
+            BridgePayload::ScheduleWakeup {
+                delay_seconds: Some(5),
+                ..
+            }
+        ));
+        // CronCreate defaults `recurring` to true.
+        match bridge_payload_for("CronCreate", json!({ "cron": "0 9 * * *", "prompt": "go" }))
+            .unwrap()
+        {
+            BridgePayload::CronCreate {
+                cron_expr,
+                recurring,
+                name,
+                ..
+            } => {
+                assert_eq!(cron_expr, "0 9 * * *");
+                assert!(recurring);
+                assert_eq!(name, None);
+            }
+            other => panic!("expected CronCreate, got {other:?}"),
+        }
+        assert!(matches!(
+            bridge_payload_for("CronList", json!({})).unwrap(),
+            BridgePayload::CronList
+        ));
+        // CronDelete accepts `name` as an alias for `id`.
+        assert!(matches!(
+            bridge_payload_for("CronDelete", json!({ "name": "morning" })).unwrap(),
+            BridgePayload::CronDelete { .. }
+        ));
+    }
+
+    #[test]
+    fn bridge_payload_for_rejects_bad_input() {
+        assert!(bridge_payload_for("ScheduleWakeup", json!({})).is_err());
+        assert!(bridge_payload_for("CronCreate", json!({ "prompt": "x" })).is_err());
+        assert!(bridge_payload_for("CronDelete", json!({})).is_err());
+        // An unrecognized tool is an error, not a panic — leaves room
+        // for future user Pi extensions to add their own host tools.
+        assert!(
+            bridge_payload_for("SomeFutureExtensionTool", json!({}))
+                .unwrap_err()
+                .contains("unknown host tool")
+        );
+    }
+
+    #[tokio::test]
+    async fn run_host_tool_forwards_payload_to_sink() {
+        struct RecordingSink {
+            last: std::sync::Mutex<Option<BridgePayload>>,
+        }
+        impl Sink for RecordingSink {
+            fn handle(
+                &self,
+                payload: BridgePayload,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = BridgeResponse> + Send + '_>>
+            {
+                Box::pin(async move {
+                    *self.last.lock().unwrap() = Some(payload);
+                    BridgeResponse::message("ok")
+                })
+            }
+        }
+        let recorder = Arc::new(RecordingSink {
+            last: std::sync::Mutex::new(None),
+        });
+        let sink: PiSink = recorder.clone();
+        let response = run_host_tool(Some(sink), "CronDelete", json!({ "id": "task-9" })).await;
+        assert!(response.ok);
+        match recorder.last.lock().unwrap().clone() {
+            Some(BridgePayload::CronDelete { id }) => assert_eq!(id, "task-9"),
+            other => panic!("expected CronDelete to reach the sink, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_host_tool_degrades_without_sink_or_on_bad_input() {
+        // No sink (control session / scheduling-disabled build).
+        let no_sink = run_host_tool(None, "CronList", json!({})).await;
+        assert!(!no_sink.ok && no_sink.error.is_some());
+        // Bad args never reach the sink.
+        let bad = run_host_tool(None, "ScheduleWakeup", json!({})).await;
+        assert!(!bad.ok && bad.error.is_some());
     }
 
     #[test]

--- a/src/agent_mcp/mod.rs
+++ b/src/agent_mcp/mod.rs
@@ -90,6 +90,15 @@ Claudette to wake this chat later with a prompt. Use the cron tools for \
 recurring routines. Use `Monitor` to subscribe to future output from a \
 background Bash task instead of polling.";
 
+/// Scheduling nudge for Pi SDK sessions. Pi has no Claudette MCP bridge —
+/// its scheduling tools are registered as *native* sidecar tools, so this
+/// is worded without the `mcp__claudette__` prefixes [`SYSTEM_PROMPT_NUDGE`]
+/// uses, and omits `send_to_user` / `Monitor` (Pi ships neither).
+pub const PI_SCHEDULING_NUDGE: &str = "\
+Native scheduling: you have the tools `ScheduleWakeup`, `CronCreate`, \
+`CronList`, and `CronDelete`. Use `ScheduleWakeup` to wake this chat later \
+with a prompt; use the cron tools for recurring routines.";
+
 /// Claude-CLI-only rules that reference MCP tools shipped by the Claude
 /// Code runtime (`AskUserQuestion`, `ExitPlanMode`). These tools do not
 /// exist in the Pi SDK or the Codex app-server harnesses, so the rules

--- a/src/agent_mcp/mod.rs
+++ b/src/agent_mcp/mod.rs
@@ -61,15 +61,14 @@ pub fn is_builtin_plugin_enabled(db: &crate::db::Database, name: &str) -> bool {
     }
 }
 
-/// System-prompt nudge appended to every fresh persistent session so the model
-/// is aware of the agent-MCP tool's purpose — the bare `tools/list` description
-/// isn't enough on its own (a model can see the tool listed and still default
-/// to "save to disk" when the user says "send me a screenshot").
-///
-/// Worded as a positive instruction with the supported-type allow-list and the
-/// failure-mode escape hatch both spelled out, so the model doesn't reach for
-/// `send_to_user` on types it can't deliver.
-pub const SYSTEM_PROMPT_NUDGE: &str = "\
+/// `send_to_user` nudge appended only when the Agent Attachments plugin is
+/// enabled. The bare `tools/list` description isn't enough on its own — a
+/// model can see the tool listed and still default to "save to disk" when
+/// the user says "send me a screenshot". Worded as a positive instruction
+/// with the supported-type allow-list and the failure-mode escape hatch
+/// both spelled out, so the model doesn't reach for `send_to_user` on types
+/// it can't deliver.
+pub const SEND_TO_USER_NUDGE: &str = "\
 Inline file delivery: this Claudette workspace exposes the MCP tool \
 `mcp__claudette__send_to_user` (server `claudette`, tool `send_to_user`). \
 When the user asks you to send / share / show them a file, call this tool \
@@ -82,17 +81,44 @@ Supported types: images (PNG/JPEG/GIF/WebP/SVG), PDF, plain text, CSV, \
 JSON, Markdown — each with its own size cap. For any other type \
 (binaries, archives, oversized files), do NOT call this tool; the call \
 will be rejected. Instead, tell the user the absolute path on disk so \
-they can open it manually.\n\
-\n\
-Native scheduling: this same server exposes `ScheduleWakeup`, `CronCreate`, \
+they can open it manually.";
+
+/// Scheduling + Monitor nudge for MCP-served harnesses (Claude / Codex).
+/// Always appended, regardless of the Agent Attachments toggle — the MCP
+/// server is now injected unconditionally, so scheduling discoverability
+/// must not regress when the user disables `send_to_user`. Pi has its own
+/// nudge ([`PI_SCHEDULING_NUDGE`]) because it ships a different tool
+/// surface (no `Monitor`, no MCP `mcp__claudette__` prefixes).
+pub const MCP_SCHEDULING_NUDGE: &str = "\
+Native scheduling: this server exposes `ScheduleWakeup`, `CronCreate`, \
 `CronList`, `CronDelete`, and `Monitor`. Use `ScheduleWakeup` when you need \
 Claudette to wake this chat later with a prompt. Use the cron tools for \
 recurring routines. Use `Monitor` to subscribe to future output from a \
 background Bash task instead of polling.";
 
+/// Compose the Claude / Codex system-prompt nudge. `MCP_SCHEDULING_NUDGE`
+/// is always included (scheduling is decoupled from the Agent Attachments
+/// toggle); `SEND_TO_USER_NUDGE` is only appended when the user has the
+/// Agent Attachments plugin enabled. Returns `None` when nothing applies
+/// (currently unreachable — scheduling is always on — but kept symmetric
+/// with the call site's `Option<String>` shape).
+#[must_use]
+pub fn mcp_system_prompt_nudge(send_to_user_enabled: bool) -> Option<String> {
+    let mut parts: Vec<&str> = Vec::with_capacity(2);
+    parts.push(MCP_SCHEDULING_NUDGE);
+    if send_to_user_enabled {
+        parts.push(SEND_TO_USER_NUDGE);
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n\n"))
+    }
+}
+
 /// Scheduling nudge for Pi SDK sessions. Pi has no Claudette MCP bridge —
 /// its scheduling tools are registered as *native* sidecar tools, so this
-/// is worded without the `mcp__claudette__` prefixes [`SYSTEM_PROMPT_NUDGE`]
+/// is worded without the `mcp__claudette__` prefixes [`MCP_SCHEDULING_NUDGE`]
 /// uses, and omits `send_to_user` / `Monitor` (Pi ships neither).
 pub const PI_SCHEDULING_NUDGE: &str = "\
 Native scheduling: you have the tools `ScheduleWakeup`, `CronCreate`, \
@@ -136,6 +162,32 @@ mod builtin_tests {
         db.set_app_setting(&builtin_plugin_setting_key("send_to_user"), "true")
             .unwrap();
         assert!(is_builtin_plugin_enabled(&db, "send_to_user"));
+    }
+
+    #[test]
+    fn nudge_with_send_to_user_enabled_contains_both_blocks() {
+        // Toggle on → scheduling + send_to_user, joined with a blank
+        // line. Splitting the two strings (rather than emitting one
+        // bundled `SYSTEM_PROMPT_NUDGE`) is what keeps scheduling
+        // discoverable when a user disables Agent Attachments.
+        let composed = mcp_system_prompt_nudge(true).expect("nudge always present");
+        assert!(composed.contains("ScheduleWakeup"));
+        assert!(composed.contains("Monitor"));
+        assert!(composed.contains("send_to_user"));
+        assert!(composed.contains("\n\n"));
+    }
+
+    #[test]
+    fn nudge_with_send_to_user_disabled_keeps_scheduling_block() {
+        // Toggle off → scheduling/Monitor guidance is still injected
+        // (the MCP server is unconditional), but the file-delivery
+        // paragraph is stripped. Pins the decoupling fix Copilot
+        // flagged on #980.
+        let composed = mcp_system_prompt_nudge(false).expect("scheduling is always on");
+        assert!(composed.contains("ScheduleWakeup"));
+        assert!(composed.contains("Monitor"));
+        assert!(!composed.contains("send_to_user"));
+        assert!(!composed.contains("Inline file delivery"));
     }
 
     #[test]

--- a/src/db/scheduling.rs
+++ b/src/db/scheduling.rs
@@ -12,6 +12,8 @@ impl Database {
         fire_at: DateTime<Utc>,
         prompt: &str,
         reason: Option<&str>,
+        backend_id: Option<&str>,
+        model: Option<&str>,
     ) -> Result<ScheduledTask, rusqlite::Error> {
         let workspace_id = self.workspace_id_for_chat_session(chat_session_id)?;
         let id = uuid::Uuid::new_v4().to_string();
@@ -20,8 +22,9 @@ impl Database {
         self.conn.execute(
             "INSERT INTO agent_scheduled_tasks
                 (id, chat_session_id, workspace_id, kind, prompt, reason, fire_at,
-                 recurring, enabled, created_at, updated_at, next_fire_at)
-             VALUES (?1, ?2, ?3, 'wakeup', ?4, ?5, ?6, 0, 1, ?7, ?7, ?6)",
+                 recurring, enabled, created_at, updated_at, next_fire_at,
+                 backend_id, model)
+             VALUES (?1, ?2, ?3, 'wakeup', ?4, ?5, ?6, 0, 1, ?7, ?7, ?6, ?8, ?9)",
             params![
                 id,
                 chat_session_id,
@@ -29,7 +32,9 @@ impl Database {
                 prompt,
                 reason,
                 fire_at,
-                now
+                now,
+                backend_id.map(str::trim).filter(|s| !s.is_empty()),
+                model.map(str::trim).filter(|s| !s.is_empty()),
             ],
         )?;
         self.get_agent_scheduled_task(&id)?
@@ -43,6 +48,8 @@ impl Database {
         cron_expr: &str,
         prompt: &str,
         recurring: bool,
+        backend_id: Option<&str>,
+        model: Option<&str>,
     ) -> Result<ScheduledTask, rusqlite::Error> {
         let workspace_id = self.workspace_id_for_chat_session(chat_session_id)?;
         let id = uuid::Uuid::new_v4().to_string();
@@ -57,8 +64,9 @@ impl Database {
         self.conn.execute(
             "INSERT INTO agent_scheduled_tasks
                 (id, chat_session_id, workspace_id, kind, name, prompt, cron_expr,
-                 recurring, enabled, created_at, updated_at, next_fire_at)
-             VALUES (?1, ?2, ?3, 'cron', ?4, ?5, ?6, ?7, 1, ?8, ?8, ?9)",
+                 recurring, enabled, created_at, updated_at, next_fire_at,
+                 backend_id, model)
+             VALUES (?1, ?2, ?3, 'cron', ?4, ?5, ?6, ?7, 1, ?8, ?8, ?9, ?10, ?11)",
             params![
                 id,
                 chat_session_id,
@@ -68,7 +76,9 @@ impl Database {
                 cron_expr,
                 if recurring { 1 } else { 0 },
                 now,
-                next
+                next,
+                backend_id.map(str::trim).filter(|s| !s.is_empty()),
+                model.map(str::trim).filter(|s| !s.is_empty()),
             ],
         )?;
         self.get_agent_scheduled_task(&id)?
@@ -83,7 +93,7 @@ impl Database {
             .query_row(
                 "SELECT id, chat_session_id, workspace_id, kind, name, prompt, reason,
                         fire_at, cron_expr, recurring, enabled, created_at, updated_at,
-                        last_fired_at, next_fire_at
+                        last_fired_at, next_fire_at, backend_id, model
                  FROM agent_scheduled_tasks
                  WHERE id = ?1",
                 params![id],
@@ -96,7 +106,7 @@ impl Database {
         let mut stmt = self.conn.prepare(
             "SELECT id, chat_session_id, workspace_id, kind, name, prompt, reason,
                     fire_at, cron_expr, recurring, enabled, created_at, updated_at,
-                    last_fired_at, next_fire_at
+                    last_fired_at, next_fire_at, backend_id, model
              FROM agent_scheduled_tasks
              ORDER BY enabled DESC, next_fire_at IS NULL, next_fire_at, created_at",
         )?;
@@ -110,7 +120,7 @@ impl Database {
         let mut stmt = self.conn.prepare(
             "SELECT id, chat_session_id, workspace_id, kind, name, prompt, reason,
                     fire_at, cron_expr, recurring, enabled, created_at, updated_at,
-                    last_fired_at, next_fire_at
+                    last_fired_at, next_fire_at, backend_id, model
              FROM agent_scheduled_tasks
              WHERE chat_session_id = ?1
              ORDER BY enabled DESC, next_fire_at IS NULL, next_fire_at, created_at",
@@ -127,7 +137,7 @@ impl Database {
         let mut stmt = self.conn.prepare(
             "SELECT id, chat_session_id, workspace_id, kind, name, prompt, reason,
                     fire_at, cron_expr, recurring, enabled, created_at, updated_at,
-                    last_fired_at, next_fire_at
+                    last_fired_at, next_fire_at, backend_id, model
              FROM agent_scheduled_tasks
              WHERE enabled = 1 AND next_fire_at IS NOT NULL AND next_fire_at <= ?1
              ORDER BY next_fire_at, created_at",
@@ -249,6 +259,8 @@ fn parse_scheduled_task_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Schedul
         updated_at: row.get(12)?,
         last_fired_at: row.get(13)?,
         next_fire_at: row.get(14)?,
+        backend_id: row.get(15)?,
+        model: row.get(16)?,
     })
 }
 
@@ -269,7 +281,14 @@ mod tests {
         let fire_at = Utc::now() + chrono::Duration::minutes(5);
 
         let task = db
-            .create_agent_wakeup(&session.id, fire_at, "check the build", Some("build"))
+            .create_agent_wakeup(
+                &session.id,
+                fire_at,
+                "check the build",
+                Some("build"),
+                None,
+                None,
+            )
             .unwrap();
         assert_eq!(task.kind, ScheduledTaskKind::Wakeup);
         assert_eq!(task.chat_session_id, session.id);
@@ -290,7 +309,15 @@ mod tests {
         let session: ChatSession = db.create_chat_session(&ws.id).unwrap();
 
         let task = db
-            .create_agent_cron_task(&session.id, Some("hourly"), "0 * * * *", "check", true)
+            .create_agent_cron_task(
+                &session.id,
+                Some("hourly"),
+                "0 * * * *",
+                "check",
+                true,
+                None,
+                None,
+            )
             .unwrap();
         assert_eq!(task.kind, ScheduledTaskKind::Cron);
         assert_eq!(task.name.as_deref(), Some("hourly"));
@@ -308,10 +335,18 @@ mod tests {
         let session_b = db.create_chat_session(&ws.id).unwrap();
 
         let task_a = db
-            .create_agent_cron_task(&session_a.id, Some("same-name"), "0 * * * *", "a", true)
+            .create_agent_cron_task(
+                &session_a.id,
+                Some("same-name"),
+                "0 * * * *",
+                "a",
+                true,
+                None,
+                None,
+            )
             .unwrap();
         let task_b = db
-            .create_agent_cron_task(&session_b.id, None, "0 * * * *", "b", true)
+            .create_agent_cron_task(&session_b.id, None, "0 * * * *", "b", true, None, None)
             .unwrap();
 
         let rows = db
@@ -347,6 +382,8 @@ mod tests {
                 &session.id,
                 now - chrono::Duration::minutes(1),
                 "check",
+                None,
+                None,
                 None,
             )
             .unwrap();

--- a/src/migrations/20260521143000_agent_scheduled_tasks_backend.sql
+++ b/src/migrations/20260521143000_agent_scheduled_tasks_backend.sql
@@ -1,0 +1,16 @@
+-- Capture which agent backend (and optional model) a scheduled task was
+-- created under, so the scheduler dispatches the firing turn to the right
+-- runtime instead of resolving to the global default backend.
+--
+-- Background: `dispatch_prompt_to_session` calls `send_chat_message` with
+-- `backend_id: None`, which `resolve_backend_request_defaults` resolves to
+-- the `default_agent_backend` app setting (defaults to "anthropic"). So a
+-- cron created from a Codex or Pi chat used to fire on Claude instead of
+-- the chat's actual backend.
+--
+-- Both columns are nullable on purpose: rows created before this migration,
+-- and agent-callable scheduling that opts not to pin a backend, keep the
+-- legacy global-default behavior.
+
+ALTER TABLE agent_scheduled_tasks ADD COLUMN backend_id TEXT;
+ALTER TABLE agent_scheduled_tasks ADD COLUMN model TEXT;

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -254,4 +254,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260521062827_checkpoint_files_dedup.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260521143000_agent_scheduled_tasks_backend",
+        sql: include_str!("20260521143000_agent_scheduled_tasks_backend.sql"),
+        legacy_version: None,
+    },
 ];

--- a/src/scheduling.rs
+++ b/src/scheduling.rs
@@ -47,6 +47,16 @@ pub struct ScheduledTask {
     pub updated_at: String,
     pub last_fired_at: Option<String>,
     pub next_fire_at: Option<String>,
+    /// Backend the task was scheduled under. The scheduler passes this
+    /// through to `send_chat_message` so a Codex- or Pi-chat cron fires
+    /// on its own backend instead of falling through to the global
+    /// `default_agent_backend` app setting. `None` for legacy rows and
+    /// for agent-callable scheduling that chose not to pin a backend —
+    /// those keep the prior global-default behavior.
+    pub backend_id: Option<String>,
+    /// Model id captured at schedule time. Forwarded to
+    /// `send_chat_message` like [`Self::backend_id`].
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -798,15 +798,19 @@ const loopHandler: NativeHandler = {
       return handled;
     }
     try {
+      // Pin the toolbar's current backend + model on the row so the cron
+      // fires on the runtime the user picked, not on whatever happens to
+      // be the global default at fire time. The host-side command now
+      // also writes a System chat message announcing the schedule (one
+      // persisted note for all 3 backends — no per-backend wiring here).
       await createCronRoutine({
         sessionId: ctx.sessionId,
         cronExpr,
         prompt,
         recurring: true,
+        backendId: ctx.selectedModelProvider || undefined,
+        model: ctx.selectedModel || undefined,
       });
-      ctx.addLocalMessage(
-        `Looping (\`${cronExpr}\`). Manage it from the scheduler (clock icon in the sidebar).`,
-      );
     } catch (e) {
       ctx.addLocalMessage(`/loop failed: ${String(e)}`);
     }
@@ -836,16 +840,18 @@ const scheduleHandler: NativeHandler = {
       const rest = trimmed.slice(firstTok.length).trim();
       if (!Number.isNaN(parsed.getTime()) && ctx.sessionId && rest) {
         // Inline schedule: known time, known prompt, known session — fire
-        // the wakeup directly instead of opening the modal.
+        // the wakeup directly instead of opening the modal. Pin the
+        // toolbar's backend + model so the cron fires on the runtime the
+        // user picked. Confirmation message is persisted by the host
+        // command (one path for all 3 backends).
         try {
           await scheduleWakeup({
             sessionId: ctx.sessionId,
             fireAt: parsed.toISOString(),
             prompt: rest,
+            backendId: ctx.selectedModelProvider || undefined,
+            model: ctx.selectedModel || undefined,
           });
-          ctx.addLocalMessage(
-            `Scheduled for ${parsed.toLocaleString()}. Manage it from the scheduler (clock icon in the sidebar).`,
-          );
         } catch (e) {
           ctx.addLocalMessage(`/schedule failed: ${String(e)}`);
         }

--- a/src/ui/src/services/tauri/scheduling.ts
+++ b/src/ui/src/services/tauri/scheduling.ts
@@ -18,6 +18,14 @@ export interface ScheduledTask {
   updated_at: string;
   last_fired_at: string | null;
   next_fire_at: string | null;
+  /** Backend the task was scheduled under. The scheduler forwards this to
+   *  `send_chat_message` on fire so a cron created from a Codex / Pi chat
+   *  runs on the same runtime it was scheduled under. `null` falls back
+   *  to the global default backend at fire time. */
+  backend_id: string | null;
+  /** Model id captured at schedule time. `null` falls back to the
+   *  backend's default model at fire time. */
+  model: string | null;
   human_schedule: string | null;
 }
 
@@ -34,13 +42,16 @@ export function runScheduledRoutine(id: string): Promise<{ ok: boolean }> {
 }
 
 /** Schedule a one-shot wakeup. Either `delaySeconds` or `fireAt` (RFC3339)
- *  must be provided. */
+ *  must be provided. Pass `backendId` / `model` to pin the runtime the
+ *  fired turn will use; both default to the global default backend. */
 export function scheduleWakeup(args: {
   sessionId: string;
   delaySeconds?: number;
   fireAt?: string;
   prompt: string;
   reason?: string;
+  backendId?: string;
+  model?: string;
 }): Promise<ScheduledTask> {
   return invoke("schedule_wakeup", {
     sessionId: args.sessionId,
@@ -48,17 +59,22 @@ export function scheduleWakeup(args: {
     fireAt: args.fireAt ?? null,
     prompt: args.prompt,
     reason: args.reason ?? null,
+    backendId: args.backendId ?? null,
+    model: args.model ?? null,
   });
 }
 
 /** Create a recurring cron routine. `cronExpr` is the standard 5-field
- *  cron expression interpreted in local time. */
+ *  cron expression interpreted in local time. See [`scheduleWakeup`] for
+ *  the `backendId` / `model` semantics. */
 export function createCronRoutine(args: {
   sessionId: string;
   name?: string;
   cronExpr: string;
   prompt: string;
   recurring?: boolean;
+  backendId?: string;
+  model?: string;
 }): Promise<ScheduledTask> {
   return invoke("create_cron_routine", {
     sessionId: args.sessionId,
@@ -66,5 +82,7 @@ export function createCronRoutine(args: {
     cronExpr: args.cronExpr,
     prompt: args.prompt,
     recurring: args.recurring ?? true,
+    backendId: args.backendId ?? null,
+    model: args.model ?? null,
   });
 }


### PR DESCRIPTION
Stacked on #975. Targets `doomspork/investigate-loops-scheduling`, not `main`.

## Summary

PR #975 added the Loops and Schedules UI plus the `/loop` and `/schedule` slash commands. That UI surface is already backend-agnostic — a cron created from a Codex or Pi chat fires correctly through `send_chat_message`. What was **not** uniform is the agent-callable side: the `ScheduleWakeup` / `CronCreate` / `CronList` / `CronDelete` tools an agent invokes on itself.

Before this branch:

- **Claude**: gets the scheduling tools via the in-process MCP server.
- **Codex**: gets them too — but only when the `send_to_user` (\"Agent Attachments\") builtin plugin is enabled. Disabling that plugin silently killed scheduling.
- **Pi**: never got them. The Pi SDK has no MCP support, so the bridge was always `None`.

This branch makes agent-callable scheduling work uniformly on all three backends, decouples scheduling from the unrelated `send_to_user` toggle, and pins the toolbar's backend + model on each scheduled row so a cron fires on the runtime it was scheduled under.

## What changed

### 1. Pi gets the four native scheduling tools (no MCP)

Pi has no MCP support, so we can't reuse the Claude / Codex injection path. Instead the Pi sidecar (`src-pi-harness/src/main.ts`) registers `ScheduleWakeup` / `CronCreate` / `CronList` / `CronDelete` as native `customTools`. Each `execute()` round-trips a generic `host_tool` JSONL message to the Rust host:

- **Sidecar**: `pendingHostTools: Map<string, {resolve, reject}>` mirrors the existing `pendingTools`/`approval()` round-trip pattern. The `abort` handler now also drains `pendingHostTools` with a rejection so an interrupted turn doesn't strand a dangling promise.
- **Host (`src/agent/pi_sdk.rs`)**: new `PiHarnessMessage::HostTool { request_id, name, args }` variant. `spawn_stdout_reader` intercepts it on the reader loop and hands it to `handle_host_tool`, which spawns a task so a slow `Database::open` can't stall stdout draining. `bridge_payload_for(name, args)` maps tool names → `BridgePayload` (snake\_case + camelCase aliases). Unknown names degrade gracefully to an error instead of panicking — forward-compatible with future user-authored Pi extensions.
- **Sink**: `PiSdkSession` carries an `Option<Arc<dyn Sink>>`. `send.rs` constructs a `ChatBridgeSink` (the same one Claude/Codex reach over their MCP socket) and passes it in. The host calls the sink in-process; the sidecar connects to nothing. Pi gets no `McpBridgeSession` and no `mcp_config` entry.

Tool activity renders in chat for free — `customTools` emit the same `tool_execution_*` SDK events that the existing `routeSessionEvent` already forwards as `tool_update` / `tool_result`.

### 2. Scheduling decoupled from `send_to_user` (for Claude and Codex)

In both the spawn block and the respawn block of `send_chat_message`, the MCP-server injection is now unconditional for Claude and Codex — we dropped the `if send_to_user_enabled` guard and the dead `CodexAppServer => None` arm. The Remote Control path got the same fix.

`send_to_user` itself remains user-toggleable: when the Agent Attachments plugin is disabled, the `SendAttachment` arm in `agent_mcp_sink.rs` calls `is_builtin_plugin_enabled` and returns a friendly error at call time. The tool stays advertised in `tools/list` rather than mutating the surface — accepted trade-off, zero subprocess plumbing.

### 3. Per-task backend + model pinning

`/loop` and `/schedule` now pin the toolbar's current `backend_id` and `model` on the task row so a cron created from a Codex / Pi chat fires on the same runtime it was scheduled under. Without this, `dispatch_prompt_to_session` fell back to the global `default_agent_backend` at fire time — which is why a `/loop` typed as the first message in a Codex chat dispatched to Claude.

- New migration `20260521143000_agent_scheduled_tasks_backend.sql` adds `backend_id TEXT` and `model TEXT` columns. Pre-migration rows keep their `NULL` values and continue to use the global default — no behavior change for existing schedules.
- `db::scheduling::create_agent_wakeup` / `create_agent_cron_task`, the model, the Tauri commands, the IPC handlers, and the frontend `scheduleWakeup` / `createCronRoutine` services all thread the pair through.
- `dispatch_task_prompt` forwards `task.backend_id` and `task.model` to `send_chat_message`. Either being `NULL` keeps the existing global-default fallback.

### 4. Persisted schedule confirmation message

When `/loop` / `/schedule` succeed, the Tauri command now writes a System `ChatMessage` to the DB and emits `chat-system-message` so the chat panel renders the \"Looping (\`*/1 * * * *\` — Every minute). Manage it from the scheduler…\" line inline — and it survives a reload. Previously this was an in-memory `addLocalMessage({persisted: false})` that evaporated on refresh. One persisted note for all three backends, no per-backend frontend code.

### 5. Pi system-prompt nudge

Pi has no `send_to_user` / `Monitor` MCP tool, so reusing `SYSTEM_PROMPT_NUDGE` would point the model at tools the sidecar doesn't register. New `PI_SCHEDULING_NUDGE` constant (`src/agent_mcp/mod.rs`) names only the four native scheduling tools and wires into `pi_custom_instructions` via `compose_system_prompt`.

## Forward-compatibility with user Pi extensions

The user may later add support for user-authored Pi extensions (`ExtensionFactory` / `pi.registerTool()` auto-discovered from `~/.pi/agent/extensions/`). Nothing here forecloses that:

- `host_tool` is a **generic harness→host tool-call channel**, keyed by tool name — not scheduling-specific. A future extension tool that needs host services can reuse the same message pair; only `bridge_payload_for`'s dispatch table is scheduling-specific today, and unknown names already degrade gracefully.
- Scheduling tools live in `customTools` — a self-contained appended group. The Pi SDK merges `customTools` with extension-provided tools independently, so adding `extensionFactories` later is orthogonal.
- Tool-name collision handling between built-in scheduling tools and extension-provided tools is **deferred** to when the extension feature lands.

## Footprint

| File | Change |
|---|---|
| `src-pi-harness/src/main.ts` | 4 `defineTool` entries, `hostTool` helper, `host_tool_result` case, `mapPermissionTools` + `abort` updates |
| `src/agent/pi_sdk.rs` | `sink` field, `HostTool` variant, `handle_host_tool`, `bridge_payload_for` helper + 5 tests |
| `src-tauri/src/commands/chat/send.rs` | Construct `ChatBridgeSink` for Pi; drop `send_to_user_enabled` guard on Claude+Codex (spawn + respawn); pass nudge |
| `src-tauri/src/commands/chat/remote_control.rs` | Same decoupling as `send.rs` |
| `src-tauri/src/agent_mcp_sink.rs` | Per-call `is_builtin_plugin_enabled` gate so `SendAttachment` returns an error when Agent Attachments is off |
| `src-tauri/src/commands/scheduling.rs` | Plumb `backend_id`/`model` through commands + dispatch; persisted creation note |
| `src-tauri/src/ipc.rs` | Extract `backend_id`/`model` from IPC params for both wakeup and cron-create |
| `src/db/scheduling.rs` + `src/scheduling.rs` | New columns on `ScheduledTask`; updated CRUD signatures |
| `src/migrations/20260521143000_agent_scheduled_tasks_backend.sql` | Additive ALTER TABLE — forward-only |
| `src/agent_mcp/mod.rs` | One `PI_SCHEDULING_NUDGE` const |
| `src/ui/src/services/tauri/scheduling.ts` + `nativeSlashCommands.ts` | Thread `backendId`/`model` through `/loop` and `/schedule`; drop ephemeral confirmation message (now persisted host-side) |
| `site/src/content/docs/features/agent-scheduling.mdx` | Document Claude/Codex/Pi parity; note Pi has no MCP bridge |

## Test plan

- [x] `cargo test -p claudette -p claudette-server -p claudette-cli --all-features`
- [x] `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features`
- [x] `cd src-pi-harness && bun install --frozen-lockfile && bunx tsc --noEmit`
- [x] `cd src/ui && bunx tsc -b`
- [x] Claude chat: `/loop 1m ping` fires on Claude every minute (decoupling didn't regress)
- [x] Codex chat: `/loop` as the first message in a fresh Codex chat fires on Codex (was previously dispatching to Claude via global-default fallback)
- [x] Pi chat: `/loop` as the first message in a fresh Pi chat fires on Pi
- [x] Settings → Plugins → disable Agent Attachments: scheduling tools still work on Claude and Codex; `send_to_user` returns the \"Agent Attachments plugin is disabled\" error
- [x] Schedule confirmation message persists across a chat reload on all three backends
- [x] Peer-reviewed by Codex: clean on `2c8ca1c2`

## Commits

- `6b13dafb` — `feat(scheduler): expose scheduling tools to Codex and Pi agents`
- `7ad64622` — `fix(scheduler): preserve Agent Attachments toggle and extend decoupling to Remote Control`
- `2c8ca1c2` — `fix(scheduler): pin backend per task and persist schedule confirmation`