### PR TITLE
fix(codex): recover app-server auth in devshell worktrees

### DIFF
--- a/src-tauri/src/commands/agent_backends/mod.rs
+++ b/src-tauri/src/commands/agent_backends/mod.rs
@@ -507,10 +507,9 @@ async fn resolve_codex_login_workspace_env(
             .into_iter()
             .find(|workspace| workspace.id == workspace_id)
             .ok_or("Workspace not found")?;
-        let worktree = workspace
-            .worktree_path
-            .clone()
-            .ok_or("Workspace has no worktree")?;
+        let Some(worktree) = codex_login_worktree_path(&workspace) else {
+            return Ok(None);
+        };
         let repo = db
             .get_repository(&workspace.repository_id)
             .map_err(|e| e.to_string())?
@@ -521,11 +520,11 @@ async fn resolve_codex_login_workspace_env(
             id: workspace.id,
             name: workspace.name,
             branch: workspace.branch_name,
-            worktree_path: worktree.clone(),
+            worktree_path: worktree.to_string_lossy().into_owned(),
             repo_path: repo.path,
             repo_id: Some(repo_id.clone()),
         };
-        (PathBuf::from(worktree), ws_info, disabled)
+        (worktree, ws_info, disabled)
     };
 
     let registry = state.plugins_snapshot().await;
@@ -540,6 +539,10 @@ async fn resolve_codex_login_workspace_env(
     )
     .await;
     Ok(Some(CodexLoginWorkspaceEnv { worktree, resolved }))
+}
+
+fn codex_login_worktree_path(workspace: &claudette::model::Workspace) -> Option<PathBuf> {
+    workspace.worktree_path.as_deref().map(PathBuf::from)
 }
 
 fn build_codex_login_command(
@@ -697,6 +700,34 @@ mod tests {
                 .get_envs()
                 .any(|(key, _)| key == "CODEX_HOME"),
             "global login should not override the user's default CODEX_HOME",
+        );
+    }
+
+    #[test]
+    fn codex_login_missing_worktree_falls_back_to_default_codex_home() {
+        let workspace = claudette::model::Workspace {
+            id: "workspace-1".to_string(),
+            repository_id: "repo-1".to_string(),
+            name: "Restoring workspace".to_string(),
+            branch_name: "main".to_string(),
+            worktree_path: None,
+            status: claudette::model::WorkspaceStatus::Active,
+            agent_status: claudette::model::AgentStatus::Idle,
+            status_line: String::new(),
+            created_at: "2026-05-22T00:00:00.000Z".to_string(),
+            sort_order: 0,
+        };
+
+        assert_eq!(codex_login_worktree_path(&workspace), None);
+        let command = build_codex_login_command(OsStr::new("codex"), None);
+
+        assert_eq!(command.as_std().get_current_dir(), None);
+        assert!(
+            !command
+                .as_std()
+                .get_envs()
+                .any(|(key, _)| key == "CODEX_HOME"),
+            "missing-worktree login should fall back to the user's default CODEX_HOME",
         );
     }
 

--- a/src-tauri/src/commands/agent_backends/mod.rs
+++ b/src-tauri/src/commands/agent_backends/mod.rs
@@ -4,14 +4,28 @@
 //! into focused submodules. See each `mod` declaration's owning file
 //! for the relevant cluster.
 
-use tauri::{AppHandle, Manager, State};
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::agent::resolve_codex_path;
 use claudette::agent_backend::{AgentBackendConfig, AgentBackendRuntimeHarness};
 use claudette::db::Database;
+use claudette::env_provider::ResolvedEnv;
 use claudette::plugin::{delete_secure_secret, load_secure_secret, save_secure_secret};
+use claudette::plugin_runtime::host_api::WorkspaceInfo;
 
 use crate::state::AppState;
+
+const CODEX_LOGIN_COMPLETE_EVENT: &str = "codex://login-complete";
+
+#[derive(Clone, Serialize)]
+struct CodexLoginComplete {
+    success: bool,
+    error: Option<String>,
+}
 
 mod auto_detect;
 mod codex_auth;
@@ -340,13 +354,19 @@ pub async fn test_agent_backend(
 }
 
 #[tauri::command]
