### PR TITLE
feat(models): add Opus 4.8 and make it the default

### DIFF
--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -14,13 +14,13 @@ Select a model from the dropdown in the chat header. Available models:
 
 | Model | ID | Description |
 |-------|-----|-------------|
-| **Opus 4.7 1M** | `opus` | Opus 4.7 with a 1M context window |
-| **Opus 4.7** | `claude-opus-4-7` | Standard Opus 4.7 (200K context) |
+| **Opus 4.8 1M** | `opus` | Opus 4.8 with a 1M context window |
+| **Opus 4.8** | `claude-opus-4-8` | Standard Opus 4.8 (200K context) |
 | **Sonnet 4.6** | `sonnet` | Fast and capable |
 | **Sonnet 4.6 1M** | `claude-sonnet-4-6[1m]` | Sonnet 4.6 with a 1M context window (extra usage) |
 | **Haiku 4.5** | `haiku` | Fastest, most affordable |
 
-Earlier-generation models (Opus 4.6, Opus 4.6 1M, Opus 4.5, Sonnet 4.5, Haiku 3.5) remain selectable in the picker as legacy entries.
+Earlier-generation models (Opus 4.7, Opus 4.7 1M, Opus 4.6, Opus 4.6 1M, Opus 4.5, Sonnet 4.5, Haiku 3.5) remain selectable in the picker as legacy entries.
 
 The model selection is per-workspace — you can use different models for different tasks.
 
@@ -30,14 +30,14 @@ Set the default model for new sessions in `Settings > Models > Default model`.
 
 You can change the model on an active chat at any time — from the toolbar dropdown or with the `/model` slash command. Whether the conversation continues depends on whether the swap stays inside the same runtime:
 
-- **Same runtime (no context loss)** — Switching between models that resolve to the same harness keeps the full transcript. The very next turn streams from the new model with every prior message available. This covers the common cases: Sonnet 4.6 ↔ Opus 4.7 on the Anthropic Claude Code path, two Pi-routed Ollama models on the same Pi card, and so on. Claudette tears down the persistent agent subprocess and respawns it with the new `--model` flag while reusing the existing session id, so the new turn resumes the prior transcript.
+- **Same runtime (no context loss)** — Switching between models that resolve to the same harness keeps the full transcript. The very next turn streams from the new model with every prior message available. This covers the common cases: Sonnet 4.6 ↔ Opus 4.8 on the Anthropic Claude Code path, two Pi-routed Ollama models on the same Pi card, and so on. Claudette tears down the persistent agent subprocess and respawns it with the new `--model` flag while reusing the existing session id, so the new turn resumes the prior transcript.
 - **Different runtime (context migrated as a prelude)** — Switching to a model whose backend uses a different runtime — e.g., Anthropic Claude Code to Codex Native, or anything to a Pi SDK target — preserves the conversation by injecting the prior history into the new harness's very first turn. Claudette reads every persisted message on the session, wraps it in a `<conversation-history>` block, and prepends that block to the user's next message before sending it to the new harness. The persisted chat history in the UI is unchanged; the prelude is only visible to the model on the next turn. Tool calls in the history are rendered as text — the new harness reads them for context but does not re-execute them. The first turn after a cross-runtime switch will be slower and use more input tokens than usual because the whole prior conversation is part of its input.
 
 You can see which runtime a model uses from the "via …" badge next to its row in the model picker. Models on a runtime that matches the picker section's default carry no badge (e.g., Pi-card models on the Pi runtime, Anthropic Claude Code models on the Claude CLI runtime).
 
 ### When the model's context window is too small
 
