### PR TITLE
feat(chat): group MCP tool calls into per-server containers

### DIFF
--- a/src-tauri/src/commands/agent_backends/mod.rs
+++ b/src-tauri/src/commands/agent_backends/mod.rs
@@ -716,6 +716,7 @@ mod tests {
             status_line: String::new(),
             created_at: "2026-05-22T00:00:00.000Z".to_string(),
             sort_order: 0,
+            input_values: None,
         };
 
         assert_eq!(codex_login_worktree_path(&workspace), None);

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -597,6 +597,14 @@
   font-size: 12px;
 }
 
+/* Plug2 marker on an MCP tool group header — sits between the chevron and
+   the server-name label. Accent-colored to read as a first-class transcript
+   element alongside the skill-activation marker. */
+.mcpGroupIcon {
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
 .turnActivities {
   border-top: 1px solid var(--divider);
   padding: 4px;

--- a/src/ui/src/components/chat/MessagesWithTurns.test.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.test.tsx
@@ -224,7 +224,10 @@ describe("MessagesWithTurns edit summaries", () => {
       />,
     );
 
-    expect(container.textContent).toContain("mcp__postgres__query");
+    // The MCP call renders in a per-server container (header "postgres")
+    // with the redundant `mcp__<server>__` prefix stripped from the row.
+    expect(container.textContent).toContain("postgres");
+    expect(container.textContent).not.toContain("mcp__postgres__query");
     expect(container.textContent).not.toContain("1 file changed");
     expect(container.textContent).not.toContain("dirty-from-other-session.ts");
   });

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -714,6 +714,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                 activities={activities}
                 label={label}
                 inline={toolDisplayMode === "inline"}
+                mcp={kind === "mcp"}
                 showFooter={showFooter}
                 collapsed={collapsed}
                 onToggle={onToggle}

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -303,6 +303,47 @@ describe("ToolActivitiesSection", () => {
     expect(container.querySelector(`.${styles.skillActivation}`)).toBeTruthy();
   });
 
+  it("renders MCP calls in a Plug2 server container with bare tool-name rows", async () => {
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-mcp"
+        toolDisplayMode="grouped"
+        searchQuery=""
+        activities={[
+          activity("mcp__datadog__load_datadog_skill", {
+            toolUseId: "mcp-1",
+            resultText: "done",
+          }),
+          activity("mcp__datadog__search_datadog_dashboards", {
+            toolUseId: "mcp-2",
+            resultText: "done",
+          }),
+        ]}
+      />,
+    );
+
+    // Header shows the server name + the Plug2 marker, collapsed by default.
+    expect(container.textContent).toContain("datadog");
+    expect(container.querySelector(`.${styles.mcpGroupIcon}`)).toBeTruthy();
+    const header = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    // Tool rows hidden while collapsed.
+    expect(container.textContent).not.toContain("load_datadog_skill");
+
+    await act(async () => {
+      header.click();
+    });
+
+    // Expanded: rows show the bare tool name, never the redundant
+    // `mcp__<server>__` prefix that already lives in the container header.
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("load_datadog_skill");
+    expect(container.textContent).toContain("search_datadog_dashboards");
+    expect(container.textContent).not.toContain("mcp__datadog__");
+  });
+
   it("collapses grouped live calls by default — even while still running", async () => {
     // Intentional behavior change: with grouped tool calls on (the
     // default for new users), live tool groups start collapsed

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import { Plug2 } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity } from "../../stores/useAppStore";
 import type { ToolDisplayMode } from "../../stores/slices/settingsSlice";
@@ -99,6 +100,7 @@ export const ToolActivitiesSection = memo(function ToolActivitiesSection({
             activities={group.activities}
             searchQuery={searchQuery}
             worktreePath={worktreePath}
+            mcp={group.kind === "mcp"}
           />
         ),
       )}
@@ -112,12 +114,15 @@ function GroupedToolActivityRows({
   activities,
   searchQuery,
   worktreePath,
+  mcp = false,
 }: {
   sessionId: string;
   label: string;
   activities: readonly ToolActivity[];
   searchQuery: string;
   worktreePath?: string | null;
+  /** MCP group: render the Plug2 icon + bare-name rows. */
+  mcp?: boolean;
 }) {
   // The user override lives in the shared slice (not local
   // `useState`) so the expand choice survives the running→completed
@@ -187,6 +192,13 @@ function GroupedToolActivityRows({
         }}
       >
         <span className={styles.toolChevron}>{isExpanded ? "⌄" : "›"}</span>
+        {mcp && (
+          <Plug2
+            size={13}
+            aria-hidden="true"
+            className={styles.mcpGroupIcon}
+          />
+        )}
         <span className={styles.turnLabel}>{label}</span>
       </div>
       {isExpanded && (
@@ -197,6 +209,7 @@ function GroupedToolActivityRows({
               activity={act}
               searchQuery={searchQuery}
               worktreePath={worktreePath}
+              mcp={mcp}
             />
           ))}
         </div>

--- a/src/ui/src/components/chat/ToolActivityRow.test.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ToolActivity } from "../../stores/useAppStore";
 import { useAppStore } from "../../stores/useAppStore";
+import styles from "./ChatPanel.module.css";
 import { ToolActivityRow } from "./ToolActivityRow";
 
 const { highlightCalls, highlightCache } = vi.hoisted(() => ({
@@ -138,6 +139,32 @@ describe("ToolActivityRow", () => {
     });
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
     expect(container.querySelector("pre")).toBeNull();
+  });
+
+  it("strips the MCP prefix from the visible name but keeps it in the toggle aria-label", async () => {
+    // Inside an MCP container the server lives in the group header, so the
+    // visible row shows the bare tool name. The toggle's accessible label
+    // keeps the server-qualified name so it stays unambiguous for assistive
+    // tech (two servers can each expose a `query` tool).
+    const container = await render(
+      <ToolActivityRow
+        activity={activity("mcp__datadog__search_datadog_dashboards")}
+        searchQuery=""
+        mcp
+      />,
+    );
+
+    const name = container.querySelector(
+      `span.${styles.toolName}`,
+    ) as HTMLElement;
+    expect(name.textContent).toBe("search_datadog_dashboards");
+
+    const toggle = container.querySelector(
+      "button[aria-label]",
+    ) as HTMLButtonElement;
+    expect(toggle.getAttribute("aria-label")).toBe(
+      "Expand mcp__datadog__search_datadog_dashboards input details",
+    );
   });
 
   it("renders AskUserQuestion details as readable question text instead of raw JSON", async () => {

--- a/src/ui/src/components/chat/ToolActivityRow.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.tsx
@@ -163,7 +163,11 @@ function GenericToolActivityRow({
     ],
   );
 
-  const label = `${expanded ? "Collapse" : "Expand"} ${displayName} input details`;
+  // The visible row shows the stripped `displayName`, but the toggle's
+  // accessible label keeps the full `activity.toolName` (incl. the
+  // `mcp__<server>__` prefix) so screen-reader users get an unambiguous,
+  // server-qualified name — two servers can each expose a `query` tool.
+  const label = `${expanded ? "Collapse" : "Expand"} ${activity.toolName} input details`;
 
   return (
     <div key={activity.toolUseId} className={styles.toolActivity}>

--- a/src/ui/src/components/chat/ToolActivityRow.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.tsx
@@ -15,6 +15,7 @@ import {
 } from "./editActivitySummary";
 import { resolveToolSummary } from "./toolMetadata";
 import { isSkillActivity, skillActivationName } from "./toolActivityGroups";
+import { parseMcpToolName } from "./mcpToolName";
 import { tryOpenAgentFileTab } from "../../utils/agentFiles";
 import type { DiffLayer } from "../../types/diff";
 import { parseAskUserQuestion } from "../../hooks/parseAgentQuestion";
@@ -29,6 +30,10 @@ interface ToolActivityRowProps {
    *  pick up the compact treatment from a `.inlineTurnActivities`
    *  ancestor instead. */
   inline?: boolean;
+  /** Set when the row is rendered inside an MCP group container (whose
+   *  header already shows the server name): drop the redundant
+   *  `mcp__<server>__` prefix and display the bare tool name. */
+  mcp?: boolean;
 }
 
 interface ToolDetails {
@@ -93,6 +98,7 @@ function GenericToolActivityRow({
   activity,
   searchQuery,
   worktreePath,
+  mcp,
 }: ToolActivityRowProps) {
   const expanded = useAppStore((s) => !!s.expandedToolUseIds[activity.toolUseId]);
   const toggleToolUseExpanded = useAppStore((s) => s.toggleToolUseExpanded);
@@ -105,6 +111,12 @@ function GenericToolActivityRow({
   const setDiffSelectedCommitHash = useAppStore((s) => s.setDiffSelectedCommitHash);
   const editSummary = summarizeToolActivityEdit(activity);
   const summary = activitySummaryText(activity);
+  // Inside an MCP container the server is already in the group header, so
+  // show just the bare tool name (`search_datadog_dashboards`) instead of
+  // the full `mcp__datadog__search_datadog_dashboards`.
+  const displayName = mcp
+    ? (parseMcpToolName(activity.toolName)?.tool ?? activity.toolName)
+    : activity.toolName;
   const details = useMemo(() => toolDetails(activity), [activity]);
   const cachedHtml = details.lang
     ? getCachedHighlight(details.content, details.lang)
@@ -151,7 +163,7 @@ function GenericToolActivityRow({
     ],
   );
 
-  const label = `${expanded ? "Collapse" : "Expand"} ${activity.toolName} input details`;
+  const label = `${expanded ? "Collapse" : "Expand"} ${displayName} input details`;
 
   return (
     <div key={activity.toolUseId} className={styles.toolActivity}>
@@ -185,7 +197,7 @@ function GenericToolActivityRow({
             className={styles.toolName}
             style={{ color: toolColor(activity.toolName) }}
           >
-            {activity.toolName}
+            {displayName}
           </span>
         )}
         {!editSummary && summary && (

--- a/src/ui/src/components/chat/TurnSummary.tsx
+++ b/src/ui/src/components/chat/TurnSummary.tsx
@@ -1,4 +1,5 @@
 import { useId, useMemo } from "react";
+import { Plug2 } from "lucide-react";
 import type { CompletedTurn, ToolActivity } from "../../stores/useAppStore";
 import type { TaskTrackerResult } from "../../hooks/useTaskTracker";
 import styles from "./ChatPanel.module.css";
@@ -59,6 +60,7 @@ export function TurnSummary({
   worktreePath,
   label,
   inline = false,
+  mcp = false,
   editSummaryFallback,
   onLoadEditPreview,
   onOpenEditFile,
@@ -84,6 +86,9 @@ export function TurnSummary({
   worktreePath?: string | null;
   label?: string;
   inline?: boolean;
+  /** MCP group: prefix the header with the Plug2 icon and render the
+   *  contained rows with their `mcp__<server>__` prefix stripped. */
+  mcp?: boolean;
   /** Rescue summary used only when activity-derived edits return null —
    *  typically the workspace-diff summary for the latest turn, where the
    *  agent's tools couldn't be parsed (Bash heredoc, MCP write tool, etc.).
@@ -147,6 +152,7 @@ export function TurnSummary({
         searchQuery={searchQuery}
         worktreePath={worktreePath}
         inline={inline}
+        mcp={mcp}
       />
     );
   });
@@ -172,6 +178,13 @@ export function TurnSummary({
             }}
           >
             <span className={styles.toolChevron}>{isExpanded ? "⌄" : "›"}</span>
+            {mcp && (
+              <Plug2
+                size={13}
+                aria-hidden="true"
+                className={styles.mcpGroupIcon}
+              />
+            )}
             <span className={styles.turnLabel}>
               {label != null ? (
                 renderTurnLabel(label)

--- a/src/ui/src/components/chat/collapsedToolGroupKey.test.ts
+++ b/src/ui/src/components/chat/collapsedToolGroupKey.test.ts
@@ -27,6 +27,18 @@ describe("collapsedToolGroupKey", () => {
     expect(collapsedToolGroupKey([activity("a", "Agent")])).toBe("agent:a");
   });
 
+  it("prefixes MCP activities with mcp: instead of tools:", () => {
+    // The discriminator keys MCP groups separately so the collapse state
+    // persists across the live→completed transition (both paths call this
+    // helper with the same first activity).
+    expect(
+      collapsedToolGroupKey([
+        activity("a", "mcp__datadog__search_datadog_dashboards"),
+        activity("b", "mcp__datadog__list_datadog_skills"),
+      ]),
+    ).toBe("mcp:a");
+  });
+
   it("returns null for an empty group", () => {
     expect(collapsedToolGroupKey([])).toBeNull();
   });

--- a/src/ui/src/components/chat/collapsedToolGroupKey.ts
+++ b/src/ui/src/components/chat/collapsedToolGroupKey.ts
@@ -1,4 +1,5 @@
 import type { ToolActivity } from "../../stores/useAppStore";
+import { isMcpToolName } from "./mcpToolName";
 
 /**
  * Stable key under which a tool-call group's user-toggled
@@ -31,9 +32,17 @@ export function collapsedToolGroupKey(
   const first = activities[0];
   if (!first) return null;
   // Match the discriminator `groupToolActivitiesForDisplay` uses for
-  // its own React `key` (`agent:` for Agent tool, `tools:` otherwise)
-  // so the slice key collides with nothing user-meaningful and reads
-  // sensibly in dev tools.
-  const kind = first.toolName === "Agent" ? "agent" : "tools";
+  // its own React `key` (`agent:` for Agent tool, `mcp:` for an MCP tool,
+  // `tools:` otherwise) so the slice key collides with nothing
+  // user-meaningful and reads sensibly in dev tools. Both render paths
+  // (live `GroupedToolActivityRows` and post-turn `TurnSummary`) call this
+  // with the same first activity, so the key stays stable across the
+  // running→completed transition.
+  const kind =
+    first.toolName === "Agent"
+      ? "agent"
+      : isMcpToolName(first.toolName)
+        ? "mcp"
+        : "tools";
   return `${kind}:${first.toolUseId}`;
 }

--- a/src/ui/src/components/chat/mcpToolName.test.ts
+++ b/src/ui/src/components/chat/mcpToolName.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { isMcpToolName, parseMcpToolName } from "./mcpToolName";
+
+describe("parseMcpToolName", () => {
+  it("splits the simple mcp__<server>__<tool> shape", () => {
+    expect(parseMcpToolName("mcp__datadog__search_datadog_dashboards")).toEqual({
+      server: "datadog",
+      tool: "search_datadog_dashboards",
+    });
+  });
+
+  it("treats only the first __ after the prefix as the server boundary", () => {
+    // Server names can contain single underscores; the tool keeps any
+    // remaining underscores intact.
+    expect(parseMcpToolName("mcp__claude_ai_Gmail__authenticate")).toEqual({
+      server: "claude_ai_Gmail",
+      tool: "authenticate",
+    });
+    expect(parseMcpToolName("mcp__datadog__load_datadog_skill")).toEqual({
+      server: "datadog",
+      tool: "load_datadog_skill",
+    });
+  });
+
+  it("returns null for non-MCP tool names", () => {
+    expect(parseMcpToolName("Read")).toBeNull();
+    expect(parseMcpToolName("Bash")).toBeNull();
+    // Missing the tool segment — not a usable MCP tool name.
+    expect(parseMcpToolName("mcp__server")).toBeNull();
+    expect(parseMcpToolName("mcp__server__")).toBeNull();
+  });
+
+  it("isMcpToolName mirrors parse success", () => {
+    expect(isMcpToolName("mcp__datadog__search")).toBe(true);
+    expect(isMcpToolName("Edit")).toBe(false);
+  });
+});

--- a/src/ui/src/components/chat/mcpToolName.ts
+++ b/src/ui/src/components/chat/mcpToolName.ts
@@ -1,0 +1,19 @@
+// MCP tools surface to the agent as `mcp__<server>__<tool>` — e.g.
+// `mcp__datadog__search_datadog_dashboards` (server `datadog`, tool
+// `search_datadog_dashboards`). The server segment may itself contain single
+// underscores (`mcp__claude_ai_Gmail__authenticate`), so the split is on the
+// FIRST `__` after the prefix: a non-greedy server capture, then everything
+// else as the tool.
+const MCP_TOOL_PATTERN = /^mcp__(.+?)__(.+)$/;
+
+export function parseMcpToolName(
+  toolName: string,
+): { server: string; tool: string } | null {
+  const match = MCP_TOOL_PATTERN.exec(toolName);
+  if (!match) return null;
+  return { server: match[1], tool: match[2] };
+}
+
+export function isMcpToolName(toolName: string): boolean {
+  return MCP_TOOL_PATTERN.test(toolName);
+}

--- a/src/ui/src/components/chat/toolActivityGroups.test.ts
+++ b/src/ui/src/components/chat/toolActivityGroups.test.ts
@@ -122,6 +122,77 @@ describe("toolActivityGroups", () => {
     expect(groups[0]?.label).toBe("rebase-on-main");
   });
 
+  it("groups consecutive same-server MCP calls into one server-labeled group", () => {
+    const groups = groupToolActivitiesForDisplay([
+      activity("mcp__datadog__load_datadog_skill"),
+      activity("mcp__datadog__list_datadog_skills"),
+      activity("mcp__datadog__search_datadog_dashboards"),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.kind).toBe("mcp");
+    expect(groups[0]?.label).toBe("datadog");
+    expect(groups[0]?.activities).toHaveLength(3);
+  });
+
+  it("splits different MCP servers into separate groups in order", () => {
+    const groups = groupToolActivitiesForDisplay([
+      activity("mcp__datadog__search_datadog_dashboards"),
+      activity("mcp__github__create_issue"),
+      activity("mcp__github__list_issues"),
+    ]);
+
+    expect(groups.map((g) => g.kind)).toEqual(["mcp", "mcp"]);
+    expect(groups.map((g) => g.label)).toEqual(["datadog", "github"]);
+    expect(groups.map((g) => g.activities.length)).toEqual([1, 2]);
+  });
+
+  it("pulls MCP calls out of the generic tool pill, preserving transcript order", () => {
+    const groups = groupToolActivitiesForDisplay([
+      activity("Read"),
+      activity("mcp__datadog__search_datadog_dashboards"),
+      activity("mcp__datadog__list_datadog_skills"),
+      activity("Write"),
+    ]);
+
+    expect(groups.map((g) => g.kind)).toEqual(["tools", "mcp", "tools"]);
+    expect(groups.map((g) => g.label)).toEqual([
+      "1 tool call",
+      "datadog",
+      "1 tool call",
+    ]);
+  });
+
+  it("breaks an MCP run around an agent or skill, like direct tools", () => {
+    const groups = groupToolActivitiesForDisplay([
+      activity("mcp__datadog__search_datadog_dashboards"),
+      activity("Skill", { inputJson: JSON.stringify({ skill: "commit-changes" }) }),
+      activity("mcp__datadog__list_datadog_skills"),
+    ]);
+
+    expect(groups.map((g) => g.kind)).toEqual(["mcp", "skill", "mcp"]);
+    expect(groups.map((g) => g.label)).toEqual([
+      "datadog",
+      "commit-changes",
+      "datadog",
+    ]);
+  });
+
+  it("does not form MCP groups in inline mode", () => {
+    const groups = groupToolActivitiesForDisplay(
+      [
+        activity("mcp__datadog__search_datadog_dashboards"),
+        activity("mcp__datadog__list_datadog_skills"),
+      ],
+      "inline",
+    );
+
+    // Inline mode is the legacy "show everything flat" rendering: one group
+    // per activity, no per-server container.
+    expect(groups).toHaveLength(2);
+    expect(groups.every((g) => g.kind !== "mcp")).toBe(true);
+  });
+
   it("derives the skill name from input, then summary, then a default", () => {
     expect(
       skillActivationName(

--- a/src/ui/src/components/chat/toolActivityGroups.ts
+++ b/src/ui/src/components/chat/toolActivityGroups.ts
@@ -1,9 +1,10 @@
 import type { ToolDisplayMode } from "../../stores/slices/settingsSlice";
 import type { ToolActivity } from "../../stores/useAppStore";
+import { parseMcpToolName } from "./mcpToolName";
 
 export type ToolActivityDisplayGroup = {
   key: string;
-  kind: "tools" | "agent" | "skill";
+  kind: "tools" | "agent" | "skill" | "mcp";
   label: string;
   activities: ToolActivity[];
 };
@@ -18,6 +19,7 @@ export function groupToolActivitiesForDisplay(
 
   const groups: ToolActivityDisplayGroup[] = [];
   let directTools: ToolActivity[] = [];
+  let mcpRun: { server: string; activities: ToolActivity[] } | null = null;
 
   const flushDirectTools = () => {
     if (directTools.length === 0) return;
@@ -30,6 +32,21 @@ export function groupToolActivitiesForDisplay(
     directTools = [];
   };
 
+  const flushMcpRun = () => {
+    if (!mcpRun) return;
+    groups.push({
+      key: `mcp:${mcpRun.server}:${mcpRun.activities
+        .map((activity) => activity.toolUseId)
+        .join(",")}`,
+      kind: "mcp",
+      label: mcpRun.server,
+      activities: mcpRun.activities,
+    });
+    mcpRun = null;
+  };
+
+  // `directTools` and `mcpRun` are mutually exclusive accumulators: pushing to
+  // either flushes the other first, so at most one is non-empty at a time.
   for (const activity of activities) {
     // Agents and skills are first-class transcript entries, not tool
     // calls — they break a run of direct tools and render on their own
@@ -37,13 +54,29 @@ export function groupToolActivitiesForDisplay(
     // marker) rather than getting bundled into the "N tool calls" pill.
     if (isAgentActivity(activity) || isSkillActivity(activity)) {
       flushDirectTools();
+      flushMcpRun();
       groups.push(activityDisplayGroup(activity));
       continue;
     }
+    // MCP tool calls get pulled out of the generic "N tool calls" pill into
+    // a per-server group (Plug2 + server name). Consecutive calls to the
+    // same server accumulate; a different server or a plain tool flushes the
+    // run, preserving transcript order.
+    const mcp = parseMcpToolName(activity.toolName);
+    if (mcp) {
+      flushDirectTools();
+      if (mcpRun && mcpRun.server !== mcp.server) flushMcpRun();
+      (mcpRun ??= { server: mcp.server, activities: [] }).activities.push(
+        activity,
+      );
+      continue;
+    }
+    flushMcpRun();
     directTools.push(activity);
   }
 
   flushDirectTools();
+  flushMcpRun();
   return groups;
 }
 


### PR DESCRIPTION
## Summary

Promotes MCP tool calls to top-level transcript elements. Previously, MCP calls (e.g. `mcp__datadog__search_datadog_dashboards`) were bundled into the generic "N tool calls" pill alongside everything else. Now each consecutive run of calls to the same MCP server renders in its own collapsible container with a `Plug2` icon and the server name, and the individual rows show the bare tool name with the redundant `mcp__<server>__` prefix stripped.

```
> Plug2  datadog
    > load_datadog_skill          datadog/visualizations
    > list_datadog_skills         dashboard creation widgets metrics
    > search_datadog_dashboards   title:"Shopify Inventory"
```

This works in **both** rendering paths — the live transcript (`ToolActivitiesSection`) and replayed completed turns (`MessagesWithTurns` → `TurnSummary`) — by extending the single shared grouping function `groupToolActivitiesForDisplay` with a new `"mcp"` group kind. As a result, MCP groups inherit all existing behavior for free: collapse-state persistence across the running→completed transition, search force-expand, the turn footer, edit-summary card, and task-progress bar.

Grouping rules:
- Consecutive calls to the same server form one container, in transcript order.
- A different server, a plain tool, an Agent, or a Skill flushes the current run (no reordering).
- Inline tool-display mode is unchanged (legacy flat rendering, full names).

## Complexity Notes

- **Two mutually-exclusive accumulators** in `groupToolActivitiesForDisplay` (`directTools` and `mcpRun`): pushing to either flushes the other first, so at most one is non-empty at a time and transcript order is preserved.
- **Collapse-key stability**: `collapsedToolGroupKey` gained an `mcp:` discriminator. Both render paths call this helper with the same first activity, so the key stays identical across the running→completed handoff and the user's expand/collapse choice survives.
- **MCP name parsing** splits on the *first* `__` after the `mcp__` prefix, so servers with single underscores (`mcp__claude_ai_Gmail__authenticate`) parse correctly.
- One existing test (`MessagesWithTurns` "does not show workspace dirty files…") pinned the old full-name rendering of `mcp__postgres__query`; it was updated to assert the new per-server container + stripped name. This is an intentional, user-visible behavior change.

## Test Steps

1. `cd src/ui && bunx tsc -b` — type check passes.
2. `cd src/ui && bun run test` — full vitest suite (2789 passed). New coverage: `mcpToolName.test.ts` (parser), `toolActivityGroups.test.ts` (consecutive / multi-server / interleaved / agent-skill breaks / inline), and a `ToolActivitiesSection` render test asserting the container, collapse, and bare-name rows.
3. `cd src/ui && bun run lint:css` — design-token check passes (new `.mcpGroupIcon` uses `var(--accent-primary)`).
4. In-app: run an agent turn that invokes one or more MCP servers. Confirm each server renders as its own collapsed container with the plug icon + server name; expand to verify rows show bare tool names. Confirm it renders identically after the turn completes and after a reload (replay path), and that expand/collapse state persists across the running→completed transition.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable) — N/A: transcript tool-call rendering (incl. the existing grouped-tool-calls behavior) is not documented in the docs site; no new setting/command/shortcut introduced.