-pub async fn launch_codex_login(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
+pub async fn launch_codex_login(
+    workspace_id: Option<String>,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     ensure_native_codex_enabled(&db)?;
+    drop(db);
+
     let codex_path = resolve_codex_path().await;
-    let mut command = codex_cli_command(codex_path);
+    let workspace_env = resolve_codex_login_workspace_env(&state, workspace_id.as_deref()).await?;
+    let mut command = build_codex_login_command(codex_path.as_os_str(), workspace_env.as_ref());
     let mut child = command
-        .arg("login")
         .spawn()
         .map_err(|e| format!("Failed to launch `codex login`: {e}"))?;
     // After `codex login` exits successfully, drop every persistent
@@ -387,6 +407,13 @@ pub async fn launch_codex_login(app: AppHandle, state: State<'_, AppState>) -> R
                     code = ?s.code(),
                     "`codex login` exited non-zero; skipping Codex session sweep"
                 );
+                let _ = app.emit(
+                    CODEX_LOGIN_COMPLETE_EVENT,
+                    CodexLoginComplete {
+                        success: false,
+                        error: Some(format!("`codex login` exited with {s}")),
+                    },
+                );
                 false
             }
             Err(err) => {
@@ -400,6 +427,13 @@ pub async fn launch_codex_login(app: AppHandle, state: State<'_, AppState>) -> R
                     target: "claudette::agent",
                     error = %err,
                     "failed to wait for `codex login` child; skipping Codex session sweep"
+                );
+                let _ = app.emit(
+                    CODEX_LOGIN_COMPLETE_EVENT,
+                    CodexLoginComplete {
+                        success: false,
+                        error: Some(format!("Failed to wait on `codex login`: {err}")),
+                    },
                 );
                 false
             }
@@ -442,8 +476,127 @@ pub async fn launch_codex_login(app: AppHandle, state: State<'_, AppState>) -> R
                 );
             }
         }
+        let _ = app.emit(
+            CODEX_LOGIN_COMPLETE_EVENT,
+            CodexLoginComplete {
+                success: true,
+                error: None,
+            },
+        );
     });
     Ok(())
+}
+
+struct CodexLoginWorkspaceEnv {
+    worktree: PathBuf,
+    resolved: ResolvedEnv,
+}
+
+async fn resolve_codex_login_workspace_env(
+    state: &AppState,
+    workspace_id: Option<&str>,
+) -> Result<Option<CodexLoginWorkspaceEnv>, String> {
+    let Some(workspace_id) = workspace_id else {
+        return Ok(None);
+    };
+    let (worktree, ws_info, disabled) = {
+        let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+        let workspace = db
+            .list_workspaces()
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .find(|workspace| workspace.id == workspace_id)
+            .ok_or("Workspace not found")?;
+        let worktree = workspace
+            .worktree_path
+            .clone()
+            .ok_or("Workspace has no worktree")?;
+        let repo = db
+            .get_repository(&workspace.repository_id)
+            .map_err(|e| e.to_string())?
+            .ok_or("Repository not found")?;
+        let repo_id = workspace.repository_id.clone();
+        let disabled = crate::commands::env::load_disabled_providers(&db, &repo_id);
+        let ws_info = WorkspaceInfo {
+            id: workspace.id,
+            name: workspace.name,
+            branch: workspace.branch_name,
+            worktree_path: worktree.clone(),
+            repo_path: repo.path,
+            repo_id: Some(repo_id.clone()),
+        };
+        (PathBuf::from(worktree), ws_info, disabled)
+    };
+
+    let registry = state.plugins_snapshot().await;
+    let resolved = claudette::env_provider::resolve_with_registry_streaming(
+        &registry,
+        &state.env_cache,
+        &worktree,
+        &ws_info,
+        &disabled,
+        None,
+        None,
+    )
+    .await;
+    Ok(Some(CodexLoginWorkspaceEnv { worktree, resolved }))
+}
+
+fn build_codex_login_command(
+    codex_path: &OsStr,
+    workspace_env: Option<&CodexLoginWorkspaceEnv>,
+) -> tokio::process::Command {
+    let login_arg = "login".to_string();
+    if let Some(ctx) = workspace_env
+        && let Some(argv) = claudette::env_provider::nix_develop_command_wrap(
+            &ctx.worktree,
+            &ctx.resolved,
+            codex_path,
+            std::slice::from_ref(&login_arg),
+        )
+    {
+        return codex_login_command_from_argv(argv, Some(&ctx.worktree));
+    }
+
+    let mut command = codex_cli_command(codex_path);
+    command.arg(login_arg);
+    apply_resolved_env_to_codex_login(&mut command, workspace_env);
+    command
+}
+
+fn codex_login_command_from_argv(
+    argv: Vec<OsString>,
+    worktree: Option<&Path>,
+) -> tokio::process::Command {
+    let mut iter = argv.into_iter();
+    let program = iter
+        .next()
+        .expect("nix develop command wrapper should include a program");
+    let mut command = codex_cli_command(program);
+    command.args(iter);
+    if let Some(worktree) = worktree {
+        command.current_dir(worktree);
+    }
+    command
+}
+
+fn apply_resolved_env_to_codex_login(
+    command: &mut tokio::process::Command,
+    workspace_env: Option<&CodexLoginWorkspaceEnv>,
+) {
+    if let Some(CodexLoginWorkspaceEnv { worktree, resolved }) = workspace_env {
+        command.current_dir(worktree);
+        resolved.apply(command);
+        command.env(
+            "PATH",
+            match resolved.vars.get("PATH") {
+                Some(Some(provider_path)) => {
+                    claudette::env::merge_path_with_enriched(provider_path)
+                }
+                _ => claudette::env::enriched_path(),
+            },
+        );
+    }
 }
 
 #[cfg(test)]