-If you switch to a model whose context window can't hold the current conversation, the agent's send fails with a "context length" / "input is too long" error. Claudette detects that error class and inlines a **"Choose a larger-context model →"** link directly into the chat error banner. Clicking it opens the toolbar's model picker so you can pick one of the 1M-context variants (Opus 4.7 1M, Sonnet 4.6 1M) or another model the registry shows with a larger window. The conversation is not lost — it stays in the chat panel, and your next send under the new model will resume it via the same in-place or cross-runtime path described above.
+If you switch to a model whose context window can't hold the current conversation, the agent's send fails with a "context length" / "input is too long" error. Claudette detects that error class and inlines a **"Choose a larger-context model →"** link directly into the chat error banner. Clicking it opens the toolbar's model picker so you can pick one of the 1M-context variants (Opus 4.8 1M, Sonnet 4.6 1M) or another model the registry shows with a larger window. The conversation is not lost — it stays in the chat panel, and your next send under the new model will resume it via the same in-place or cross-runtime path described above.
 
 ## Reasoning Effort
 
@@ -49,7 +49,7 @@ Control how much reasoning the agent applies to each response:
 | **Low** | Fast, minimal reasoning | Opus, Sonnet |
 | **Medium** | Balanced | Opus, Sonnet |
 | **High** | Deep reasoning | Opus, Sonnet |
-| **XHigh** | Extended reasoning budget | Opus 4.7 only |
+| **XHigh** | Extended reasoning budget | Opus 4.7+ only |
 | **Max** | Maximum reasoning budget | Opus and Sonnet (effort-capable models) |
 
 Select the effort level from the dropdown in the chat header, next to the model selector.

--- a/site/src/content/docs/features/cli-client.mdx
+++ b/site/src/content/docs/features/cli-client.mdx
@@ -151,11 +151,11 @@ Boolean flags are tri-state — pass `--plan` to force on, `--no-plan` to force 
 
 | Flag | Values | Effect |
 |---|---|---|
-| `--model` | `opus`, `sonnet`, `haiku`, `claude-opus-4-7`, ... | Override model for this turn |
+| `--model` | `opus`, `sonnet`, `haiku`, `claude-opus-4-8`, ... | Override model for this turn |
 | `--plan` / `--no-plan` | — | Plan mode (read-only until approved) |
 | `--thinking` / `--no-thinking` | — | Extended thinking |
 | `--fast` / `--no-fast` | — | Fast mode (built-in support: Opus 4.6) |
