### PR TITLE
fix(workspace): run setup/archive scripts through login+interactive shell

### DIFF
--- a/site/src/content/docs/features/per-repo-settings.mdx
+++ b/site/src/content/docs/features/per-repo-settings.mdx
@@ -26,7 +26,13 @@ python -m venv .venv && source .venv/bin/activate && pip install -r requirements
 mix deps.get && mix ecto.setup
 ```
 
-The script runs in the workspace's worktree directory using your platform's default shell — `sh -c` on macOS and Linux, `cmd.exe /S /C` on Windows — so write the script in whichever syntax matches your host. [Workspace environment variables](/claudette/features/settings/#environment-variables) like `$CLAUDETTE_WORKSPACE_NAME` and `$CLAUDETTE_ROOT_PATH` are available in setup scripts (use `%CLAUDETTE_WORKSPACE_NAME%` etc. in `cmd.exe`).
+The script runs in the workspace's worktree directory through your shell. On macOS and Linux it runs as a **login + interactive shell** (`$SHELL -l -i -c`, falling back to `sh -c` when `$SHELL` is unset), so it sources your profile (`.zprofile`/`.zlogin` and `.zshrc`, or the bash equivalents) — environment variables you export there (API keys, tokens, `$JWT_CLIENT_ID`, etc.) are visible to the setup script, matching what the integrated terminal sees. This matters most for a Dock-launched app, which otherwise inherits a profile-less environment. Windows runs `cmd.exe /S /C`. Because the script runs under your actual shell, write it in that shell's syntax.
+
+[Workspace environment variables](/claudette/features/settings/#environment-variables) like `$CLAUDETTE_WORKSPACE_NAME` and `$CLAUDETTE_ROOT_PATH` are available in setup scripts (use `%CLAUDETTE_WORKSPACE_NAME%` etc. in `cmd.exe`).
+
+:::note
+The setup script runs **before** the env-provider stack (direnv, mise, dotenv, Nix devshell) resolves — that ordering lets a setup script *prime* those providers (`direnv allow`, `mise install`, generating a `.env`). As a result, variables contributed by those providers are **not** yet available inside the setup script, even though the terminal and agent get them afterward. Your shell profile, however, *is* sourced (see above).
+:::
 
 By default, Claudette shows a confirmation modal with the script contents before running it. Tick **Skip confirmation when running setup scripts** in the repo settings (or **Always run setup scripts for this repo** in the modal) to opt into auto-run for that repository.
 
@@ -47,7 +53,7 @@ git stash push -u -m "claudette archive"
 docker compose down
 ```
 
-The script runs in the workspace's worktree directory through the same platform shell as the setup script (`sh -c` on macOS/Linux, `cmd.exe /S /C` on Windows) and has access to the same workspace environment variables. The worktree is still on disk while the script runs, so any commands that need to read workspace files will work as expected.
+The script runs in the workspace's worktree directory through the same shell as the setup script (a login + interactive `$SHELL -l -i -c` on macOS/Linux — so your profile is sourced — falling back to `sh -c`; `cmd.exe /S /C` on Windows) and has access to the same workspace environment variables. The worktree is still on disk while the script runs, so any commands that need to read workspace files will work as expected.
 
 By default, Claudette prompts before archiving when an archive script is configured — the modal shows the script contents and lets you choose **Run & Archive** or **Archive without running**. Tick **Skip confirmation when running archive scripts** in repo settings (or **Always run archive scripts for this repo** in the modal) to skip the prompt for that repository.
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -169,12 +169,18 @@ pub(crate) async fn create_workspace_inner(
     // worktree and either error or sit waiting for the user to allow
     // them manually, defeating the whole point of a setup script.
     //
-    // Tradeoff: the script runs with the system PATH (plus
-    // `enriched_path()`) instead of the env-provider-merged
-    // environment. Setup scripts in the wild assume this — they expect
-    // to be the thing that *installs* tool versions, not to consume
-    // them. The agent and terminal still get the merged env after
-    // resolve runs.
+    // Tradeoff: the script does not see the env-provider-merged
+    // environment (direnv / mise / dotenv / nix-devshell) — that resolves
+    // afterwards. Setup scripts in the wild assume this — they expect to
+    // be the thing that *installs* / *primes* those, not to consume them.
+    // The agent and terminal still get the merged env after resolve runs.
+    //
+    // It DOES, however, see the user's shell profile: the script runs
+    // through `$SHELL -l -i -c` (see `build_script_command`), so vars
+    // exported in `.zprofile` / `.zshrc` are available — matching the
+    // interactive terminal. Without that, a Dock-launched app's
+    // profile-less launchd env left setup unable to read user-exported
+    // secrets the terminal could see.
     //
     // The WS server (`src-server/handler.rs`) has always run setup
     // with `resolved_env = None` (no plugin registry server-side), so

--- a/src/ops/workspace.rs
+++ b/src/ops/workspace.rs
@@ -315,21 +315,63 @@ async fn create_inner(
     })
 }
 
