### PR TITLE
feat(chat): add Ultracode composer toggle for Opus 4.8

### DIFF
--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -56,6 +56,14 @@ Select the effort level from the dropdown in the chat header, next to the model 
 
 Set the default in `Settings > Models > Default effort level`.
 
+## Ultracode
+
+Ultracode is Claude Code's top effort tier — **XHigh reasoning plus standing dynamic-workflow orchestration**, so the agent leans on multi-agent workflows to produce the most exhaustive, correct answer rather than the fastest one. It is meant for large, high-stakes tasks where thoroughness matters more than turnaround.
+
+When the active model is **Opus 4.8** (the `opus` 1M alias or `claude-opus-4-8`), an **Ultracode** pill appears in the chat header toolbar, next to the reasoning controls. It is hidden on every other model, because ultracode requires an xhigh-capable model. Toggling it on sets `CLAUDE_CODE_EFFORT_LEVEL=ultracode` on the agent subprocess; because that variable is read once when the process spawns, flipping the toggle restarts the agent session so the next turn picks up the new tier (the conversation transcript is preserved).
+
+Ultracode is session-scoped — it is remembered per chat session but is intentionally never promoted to a saved default, matching Claude Code's own behavior for this tier.
+
 ## Extended Thinking
 
 When enabled, the agent shows its reasoning process in expandable "thinking" blocks before its response.

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -76,6 +76,7 @@ pub async fn handle_request(
                 .map(String::from);
             let chrome_enabled = params.get("chrome_enabled").and_then(|v| v.as_bool());
             let disable_1m_context = params.get("disable_1m_context").and_then(|v| v.as_bool());
+            let ultracode = params.get("ultracode").and_then(|v| v.as_bool());
             let backend_id = params
                 .get("backend_id")
                 .and_then(|v| v.as_str())
@@ -96,6 +97,7 @@ pub async fn handle_request(
                 effort,
                 chrome_enabled,
                 disable_1m_context,
+                ultracode,
                 backend_id,
                 mentioned_files,
             )
@@ -537,6 +539,7 @@ async fn handle_send_chat_message(
     effort: Option<String>,
     chrome_enabled: Option<bool>,
     disable_1m_context: Option<bool>,
+    ultracode: Option<bool>,
     backend_id: Option<String>,
     mentioned_files: Option<Vec<String>>,
 ) -> Result<serde_json::Value, String> {
@@ -711,6 +714,7 @@ async fn handle_send_chat_message(
         chrome_enabled: chrome_enabled.unwrap_or(false),
         mcp_config,
         disable_1m_context: disable_1m_context.unwrap_or(false),
+        ultracode: ultracode.unwrap_or(false),
         // The standalone server binary does not implement Claudette's teammate
         // bridge child-mode args, so do not ask Claude Code to launch it as the
         // teammate command from headless remote sessions.

--- a/src-tauri/src/commands/chat/remote_control.rs
+++ b/src-tauri/src/commands/chat/remote_control.rs
@@ -50,6 +50,7 @@ struct RemoteControlLaunchOptions {
     effort: Option<String>,
     chrome_enabled: Option<bool>,
     disable_1m_context: Option<bool>,
+    ultracode: Option<bool>,
     backend_id: Option<String>,
 }
 
@@ -78,6 +79,7 @@ pub async fn set_claude_remote_control(
     effort: Option<String>,
     chrome_enabled: Option<bool>,
     disable_1m_context: Option<bool>,
+    ultracode: Option<bool>,
     backend_id: Option<String>,
     app: AppHandle,
     state: State<'_, AppState>,
@@ -91,6 +93,7 @@ pub async fn set_claude_remote_control(
         effort,
         chrome_enabled,
         disable_1m_context,
+        ultracode,
         backend_id,
     };
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
@@ -568,6 +571,7 @@ async fn ensure_persistent_session_for_remote_control(
         chrome_enabled: launch_options.chrome_enabled.unwrap_or(false),
         mcp_config,
         disable_1m_context: launch_options.disable_1m_context.unwrap_or(false),
+        ultracode: launch_options.ultracode.unwrap_or(false),
         team_agent_session_tabs_enabled,
         backend_runtime,
         hook_bridge: None,

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -606,6 +606,7 @@ struct ChatTurnSettingsPayload<'a> {
     effort: Option<&'a str>,
     chrome_enabled: bool,
     disable_1m_context: bool,
+    ultracode: bool,
 }
 
 #[derive(serde::Serialize)]
@@ -1112,6 +1113,7 @@ pub async fn send_chat_message(
     effort: Option<String>,
     chrome_enabled: Option<bool>,
     disable_1m_context: Option<bool>,
+    ultracode: Option<bool>,
     backend_id: Option<String>,
     attachments: Option<Vec<AttachmentInput>>,
     app: AppHandle,
@@ -1565,6 +1567,7 @@ pub async fn send_chat_message(
         chrome_enabled: chrome_enabled.unwrap_or(false),
         mcp_config,
         disable_1m_context: disable_1m_context.unwrap_or(false),
+        ultracode: ultracode.unwrap_or(false),
         team_agent_session_tabs_enabled: team_agent_tabs_enabled,
         backend_runtime: backend_runtime.clone(),
         hook_bridge: None,
@@ -1587,6 +1590,7 @@ pub async fn send_chat_message(
             effort: agent_settings.effort.as_deref(),
             chrome_enabled: agent_settings.chrome_enabled,
             disable_1m_context: agent_settings.disable_1m_context,
+            ultracode: agent_settings.ultracode,
         },
     );
 

--- a/src-tauri/src/commands/scheduling.rs
+++ b/src-tauri/src/commands/scheduling.rs
@@ -244,19 +244,20 @@ pub async fn dispatch_prompt_to_session(
     let state = app.state::<AppState>();
     crate::commands::chat::send::send_chat_message(
         chat_session_id,
-        None,
+        None, // message_id
         prompt,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
+        None, // mentioned_files
+        None, // permission_level
+        None, // model
+        None, // fast_mode
+        None, // thinking_enabled
+        None, // plan_mode
+        None, // effort
+        None, // chrome_enabled
+        None, // disable_1m_context
+        None, // ultracode
+        None, // backend_id
+        None, // attachments
         app.clone(),
         state,
     )

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -923,6 +923,7 @@ async fn handle_send_chat_message(
         parsed.effort,
         parsed.chrome_enabled,
         parsed.disable_1m_context,
+        parsed.ultracode,
         parsed.backend_id,
         parsed.attachments,
         app.clone(),
@@ -1029,6 +1030,7 @@ pub(crate) struct SendChatParams {
     pub effort: Option<String>,
     pub chrome_enabled: Option<bool>,
     pub disable_1m_context: Option<bool>,
+    pub ultracode: Option<bool>,
     pub backend_id: Option<String>,
     pub permission_level: Option<String>,
     pub attachments: Option<Vec<crate::commands::chat::AttachmentInput>>,
@@ -1066,6 +1068,7 @@ pub(crate) fn parse_send_chat_params(params: &serde_json::Value) -> Result<SendC
         effort: str_param("effort"),
         chrome_enabled: bool_param("chrome_enabled"),
         disable_1m_context: bool_param("disable_1m_context"),
+        ultracode: bool_param("ultracode"),
         backend_id: str_param("backend_id")
             .or_else(|| str_param("backendId"))
             .or_else(|| str_param("model_provider"))
@@ -1788,6 +1791,7 @@ mod tests {
             "effort": "high",
             "chrome_enabled": true,
             "disable_1m_context": true,
+            "ultracode": true,
             "permission_level": "acceptEdits",
             "mentioned_files": ["/tmp/a.rs"],
             "attachments": [{
@@ -1807,6 +1811,7 @@ mod tests {
         assert_eq!(parsed.effort.as_deref(), Some("high"));
         assert_eq!(parsed.chrome_enabled, Some(true));
         assert_eq!(parsed.disable_1m_context, Some(true));
+        assert_eq!(parsed.ultracode, Some(true));
         assert_eq!(parsed.permission_level.as_deref(), Some("acceptEdits"));
         assert_eq!(
             parsed.mentioned_files.as_ref().unwrap(),
@@ -1829,6 +1834,7 @@ mod tests {
         assert_eq!(parsed.effort, None);
         assert_eq!(parsed.chrome_enabled, None);
         assert_eq!(parsed.disable_1m_context, None);
+        assert_eq!(parsed.ultracode, None);
         assert_eq!(parsed.permission_level, None);
     }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -76,6 +76,13 @@ pub struct AgentSettings {
     /// selected model runs at its 200k window. Derived frontend-side from
     /// the model registry's `contextWindowTokens`.
     pub disable_1m_context: bool,
+    /// When true, set `CLAUDE_CODE_EFFORT_LEVEL=ultracode` on the spawned CLI
+    /// process so Claude Code runs at its top "ultracode" effort tier (xhigh
+    /// reasoning plus standing dynamic-workflow orchestration). Session-level:
+    /// the env var is read once at process spawn, so the UI toggle resets the
+    /// agent session to re-spawn with the new value (mirrors `chrome_enabled`).
+    /// Only offered for xhigh-capable Opus 4.8 in the composer.
+    pub ultracode: bool,
     /// When true, redirect Claude Code agent-team teammates into Claudette
     /// session tabs. Defaults to true for new users; settings can opt out.
     pub team_agent_session_tabs_enabled: bool,
@@ -104,6 +111,7 @@ impl Default for AgentSettings {
             chrome_enabled: false,
             mcp_config: None,
             disable_1m_context: false,
+            ultracode: false,
             team_agent_session_tabs_enabled: true,
             backend_runtime: AgentBackendRuntime::default(),
             hook_bridge: None,

--- a/src/agent/process.rs
+++ b/src/agent/process.rs
@@ -114,6 +114,14 @@ pub async fn run_turn(
         cmd.env("CLAUDE_CODE_DISABLE_1M_CONTEXT", "1");
     }
 
+    // Ultracode is the top effort tier; Claudette drives normal effort via the
+    // `--effort` flag, so the env var is reserved for ultracode and we clear any
+    // inherited value when the toggle is off for deterministic behavior.
+    cmd.env_remove("CLAUDE_CODE_EFFORT_LEVEL");
+    if settings.ultracode {
+        cmd.env("CLAUDE_CODE_EFFORT_LEVEL", "ultracode");
+    }
+
     if let Some(ref bridge) = settings.hook_bridge {
         cmd.env(
             crate::agent_mcp::server::ENV_SOCKET_ADDR,

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -113,6 +113,14 @@ impl PersistentSession {
         if settings.disable_1m_context {
             cmd.env("CLAUDE_CODE_DISABLE_1M_CONTEXT", "1");
         }
+        // Ultracode is the top effort tier; Claudette drives normal effort via
+        // the `--effort` flag, so the env var is reserved for ultracode and we
+        // clear any inherited value when the toggle is off for deterministic
+        // behavior.
+        cmd.env_remove("CLAUDE_CODE_EFFORT_LEVEL");
+        if settings.ultracode {
+            cmd.env("CLAUDE_CODE_EFFORT_LEVEL", "ultracode");
+        }
         if let Some(ref bridge) = settings.hook_bridge {
             cmd.env(
                 crate::agent_mcp::server::ENV_SOCKET_ADDR,

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -885,6 +885,7 @@ function App() {
       effort: string | null;
       chromeEnabled: boolean;
       disable1mContext: boolean;
+      ultracode: boolean;
     }>("chat-turn-settings", (event) => {
       useAppStore.getState().applyChatTurnSettings({
         chatSessionId: event.payload.chatSessionId,
@@ -895,6 +896,7 @@ function App() {
         planMode: event.payload.planMode,
         effort: event.payload.effort,
         chromeEnabled: event.payload.chromeEnabled,
+        ultracode: event.payload.ultracode,
       });
     });
 

--- a/src/ui/src/components/chat/chatMessageDispatch.ts
+++ b/src/ui/src/components/chat/chatMessageDispatch.ts
@@ -3,6 +3,7 @@ import { useAppStore } from "../../stores/useAppStore";
 import type { PermissionLevel } from "../../stores/useAppStore";
 import type { AttachmentInput } from "../../types/chat";
 import { shouldDisable1mContext } from "./chatHelpers";
+import { isUltracodeSupported } from "./modelCapabilities";
 import {
   buildSendFailureSystemMessage,
   shouldRecordSendFailureInChat,
@@ -73,6 +74,11 @@ export async function dispatchChatMessage({
     const effort = resolveUltrathinkEffort(trimmed, state.effortLevel[sessionId]);
     const chromeEnabled = state.chromeEnabled[sessionId] || false;
     const disable1mContext = shouldDisable1mContext(selectedModel);
+    // Ultracode is gated to Opus 4.8 in the composer. Re-check the model here
+    // so a lingering toggle (e.g. the user switched away from 4.8) never sends
+    // ultracode to a non-xhigh-capable model.
+    const ultracode =
+      (state.ultracode[sessionId] || false) && isUltracodeSupported(selectedModel ?? "");
 
     if (workspace.remote_connection_id) {
       await sendRemoteCommand(workspace.remote_connection_id, "send_chat_message", {
@@ -88,6 +94,7 @@ export async function dispatchChatMessage({
         effort: effort ?? null,
         chrome_enabled: chromeEnabled,
         disable_1m_context: disable1mContext,
+        ultracode,
       });
     } else {
       await sendChatMessage(
@@ -105,6 +112,7 @@ export async function dispatchChatMessage({
         selectedProvider ?? undefined,
         attachments,
         messageId,
+        ultracode || undefined,
       );
     }
   } catch (e) {

--- a/src/ui/src/components/chat/composer/ComposerToolbar.test.tsx
+++ b/src/ui/src/components/chat/composer/ComposerToolbar.test.tsx
@@ -9,6 +9,7 @@ interface MockState {
   selectedModelProvider: Record<string, string>;
   disable1mContext: boolean;
   planMode: Record<string, boolean>;
+  ultracode: Record<string, boolean>;
   modelSelectorOpen: boolean;
   keybindings: Record<string, unknown>;
   claudeFlagsByWorkspace: Record<string, { resolved: string[] } | undefined>;
@@ -18,6 +19,7 @@ interface MockState {
   setPlanMode: ReturnType<typeof vi.fn>;
   setEffortLevel: ReturnType<typeof vi.fn>;
   setChromeEnabled: ReturnType<typeof vi.fn>;
+  setUltracode: ReturnType<typeof vi.fn>;
   setShowThinkingBlocks: ReturnType<typeof vi.fn>;
   setModelSelectorOpen: ReturnType<typeof vi.fn>;
   loadWorkspaceClaudeFlags: ReturnType<typeof vi.fn>;
@@ -30,6 +32,7 @@ const appStore = vi.hoisted(
       selectedModelProvider: { s1: "anthropic" },
       disable1mContext: false,
       planMode: { s1: false },
+      ultracode: { s1: false },
       modelSelectorOpen: false,
       keybindings: {},
       claudeFlagsByWorkspace: { w1: { resolved: [] } },
@@ -39,6 +42,7 @@ const appStore = vi.hoisted(
       setPlanMode: vi.fn(),
       setEffortLevel: vi.fn(),
       setChromeEnabled: vi.fn(),
+      setUltracode: vi.fn(),
       setShowThinkingBlocks: vi.fn(),
       setModelSelectorOpen: vi.fn(),
       loadWorkspaceClaudeFlags: vi.fn(),
@@ -47,6 +51,8 @@ const appStore = vi.hoisted(
 
 const serviceMocks = vi.hoisted(() => ({
   getAppSetting: vi.fn((_key: string) => Promise.resolve(null as string | null)),
+  setAppSetting: vi.fn(() => Promise.resolve()),
+  resetAgentSession: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("../../../stores/useAppStore", () => ({
@@ -55,6 +61,8 @@ vi.mock("../../../stores/useAppStore", () => ({
 
 vi.mock("../../../services/tauri", () => ({
   getAppSetting: serviceMocks.getAppSetting,
+  setAppSetting: serviceMocks.setAppSetting,
+  resetAgentSession: serviceMocks.resetAgentSession,
 }));
 
 vi.mock("../useModelRegistry", () => ({
@@ -163,11 +171,15 @@ function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
 
 beforeEach(() => {
   serviceMocks.getAppSetting.mockClear();
+  serviceMocks.setAppSetting.mockClear();
+  serviceMocks.resetAgentSession.mockClear();
   appStore.setSelectedModel.mockClear();
   appStore.setPlanMode.mockClear();
+  appStore.setUltracode.mockClear();
   appStore.selectedModel = { s1: "opus" };
   appStore.selectedModelProvider = { s1: "anthropic" };
   appStore.planMode = { s1: false };
+  appStore.ultracode = { s1: false };
 });
 
 afterEach(async () => {
@@ -209,5 +221,46 @@ describe("ComposerToolbar disable semantics", () => {
     expect(buttonByText(container, "Opus").disabled).toBe(true);
     expect(buttonByText(container, "Plan").disabled).toBe(true);
     expect(buttonByText(container, "Thinking").disabled).toBe(true);
+  });
+});
+
+describe("ComposerToolbar Ultracode toggle", () => {
+  function maybeButtonByText(
+    container: HTMLElement,
+    text: string,
+  ): HTMLButtonElement | undefined {
+    return Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes(text),
+    );
+  }
+
+  it("offers Ultracode on Opus 4.8", async () => {
+    appStore.selectedModel = { s1: "claude-opus-4-8" };
+    const { container } = await renderToolbar({});
+    expect(maybeButtonByText(container, "Ultracode")).toBeDefined();
+  });
+
+  it("hides Ultracode on models other than Opus 4.8", async () => {
+    appStore.selectedModel = { s1: "sonnet" };
+    const { container } = await renderToolbar({});
+    expect(maybeButtonByText(container, "Ultracode")).toBeUndefined();
+  });
+
+  it("persists and resets the session when toggled on", async () => {
+    appStore.selectedModel = { s1: "opus" };
+    appStore.ultracode = { s1: false };
+    const { container } = await renderToolbar({});
+
+    await act(async () => {
+      buttonByText(container, "Ultracode").click();
+      await Promise.resolve();
+    });
+
+    expect(appStore.setUltracode).toHaveBeenCalledWith("s1", true);
+    expect(serviceMocks.setAppSetting).toHaveBeenCalledWith(
+      "ultracode_enabled:s1",
+      "true",
+    );
+    expect(serviceMocks.resetAgentSession).toHaveBeenCalledWith("s1");
   });
 });

--- a/src/ui/src/components/chat/composer/ComposerToolbar.tsx
+++ b/src/ui/src/components/chat/composer/ComposerToolbar.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { CircleDollarSign, Sparkles, BookOpen } from "lucide-react";
+import { CircleDollarSign, Sparkles, BookOpen, Atom } from "lucide-react";
 import { useAppStore } from "../../../stores/useAppStore";
-import { getAppSetting } from "../../../services/tauri";
+import { getAppSetting, setAppSetting, resetAgentSession } from "../../../services/tauri";
 import { tooltipAttributes } from "../../../hotkeys/display";
 import { isMacHotkeyPlatform } from "../../../hotkeys/platform";
 import { ModelSelector, is1mContextModel, get1mFallback } from "../ModelSelector";
 import { findModelInRegistry } from "../modelRegistry";
 import { useModelRegistry } from "../useModelRegistry";
-import { isFastSupported, isEffortSupported } from "../modelCapabilities";
+import { isFastSupported, isEffortSupported, isUltracodeSupported } from "../modelCapabilities";
 import {
   normalizeReasoningLevel,
   reasoningVariantForModel,
@@ -54,6 +54,7 @@ export function ComposerToolbar({
   const selectedProvider = useAppStore((s) => s.selectedModelProvider[sessionId] ?? "anthropic");
   const disable1mContext = useAppStore((s) => s.disable1mContext);
   const planMode = useAppStore((s) => s.planMode[sessionId] ?? false);
+  const ultracode = useAppStore((s) => s.ultracode[sessionId] ?? false);
   const modelSelectorOpen = useAppStore((s) => s.modelSelectorOpen);
   const keybindings = useAppStore((s) => s.keybindings);
   const setSelectedModel = useAppStore((s) => s.setSelectedModel);
@@ -61,6 +62,7 @@ export function ComposerToolbar({
   const setThinkingEnabled = useAppStore((s) => s.setThinkingEnabled);
   const setEffortLevel = useAppStore((s) => s.setEffortLevel);
   const setChromeEnabled = useAppStore((s) => s.setChromeEnabled);
+  const setUltracode = useAppStore((s) => s.setUltracode);
   const setShowThinkingBlocks = useAppStore((s) => s.setShowThinkingBlocks);
   const setModelSelectorOpen = useAppStore((s) => s.setModelSelectorOpen);
   const claudeFlagsState = useAppStore(
@@ -90,7 +92,7 @@ export function ComposerToolbar({
   useEffect(() => {
     let cancelled = false;
     async function load() {
-      const [model, provider, fast, thinking, plan, effort, showThinking, chrome, defModel, defProvider, defFast, defThinking, defPlan, defEffort, defShowThinking, defChrome] = await Promise.all([
+      const [model, provider, fast, thinking, plan, effort, showThinking, chrome, defModel, defProvider, defFast, defThinking, defPlan, defEffort, defShowThinking, defChrome, ultra] = await Promise.all([
         getAppSetting(`model:${sessionId}`),
         getAppSetting(`model_provider:${sessionId}`),
         getAppSetting(`fast_mode:${sessionId}`),
@@ -107,6 +109,7 @@ export function ComposerToolbar({
         getAppSetting("default_effort"),
         getAppSetting("default_show_thinking"),
         getAppSetting("default_chrome"),
+        getAppSetting(`ultracode_enabled:${sessionId}`),
       ]);
       if (cancelled) return;
       const loadedModel = model ?? defModel ?? "opus";
@@ -133,11 +136,14 @@ export function ComposerToolbar({
       }
       setShowThinkingBlocks(sessionId, showThinking === "true" || (!showThinking && defShowThinking === "true"));
       setChromeEnabled(sessionId, chrome === "true" || (!chrome && defChrome === "true"));
+      // Ultracode is session-scoped: remembered per session, but never read
+      // from a global default (matches Claude Code's own ultracode semantics).
+      setUltracode(sessionId, ultra === "true");
       setLoaded(true);
     }
     load();
     return () => { cancelled = true; };
-  }, [sessionId, setSelectedModel, setFastMode, setThinkingEnabled, setEffortLevel, setShowThinkingBlocks, setChromeEnabled]);
+  }, [sessionId, setSelectedModel, setFastMode, setThinkingEnabled, setEffortLevel, setShowThinkingBlocks, setChromeEnabled, setUltracode]);
 
   const handleModelSelect = useCallback(
     async (model: string, providerId = "anthropic") => {
@@ -152,6 +158,16 @@ export function ComposerToolbar({
   const togglePlan = useCallback(async () => {
     await setPlanModeAndPersist(sessionId, !planMode);
   }, [sessionId, planMode]);
+
+  // Ultracode drives the `CLAUDE_CODE_EFFORT_LEVEL=ultracode` env, which the
+  // agent reads only at process spawn. Reset the session so the next turn
+  // re-spawns with the new value — same pattern as the Chrome toggle.
+  const toggleUltracode = useCallback(async () => {
+    const next = !ultracode;
+    setUltracode(sessionId, next);
+    await setAppSetting(`ultracode_enabled:${sessionId}`, String(next));
+    await resetAgentSession(sessionId);
+  }, [sessionId, ultracode, setUltracode]);
 
   // The Cmd/Ctrl+T thinking-mode hotkey lived here as a raw
   // `window.addEventListener("keydown")` listener. It's been removed —
@@ -173,6 +189,10 @@ export function ComposerToolbar({
     ? `${currentModel.providerLabel} / ${currentModel.label}`
     : currentModel?.label ?? selectedModel;
   const isExtraUsage = currentModel?.extraUsage ?? false;
+  // Ultracode is offered only on Opus 4.8 (the xhigh-capable, product-gated
+  // model). Hidden entirely on every other model rather than disabled.
+  const ultracodeAvailable =
+    selectedProvider === "anthropic" && isUltracodeSupported(selectedModel);
   const isMac = isMacHotkeyPlatform();
 
   if (!loaded) return null;
@@ -216,6 +236,18 @@ export function ComposerToolbar({
       />
 
       <ReasoningPill sessionId={sessionId} disabled={mutationDisabled} />
+
+      {ultracodeAvailable && (
+        <ToolbarPill
+          icon={<Atom size={14} />}
+          label="Ultracode"
+          active={ultracode}
+          onClick={toggleUltracode}
+          disabled={mutationDisabled}
+          title={`${ultracode ? "Disable" : "Enable"} Ultracode — xhigh effort + standing workflow orchestration (Opus 4.8 only)`}
+          ariaPressed={ultracode}
+        />
+      )}
 
       <ClaudeFlagsTooltip resolved={resolvedFlags} />
 

--- a/src/ui/src/components/chat/composer/OverflowMenu.test.tsx
+++ b/src/ui/src/components/chat/composer/OverflowMenu.test.tsx
@@ -21,6 +21,7 @@ interface MockState {
   planMode: Record<string, boolean>;
   effortLevel: Record<string, string>;
   chromeEnabled: Record<string, boolean>;
+  ultracode: Record<string, boolean>;
   setFastMode: ReturnType<typeof vi.fn>;
   setChromeEnabled: ReturnType<typeof vi.fn>;
   clearAgentQuestion: ReturnType<typeof vi.fn>;
@@ -40,6 +41,7 @@ const appStore = vi.hoisted(
       planMode: {},
       effortLevel: {},
       chromeEnabled: {},
+      ultracode: {},
       setFastMode: vi.fn(),
       setChromeEnabled: vi.fn(),
       clearAgentQuestion: vi.fn(),

--- a/src/ui/src/components/chat/composer/OverflowMenu.tsx
+++ b/src/ui/src/components/chat/composer/OverflowMenu.tsx
@@ -13,7 +13,7 @@ import {
   type ClaudeRemoteControlStatus,
 } from "../../../services/tauri";
 import { shouldDisable1mContext } from "../chatHelpers";
-import { isFastSupported } from "../modelCapabilities";
+import { isFastSupported, isUltracodeSupported } from "../modelCapabilities";
 import { useSelectedModelEntry } from "../useSelectedModelEntry";
 import styles from "./OverflowMenu.module.css";
 
@@ -67,6 +67,7 @@ export function OverflowMenu({
   const planMode = useAppStore((s) => s.planMode[sessionId] ?? false);
   const effortLevel = useAppStore((s) => s.effortLevel[sessionId] ?? "auto");
   const chromeEnabled = useAppStore((s) => s.chromeEnabled[sessionId] ?? false);
+  const ultracode = useAppStore((s) => s.ultracode[sessionId] ?? false);
   const setFastMode = useAppStore((s) => s.setFastMode);
   const setChromeEnabled = useAppStore((s) => s.setChromeEnabled);
   const clearAgentQuestion = useAppStore((s) => s.clearAgentQuestion);
@@ -138,6 +139,10 @@ export function OverflowMenu({
           effort: effortLevel,
           chromeEnabled,
           disable1mContext: shouldDisable1mContext(selectedModel),
+          ultracode:
+            ultracode &&
+            selectedProvider === "anthropic" &&
+            isUltracodeSupported(selectedModel),
         });
         setRemoteControlStatus(next);
       } catch (err) {
@@ -162,6 +167,7 @@ export function OverflowMenu({
       selectedProvider,
       sessionId,
       thinkingEnabled,
+      ultracode,
     ],
   );
 

--- a/src/ui/src/components/chat/modelCapabilities.ts
+++ b/src/ui/src/components/chat/modelCapabilities.ts
@@ -10,6 +10,11 @@ const XHIGH_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-opus-4-7
 /** Models that support the "max" effort level. */
 const MAX_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6[1m]"]);
 
+/** Models that support the "ultracode" effort tier (xhigh + standing
+ *  dynamic-workflow orchestration). Gated to Opus 4.8 — the `opus` alias
+ *  currently resolves to Opus 4.8 1M and `claude-opus-4-8` is the 200k pin. */
+const ULTRACODE_SUPPORTED_MODELS = new Set(["opus", "claude-opus-4-8"]);
+
 export function isFastSupported(model: string): boolean {
   return FAST_SUPPORTED_MODELS.has(model);
 }
@@ -24,4 +29,10 @@ export function isXhighEffortAllowed(model: string): boolean {
 
 export function isMaxEffortAllowed(model: string): boolean {
   return MAX_EFFORT_MODELS.has(model);
+}
+
+/** Whether the Ultracode composer toggle should be offered for `model`.
+ *  Only Opus 4.8 is xhigh-capable *and* product-gated for ultracode. */
+export function isUltracodeSupported(model: string): boolean {
+  return ULTRACODE_SUPPORTED_MODELS.has(model);
 }

--- a/src/ui/src/hooks/useQueuedMessageAutoDispatch.test.tsx
+++ b/src/ui/src/hooks/useQueuedMessageAutoDispatch.test.tsx
@@ -156,6 +156,7 @@ describe("useQueuedMessageAutoDispatch", () => {
       undefined,
       undefined,
       expect.any(String),
+      undefined,
     );
     expect(useAppStore.getState().selectedWorkspaceId).toBe("ws-a");
     expect(useAppStore.getState().queuedMessages["session-b"]).toBeUndefined();

--- a/src/ui/src/services/tauri/chat.ts
+++ b/src/ui/src/services/tauri/chat.ts
@@ -38,6 +38,7 @@ export function sendChatMessage(
   backendId?: string,
   attachments?: AttachmentInput[],
   messageId?: string,
+  ultracode?: boolean,
 ): Promise<void> {
   return invoke("send_chat_message", {
     sessionId,
@@ -52,6 +53,7 @@ export function sendChatMessage(
     effort: effort ?? null,
     chromeEnabled: chromeEnabled ?? null,
     disable1mContext: disable1mContext ?? null,
+    ultracode: ultracode ?? null,
     backendId: backendId ?? null,
     attachments: attachments ?? null,
   });

--- a/src/ui/src/services/tauri/remoteControl.ts
+++ b/src/ui/src/services/tauri/remoteControl.ts
@@ -35,6 +35,7 @@ export function setClaudeRemoteControl(
     effort?: string | null;
     chromeEnabled?: boolean;
     disable1mContext?: boolean;
+    ultracode?: boolean;
     backendId?: string;
   } = {},
 ): Promise<ClaudeRemoteControlStatus> {
@@ -49,6 +50,7 @@ export function setClaudeRemoteControl(
     effort: options.effort ?? null,
     chromeEnabled: options.chromeEnabled ?? null,
     disable1mContext: options.disable1mContext ?? null,
+    ultracode: options.ultracode ?? null,
     backendId: options.backendId ?? null,
   });
 }

--- a/src/ui/src/stores/slices/toolbarSlice.test.ts
+++ b/src/ui/src/stores/slices/toolbarSlice.test.ts
@@ -11,6 +11,7 @@ describe("toolbarSlice.applyChatTurnSettings", () => {
       planMode: {},
       effortLevel: {},
       chromeEnabled: {},
+      ultracode: {},
     });
   });
 
@@ -24,6 +25,7 @@ describe("toolbarSlice.applyChatTurnSettings", () => {
       planMode: true,
       effort: "high",
       chromeEnabled: true,
+      ultracode: true,
     });
     const s = useAppStore.getState();
     expect(s.selectedModel["sess-1"]).toBe("sonnet");
@@ -32,6 +34,7 @@ describe("toolbarSlice.applyChatTurnSettings", () => {
     expect(s.planMode["sess-1"]).toBe(true);
     expect(s.effortLevel["sess-1"]).toBe("high");
     expect(s.chromeEnabled["sess-1"]).toBe(true);
+    expect(s.ultracode["sess-1"]).toBe(true);
     expect(s.fastMode["sess-1"]).toBe(false);
   });
 
@@ -44,6 +47,7 @@ describe("toolbarSlice.applyChatTurnSettings", () => {
       thinkingEnabled: { "sess-1": true },
       fastMode: { "sess-1": true },
       chromeEnabled: { "sess-1": true },
+      ultracode: { "sess-1": true },
     });
     useAppStore.getState().applyChatTurnSettings({
       chatSessionId: "sess-1",
@@ -54,12 +58,14 @@ describe("toolbarSlice.applyChatTurnSettings", () => {
       planMode: false,
       effort: null,
       chromeEnabled: false,
+      ultracode: false,
     });
     const s = useAppStore.getState();
     expect(s.planMode["sess-1"]).toBe(false);
     expect(s.thinkingEnabled["sess-1"]).toBe(false);
     expect(s.fastMode["sess-1"]).toBe(false);
     expect(s.chromeEnabled["sess-1"]).toBe(false);
+    expect(s.ultracode["sess-1"]).toBe(false);
   });
 
   // model=null means the agent fell back to a workspace/global default we
@@ -81,6 +87,7 @@ describe("toolbarSlice.applyChatTurnSettings", () => {
       planMode: false,
       effort: null,
       chromeEnabled: false,
+      ultracode: false,
     });
     const s = useAppStore.getState();
     expect(s.selectedModel["sess-1"]).toBe("opus");
@@ -103,6 +110,7 @@ describe("toolbarSlice.applyChatTurnSettings", () => {
       planMode: false,
       effort: null,
       chromeEnabled: false,
+      ultracode: false,
     });
     const s = useAppStore.getState();
     expect(s.selectedModel["sess-1"]).toBe("sonnet");

--- a/src/ui/src/stores/slices/toolbarSlice.ts
+++ b/src/ui/src/stores/slices/toolbarSlice.ts
@@ -14,6 +14,7 @@ export interface ChatTurnSettings {
   planMode: boolean;
   effort: string | null;
   chromeEnabled: boolean;
+  ultracode: boolean;
 }
 
 export interface ToolbarSlice {
@@ -24,6 +25,10 @@ export interface ToolbarSlice {
   planMode: Record<string, boolean>;
   effortLevel: Record<string, string>;
   chromeEnabled: Record<string, boolean>;
+  /** Ultracode (top "ultracode" effort tier) toggle, keyed by session id.
+   *  Only offered for Opus 4.8 in the composer; drives the
+   *  `CLAUDE_CODE_EFFORT_LEVEL=ultracode` env on the spawned agent. */
+  ultracode: Record<string, boolean>;
   modelSelectorOpen: boolean;
   setSelectedModel: (wsId: string, model: string, providerId?: string) => void;
   setSelectedModelProvider: (wsId: string, providerId: string) => void;
@@ -32,6 +37,7 @@ export interface ToolbarSlice {
   setPlanMode: (wsId: string, enabled: boolean) => void;
   setEffortLevel: (wsId: string, level: string) => void;
   setChromeEnabled: (wsId: string, enabled: boolean) => void;
+  setUltracode: (wsId: string, enabled: boolean) => void;
   setModelSelectorOpen: (open: boolean) => void;
   applyChatTurnSettings: (settings: ChatTurnSettings) => void;
 }
@@ -49,6 +55,7 @@ export const createToolbarSlice: StateCreator<
   planMode: {},
   effortLevel: {},
   chromeEnabled: {},
+  ultracode: {},
   modelSelectorOpen: false,
   setSelectedModel: (wsId, model, providerId) =>
     set((s) => ({
@@ -81,6 +88,10 @@ export const createToolbarSlice: StateCreator<
     set((s) => ({
       chromeEnabled: { ...s.chromeEnabled, [wsId]: enabled },
     })),
+  setUltracode: (wsId, enabled) =>
+    set((s) => ({
+      ultracode: { ...s.ultracode, [wsId]: enabled },
+    })),
   setModelSelectorOpen: (open) => set({ modelSelectorOpen: open }),
   // Apply settings reported by the backend after a turn lands. Booleans are
   // always part of the resolved AgentSettings (false ≠ "unset"), so they
@@ -97,6 +108,7 @@ export const createToolbarSlice: StateCreator<
     planMode,
     effort,
     chromeEnabled,
+    ultracode,
   }) =>
     set((s) => {
       const next: Partial<ToolbarSlice> = {
@@ -104,6 +116,7 @@ export const createToolbarSlice: StateCreator<
         thinkingEnabled: { ...s.thinkingEnabled, [chatSessionId]: thinkingEnabled },
         planMode: { ...s.planMode, [chatSessionId]: planMode },
         chromeEnabled: { ...s.chromeEnabled, [chatSessionId]: chromeEnabled },
+        ultracode: { ...s.ultracode, [chatSessionId]: ultracode },
       };
       if (model !== null) {
         next.selectedModel = { ...s.selectedModel, [chatSessionId]: model };


### PR DESCRIPTION
### Summary

Adds an **Ultracode** toggle to the chat composer toolbar, shown only when the active model is **Opus 4.8**. Enabling it spawns the Claude Code agent with `CLAUDE_CODE_EFFORT_LEVEL=ultracode` — Claude Code's top effort tier (**xhigh reasoning + standing dynamic-workflow orchestration**), for large, high-stakes tasks where thoroughness beats turnaround.

Investigation of the installed `claude` CLI confirmed ultracode is the top rung of the effort ladder (`low → medium → high → xhigh → max → ultracode`), set via the `CLAUDE_CODE_EFFORT_LEVEL` env var and requiring an xhigh-capable model — which Opus 4.8 is. Claudette already passes *normal* effort via the `--effort` flag (whose allowlist stops at `max`), so the env var is the correct, non-conflicting carrier for ultracode.

```mermaid
flowchart LR
  Toggle["Ultracode pill<br/>(ComposerToolbar, Opus 4.8 only)"] -->|"setUltracode + persist"| Store["toolbarSlice<br/>ultracode[session]"]
  Toggle -->|"resetAgentSession()"| Respawn["agent re-spawn"]
  Store --> Dispatch["dispatchChatMessage<br/>(re-gates on model)"]
  Dispatch -->|"ultracode"| Send["send_chat_message<br/>ipc / handler / scheduling /<br/>remote-control launch"]
  Send --> AS["AgentSettings.ultracode"]
  AS --> Spawn["PersistentSession::start /<br/>build_agent_command"]
  Spawn -->|"CLAUDE_CODE_EFFORT_LEVEL=ultracode"| Claude["claude subprocess"]
```

### Complexity Notes

- **Env var, not the `--effort` flag.** The startup `--effort` flag's documented values stop at `max` (confirmed by the repo's own `claude --help` fixture); `ultracode` is only accepted by the interactive `/effort` command. `CLAUDE_CODE_EFFORT_LEVEL=ultracode` is the documented session override, so it's the carrier. `session.rs`/`process.rs` `env_remove` the var when off (so Claudette's `--effort` flag stays authoritative) and set it when on — mirroring the existing `CLAUDE_CODE_DISABLE_1M_CONTEXT` block.
- **`chrome_enabled` pattern, not drift detection.** The env var is read once at process spawn, so the toggle calls `resetAgentSession()` to re-spawn on the next turn (transcript preserved). This avoids threading a flag through `chat.rs` drift logic + ~12 `AppSession` initializers that the `disable_1m_context` path requires.
- **Model gating has a subtlety.** Opus 4.8 has *two* ids — `opus` (the default 1M alias) and `claude-opus-4-8` (200k). `isUltracodeSupported()` matches both, so the pill shows on the default model too. `dispatchChatMessage` re-checks the model so a lingering toggle (after switching away from 4.8) can never send ultracode to a non-xhigh model.
- **Session-scoped, no global default** — matches Claude Code's own "ultracode never persists as a default" behavior. Intentionally *not* wired into pinned prompts or the CLI.

### Test Steps

Automated (all green locally):
1. `cargo fmt --all --check` and `cargo clippy -p claudette -p claudette-server --all-targets --all-features` — clean.
2. `cargo test -p claudette -p claudette-server --all-features` — pass.
3. `cd src/ui && bunx tsc -b && bun run test` — 2807 pass (incl. new toolbarSlice / ComposerToolbar / OverflowMenu cases) and `bun run lint:css` clean.

Manual UAT in a dev build (`./scripts/dev.sh`):
1. Open a chat on **Opus 4.8** → an **Ultracode** pill (atom icon) appears next to Thinking.
2. Switch the model to e.g. Sonnet 4.6 → the pill disappears. Switch back to Opus 4.8 → it returns.
3. Toggle Ultracode **on**, send a message → the next turn re-spawns the agent; a system-reminder reading *"Ultracode is on…"* should appear (and `/effort` in the session reports `ultracode`).
4. Reload the app → the per-session toggle state is remembered; a brand-new session starts with it **off**.

### Checklist
- [x] Tests added/updated
- [x] Documentation updated (`agent-configuration.mdx`)