-| `--effort` | `low`, `medium`, `high`, `xhigh`, `max` | Reasoning effort (`xhigh` requires Opus 4.7) |
+| `--effort` | `low`, `medium`, `high`, `xhigh`, `max` | Reasoning effort (`xhigh` requires Opus 4.7+) |
 | `--chrome` / `--no-chrome` | — | Chrome browser tool |
 | `--disable-1m-context` | — | Suppress Max-plan auto-upgrade to a 1M context window |
 | `--permission` | `default`, `acceptEdits`, `bypassPermissions` | Permission level |

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -33,7 +33,7 @@ Default values applied to all new agent sessions. Per-workspace overrides are av
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| Default model | Model for new chats (Opus 4.7 1M, Opus 4.7, Sonnet 4.6, Sonnet 4.6 1M, Haiku 4.5; older models such as Opus 4.6 / 4.5 remain selectable behind the picker's "More" disclosure) | — |
+| Default model | Model for new chats (Opus 4.8 1M, Opus 4.8, Sonnet 4.6, Sonnet 4.6 1M, Haiku 4.5; older models such as Opus 4.7 / 4.6 / 4.5 remain selectable behind the picker's "More" disclosure) | — |
 | Default effort / Codex intelligence | Claude models use effort levels (`auto`, `low`, `medium`, `high`, `xhigh`, `max` where supported). Codex uses intelligence levels (`low`, `medium`, `high`, `xhigh`). | Auto / High |
 | Default thinking | Enable extended thinking for Claude models. Codex does not expose a reasoning on/off toggle; use Codex intelligence instead. | Off |
 | Show thinking / reasoning blocks | Display Claude thinking blocks or Codex reasoning summaries in the chat UI. | Off |

--- a/src-cli/src/commands/chat.rs
+++ b/src-cli/src/commands/chat.rs
@@ -149,7 +149,7 @@ pub enum Action {
         #[arg(long = "no-fast", overrides_with = "fast", hide = true)]
         no_fast: bool,
         /// Effort level: `low`, `medium`, `high`, `xhigh`, `max`
-        /// (`xhigh` requires Opus 4.7).
+        /// (`xhigh` requires Opus 4.7+).
         #[arg(long)]
         effort: Option<String>,
         /// Enable Chrome browser mode for this session. Pair: `--no-chrome`

--- a/src/ui/src/components/chat/applySelectedModel.test.ts
+++ b/src/ui/src/components/chat/applySelectedModel.test.ts
@@ -253,7 +253,7 @@ describe("applySelectedModel", () => {
 
       expect(appStore.setSelectedModel).toHaveBeenCalledWith(
         "sess-1",
-        "claude-opus-4-7",
+        "claude-opus-4-8",
         "anthropic",
       );
       expect(serviceMocks.resetAgentSession).not.toHaveBeenCalled();

--- a/src/ui/src/components/chat/applySelectedModel.ts
+++ b/src/ui/src/components/chat/applySelectedModel.ts
@@ -30,7 +30,7 @@ import {
  *
  * Session-handling rule, by swap kind:
  *
- * - **Same harness** (e.g. Sonnet 4.6 <-> Opus 4.7 on the Anthropic Claude
+ * - **Same harness** (e.g. Sonnet 4.6 <-> Opus 4.8 on the Anthropic Claude
  *   Code path, or two Pi-routed Ollama models): preserve
  *   `chat_sessions.session_id` so the next turn resumes the prior
  *   transcript via `claude --resume` (Claude CLI) or its harness-native

--- a/src/ui/src/components/chat/modelCapabilities.test.ts
+++ b/src/ui/src/components/chat/modelCapabilities.test.ts
@@ -32,6 +32,10 @@ describe("isEffortSupported", () => {
     expect(isEffortSupported("opus")).toBe(true);
   });
 
+  it("returns true for claude-opus-4-8", () => {
+    expect(isEffortSupported("claude-opus-4-8")).toBe(true);
+  });
+
   it("returns true for claude-opus-4-7", () => {
     expect(isEffortSupported("claude-opus-4-7")).toBe(true);
   });
@@ -66,6 +70,10 @@ describe("isXhighEffortAllowed", () => {
     expect(isXhighEffortAllowed("opus")).toBe(true);
   });
 
+  it("returns true for claude-opus-4-8", () => {
+    expect(isXhighEffortAllowed("claude-opus-4-8")).toBe(true);
+  });
+
   it("returns true for claude-opus-4-7", () => {
     expect(isXhighEffortAllowed("claude-opus-4-7")).toBe(true);
   });
@@ -90,6 +98,10 @@ describe("isXhighEffortAllowed", () => {
 describe("isMaxEffortAllowed", () => {
   it("returns true for opus", () => {
     expect(isMaxEffortAllowed("opus")).toBe(true);
+  });
+
+  it("returns true for claude-opus-4-8", () => {
+    expect(isMaxEffortAllowed("claude-opus-4-8")).toBe(true);
   });
 
   it("returns true for claude-opus-4-7", () => {

--- a/src/ui/src/components/chat/modelCapabilities.ts
+++ b/src/ui/src/components/chat/modelCapabilities.ts
@@ -2,13 +2,13 @@
 const FAST_SUPPORTED_MODELS = new Set(["claude-opus-4-6", "claude-opus-4-6[1m]"]);
 
 /** Models that support effort levels. */
-const EFFORT_SUPPORTED_MODELS = new Set(["opus", "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6[1m]"]);
+const EFFORT_SUPPORTED_MODELS = new Set(["opus", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6[1m]"]);
 
 /** Models that support the "xhigh" effort level (Opus 4.7+ only). */
-const XHIGH_EFFORT_MODELS = new Set(["opus", "claude-opus-4-7"]);
+const XHIGH_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-7[1m]"]);
 
 /** Models that support the "max" effort level. */
-const MAX_EFFORT_MODELS = new Set(["opus", "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6[1m]"]);
+const MAX_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6[1m]"]);
 
 export function isFastSupported(model: string): boolean {
   return FAST_SUPPORTED_MODELS.has(model);

--- a/src/ui/src/components/chat/modelRegistry.test.ts
+++ b/src/ui/src/components/chat/modelRegistry.test.ts
@@ -20,7 +20,7 @@ describe("modelRegistry", () => {
     }
   });
 
-  // `"opus"` is the 1M alias of Opus 4.7 whose id lacks the `[1m]` suffix
+  // `"opus"` is the 1M alias of Opus 4.8 whose id lacks the `[1m]` suffix
   // other 1M variants use. Keep the explicit `id === "opus"` check — removing
   // it would silently misclassify the alias as a 200k model.
   it("1M-context variants report 1_000_000", () => {
@@ -63,7 +63,8 @@ describe("modelRegistry", () => {
 
   describe("get1mFallback", () => {
     it("maps 1M models to their 200K equivalents", () => {
-      expect(get1mFallback("opus")).toBe("claude-opus-4-7");
+      expect(get1mFallback("opus")).toBe("claude-opus-4-8");
+      expect(get1mFallback("claude-opus-4-7[1m]")).toBe("claude-opus-4-7");
       expect(get1mFallback("claude-sonnet-4-6[1m]")).toBe("sonnet");
       expect(get1mFallback("claude-opus-4-6[1m]")).toBe("claude-opus-4-6");
     });

--- a/src/ui/src/components/chat/modelRegistry.ts
+++ b/src/ui/src/components/chat/modelRegistry.ts
@@ -57,7 +57,8 @@ export function is1mContextModel(modelId: string): boolean {
 }
 
 const NON_1M_FALLBACKS: Record<string, string> = {
-  "opus": "claude-opus-4-7",
+  "opus": "claude-opus-4-8",
+  "claude-opus-4-7[1m]": "claude-opus-4-7",
   "claude-sonnet-4-6[1m]": "sonnet",
   "claude-opus-4-6[1m]": "claude-opus-4-6",
 };
@@ -74,11 +75,13 @@ export const MODELS: readonly Model[] = [
   // We optimize for Max/Team/Enterprise (Claudette's primary audience), so only Sonnet 1M
   // carries the indicator; Pro users selecting Opus 1M see no warning even though it
   // counts against their extra-usage allotment.
-  { id: "opus", label: "Opus 4.7 1M", group: "Claude Code", extraUsage: false, contextWindowTokens: 1_000_000 },
-  { id: "claude-opus-4-7", label: "Opus 4.7", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
+  { id: "opus", label: "Opus 4.8 1M", group: "Claude Code", extraUsage: false, contextWindowTokens: 1_000_000 },
+  { id: "claude-opus-4-8", label: "Opus 4.8", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
   { id: "sonnet", label: "Sonnet 4.6", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
   { id: "claude-sonnet-4-6[1m]", label: "Sonnet 4.6 1M", group: "Claude Code", extraUsage: true, contextWindowTokens: 1_000_000 },
   { id: "haiku", label: "Haiku 4.5", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
+  { id: "claude-opus-4-7", label: "Opus 4.7", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
+  { id: "claude-opus-4-7[1m]", label: "Opus 4.7 1M", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 1_000_000 },
   { id: "claude-opus-4-6", label: "Opus 4.6", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
   { id: "claude-opus-4-6[1m]", label: "Opus 4.6 1M", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 1_000_000 },
   { id: "claude-opus-4-5", label: "Opus 4.5", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },

--- a/src/usage/pricing.rs
+++ b/src/usage/pricing.rs
@@ -94,6 +94,13 @@ const PRICING_TABLE: &[(&str, ModelPricing)] = &[
     ),
     // -- Anthropic (only used when local-aggregating, e.g. via Pi) -----
     (
+        "claude-opus-4-8",
+        ModelPricing {
+            prompt_per_mtok_usd: 15.00,
+            completion_per_mtok_usd: 75.00,
+        },
+    ),
+    (
         "claude-opus-4-7",
         ModelPricing {
             prompt_per_mtok_usd: 15.00,


### PR DESCRIPTION
## Summary

Opus 4.8 shipped today. This makes it the default model, following the exact alias-migration pattern used for the prior 4.6 → 4.7 transition.

- The `opus` alias now resolves to **Opus 4.8 1M**. Since the default model is already the `opus` alias in all default sites, the default becomes 4.8 with **no separate default change**.
- New pinned **Opus 4.8** (200K) added as a primary picker option.
- **Opus 4.7** demoted to legacy and split into two pinned entries — `claude-opus-4-7` (200K) plus a new `claude-opus-4-7[1m]` — so the 4.7 1M path survives the alias move (it previously only existed *as* the alias).
- 4.8 gets effort / xhigh / max parity with 4.7, the `$15/$75` MTok pricing row, and a 1M variant. No fast mode (consistent with 4.7).
- User-facing docs synced per the repo's documentation-discipline rule (model table, settings reference, CLI flag help, effort table).

```mermaid
flowchart LR
  subgraph Before
    A1["opus (alias)"] --> B1["Opus 4.7 1M"]
    A2["claude-opus-4-7"] --> B2["Opus 4.7 200K"]
  end
  subgraph After
    C1["opus (alias)"] --> D1["Opus 4.8 1M"]
    C2["claude-opus-4-8"] --> D2["Opus 4.8 200K"]
    C3["claude-opus-4-7"] --> D3["Opus 4.7 200K (legacy)"]
    C4["claude-opus-4-7[1m]"] --> D4["Opus 4.7 1M (legacy)"]
  end
```

## Complexity Notes

- **The `opus` alias is a moving pointer, not a pinned id.** Moving it to 4.8 silently retargets the existing default for every user. This is intentional and matches how 4.6→4.7 was done — but it means anyone with the default selected gets 4.8 on their next new session.
- **4.7 1M had no pinned id before this PR** — it only existed as the `opus` alias. Without the new `claude-opus-4-7[1m]` legacy entry, resuming an old 4.7-1M session would have lost its model id. The `get1mFallback` map and a registry invariant test (`every 1M model has a fallback that exists in the registry`) both pin this.
- Model metadata is spread across several surfaces with **no single source of truth** (TS registry, capability sets, Rust pricing, docs, tests). All were updated together.
- **Out of scope (flagged):** the Pi backend's `builtin_pi_sdk` manual model list in `src/agent_backend.rs` was left untouched — it lists older Anthropic *examples*, not the Claude Code curated registry this PR targets.

## Test Steps

1. `cd src/ui && bun run test` — full vitest suite (2794 passing); `modelRegistry`, `modelCapabilities`, and `applySelectedModel` cover the new ids and the `opus → claude-opus-4-8` fallback.
2. `cd src/ui && bunx tsc -b` — clean type check.
3. `cargo test -p claudette -p claudette-cli --all-features` and `cargo clippy -p claudette -p claudette-cli --all-targets --all-features` — pricing lookup + clippy clean.
4. In the running app: open the chat model picker and confirm **Opus 4.8 1M** and **Opus 4.8** appear as primary entries, with **Opus 4.7 / 4.7 1M** demoted under "More". Confirm a new session defaults to Opus 4.8.
5. With a 4.8 model selected, confirm the effort dropdown offers `xhigh` and `max`.

## Checklist
- [x] Tests added/updated
- [x] Documentation updated (if applicable)