@@ -526,6 +679,109 @@ mod tests {
             source[helper_start..helper_end].contains("claudette::process::command(program)"),
             "Codex CLI helper must use the Windows-safe process constructor",
         );
+    }
+
+    #[test]
+    fn codex_login_without_workspace_uses_default_codex_home() {
+        let command = build_codex_login_command(OsStr::new("codex"), None);
+
+        assert_eq!(command.as_std().get_current_dir(), None);
+        assert_eq!(command.as_std().get_program(), "codex");
+        assert_eq!(
+            command.as_std().get_args().collect::<Vec<_>>(),
+            vec![OsStr::new("login")]
+        );
+        assert!(
+            !command
+                .as_std()
+                .get_envs()
+                .any(|(key, _)| key == "CODEX_HOME"),
+            "global login should not override the user's default CODEX_HOME",
+        );
+    }
+
+    #[test]
+    fn codex_login_with_workspace_uses_repo_local_codex_home() {
+        let worktree = PathBuf::from("/tmp/speckit-worktree");
+        let ctx = CodexLoginWorkspaceEnv {
+            worktree: worktree.clone(),
+            resolved: ResolvedEnv {
+                vars: HashMap::from([("CODEX_HOME".to_string(), Some(".codex".to_string()))]),
+                sources: Vec::new(),
+            },
+        };
+
+        let command = build_codex_login_command(OsStr::new("codex"), Some(&ctx));
+
+        assert_eq!(command.as_std().get_program(), "codex");
+        assert_eq!(
+            command.as_std().get_args().collect::<Vec<_>>(),
+            vec![OsStr::new("login")]
+        );
+        assert_eq!(command.as_std().get_current_dir(), Some(worktree.as_path()));
+        let codex_home = command
+            .as_std()
+            .get_envs()
+            .find_map(|(key, value)| (key == "CODEX_HOME").then_some(value))
+            .flatten();
+        assert_eq!(codex_home, Some(std::ffi::OsStr::new(".codex")));
+    }
+
+    #[test]
+    fn codex_login_with_nix_devshell_uses_app_server_wrap() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("flake.nix"), "{}").unwrap();
+        let ctx = CodexLoginWorkspaceEnv {
+            worktree: tmp.path().to_path_buf(),
+            resolved: ResolvedEnv {
+                vars: HashMap::from([("CODEX_HOME".to_string(), Some(".codex".to_string()))]),
+                sources: vec![claudette::env_provider::ResolvedSource {
+                    plugin_name: "env-nix-devshell".to_string(),
+                    detected: true,
+                    vars_contributed: 1,
+                    cached: false,
+                    evaluated_at: std::time::SystemTime::now(),
+                    error: None,
+                }],
+            },
+        };
+
+        let command = build_codex_login_command(OsStr::new("codex"), Some(&ctx));
+
+        assert_eq!(command.as_std().get_current_dir(), Some(tmp.path()));
+        if claudette::env::which_in_enriched_path("nix").is_ok() {
+            assert!(
+                command
+                    .as_std()
+                    .get_program()
+                    .to_string_lossy()
+                    .ends_with("nix"),
+                "devshell Codex login should use the same nix develop wrapper as app-server"
+            );
+            assert_eq!(
+                command
+                    .as_std()
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>(),
+                vec!["develop", "--command", "codex", "login"]
+            );
+            assert!(
+                !command
+                    .as_std()
+                    .get_envs()
+                    .any(|(key, _)| key == "CODEX_HOME"),
+                "wrapped login should let the devshell provide CODEX_HOME just like app-server"
+            );
+            return;
+        }
+
+        let codex_home = command
+            .as_std()
+            .get_envs()
+            .find_map(|(key, value)| (key == "CODEX_HOME").then_some(value))
+            .flatten();
+        assert_eq!(codex_home, Some(std::ffi::OsStr::new(".codex")));
     }
 
     #[test]

--- a/src-tauri/src/commands/agent_backends_disabled.rs
+++ b/src-tauri/src/commands/agent_backends_disabled.rs
@@ -117,7 +117,7 @@ pub async fn test_agent_backend(
 }
 
 #[tauri::command]