-/// Build the platform-default shell invocation Claudette uses to run
-/// user setup / archive scripts.
+/// The user's shell (`$SHELL`) when it is set to an absolute path, else
+/// `None`. Used to decide whether a setup / archive script can be run
+/// through the user's own shell (sourcing their profile) or must fall back
+/// to a profile-less POSIX `sh`.
+#[cfg(not(windows))]
+fn user_shell() -> Option<std::ffi::OsString> {
+    let shell = std::env::var_os("SHELL")?;
+    std::path::Path::new(&shell).is_absolute().then_some(shell)
+}
+
+/// Decide the Unix program + argument flags used to run a setup / archive
+/// script. With a real `$SHELL`, invoke it login + interactive
+/// (`-l -i -c`) so it sources the user's profile — `.zprofile`/`.zlogin`
+/// via `-l` and `.zshrc` via `-i` — matching what the integrated terminal
+/// exposes. `None` falls back to a profile-less POSIX `sh -c`.
 ///
-/// POSIX hosts get `sh -c <script>`; Windows gets `cmd.exe /S /C <script>`
-/// so a stock install (no Git Bash on PATH) can still execute scripts —
-/// this matches the shape `commands/settings.rs::build_notification_command`
-/// already uses for user-supplied notification commands. Common spawn
-/// configuration (cwd, enriched PATH, piped stdio, Unix process group for
-/// timeout-driven SIGKILL of the entire subtree) is applied here so the
+/// Split out as a pure function so the flag selection is unit-testable
+/// without spawning a shell or mutating the process-global `$SHELL`.
+#[cfg(not(windows))]
+fn unix_script_invocation(
+    user_shell: Option<std::ffi::OsString>,
+) -> (std::ffi::OsString, &'static [&'static str]) {
+    match user_shell {
+        Some(shell) => (shell, &["-l", "-i", "-c"]),
+        None => (std::ffi::OsString::from("sh"), &["-c"]),
+    }
+}
+
+/// Build the shell invocation Claudette uses to run user setup / archive
+/// scripts.
+///
+/// On Unix the script runs through the user's own shell with login +
+/// interactive flags (`$SHELL -l -i -c <script>`) so it sources their
+/// profile (`.zprofile`/`.zlogin` + `.zshrc`). This matches the
+/// environment the integrated terminal exposes: a Dock-launched macOS app
+/// inherits a profile-less launchd env, so without this a setup script
+/// can't see vars the user exports in their shell rc (e.g. `$JWT_CLIENT_ID`
+/// in `.zshrc`) even though the terminal — which runs an interactive shell
+/// — can. When `$SHELL` is unset or relative we fall back to POSIX
+/// `sh -c <script>`. Note the script interpreter becomes the user's shell;
+/// scripts relying on strict POSIX/bash syntax should account for that.
+///
+/// Windows gets `cmd.exe /S /C <script>` so a stock install (no Git Bash on
+/// PATH) can still execute scripts — this matches the shape
+/// `commands/settings.rs::build_notification_command` already uses for
+/// user-supplied notification commands.
+///
+/// Common spawn configuration (cwd, enriched PATH, null stdin so an
+/// interactive shell can't block on input, piped stdio, Unix process group
+/// for timeout-driven SIGKILL of the entire subtree) is applied here so the
 /// two callers — setup and archive — stay byte-identical.
 fn build_script_command(script: &str, worktree_path: &Path) -> TokioCommand {
     #[cfg(not(windows))]
     let mut cmd = {
-        let mut c = crate::process::command("sh");
-        c.arg("-c").arg(script);
+        let (program, flags) = unix_script_invocation(user_shell());
+        let mut c = crate::process::command(&program);
+        c.args(flags).arg(script);
         c
     };
     #[cfg(windows)]
@@ -343,6 +385,9 @@ fn build_script_command(script: &str, worktree_path: &Path) -> TokioCommand {
     };
     cmd.current_dir(worktree_path)
         .env("PATH", enriched_path())
+        // Null stdin: with `-i` an interactive shell would otherwise try to
+        // read from whatever stdin the app inherited and could block.
+        .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
     // Process group on Unix so a timeout SIGKILL hits every grandchild
@@ -1759,18 +1804,19 @@ mod tests {
     }
 
     /// `build_script_command` must produce a Command that actually runs
-    /// the user-supplied script on the host's default shell — `sh -c` on
-    /// Unix and `cmd.exe /S /C` on Windows. Before the cross-platform
-    /// gating was added, every Windows host without Git Bash on PATH
-    /// failed setup-script execution with an opaque ENOENT.
+    /// the user-supplied script on the host's shell — `$SHELL -l -i -c`
+    /// (or `sh -c` when `$SHELL` is unset) on Unix and `cmd.exe /S /C` on
+    /// Windows. Before the cross-platform gating was added, every Windows
+    /// host without Git Bash on PATH failed setup-script execution with an
+    /// opaque ENOENT.
     ///
     /// We assert the contract end-to-end: spawn the helper with a
-    /// trivial `echo` (recognised by both shells), run the command,
+    /// trivial `echo` (recognised by every shell), run the command,
     /// and read the stdout the script actually produced.
     #[tokio::test]
     async fn build_script_command_executes_on_host_shell() {
         let cwd = tempfile::tempdir().unwrap();
-        // `echo hello` is a builtin on both `cmd.exe` and POSIX shells,
+        // `echo hello` is a builtin on `cmd.exe` and every POSIX shell,
         // so the test is independent of any external binary on PATH.
         let mut cmd = build_script_command("echo hello", cwd.path());
         let output = cmd.output().await.expect("spawn host shell");
@@ -1781,13 +1827,37 @@ mod tests {
             String::from_utf8_lossy(&output.stderr),
         );
         let stdout = String::from_utf8_lossy(&output.stdout);
-        // Trim because Windows `cmd.exe /C echo hello` emits "hello\r\n"
-        // and POSIX `sh -c 'echo hello'` emits "hello\n".
+        // Take the last non-empty line: a login + interactive `$SHELL`
+        // may print a profile banner before our `echo` output (same
+        // reason `login_shell_path_probe` reads the last line). Windows
+        // `cmd.exe /C echo hello` emits "hello\r\n"; POSIX shells emit
+        // "hello\n" — `.trim()` normalises both.
+        let last_line = stdout.lines().rfind(|l| !l.trim().is_empty());
         assert_eq!(
-            stdout.trim(),
-            "hello",
+            last_line.map(str::trim),
+            Some("hello"),
             "expected `echo hello` stdout, got {stdout:?}",
         );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_script_invocation_uses_login_interactive_shell() {
+        let shell = std::ffi::OsString::from("/bin/zsh");
+        let (program, flags) = unix_script_invocation(Some(shell.clone()));
+        assert_eq!(program, shell);
+        // `-l` sources the login profile (.zprofile/.zlogin), `-i` the
+        // interactive rc (.zshrc) where users commonly export secrets —
+        // both are needed to match the integrated terminal's env.
+        assert_eq!(flags, &["-l", "-i", "-c"]);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_script_invocation_falls_back_to_posix_sh() {
+        let (program, flags) = unix_script_invocation(None);
+        assert_eq!(program, std::ffi::OsString::from("sh"));
+        assert_eq!(flags, &["-c"]);
     }
 
     /// `kill_script_subtree` must terminate a hung script's full


### PR DESCRIPTION
## Summary

Setup and archive scripts ran under a profile-less `sh -c`. A Dock-launched macOS app inherits a profile-less launchd environment, so the setup script could not see variables exported in the user's shell rc (e.g. `$JWT_CLIENT_ID` in `.zshrc`) — even though the integrated terminal, which spawns an interactive login shell, could. Setup also runs *before* the env-provider stack resolves, so direnv/mise/dotenv never carried these vars to it either.

This makes the script run through the user's own shell with login + interactive flags so it sources their profile, matching what the terminal exposes.

```mermaid
flowchart LR
  subgraph Before
    A1[create workspace] --> B1["setup: sh -c<br/>(no profile)"] --> C1[env-provider resolve]
  end
  subgraph After
    A2[create workspace] --> B2["setup: $SHELL -l -i -c<br/>(.zprofile + .zshrc sourced)"] --> C2[env-provider resolve]
  end
```

**What changed (`src/ops/workspace.rs`):**
- On Unix, `build_script_command` now invokes `$SHELL -l -i -c <script>` (`-l` sources `.zprofile`/`.zlogin`, `-i` sources `.zshrc`), falling back to `sh -c` when `$SHELL` is unset or not absolute.
- `stdin` is set to null so an interactive shell can't block on input.
- Windows is unchanged (`cmd.exe /S /C`).
- Extracted a pure `unix_script_invocation()` helper (unit-tested) and a `user_shell()` helper.

Also updated the explanatory comment in `src-tauri/src/commands/workspace.rs` and the `per-repo-settings.mdx` docs (setup + archive sections, plus a note that env-provider vars remain unavailable to setup by design, since setup *primes* that stack).

### Background

The regression was commonly attributed to the "workspace variables" feature (#807), but that only swapped the setup call's `None` → declared-inputs env. The env that setup runs in was actually changed by #754 (setup-before-env-provider ordering), and for a `~/.zshrc`-sourced var the real trigger is launch context (Dock vs. terminal). The env-provider `ResolvedEnv` never carried shell-profile vars, so sourcing the profile is the correct fix.

## Complexity Notes

- **Interpreter change**: setup/archive scripts now run under the user's actual shell, not POSIX `sh`. Transparent for zsh/bash; a non-POSIX shell (fish) or strict bashisms could behave differently. Both callers (setup *and* archive) share `build_script_command`, so this applies to archive scripts too.
- **Interactive shell without a tty**: with `-i`, bash emits job-control notices to stderr (harmless; captured into the workspace terminal stream). zsh is quiet. stdin is null'd to prevent blocking.
- The end-to-end shell test now reads the *last* non-empty stdout line so a profile banner can't make it flaky.

## Test Steps

1. `cargo test -p claudette --all-features` — all pass (incl. new `unix_script_invocation_*` tests and the updated `build_script_command_executes_on_host_shell`).
2. `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` — zero warnings.
3. `cargo fmt --all --check` — clean.
4. Manual (macOS, **launch Claudette from Dock**, not a terminal):
   - Export a var in `~/.zshrc`, e.g. `export JWT_CLIENT_ID=abc123`.
   - Set a repo setup script that echoes it, e.g. `echo "client=$JWT_CLIENT_ID"`.
   - Create a workspace and watch the setup output in the Claudette Terminal tab — it should now print `client=abc123`.
   - Confirm the integrated terminal still shows the same value (no regression).

## Checklist
- [x] Tests added/updated
- [x] Documentation updated (if applicable)