### PR TITLE
fix(scm): restore sidebar PR/CI indicators by rechecking plugin CLI availability at use

### DIFF
--- a/src/plugin_runtime/mod.rs
+++ b/src/plugin_runtime/mod.rs
@@ -116,7 +116,9 @@ pub struct LoadedPlugin {
 }
 
 impl LoadedPlugin {
-    /// Whether this plugin's `required_clis` resolve on PATH *right now*.
+    /// Whether this plugin's `required_clis` should be treated as available,
+    /// healing a stale "unavailable" snapshot by re-resolving against the
+    /// current enriched PATH.
     ///
     /// `cli_available` is a one-shot snapshot taken at registry discovery
     /// (`PluginRegistry::discover`). On a Finder/Dock-launched app the
@@ -129,10 +131,21 @@ impl LoadedPlugin {
     /// restart, and also picks up a CLI the user installs or a `.zshrc` edit
     /// made mid-session.
     ///
-    /// Cheap and non-blocking: the already-available path is a single bool
-    /// read; the recovery path is a `which` PATH search, never the up-to-5s
-    /// shell probe (that only ever runs via `prewarm_shell_env` / the
-    /// rc-file watcher). Safe to call from the async SCM poll loop.
+    /// Asymmetric by design — this is NOT a true "is it available this
+    /// instant" check:
+    /// - A snapshot of `true` is trusted and returned as-is, with no
+    ///   re-check, so this will keep reporting `true` for a CLI that was
+    ///   present at discovery but has since been removed (runtime errors
+    ///   from the failed invocation cover that case). The win is that the
+    ///   common already-available call stays a single bool read.
+    /// - Only a `false` snapshot triggers the live recovery check, which is
+    ///   a synchronous `which` PATH search (bounded filesystem lookups), NOT
+    ///   the up-to-5s shell probe (that only ever runs via
+    ///   `prewarm_shell_env` / the rc-file watcher).
+    ///
+    /// So it is cheap enough for the periodic SCM poll loop and the
+    /// `call_operation` gate, but it is not strictly non-blocking on the
+    /// recovery path — do not call it on latency-critical hot paths.
     pub fn cli_available_now(&self) -> bool {
         self.cli_available || check_clis_available(&self.manifest.required_clis)
     }

--- a/src/plugin_runtime/mod.rs
+++ b/src/plugin_runtime/mod.rs
@@ -115,6 +115,29 @@ pub struct LoadedPlugin {
     pub trust: PluginTrust,
 }
 
+impl LoadedPlugin {
+    /// Whether this plugin's `required_clis` resolve on PATH *right now*.
+    ///
+    /// `cli_available` is a one-shot snapshot taken at registry discovery
+    /// (`PluginRegistry::discover`). On a Finder/Dock-launched app the
+    /// login-shell PATH probe (`prewarm_shell_env`) runs asynchronously and
+    /// usually finishes *after* discovery, so a CLI installed only under e.g.
+    /// `/opt/homebrew/bin` is missed and the snapshot latches `false` for the
+    /// whole session — which silently hides SCM providers (`gh`/`glab`) and
+    /// makes the sidebar PR/CI indicators disappear. Re-checking against the
+    /// (now-warm) enriched PATH lets the next consumer recover without a
+    /// restart, and also picks up a CLI the user installs or a `.zshrc` edit
+    /// made mid-session.
+    ///
+    /// Cheap and non-blocking: the already-available path is a single bool
+    /// read; the recovery path is a `which` PATH search, never the up-to-5s
+    /// shell probe (that only ever runs via `prewarm_shell_env` / the
+    /// rc-file watcher). Safe to call from the async SCM poll loop.
+    pub fn cli_available_now(&self) -> bool {
+        self.cli_available || check_clis_available(&self.manifest.required_clis)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum PluginError {
     CliNotFound(String),
@@ -681,7 +704,14 @@ impl PluginRegistry {
             });
         }
 
-        if !plugin.cli_available {
+        // Re-check availability at use rather than trusting the
+        // discovery-time `cli_available` snapshot: that snapshot can latch
+        // `false` when the login-shell PATH probe hadn't warmed yet at
+        // startup (Finder-launched app), and the manual-override SCM fetch
+        // path reaches this gate. `cli_available_now()` keeps the warm
+        // bool as a fast path and only re-runs `which` when the snapshot
+        // was false.
+        if !plugin.cli_available_now() {
             let cli_list = plugin.manifest.required_clis.join(", ");
             return Err(PluginError::CliNotFound(cli_list));
         }

--- a/src/scm/detect.rs
+++ b/src/scm/detect.rs
@@ -56,7 +56,12 @@ pub fn detect_provider(
     let mut best_match: Option<(String, usize)> = None;
 
     for (name, plugin) in plugins {
-        if !plugin.cli_available {
+        // `cli_available_now()` rather than the raw `cli_available`
+        // snapshot: discovery can latch `false` for `gh`/`glab` when the
+        // login-shell PATH probe hasn't warmed yet at startup, which would
+        // otherwise hide the provider — and the sidebar PR/CI indicator —
+        // for the whole session. The recheck recovers once the PATH warms.
+        if !plugin.cli_available_now() {
             continue;
         }
         for pattern in &plugin.manifest.remote_patterns {
@@ -219,7 +224,46 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_detect_provider_recovers_when_cli_now_resolvable() {
+        // Regression guard for the #990 fallout: plugin discovery can latch
+        // cli_available=false when the login-shell PATH probe hasn't warmed
+        // yet (Finder-launched app, cold shell-env cache). detect_provider
+        // must re-check availability at use, so a now-resolvable CLI
+        // restores the provider — and the sidebar PR/CI indicator — instead
+        // of staying hidden for the whole session. Empty required_clis here
+        // stands in for "the required CLIs now resolve on PATH".
+        let mut plugins = HashMap::new();
+        plugins.insert(
+            "github".to_string(),
+            make_plugin_with_clis("github", &["github.com"], false, vec![]),
+        );
+
+        assert_eq!(
+            detect_provider("https://github.com/user/repo.git", &plugins),
+            Some("github".to_string())
+        );
+    }
+
     fn make_plugin(name: &str, patterns: &[&str], cli_available: bool) -> LoadedPlugin {
+        // A genuinely-unavailable plugin must also declare a CLI that won't
+        // resolve on PATH; otherwise the self-healing `cli_available_now()`
+        // recheck would trivially pass on an empty required_clis list and
+        // the "unavailable" tests would no longer exercise unavailability.
+        let required_clis = if cli_available {
+            vec![]
+        } else {
+            vec!["claudette-scm-detect-test-absent-cli".to_string()]
+        };
+        make_plugin_with_clis(name, patterns, cli_available, required_clis)
+    }
+
+    fn make_plugin_with_clis(
+        name: &str,
+        patterns: &[&str],
+        cli_available: bool,
+        required_clis: Vec<String>,
+    ) -> LoadedPlugin {
         use crate::plugin_runtime::manifest::PluginManifest;
         LoadedPlugin {
             manifest: PluginManifest {
@@ -227,7 +271,7 @@ mod tests {
                 display_name: name.to_string(),
                 version: "1.0.0".to_string(),
                 description: "test".to_string(),
-                required_clis: vec![],
+                required_clis,
                 remote_patterns: patterns.iter().map(|s| s.to_string()).collect(),
                 operations: vec![],
                 config_schema: std::collections::HashMap::new(),


### PR DESCRIPTION
## Summary

The sidebar stopped showing any SCM (PR/CI) status indicators. This restores them by making plugin CLI-availability self-healing instead of trusting a stale startup snapshot.

## Root cause

A regression from #990 (shell-env inheritance). That PR rewrote `shell_path()` from a lazy, self-priming login-shell probe into a pure cache read that returns `None` until the async `prewarm_shell_env` thread warms it. But `PluginRegistry::discover()` runs at `main.rs:484`, **before** `prewarm_shell_env` is spawned (`main.rs:865`):

1. Discovery sees a **cold** shell-env cache → `enriched_path()` falls back to the bare process PATH.
2. On a **Finder/Dock-launched** build that's the minimal launchd PATH (no `/opt/homebrew/bin`), so `which_in_enriched_path("gh"/"glab")` fails.
3. `cli_available` is computed **once** at discovery and **never recomputed** → latched `false` for the whole session.
4. `detect_provider` skips `!cli_available` plugins → the SCM poll's `Ok(None)` branch *deletes* the cache row and emits a clearing `scm-data-updated` (`pull_request: None`).
5. Frontend sets `hasPr: false` → `resolveScmPrIcon` returns `null` → **every PR/CI icon disappears** and doesn't survive restart.

It escaped CI/dev because terminal-launched dev builds inherit the full shell PATH in their process env, so the cold-cache fallback still finds `gh` and `cli_available` latches `true`. Only Finder-launched release builds hit it — the dev-invisible, release-only spawn-time PATH trap CLAUDE.md warns about.

The frontend render/store path and the `WorkspaceScmLinkIcon` (project-view, default-off) were both ruled out.

## Fix

Re-check availability **at the point of use** rather than trusting the discovery-time snapshot:

- New `LoadedPlugin::cli_available_now()` = `cached || live check_clis_available(...)`. The already-available path is a single bool read; only the recovery path runs a `which` PATH search — **never** the up-to-5s shell probe (that only runs via `prewarm_shell_env` / the rc-watcher), so it's safe in the async SCM poll loop.
- Wired into the two gates on the SCM data-production path:
  - `detect_provider` (`src/scm/detect.rs`) — the auto-detect/poll path.
  - `call_operation`'s `CliNotFound` short-circuit (`src/plugin_runtime/mod.rs`) — the fetch/manual-override path. Both are required: detection alone would resolve the provider only for the fetch to fail at the second gate.

A deliberately-rejected alternative — making `shell_path()` probe synchronously when cold — would reintroduce a potential 5s stall on a Tokio worker (`src/git.rs` explicitly guards against this with `shell_path_is_cached()`). Re-checking at use avoids both the startup-ordering fragility and the blocking-probe hazard, and as a bonus recovers when a CLI is installed or `.zshrc` is edited mid-session.

## Out of scope (intentional)

- The Settings → Plugins "CLI missing" badge reads the raw discovery snapshot via the plugin-list payload (`commands/scm.rs`); it may still show stale until restart. Fixing it would change a command-payload value and re-`which` every plugin (incl. env-providers) on each list fetch.
- `is_cli_available` (env-provider soft-skip, #718) is left on the raw snapshot to preserve that contract and its tests.

## Testing

- `cargo test -p claudette --lib` → **1517 passed, 0 failed**, including the new `test_detect_provider_recovers_when_cli_now_resolvable` and the existing `test_detect_provider_cli_unavailable` (tightened so it still genuinely exercises unavailability under the recheck).
- `cargo clippy -p claudette --all-targets --all-features` clean under `RUSTFLAGS="-Dwarnings"`.
- `cargo fmt --all --check` clean.

**Verification caveat:** this only reproduces in a Finder/Dock-launched build (cold launchd PATH); a terminal-launched dev build already works because it inherits the full shell PATH. The unit test is the deterministic proof that detection recovers once the CLI is resolvable; a true end-to-end check needs a packaged `.app` launched from Finder.

## Regression safety

No DB schema/migrations, no Tauri command payload *shapes*, no settings keys, no plugin manifest schema, no localized strings, no UI controls changed. The intentional `Ok(None)` cache-eviction behavior is preserved — the fix addresses its *cause* (the latched `false`), not the eviction itself.