### PR TITLE
feat(models): add Fable 5 as a selectable Anthropic model

### DIFF
--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -48,11 +48,11 @@ Control how much reasoning the agent applies to each response:
 | Level | Description | Available Models |
 |-------|-------------|-----------------|
 | **Auto** | Let Claude decide (default) | All models |
-| **Low** | Fast, minimal reasoning | Opus, Sonnet |
-| **Medium** | Balanced | Opus, Sonnet |
-| **High** | Deep reasoning | Opus, Sonnet |
+| **Low** | Fast, minimal reasoning | Opus, Sonnet, Fable 5 |
+| **Medium** | Balanced | Opus, Sonnet, Fable 5 |
+| **High** | Deep reasoning | Opus, Sonnet, Fable 5 |
 | **XHigh** | Extended reasoning budget | Opus 4.7+, Fable 5 |
-| **Max** | Maximum reasoning budget | Opus and Sonnet (effort-capable models) |
+| **Max** | Maximum reasoning budget | Opus, Sonnet, Fable 5 (effort-capable models) |
 
 Select the effort level from the dropdown in the chat header, next to the model selector.
 

--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -19,6 +19,8 @@ Select a model from the dropdown in the chat header. Available models:
 | **Sonnet 4.6** | `sonnet` | Fast and capable |
 | **Sonnet 4.6 1M** | `claude-sonnet-4-6[1m]` | Sonnet 4.6 with a 1M context window (extra usage) |
 | **Haiku 4.5** | `haiku` | Fastest, most affordable |
+| **Fable 5** | `claude-fable-5` | Opus-class model with full effort support, incl. XHigh (200K context) |
+| **Fable 5 1M** | `claude-fable-5[1m]` | Fable 5 with a 1M context window |
 
 Earlier-generation models (Opus 4.7, Opus 4.7 1M, Opus 4.6, Opus 4.6 1M, Opus 4.5, Sonnet 4.5, Haiku 3.5) remain selectable in the picker as legacy entries.
 
@@ -49,7 +51,7 @@ Control how much reasoning the agent applies to each response:
 | **Low** | Fast, minimal reasoning | Opus, Sonnet |
 | **Medium** | Balanced | Opus, Sonnet |
 | **High** | Deep reasoning | Opus, Sonnet |
-| **XHigh** | Extended reasoning budget | Opus 4.7+ only |
+| **XHigh** | Extended reasoning budget | Opus 4.7+, Fable 5 |
 | **Max** | Maximum reasoning budget | Opus and Sonnet (effort-capable models) |
 
 Select the effort level from the dropdown in the chat header, next to the model selector.

--- a/site/src/content/docs/features/cli-client.mdx
+++ b/site/src/content/docs/features/cli-client.mdx
@@ -151,11 +151,11 @@ Boolean flags are tri-state — pass `--plan` to force on, `--no-plan` to force 
 
 | Flag | Values | Effect |
 |---|---|---|
-| `--model` | `opus`, `sonnet`, `haiku`, `claude-opus-4-8`, ... | Override model for this turn |
+| `--model` | `opus`, `sonnet`, `haiku`, `claude-opus-4-8`, `claude-fable-5`, ... | Override model for this turn |
 | `--plan` / `--no-plan` | — | Plan mode (read-only until approved) |
 | `--thinking` / `--no-thinking` | — | Extended thinking |
 | `--fast` / `--no-fast` | — | Fast mode (built-in support: Opus 4.6) |