-pub async fn launch_codex_login() -> Result<(), String> {
+pub async fn launch_codex_login(_workspace_id: Option<String>) -> Result<(), String> {
     Err(disabled_error())
 }
 

--- a/src/agent/codex_app_server.rs
+++ b/src/agent/codex_app_server.rs
@@ -656,10 +656,16 @@ impl CodexAppServerSession {
             )
         })? {
             Ok(response) => Ok(response),
-            Err(error) => Err(format!(
-                "Codex app-server `{}` failed: {}",
-                request.method, error.error.message
-            )),
+            Err(error) => {
+                if codex_error_indicates_auth_expiry(&error.error.message) {
+                    self.auth_expired.store(true, Ordering::SeqCst);
+                    return Err(CODEX_AUTH_EXPIRED_MESSAGE.to_string());
+                }
+                Err(format!(
+                    "Codex app-server `{}` failed: {}",
+                    request.method, error.error.message
+                ))
+            }
         }
     }
 
@@ -1020,7 +1026,14 @@ pub(crate) fn codex_stderr_indicates_auth_expiry(line: &str) -> bool {
     line.contains("Failed to refresh token")
         || line.contains("Please log out and sign in again")
         || (line.contains("401 Unauthorized")
-            && line.contains("wss://chatgpt.com/backend-api/codex/responses"))
+            && (line.contains("wss://chatgpt.com/backend-api/codex/responses")
+                || line.contains("wss://api.openai.com/v1/responses")))
+}
+
+fn codex_error_indicates_auth_expiry(message: &str) -> bool {
+    message
+        .to_ascii_lowercase()
+        .contains("codex account authentication required")
 }
 
 async fn fail_pending_requests(pending: &PendingRequests, reason: &str) {
@@ -1258,7 +1271,13 @@ where
         let Some(first_char) = trimmed.chars().next() else {
             continue;
         };
-        if !is_json_value_start(first_char) {
+        if first_char == '[' {
+            return Err(format!(
+                "Unsupported Codex app-server JSON-RPC message shape: expected object line, got {}",
+                truncate_protocol_line(trimmed)
+            ));
+        }
+        if first_char != '{' {
             skipped_preamble_lines += 1;
             if skipped_preamble_lines > MAX_CODEX_STDOUT_PREAMBLE_LINES {
                 return Err(format!(
@@ -1273,20 +1292,10 @@ where
             );
             continue;
         }
-        if first_char != '{' {
-            return Err(format!(
-                "Unsupported Codex app-server JSON-RPC message shape: expected object line, got {}",
-                truncate_protocol_line(trimmed)
-            ));
-        }
         return parse_jsonrpc_line(trimmed)
             .map(Some)
             .map_err(|e| format!("Failed to parse Codex app-server JSON-RPC line: {e}"));
     }
-}
-
-fn is_json_value_start(ch: char) -> bool {
-    matches!(ch, '{' | '[' | '"' | 't' | 'f' | 'n' | '-' | '0'..='9')
 }
 
 fn truncate_protocol_line(line: &str) -> String {
@@ -3422,6 +3431,7 @@ mod tests {
 \n\
 \x1b[1m[[general commands]]\x1b[0m\n\
 \n\
+  fix                   - Auto-fix code (standardrb --fix)\n\
   menu                  - prints this menu\n\
 {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\n";
         let mut reader = tokio::io::BufReader::new(&input[..]);
@@ -5609,6 +5619,30 @@ mod tests {
                     websocket: HTTP error: 401 Unauthorized, url: \
                     wss://chatgpt.com/backend-api/codex/responses";
         assert!(codex_stderr_indicates_auth_expiry(line));
+    }
+
+    #[test]
+    fn detects_openai_responses_websocket_401() {
+        let line = "\u{1b}[2m2026-05-22T02:12:39.001347Z\u{1b}[0m \
+                    \u{1b}[31mERROR\u{1b}[0m \
+                    \u{1b}[2mcodex_api::endpoint::responses_websocket\u{1b}[0m: \
+                    failed to connect to websocket: HTTP error: 401 Unauthorized, \
+                    url: wss://api.openai.com/v1/responses";
+        assert!(codex_stderr_indicates_auth_expiry(line));
+    }
+
+    #[test]
+    fn detects_rate_limit_read_auth_required_error() {
+        assert!(codex_error_indicates_auth_expiry(
+            "codex account authentication required to read rate limits"
+        ));
+    }
+
+    #[test]
+    fn ignores_unrelated_rate_limit_errors() {
+        assert!(!codex_error_indicates_auth_expiry(
+            "account/rateLimits/read failed because the network is unavailable"
+        ));
     }
 
     #[test]

--- a/src/ui/src/components/auth/ChatAuthFailureCallout.test.tsx
+++ b/src/ui/src/components/auth/ChatAuthFailureCallout.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAppStore } from "../../stores/useAppStore";
+import { ChatAuthFailureCallout } from "./ChatAuthFailureCallout";
+
+const serviceMocks = vi.hoisted(() => ({
+  getClaudeAuthStatus: vi.fn(() =>
+    Promise.resolve({
+      state: "signed_out",
+      loggedIn: false,
+      verified: false,
+      authMethod: null,
+      apiProvider: null,
+      message: null,
+    }),
+  ),
+  claudeAuthLogin: vi.fn(() => Promise.resolve()),
+  cancelClaudeAuthLogin: vi.fn(() => Promise.resolve()),
+  submitClaudeAuthCode: vi.fn(() => Promise.resolve()),
+  launchCodexLogin: vi.fn(() => Promise.resolve()),
+}));
+
+const eventMocks = vi.hoisted(() => {
+  const listeners = new Map<
+    string,
+    Array<(event: { payload: unknown }) => void>
+  >();
+  return {
+    listeners,
+    listen: vi.fn(
+      (event: string, handler: (event: { payload: unknown }) => void) => {
+        listeners.set(event, [...(listeners.get(event) ?? []), handler]);
+        return Promise.resolve(() => {
+          listeners.set(
+            event,
+            (listeners.get(event) ?? []).filter((entry) => entry !== handler),
+          );
+        });
+      },
+    ),
+  };
+});
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: eventMocks.listen,
+}));
+
+vi.mock("../../services/tauri", () => serviceMocks);
+
+const CODEX_AUTH_ERROR =
+  "Codex authentication expired. Run /login (or `codex login` in a terminal), then send the message again.";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function renderCallout() {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      <ChatAuthFailureCallout
+        error={CODEX_AUTH_ERROR}
+        messageId="assistant-1"
+      />,
+    );
+  });
+  return container;
+}
+
+beforeEach(() => {
+  serviceMocks.launchCodexLogin.mockClear();
+  serviceMocks.launchCodexLogin.mockResolvedValue(undefined);
+  eventMocks.listen.mockClear();
+  eventMocks.listeners.clear();
+  useAppStore.setState({
+    claudeAuthFailure: {
+      messageId: "assistant-1",
+      error: CODEX_AUTH_ERROR,
+    },
+    resolvedClaudeAuthFailureMessageId: null,
+    selectedWorkspaceId: "workspace-1",
+  });
+});
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount());
+  }
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("ChatAuthFailureCallout", () => {
+  it("marks Codex auth failures recovered when Codex login completes", async () => {
+    const element = await renderCallout();
+    const button = Array.from(element.querySelectorAll("button")).find((item) =>
+      item.textContent?.includes("auth_sign_in"),
+    );
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(serviceMocks.launchCodexLogin).toHaveBeenCalledWith("workspace-1");
+
+    await act(async () => {
+      eventMocks.listeners.get("codex://login-complete")?.forEach((handler) => {
+        handler({ payload: { success: true, error: null } });
+      });
+      await Promise.resolve();
+    });
+
+    expect(useAppStore.getState().claudeAuthFailure).toBeNull();
+    expect(useAppStore.getState().resolvedClaudeAuthFailureMessageId).toBe(
+      "assistant-1",
+    );
+  });
+});

