### PR TITLE
fix(codex): tolerate app-server stdout preambles

### DIFF
--- a/src/agent/codex_app_server.rs
+++ b/src/agent/codex_app_server.rs
@@ -20,6 +20,7 @@ use super::{
 type CodexStdin = Arc<tokio::sync::Mutex<ChildStdin>>;
 type PendingRequests = Arc<tokio::sync::Mutex<BTreeMap<JsonRpcId, PendingCodexRequest>>>;
 type TurnOutputBuffer = Arc<tokio::sync::Mutex<CodexTurnOutput>>;
+const MAX_CODEX_STDOUT_PREAMBLE_LINES: usize = 256;
 
 struct PendingCodexRequest {
     method: String,
@@ -1240,6 +1241,7 @@ where
     R: AsyncBufRead + Unpin,
 {
     let mut line = String::new();
+    let mut skipped_preamble_lines = 0usize;
     loop {
         line.clear();
         let bytes = reader
@@ -1253,9 +1255,35 @@ where
         if trimmed.is_empty() {
             continue;
         }
+        if !trimmed.starts_with('{') {
+            skipped_preamble_lines += 1;
+            if skipped_preamble_lines > MAX_CODEX_STDOUT_PREAMBLE_LINES {
+                return Err(format!(
+                    "Codex app-server stdout produced too many non-JSON preamble lines before JSON-RPC; last line: {}",
+                    truncate_protocol_line(trimmed)
+                ));
+            }
+            tracing::debug!(
+                target: "claudette::agent",
+                line = %truncate_protocol_line(trimmed),
+                "skipping non-JSON Codex app-server stdout preamble"
+            );
+            continue;
+        }
         return parse_jsonrpc_line(trimmed)
             .map(Some)
             .map_err(|e| format!("Failed to parse Codex app-server JSON-RPC line: {e}"));
+    }
+}
+
+fn truncate_protocol_line(line: &str) -> String {
+    const MAX_LEN: usize = 160;
+    let mut chars = line.chars();
+    let truncated = chars.by_ref().take(MAX_LEN).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
     }
 }
 
@@ -3372,6 +3400,44 @@ mod tests {
                 .expect("eof succeeds")
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn skips_devshell_stdout_preamble_before_jsonrpc() {
+        let input =
+            b"\x1b[33m[devshell] lib/agent_sdk/dist is missing -- run `agent-sdk-build`.\x1b[0m\n\
+\n\
+\x1b[1m[[general commands]]\x1b[0m\n\
+\n\
+  menu                  - prints this menu\n\
+{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n";
+        let mut reader = tokio::io::BufReader::new(&input[..]);
+
+        let message = read_jsonrpc_message(&mut reader)
+            .await
+            .expect("devshell preamble is skipped")
+            .expect("json-rpc response");
+
+        assert!(matches!(
+            message,
+            JsonRpcMessage::Response(JsonRpcResponse {
+                id: Some(JsonRpcId::Integer(1)),
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn malformed_jsonrpc_object_still_errors() {
+        let input = br#"{"jsonrpc":"2.0","id":1,"result":
+"#;
+        let mut reader = tokio::io::BufReader::new(&input[..]);
+
+        let err = read_jsonrpc_message(&mut reader)
+            .await
+            .expect_err("object-shaped protocol corruption must not be skipped");
+
+        assert!(err.contains("Failed to parse Codex app-server JSON-RPC line"));
     }
 
     #[test]

--- a/src/agent/codex_app_server.rs
+++ b/src/agent/codex_app_server.rs
@@ -1255,11 +1255,14 @@ where
         if trimmed.is_empty() {
             continue;
         }
-        if !trimmed.starts_with('{') {
+        let Some(first_char) = trimmed.chars().next() else {
+            continue;
+        };
+        if !is_json_value_start(first_char) {
             skipped_preamble_lines += 1;
             if skipped_preamble_lines > MAX_CODEX_STDOUT_PREAMBLE_LINES {
                 return Err(format!(
-                    "Codex app-server stdout produced too many non-JSON preamble lines before JSON-RPC; last line: {}",
+                    "Codex app-server stdout produced too many unexpected non-JSON-RPC lines; last line: {}",
                     truncate_protocol_line(trimmed)
                 ));
             }
@@ -1270,10 +1273,20 @@ where
             );
             continue;
         }
+        if first_char != '{' {
+            return Err(format!(
+                "Unsupported Codex app-server JSON-RPC message shape: expected object line, got {}",
+                truncate_protocol_line(trimmed)
+            ));
+        }
         return parse_jsonrpc_line(trimmed)
             .map(Some)
             .map_err(|e| format!("Failed to parse Codex app-server JSON-RPC line: {e}"));
     }
+}
+
+fn is_json_value_start(ch: char) -> bool {
+    matches!(ch, '{' | '[' | '"' | 't' | 'f' | 'n' | '-' | '0'..='9')
 }
 
 fn truncate_protocol_line(line: &str) -> String {
@@ -3438,6 +3451,19 @@ mod tests {
             .expect_err("object-shaped protocol corruption must not be skipped");
 
         assert!(err.contains("Failed to parse Codex app-server JSON-RPC line"));
+    }
+
+    #[tokio::test]
+    async fn unsupported_jsonrpc_batch_shape_errors() {
+        let input = br#"[{"jsonrpc":"2.0","id":1,"result":{"ok":true}}]
+"#;
+        let mut reader = tokio::io::BufReader::new(&input[..]);
+
+        let err = read_jsonrpc_message(&mut reader)
+            .await
+            .expect_err("batch-shaped protocol lines must not be skipped");
+
+        assert!(err.contains("Unsupported Codex app-server JSON-RPC message shape"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- tolerate bounded non-JSON stdout preamble lines before parsing Codex app-server JSON-RPC
- keep malformed JSON-RPC object lines as hard protocol errors
- add regression coverage for devshell banner output and malformed JSON

## Root Cause

Codex app-server sessions can be launched through workspace env wrappers such as `nix develop --command`. In the failing `smooth-rose` worktree, the devshell printed a colored banner and command menu to stdout before the wrapped Codex process emitted its first JSON-RPC message. Claudette read that first stdout line as app-server protocol data, so `initialize` failed with `expected value at line 1 column 1`.

The reader now skips a bounded number of lines that cannot be JSON-RPC objects before parsing the first `{...}` message. If a line looks like a JSON object but is malformed, it still fails immediately so real protocol corruption is not hidden.

## User Impact

This restores Codex Native startup in repositories whose env-provider/devshell setup writes shell banners, menus, or similar startup text to stdout before the agent process starts speaking JSON-RPC.

## Docs

No user-facing docs changed. This is an internal protocol robustness fix with no new settings, commands, flags, or visible workflow changes.

## Validation

- `nix develop -c cargo test -p claudette codex_app_server -- --nocapture`
- `nix develop -c cargo fmt --all --check`
- `git diff --check`