-| `--effort` | `low`, `medium`, `high`, `xhigh`, `max` | Reasoning effort (`xhigh` requires Opus 4.7+) |
+| `--effort` | `low`, `medium`, `high`, `xhigh`, `max` | Reasoning effort (`xhigh` requires Opus 4.7+ or Fable 5) |
 | `--chrome` / `--no-chrome` | — | Chrome browser tool |
 | `--disable-1m-context` | — | Suppress Max-plan auto-upgrade to a 1M context window |
 | `--permission` | `default`, `acceptEdits`, `bypassPermissions` | Permission level |

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -33,7 +33,7 @@ Default values applied to all new agent sessions. Per-workspace overrides are av
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| Default model | Model for new chats (Opus 4.8 1M, Opus 4.8, Sonnet 4.6, Sonnet 4.6 1M, Haiku 4.5; older models such as Opus 4.7 / 4.6 / 4.5 remain selectable behind the picker's "More" disclosure) | — |
+| Default model | Model for new chats (Opus 4.8 1M, Opus 4.8, Sonnet 4.6, Sonnet 4.6 1M, Haiku 4.5, Fable 5, Fable 5 1M; older models such as Opus 4.7 / 4.6 / 4.5 remain selectable behind the picker's "More" disclosure) | — |
 | Default effort / Codex intelligence | Claude models use effort levels (`auto`, `low`, `medium`, `high`, `xhigh`, `max` where supported). Codex uses intelligence levels (`low`, `medium`, `high`, `xhigh`). | Auto / High |
 | Default thinking | Enable extended thinking for Claude models. Codex does not expose a reasoning on/off toggle; use Codex intelligence instead. | Off |
 | Show thinking / reasoning blocks | Display Claude thinking blocks or Codex reasoning summaries in the chat UI. | Off |

--- a/src-cli/src/commands/chat.rs
+++ b/src-cli/src/commands/chat.rs
@@ -149,7 +149,7 @@ pub enum Action {
         #[arg(long = "no-fast", overrides_with = "fast", hide = true)]
         no_fast: bool,
         /// Effort level: `low`, `medium`, `high`, `xhigh`, `max`
-        /// (`xhigh` requires Opus 4.7+).
+        /// (`xhigh` requires Opus 4.7+ or Fable 5).
         #[arg(long)]
         effort: Option<String>,
         /// Enable Chrome browser mode for this session. Pair: `--no-chrome`

--- a/src/ui/src/components/chat/modelCapabilities.test.ts
+++ b/src/ui/src/components/chat/modelCapabilities.test.ts
@@ -18,6 +18,10 @@ describe("isFastSupported", () => {
     expect(isFastSupported("claude-opus-4-7")).toBe(false);
   });
 
+  it("returns false for claude-fable-5 (Opus-class but fast is Opus-4.6-only)", () => {
+    expect(isFastSupported("claude-fable-5")).toBe(false);
+  });
+
   it("returns false for sonnet", () => {
     expect(isFastSupported("sonnet")).toBe(false);
   });
@@ -34,6 +38,14 @@ describe("isEffortSupported", () => {
 
   it("returns true for claude-opus-4-8", () => {
     expect(isEffortSupported("claude-opus-4-8")).toBe(true);
+  });
+
+  it("returns true for claude-fable-5", () => {
+    expect(isEffortSupported("claude-fable-5")).toBe(true);
+  });
+
+  it("returns true for claude-fable-5[1m]", () => {
+    expect(isEffortSupported("claude-fable-5[1m]")).toBe(true);
   });
 
   it("returns true for claude-opus-4-7", () => {
@@ -74,6 +86,10 @@ describe("isXhighEffortAllowed", () => {
     expect(isXhighEffortAllowed("claude-opus-4-8")).toBe(true);
   });
 
+  it("returns true for claude-fable-5", () => {
+    expect(isXhighEffortAllowed("claude-fable-5")).toBe(true);
+  });
+
   it("returns true for claude-opus-4-7", () => {
     expect(isXhighEffortAllowed("claude-opus-4-7")).toBe(true);
   });
@@ -102,6 +118,10 @@ describe("isMaxEffortAllowed", () => {
 
   it("returns true for claude-opus-4-8", () => {
     expect(isMaxEffortAllowed("claude-opus-4-8")).toBe(true);
+  });
+
+  it("returns true for claude-fable-5", () => {
+    expect(isMaxEffortAllowed("claude-fable-5")).toBe(true);
   });
 
   it("returns true for claude-opus-4-7", () => {

--- a/src/ui/src/components/chat/modelCapabilities.ts
+++ b/src/ui/src/components/chat/modelCapabilities.ts
@@ -2,13 +2,13 @@
 const FAST_SUPPORTED_MODELS = new Set(["claude-opus-4-6", "claude-opus-4-6[1m]"]);
 
 /** Models that support effort levels. */
-const EFFORT_SUPPORTED_MODELS = new Set(["opus", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6[1m]"]);
+const EFFORT_SUPPORTED_MODELS = new Set(["opus", "claude-opus-4-8", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6[1m]"]);
 
-/** Models that support the "xhigh" effort level (Opus 4.7+ only). */
-const XHIGH_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-7[1m]"]);
+/** Models that support the "xhigh" effort level (Opus 4.7+ and Fable 5). */
+const XHIGH_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]"]);
 
 /** Models that support the "max" effort level. */
-const MAX_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6[1m]"]);
+const MAX_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6[1m]"]);
 
 export function isFastSupported(model: string): boolean {
   return FAST_SUPPORTED_MODELS.has(model);

--- a/src/ui/src/components/chat/modelRegistry.test.ts
+++ b/src/ui/src/components/chat/modelRegistry.test.ts
@@ -64,6 +64,7 @@ describe("modelRegistry", () => {
   describe("get1mFallback", () => {
     it("maps 1M models to their 200K equivalents", () => {
       expect(get1mFallback("opus")).toBe("claude-opus-4-8");
+      expect(get1mFallback("claude-fable-5[1m]")).toBe("claude-fable-5");
       expect(get1mFallback("claude-opus-4-7[1m]")).toBe("claude-opus-4-7");
       expect(get1mFallback("claude-sonnet-4-6[1m]")).toBe("sonnet");
       expect(get1mFallback("claude-opus-4-6[1m]")).toBe("claude-opus-4-6");

--- a/src/ui/src/components/chat/modelRegistry.ts
+++ b/src/ui/src/components/chat/modelRegistry.ts
@@ -58,6 +58,7 @@ export function is1mContextModel(modelId: string): boolean {
 
 const NON_1M_FALLBACKS: Record<string, string> = {
   "opus": "claude-opus-4-8",
+  "claude-fable-5[1m]": "claude-fable-5",
   "claude-opus-4-7[1m]": "claude-opus-4-7",
   "claude-sonnet-4-6[1m]": "sonnet",
   "claude-opus-4-6[1m]": "claude-opus-4-6",
@@ -80,6 +81,12 @@ export const MODELS: readonly Model[] = [
   { id: "sonnet", label: "Sonnet 4.6", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
   { id: "claude-sonnet-4-6[1m]", label: "Sonnet 4.6 1M", group: "Claude Code", extraUsage: true, contextWindowTokens: 1_000_000 },
   { id: "haiku", label: "Haiku 4.5", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
+  // Fable 5 is an Opus-class Anthropic model (effort incl. xhigh/max, 1M variant).
+  // It has no bare alias — the concrete id carries through to the Claude CLI `--model`
+  // arg and passes the `claude-` prefix gate in `gateway_translate.rs`. The 1M variant
+  // uses the `[1m]` suffix convention so `is1mContextModel` detects it without a special case.
+  { id: "claude-fable-5", label: "Fable 5", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
+  { id: "claude-fable-5[1m]", label: "Fable 5 1M", group: "Claude Code", extraUsage: false, contextWindowTokens: 1_000_000 },
   { id: "claude-opus-4-7", label: "Opus 4.7", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
   { id: "claude-opus-4-7[1m]", label: "Opus 4.7 1M", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 1_000_000 },
   { id: "claude-opus-4-6", label: "Opus 4.6", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },

--- a/src/ui/src/components/command-palette/commands.ts
+++ b/src/ui/src/components/command-palette/commands.ts
@@ -234,7 +234,7 @@ export function buildEffortCommands(
     { id: "low", label: "Low", description: "Fast, minimal reasoning" },
     { id: "medium", label: "Medium", description: "Balanced" },
     { id: "high", label: "High", description: "Deep reasoning" },
-    { id: "xhigh", label: "Extra High", description: "Extended reasoning (Opus 4.7+)" },
+    { id: "xhigh", label: "Extra High", description: "Extended reasoning (Opus 4.7+, Fable 5)" },
     { id: "max", label: "Max", description: "Full budget" },
   ];
   const levels = !isEffortSupported(selectedModel)

--- a/src/usage/pricing.rs
+++ b/src/usage/pricing.rs
@@ -93,6 +93,15 @@ const PRICING_TABLE: &[(&str, ModelPricing)] = &[
         },
     ),
     // -- Anthropic (only used when local-aggregating, e.g. via Pi) -----
+    // Fable 5 is priced at 2x Opus. The `[1m]` variant matches this same
+    // prefix via `starts_with`, so a single entry covers both ids.
+    (
+        "claude-fable-5",
+        ModelPricing {
+            prompt_per_mtok_usd: 30.00,
+            completion_per_mtok_usd: 150.00,
+        },
+    ),
     (
         "claude-opus-4-8",
         ModelPricing {
@@ -145,6 +154,16 @@ mod tests {
     fn lookup_known_model() {
         let p = lookup("gpt-5.4").expect("gpt-5.4 has pricing");
         assert!((p.prompt_per_mtok_usd - 1.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lookup_fable_5_priced_at_2x_opus() {
+        let p = lookup("claude-fable-5").expect("claude-fable-5 has pricing");
+        assert!((p.prompt_per_mtok_usd - 30.00).abs() < f64::EPSILON);
+        assert!((p.completion_per_mtok_usd - 150.00).abs() < f64::EPSILON);
+        // The 1M variant shares the bare prefix via `starts_with`.
+        let one_m = lookup("claude-fable-5[1m]").expect("1M variant resolves to same pricing");
+        assert!((one_m.prompt_per_mtok_usd - 30.00).abs() < f64::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
### Summary

Adds **Fable 5** as a new Opus-class Anthropic model, selectable in the picker **without** changing the default (Opus 4.8 stays the default). This mirrors the prior Opus 4.8 transition, but for a brand-new, non-aliased name that also ships a 1M-context variant.

- **Registry** — two `MODELS` entries: `claude-fable-5` (200K) and `claude-fable-5[1m]` (1M), plus a `NON_1M_FALLBACKS` mapping for the 1M → 200K fallback.
- **Capabilities** — Fable 5 joins the effort / xhigh / max sets (it is *not* added to fast mode, which is Opus-4.6-only).
- **Pricing** — `claude-fable-5` at **$30 / $150** per Mtok (2× Opus), for local cost aggregation (e.g. via Pi).
- **Docs + help text** — model-selection table, default-model row, `--model` flag examples, and the `xhigh requires Opus 4.7+` strings (CLI help + command palette) now include Fable 5.

The key design choice is the concrete id `claude-fable-5` (no bare `fable` alias). Because it starts with `claude-`, it passes the one hard allow-list gate (`is_claude_code_model_alias` in `gateway_translate.rs`) for free — so **no** Rust routing/validation or default-model changes were needed. The id flows verbatim to the Claude CLI `--model` arg, and every picker / `/model` / command-palette surface renders it automatically from the registry.

```mermaid
flowchart LR
    A["claude-fable-5 in MODELS"] --> B["buildModelRegistry()"]
    B --> C["Picker / /model / palette<br/>(auto-render)"]
    A --> D["--model claude-fable-5"]
    D --> E{"is_claude_code_model_alias?"}
    E -->|"starts_with('claude-') ✓"| F["Claude CLI resolves it"]
    A --> G["modelCapabilities Sets<br/>effort / xhigh / max"]
    A --> H["pricing.rs prefix lookup<br/>covers [1m] too"]
```

### Complexity Notes

- **The capability Sets are the silent-failure risk.** A model omitted from `modelCapabilities.ts` still *works*, but its effort/xhigh UI silently disappears. Fable 5 is added to EFFORT, XHIGH, and MAX (both the bare and `[1m]` ids), with matching tests pinning the exact profile — including an explicit `isFastSupported('claude-fable-5') === false` to lock in the "no fast mode" decision.
- **One pricing entry covers both ids.** `pricing::lookup` matches by `starts_with`, so `claude-fable-5[1m]` resolves to the same `claude-fable-5` row. A test asserts both.
- **The 1M variant uses the `[1m]` suffix, not a bare alias.** Unlike the `opus` alias (whose id lacks `[1m]` and needs a special case in `is1mContextModel`), the suffixed id is detected automatically.

### Test Steps

1. **Frontend unit:** `cd src/ui && bun run test` — registry + capability suites pass (73 in those two files; 2809 total).
2. **Type-check:** `cd src/ui && bunx tsc -b` — exits 0.
3. **Rust pricing:** `cargo test -p claudette pricing` — includes `lookup_fable_5_priced_at_2x_opus` (asserts $30/$150 and that `claude-fable-5[1m]` resolves).
4. **Lint/format:** `cargo fmt --all --check`, `RUSTFLAGS="-Dwarnings" cargo clippy -p claudette -p claudette-cli --all-targets --all-features`, `cd src/ui && bun run lint:css` — all clean.
5. **Manual (running app):** open the chat model picker → **Fable 5** and **Fable 5 1M** appear as primary (non-legacy) entries → select Fable 5 → the effort selector offers up to **XHigh/Max**, and **fast mode** is hidden → `/model claude-fable-5` resolves the same way.

### Checklist
- [x] Tests added/updated
- [x] Documentation updated (if applicable)