--- a/src/ui/src/components/auth/ChatAuthFailureCallout.tsx
+++ b/src/ui/src/components/auth/ChatAuthFailureCallout.tsx
@@ -34,7 +34,7 @@ export function ChatAuthFailureCallout({
   const closeChatAuthLoginPanel = useAppStore(
     (s) => s.closeChatAuthLoginPanel,
   );
-  const { validateAuthLoginSuccess } = useClaudeAuthRecovery();
+  const { markAuthRecovered, validateAuthLoginSuccess } = useClaudeAuthRecovery();
   // Both hooks must be called unconditionally — React rules-of-hooks.
   // The unused controller stays inert (idle authState, never invoked).
   const claudeController = useClaudeAuthLogin({
@@ -42,7 +42,9 @@ export function ChatAuthFailureCallout({
       await validateAuthLoginSuccess();
     },
   });
-  const codexController = useCodexAuthLogin();
+  const codexController = useCodexAuthLogin({
+    onSuccess: markAuthRecovered,
+  });
   const controller =
     provider === "codex" ? codexController : claudeController;
   const {

--- a/src/ui/src/components/auth/claudeAuth.test.ts
+++ b/src/ui/src/components/auth/claudeAuth.test.ts
@@ -28,8 +28,29 @@ const serviceMocks = vi.hoisted(() => ({
   launchCodexLogin: vi.fn(() => Promise.resolve()),
 }));
 
+const eventMocks = vi.hoisted(() => {
+  const listeners = new Map<
+    string,
+    Array<(event: { payload: unknown }) => void>
+  >();
+  return {
+    listeners,
+    listen: vi.fn(
+      (event: string, handler: (event: { payload: unknown }) => void) => {
+        listeners.set(event, [...(listeners.get(event) ?? []), handler]);
+        return Promise.resolve(() => {
+          listeners.set(
+            event,
+            (listeners.get(event) ?? []).filter((entry) => entry !== handler),
+          );
+        });
+      },
+    ),
+  };
+});
+
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn(() => Promise.resolve(() => {})),
+  listen: eventMocks.listen,
 }));
 
 vi.mock("../../services/tauri", () => serviceMocks);
@@ -41,10 +62,12 @@ import {
   isClaudeAuthError,
   isCodexAuthError,
   useClaudeAuthRecovery,
+  useCodexAuthLogin,
 } from "./claudeAuth";
 import { useAppStore } from "../../stores/useAppStore";
 
 type RecoveryApi = ReturnType<typeof useClaudeAuthRecovery>;
+type CodexLoginApi = ReturnType<typeof useCodexAuthLogin>;
 
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
@@ -65,6 +88,25 @@ function renderRecoveryHarness(onReady: (api: RecoveryApi) => void) {
   });
 }
 
+function renderCodexLoginHarness(
+  onReady: (api: CodexLoginApi) => void,
+  options?: Parameters<typeof useCodexAuthLogin>[0],
+) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  function Harness() {
+    const api = useCodexAuthLogin(options);
+    useEffect(() => onReady(api), [api]);
+    return null;
+  }
+
+  act(() => {
+    root?.render(createElement(Harness));
+  });
+}
+
 beforeEach(() => {
   serviceMocks.getClaudeAuthStatus.mockReset();
   serviceMocks.getClaudeAuthStatus.mockResolvedValue({
@@ -75,9 +117,14 @@ beforeEach(() => {
     apiProvider: null,
     message: null,
   });
+  serviceMocks.launchCodexLogin.mockReset();
+  serviceMocks.launchCodexLogin.mockResolvedValue(undefined);
+  eventMocks.listen.mockClear();
+  eventMocks.listeners.clear();
   useAppStore.setState({
     claudeAuthFailure: null,
     resolvedClaudeAuthFailureMessageId: null,
+    selectedWorkspaceId: null,
   });
 });
 
@@ -205,6 +252,57 @@ describe("cleanClaudeAuthError", () => {
     expect(cleanClaudeAuthError("Not logged in · Please run /login")).toBe(
       "Not logged in",
     );
+  });
+});
+
+describe("useCodexAuthLogin", () => {
+  it("launches Codex login with the selected workspace id", async () => {
+    useAppStore.setState({ selectedWorkspaceId: "workspace-1" });
+    let api: CodexLoginApi | null = null;
+    renderCodexLoginHarness((next) => {
+      api = next;
+    });
+
+    await act(async () => {
+      await api?.startAuthLogin();
+    });
+
+    expect(serviceMocks.launchCodexLogin).toHaveBeenCalledWith("workspace-1");
+  });
+
+  it("keeps global Codex login when no workspace is selected", async () => {
+    let api: CodexLoginApi | null = null;
+    renderCodexLoginHarness((next) => {
+      api = next;
+    });
+
+    await act(async () => {
+      await api?.startAuthLogin();
+    });
+
+    expect(serviceMocks.launchCodexLogin).toHaveBeenCalledWith(null);
+  });
+
+  it("finishes successfully when the Codex login completion event arrives", async () => {
+    const onSuccess = vi.fn(() => Promise.resolve());
+    let api!: CodexLoginApi;
+    renderCodexLoginHarness((next) => {
+      api = next;
+    }, { onSuccess });
+
+    await act(async () => {
+      await api.startAuthLogin();
+    });
+
+    await act(async () => {
+      eventMocks.listeners.get("codex://login-complete")?.forEach((handler) => {
+        handler({ payload: { success: true, error: null } });
+      });
+      await Promise.resolve();
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(api.authState.status).toBe("success");
   });
 });
 

--- a/src/ui/src/components/auth/claudeAuth.ts
+++ b/src/ui/src/components/auth/claudeAuth.ts
@@ -296,35 +296,85 @@ export function useClaudeAuthLogin({
  * Unlike Claude Code, the Codex CLI's `codex login` flow is a one-shot
  * browser handoff — it does not emit progress events or accept a paste-
  * back auth code, so `manualUrl` is always null and `submitAuthCode` is
- * a no-op. The success signal lands implicitly via
- * `launch_codex_login`'s post-exit sweep that tears down any
- * persistent Codex session; the user then re-sends the message and a
- * fresh app-server picks up the new tokens. The controller stays in
- * `running` until the user explicitly cancels via the close button,
- * because there is no FE-visible "browser flow finished" signal.
+ * a no-op. Completion lands through a Codex-specific event after
+ * `launch_codex_login`'s post-exit sweep has torn down stale persistent
+ * Codex sessions, so a fresh app-server picks up the new tokens.
  */
 export function useCodexAuthLogin({
-  onSuccess: _onSuccess,
+  onSuccess,
 }: {
   onSuccess?: () => void | Promise<void>;
 } = {}) {
+  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const onSuccessRef = useRef(onSuccess);
+  const loginInFlightRef = useRef(false);
   const [authState, setAuthState] = useState<ClaudeAuthLoginState>({
     status: "idle",
   });
 
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+  }, [onSuccess]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: UnlistenFn | null = null;
+    listen<AuthLoginComplete>("codex://login-complete", (event) => {
+      if (!loginInFlightRef.current) return;
+      loginInFlightRef.current = false;
+      const { success, error } = event.payload;
+      if (!success) {
+        setAuthState({
+          status: "error",
+          error: error ?? "Codex sign-in failed.",
+        });
+        return;
+      }
+
+      void Promise.resolve(onSuccessRef.current?.())
+        .then(() => {
+          setAuthState({ status: "success" });
+        })
+        .catch((err) => {
+          setAuthState({
+            status: "error",
+            error:
+              err instanceof Error
+                ? err.message
+                : String(err || "Codex sign-in could not be verified."),
+          });
+        });
+    })
+      .then((fn) => {
+        if (cancelled) fn();
+        else unlisten = fn;
+      })
+      .catch((err) => {
+        console.error("Failed to subscribe to codex://login-complete", err);
+      });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
   const startAuthLogin = useCallback(async () => {
+    loginInFlightRef.current = true;
     setAuthState({ status: "running", manualUrl: null });
     try {
-      await launchCodexLogin();
+      await launchCodexLogin(selectedWorkspaceId);
     } catch (e) {
+      loginInFlightRef.current = false;
       setAuthState({ status: "error", error: String(e) });
     }
-  }, []);
+  }, [selectedWorkspaceId]);
 
   const cancelAuthLogin = useCallback(async () => {
     // No backend cancel — `codex login` runs detached. Just reset the
     // UI so the user can dismiss the spinner if they completed the
     // browser flow and want to retry their message.
+    loginInFlightRef.current = false;
     setAuthState({ status: "idle" });
   }, []);
 

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -628,7 +628,9 @@ export function ChatPanel() {
             appVersion,
             addLocalMessage,
             startClaudeAuthLogin: startChatClaudeAuthLogin,
-            startCodexLogin: launchCodexLogin,
+            startCodexLogin: async () => {
+              await launchCodexLogin(selectedWorkspaceId);
+            },
             startPiLogin: async () => {
               useAppStore.getState().openModal("piLogin", {
                 workingDir: ws?.worktree_path ?? "",

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -26,6 +26,7 @@ import { findLatestPlanFilePath } from "./planFilePath";
 import { setPlanModeAndPersist } from "./planModePersistence";
 import type { PermissionLevel } from "../../stores/useAppStore";
 import { dispatchChatMessage } from "./chatMessageDispatch";
+import { shouldRecordSendFailureInChat } from "./chatSendFailure";
 import { reconstructCompletedTurns } from "../../utils/reconstructTurns";
 import type { AttachmentInput } from "../../types/chat";
 import {
@@ -748,7 +749,9 @@ export function ChatPanel() {
     } catch (e) {
       const errMsg = String(e);
       console.error("dispatchChatMessage failed:", errMsg);
-      setError(errMsg);
+      if (!shouldRecordSendFailureInChat(errMsg)) {
+        setError(errMsg);
+      }
     }
   };
 

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -845,6 +845,10 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
             );
           }
         }
+        const isAuthFailureMessage =
+          (msg.role === "Assistant" || msg.role === "System") &&
+          isClaudeAuthError(msg.content);
+
         // Default rendering for User, Assistant, and non-sentinel System messages.
         return (
           <React.Fragment key={msg.id}>
@@ -854,7 +858,11 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
               streamingMessageNode
             ) : (
               <div
-                className={`${styles.message} ${styles[roleClassKey(msg.role, msg.content)]}${
+                className={`${styles.message} ${styles[
+                  roleClassKey(msg.role, msg.content, {
+                    forceSystemBlock: isAuthFailureMessage,
+                  })
+                ]}${
                   msg.role === "Assistant" && msg.thinking && showThinkingBlocks
                     ? ` ${styles.messageLeadingThinking}`
                     : ""
@@ -962,16 +970,14 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                       })}
                     </div>
                   )}
-                  {(msg.role === "Assistant" || msg.role === "System") &&
-                  isClaudeAuthError(msg.content) &&
+                  {isAuthFailureMessage &&
                   msg.id === lastAuthFailureMessageId &&
                   msg.id !== resolvedClaudeAuthFailureMessageId ? (
                     <ChatAuthFailureCallout
                       error={msg.content}
                       messageId={msg.id}
                     />
-                  ) : (msg.role === "Assistant" || msg.role === "System") &&
-                    isClaudeAuthError(msg.content) ? (
+                  ) : isAuthFailureMessage ? (
                     <div
                       className={
                         msg.id === resolvedClaudeAuthFailureMessageId

--- a/src/ui/src/components/chat/messageRendering.test.ts
+++ b/src/ui/src/components/chat/messageRendering.test.ts
@@ -68,4 +68,12 @@ describe("roleClassKey", () => {
       "role_System_block",
     );
   });
+
+  it("allows auth failures to opt out of the centered system pill", () => {
+    expect(
+      roleClassKey("System", "Not logged in · Please run /login", {
+        forceSystemBlock: true,
+      }),
+    ).toBe("role_System_block");
+  });
 });

--- a/src/ui/src/components/chat/messageRendering.ts
+++ b/src/ui/src/components/chat/messageRendering.ts
@@ -32,8 +32,15 @@ export function shouldRenderAsMarkdown(role: ChatRole): boolean {
  * Returns the key used to look up the CSS module class (e.g.
  * `styles.role_User`, `styles.role_System_block`).
  */
-export function roleClassKey(role: ChatRole, content: string): string {
-  if (role === "System" && content.includes("\n")) {
+export function roleClassKey(
+  role: ChatRole,
+  content: string,
+  options: { forceSystemBlock?: boolean } = {},
+): string {
+  if (
+    role === "System" &&
+    (options.forceSystemBlock === true || content.includes("\n"))
+  ) {
     return "role_System_block";
   }
   return `role_${role}`;

--- a/src/ui/src/services/tauri/agentBackends.ts
+++ b/src/ui/src/services/tauri/agentBackends.ts
@@ -123,8 +123,8 @@ export function testAgentBackend(backendId: string): Promise<BackendStatus> {
   return invoke("test_agent_backend", { backendId });
 }
 
-export function launchCodexLogin(): Promise<void> {
-  return invoke("launch_codex_login");
+export function launchCodexLogin(workspaceId?: string | null): Promise<void> {
+  return invoke("launch_codex_login", { workspaceId: workspaceId ?? null });
 }
 
 export function setAgentBackendRuntimeHarness(


### PR DESCRIPTION
## Summary

- Tolerate noisy Codex app-server stdout from devshells so JSON-RPC initialization can recover from shell menus and helper output.
- Surface Codex auth-expired failures as the shared in-chat auth recovery card instead of leaving native Codex sessions spinning silently.
- Align the shared auth-card layout with normal Claude Code recovery UI and suppress the duplicate bottom error banner for auth failures.
- Run Codex sign-in through the selected workspace env, including `nix develop --command codex login`, so repo-local `CODEX_HOME=.codex` writes auth into the same worktree the app-server reads.
- Emit a Codex-specific login completion event after stale app-server sessions are swept, then mark the failed message recovered so the auth card clears like Claude Code.

## Root Cause

Native Codex app-server was being started in the workspace environment, but recovery login was not using the same process model. In Nix/devshell repos such as Speckit-style projects, the app-server reads credentials from a repo-local `CODEX_HOME=.codex`, while direct `codex login` can write somewhere else. Separately, Codex login had no frontend completion event, so the shared auth callout remained in its running state even after authentication succeeded.

## User Impact

- New Codex sessions no longer fail initialization on devshell menu output.
- Expired Codex credentials now show the same shared sign-in UX as Claude Code.
- Completing Codex login from a repo-local Codex home clears the auth card and restarts future app-server sessions with fresh credentials.
- Default/global Codex login behavior remains unchanged when no workspace is selected.

## Regression Coverage

- Added backend tests for default Codex login, repo-local `.codex`, and Nix devshell `nix develop --command codex login` wrapping.
- Added frontend tests for selected-workspace Codex login dispatch, Codex completion events, and clearing recovered chat auth failures.
- Added message rendering coverage for the auth-card layout path.

## Validation

- `nix develop -c cargo test -p claudette-tauri agent_backends -- --nocapture`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run test -- src/components/auth/claudeAuth.test.ts src/components/auth/ChatAuthFailureCallout.test.tsx src/components/chat/messageRendering.test.ts src/components/chat/MessagesWithTurns.test.tsx src/components/chat/chatSendFailure.test.ts`
- `nix develop -c cargo fmt --all --check`
- `git diff --check`
