### PR TITLE
feat(agent): add MCP tools for agent-initiated user interaction

### DIFF
--- a/src-tauri/src/agent_mcp_sink.rs
+++ b/src-tauri/src/agent_mcp_sink.rs
@@ -20,13 +20,15 @@ use std::time::Duration;
 use base64::Engine;
 use claudette::agent_mcp::bridge::Sink;
 use claudette::agent_mcp::protocol::{BridgePayload, BridgeResponse};
+use claudette::agent_mcp::tools::interaction;
 use claudette::agent_mcp::tools::send_to_user::policy;
 use claudette::db::Database;
-use claudette::model::{Attachment, AttachmentOrigin};
+use claudette::model::{AgentConclusion, Attachment, AttachmentOrigin};
 use serde::Serialize;
+use serde_json::Value;
 use tauri::{AppHandle, Emitter, Manager};
 
-use crate::state::AppState;
+use crate::state::{AppState, AttentionKind, PendingPermission};
 
 /// Tauri-side implementation of [`Sink`] — one per persistent agent session.
 ///
@@ -169,6 +171,305 @@ async fn handle_payload(
             monitor_background_task(app, db_path, workspace_id, chat_session_id, task_id, until)
                 .await
         }
+        BridgePayload::AskUser { questions } => {
+            ask_user(app, workspace_id, chat_session_id, questions).await
+        }
+        BridgePayload::RequestReview {
+            summary,
+            detail,
+            options: _,
+        } => request_review(app, workspace_id, chat_session_id, summary, detail).await,
+        BridgePayload::PresentConclusion {
+            title,
+            summary,
+            artifacts,
+        } => {
+            present_conclusion(
+                app,
+                db_path,
+                workspace_id,
+                chat_session_id,
+                title,
+                summary,
+                artifacts,
+            )
+            .await
+        }
+    }
+}
+
+/// Block until the user answers an `ask_user` prompt. Renders through the
+/// existing `AgentQuestionCard` (keyed by `questions`), so a Pi / Codex / Claude
+/// agent all surface the same UI. The user's answers are returned as the tool
+/// result.
+async fn ask_user(
+    app: AppHandle,
+    workspace_id: String,
+    chat_session_id: String,
+    questions: Value,
+) -> BridgeResponse {
+    let input = interaction::ask_card_input(questions);
+    match block_on_interactive(
+        &app,
+        &workspace_id,
+        &chat_session_id,
+        "ask_user",
+        "AskUserQuestion",
+        input,
+        AttentionKind::Ask,
+    )
+    .await
+    {
+        Ok(answer) => BridgeResponse::data("The user answered.".to_string(), answer),
+        Err(resp) => resp,
+    }
+}
+
+/// Block until the user returns a verdict on a `request_review` prompt. Renders
+/// through the existing `PlanApprovalCard` (keyed by `plan`); the
+/// `claudetteReview` marker on the input lets the frontend offer the
+/// approve / deny / suggest verdicts. Returns `{ verdict, note }`.
+async fn request_review(
+    app: AppHandle,
+    workspace_id: String,
+    chat_session_id: String,
+    summary: String,
+    detail: Option<String>,
+) -> BridgeResponse {
+    let input = interaction::review_card_input(&summary, detail.as_deref());
+    match block_on_interactive(
+        &app,
+        &workspace_id,
+        &chat_session_id,
+        "request_review",
+        "ExitPlanMode",
+        input,
+        AttentionKind::Plan,
+    )
+    .await
+    {
+        Ok(answer) => {
+            let verdict = answer
+                .get("verdict")
+                .and_then(Value::as_str)
+                .unwrap_or("respond");
+            BridgeResponse::data(format!("The user's verdict: {verdict}."), answer)
+        }
+        Err(resp) => resp,
+    }
+}
+
+/// Register an interactive control and await the user's reply.
+///
+/// This reuses the same `pending_permissions` + attention machinery the Claude
+/// CLI control requests use, but the reply comes back through a oneshot (not a
+/// `control_response` to a CLI), since the agent is suspended inside its MCP
+/// tool call rather than on the CLI's stdin. Returns the answer value on
+/// success, or a ready-made error `BridgeResponse` if the session is gone or
+/// the interaction is cancelled.
+async fn block_on_interactive(
+    app: &AppHandle,
+    workspace_id: &str,
+    chat_session_id: &str,
+    mcp_tool: &str,
+    tool_name: &str,
+    input: Value,
+    kind: AttentionKind,
+) -> Result<Value, BridgeResponse> {
+    let tool_use_id = uuid::Uuid::new_v4().to_string();
+    let state = app.state::<AppState>();
+
+    // Register the pending control on the session so the existing card renders
+    // and the existing CLI responders (`claudette chat answer/approve-plan`)
+    // can resolve it too. Bail if the session vanished between turn start and
+    // this tool call.
+    {
+        let mut agents = state.agents.write().await;
+        let Some(session) = agents.get_mut(chat_session_id) else {
+            return Err(BridgeResponse::err(
+                "chat session is no longer active".to_string(),
+            ));
+        };
+        session.needs_attention = true;
+        session.attention_kind = Some(kind);
+        session.pending_permissions.insert(
+            tool_use_id.clone(),
+            PendingPermission {
+                // MCP-origin requests have no CLI control_request to answer; the
+                // request_id is unused for routing but kept stable for the
+                // notification dedup check below.
+                request_id: tool_use_id.clone(),
+                tool_name: tool_name.to_string(),
+                original_input: input.clone(),
+            },
+        );
+    }
+
+    // Register the reply channel *after* the pending control exists but
+    // *before* the frontend can see the prompt — so the user can't answer
+    // before there's a sender to route to.
+    let rx = state
+        .register_mcp_reply(tool_use_id.clone(), chat_session_id.to_string())
+        .await;
+
+    // Surface to the UI like a CLI control request, but carry an `origin`
+    // discriminator so the frontend / `/claudette-debug` / anyone tailing the
+    // event stream can tell a Claudette MCP-tool prompt from a native
+    // `AskUserQuestion` / `ExitPlanMode` (which omit these fields). `mcp_tool`
+    // names the exact tool the agent called.
+    let payload = serde_json::json!({
+        "workspace_id": workspace_id,
+        "chat_session_id": chat_session_id,
+        "tool_use_id": tool_use_id,
+        "tool_name": tool_name,
+        "input": input,
+        "origin": "claudette_mcp",
+        "mcp_tool": mcp_tool,
+    });
+    let _ = app.emit("agent-permission-prompt", &payload);
+
+    // One info-level line per invocation on a dedicated target. This is the
+    // unambiguous "our tool ran, not the native one" signal: native controls
+    // log on `claudette::chat`, never here. Tail with
+    // `grep claudette::agent_mcp ~/.claudette/logs/claudette.<date>.log`.
+    tracing::info!(
+        target: "claudette::agent_mcp",
+        mcp_tool = %mcp_tool,
+        chat_session_id = %chat_session_id,
+        tool_use_id = %tool_use_id,
+        "MCP interactive prompt registered — awaiting user response"
+    );
+
+    spawn_attention_notification(app, workspace_id, chat_session_id, &tool_use_id, kind);
+
+    // Block until the user responds (no timeout — the human takes as long as
+    // they take). A dropped sender (session torn down) lands in the Err arm.
+    match rx.await {
+        Ok(answer) => {
+            tracing::info!(
+                target: "claudette::agent_mcp",
+                mcp_tool = %mcp_tool,
+                tool_use_id = %tool_use_id,
+                "MCP interactive prompt answered — resuming agent"
+            );
+            Ok(answer)
+        }
+        Err(_) => {
+            // The reply channel was dropped (stop / reset / migrate). Clear any
+            // lingering pending entry so the card doesn't stick around, then
+            // tell the agent the interaction was abandoned.
+            let mut agents = state.agents.write().await;
+            if let Some(session) = agents.get_mut(chat_session_id) {
+                session.pending_permissions.remove(&tool_use_id);
+                if session.pending_permissions.is_empty() {
+                    session.reset_attention();
+                }
+            }
+            tracing::info!(
+                target: "claudette::agent_mcp",
+                mcp_tool = %mcp_tool,
+                tool_use_id = %tool_use_id,
+                "MCP interactive prompt cancelled (session stopped or reset)"
+            );
+            Err(BridgeResponse::err(
+                "the interaction was cancelled (the session was stopped or reset)".to_string(),
+            ))
+        }
+    }
+}
+
+/// Fire the attention notification after the frontend has had a moment to paint
+/// the card, mirroring `route_turn_control_request`. Detached + re-checks the
+/// pending entry so a fast answer or a stacked prompt doesn't double-notify.
+fn spawn_attention_notification(
+    app: &AppHandle,
+    workspace_id: &str,
+    chat_session_id: &str,
+    tool_use_id: &str,
+    kind: AttentionKind,
+) {
+    let app = app.clone();
+    let workspace_id = workspace_id.to_string();
+    let chat_session_id = chat_session_id.to_string();
+    let tool_use_id = tool_use_id.to_string();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(
+            crate::commands::chat::ATTENTION_NOTIFY_DELAY_MS,
+        ))
+        .await;
+        let state = app.state::<AppState>();
+        let should_notify = {
+            let mut agents = state.agents.write().await;
+            let Some(session) = agents.get_mut(&chat_session_id) else {
+                return;
+            };
+            if session.attention_notification_sent {
+                false
+            } else {
+                let still_pending = session.pending_permissions.contains_key(&tool_use_id);
+                if still_pending {
+                    session.attention_notification_sent = true;
+                }
+                still_pending
+            }
+        };
+        if should_notify {
+            crate::tray::notify_attention(&app, &workspace_id, kind);
+        }
+    });
+}
+
+/// Persist and surface a finished-work conclusion. Non-blocking: writes the
+/// `agent_conclusions` row, emits `agent-conclusion-created` so the chat
+/// surface can render it live, and returns immediately.
+async fn present_conclusion(
+    app: AppHandle,
+    db_path: PathBuf,
+    workspace_id: String,
+    chat_session_id: String,
+    title: Option<String>,
+    summary: String,
+    artifacts: Option<Vec<String>>,
+) -> BridgeResponse {
+    if let Err(reason) = interaction::validate_summary(&summary, "summary") {
+        return BridgeResponse::err(reason);
+    }
+
+    // Anchor to the in-flight turn's user message when there is one, so a
+    // rollback removes the conclusion with the turn. `None` is fine — the row
+    // still persists and sorts by created_at.
+    let message_id = {
+        let state = app.state::<AppState>();
+        let agents = state.agents.read().await;
+        agents
+            .get(&chat_session_id)
+            .and_then(|s| s.last_user_msg_id.clone())
+    };
+
+    let conclusion = AgentConclusion {
+        id: uuid::Uuid::new_v4().to_string(),
+        chat_session_id: chat_session_id.clone(),
+        workspace_id: workspace_id.clone(),
+        message_id,
+        title,
+        summary,
+        artifacts: artifacts.unwrap_or_default(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+
+    match Database::open(&db_path).and_then(|db| db.insert_agent_conclusion(&conclusion)) {
+        Ok(()) => {
+            tracing::info!(
+                target: "claudette::agent_mcp",
+                mcp_tool = "present_conclusion",
+                chat_session_id = %chat_session_id,
+                conclusion_id = %conclusion.id,
+                "MCP conclusion recorded"
+            );
+            let _ = app.emit("agent-conclusion-created", &conclusion);
+            BridgeResponse::message("Conclusion recorded and shown to the user.".to_string())
+        }
+        Err(err) => BridgeResponse::err(format!("persist conclusion: {err}")),
     }
 }
 

--- a/src-tauri/src/commands/chat/conclusions.rs
+++ b/src-tauri/src/commands/chat/conclusions.rs
@@ -1,0 +1,20 @@
+use tauri::State;
+
+use claudette::db::Database;
+use claudette::model::AgentConclusion;
+
+use crate::state::AppState;
+
+/// Load every conclusion the agent has presented in a chat session (oldest
+/// first), so the chat surface can render the inline conclusion cards on
+/// session open / reload. Live conclusions arrive separately via the
+/// `agent-conclusion-created` event.
+#[tauri::command]
+pub async fn load_agent_conclusions_for_session(
+    session_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<AgentConclusion>, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.list_agent_conclusions_for_session(&session_id)
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/chat/interaction.rs
+++ b/src-tauri/src/commands/chat/interaction.rs
@@ -54,6 +54,20 @@ pub async fn submit_agent_answer(
     annotations: Option<serde_json::Value>,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
+    // MCP-origin branch: when the question came from the `ask_user` MCP tool
+    // the agent is suspended inside its tool call (not on the CLI's stdin), so
+    // the answer must be routed to the awaiting oneshot, not a control_response.
+    if state.is_mcp_pending(&tool_use_id).await {
+        return submit_mcp_answer(
+            state.inner(),
+            &session_id,
+            &tool_use_id,
+            "AskUserQuestion",
+            serde_json::json!({ "answers": answers, "annotations": annotations }),
+        )
+        .await;
+    }
+
     // Validate everything BEFORE removing the pending entry: if the session
     // has been torn down or the entry maps to the wrong tool, the entry must
     // stay so the user (or the correct submit_* command) can still see it.
@@ -123,6 +137,50 @@ pub async fn submit_agent_answer(
         .await
 }
 
+/// Resolve a pending control that originated from a Claudette MCP tool
+/// (`ask_user` / `request_review`) by sending `answer` to the awaiting bridge
+/// handler's oneshot. Mirrors the validate-before-remove discipline of the CLI
+/// path, but there is no `persistent_session` to reply to — the agent is
+/// suspended inside its MCP tool call.
+async fn submit_mcp_answer(
+    state: &AppState,
+    session_id: &str,
+    tool_use_id: &str,
+    expected_tool: &str,
+    answer: serde_json::Value,
+) -> Result<(), String> {
+    {
+        let mut agents = state.agents.write().await;
+        if let Some(session) = agents.get_mut(session_id) {
+            if let Some(p) = session.pending_permissions.get(tool_use_id)
+                && p.tool_name != expected_tool
+            {
+                return Err(format!(
+                    "Pending tool for {tool_use_id} is {}, not {expected_tool}",
+                    p.tool_name
+                ));
+            }
+            session.pending_permissions.remove(tool_use_id);
+            session.reset_attention();
+        }
+    }
+    let Some(pending) = state.take_mcp_reply(tool_use_id).await else {
+        return Err(format!(
+            "No pending MCP interaction for tool_use_id {tool_use_id}"
+        ));
+    };
+    tracing::info!(
+        target: "claudette::agent_mcp",
+        tool_use_id = %tool_use_id,
+        expected_tool = %expected_tool,
+        "routing user response to MCP interactive prompt"
+    );
+    // Send failing means the agent's tool call already returned (e.g. the
+    // session was torn down and the receiver dropped) — nothing left to do.
+    let _ = pending.reply.send(answer);
+    Ok(())
+}
+
 fn build_attention_response(
     pending: &PendingPermission,
     approved: bool,
@@ -178,6 +236,22 @@ async fn submit_approval_response(
     reason: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
+    // MCP-origin branch: a `request_review` verdict routes to the awaiting
+    // oneshot. `approved` maps to approve/deny today; the third "suggest"
+    // verdict arrives once the frontend card exposes it (the answer shape
+    // already carries an explicit `verdict` string for that).
+    if state.is_mcp_pending(&tool_use_id).await {
+        let verdict = if approved { "approve" } else { "deny" };
+        return submit_mcp_answer(
+            state.inner(),
+            &session_id,
+            &tool_use_id,
+            "ExitPlanMode",
+            serde_json::json!({ "verdict": verdict, "note": reason }),
+        )
+        .await;
+    }
+
     // Same validate-before-remove pattern as submit_agent_answer — see that
     // function for the rationale.
     let (pending, ps) = {

--- a/src-tauri/src/commands/chat/interaction.rs
+++ b/src-tauri/src/commands/chat/interaction.rs
@@ -58,12 +58,15 @@ pub async fn submit_agent_answer(
     // the agent is suspended inside its tool call (not on the CLI's stdin), so
     // the answer must be routed to the awaiting oneshot, not a control_response.
     if state.is_mcp_pending(&tool_use_id).await {
+        // Return the answers map directly (keyed by question text), matching the
+        // `ask_user` tool's documented contract. `annotations` is always null on
+        // the MCP path (the card never sends it), so there's nothing to carry.
         return submit_mcp_answer(
             state.inner(),
             &session_id,
             &tool_use_id,
             "AskUserQuestion",
-            serde_json::json!({ "answers": answers, "annotations": annotations }),
+            serde_json::to_value(&answers).unwrap_or(serde_json::Value::Null),
         )
         .await;
     }
@@ -237,11 +240,18 @@ async fn submit_approval_response(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     // MCP-origin branch: a `request_review` verdict routes to the awaiting
-    // oneshot. `approved` maps to approve/deny today; the third "suggest"
-    // verdict arrives once the frontend card exposes it (the answer shape
-    // already carries an explicit `verdict` string for that).
+    // oneshot. The existing plan card surfaces "Approve" or a feedback textarea;
+    // that feedback path is semantically "suggest changes", so map
+    // approved=false WITH a non-empty note to `suggest` and reserve `deny` for
+    // an explicit deny-without-note (not reachable from today's card, but kept
+    // for completeness so the agent can tell the two apart).
     if state.is_mcp_pending(&tool_use_id).await {
-        let verdict = if approved { "approve" } else { "deny" };
+        let has_note = reason.as_deref().is_some_and(|r| !r.trim().is_empty());
+        let verdict = match (approved, has_note) {
+            (true, _) => "approve",
+            (false, true) => "suggest",
+            (false, false) => "deny",
+        };
         return submit_mcp_answer(
             state.inner(),
             &session_id,

--- a/src-tauri/src/commands/chat/lifecycle.rs
+++ b/src-tauri/src/commands/chat/lifecycle.rs
@@ -82,6 +82,10 @@ pub async fn stop_agent(
     if let Some((ref ps, drained)) = to_deny_stop {
         deny_drained_permissions(drained, ps, "Session stopped by user.").await;
     }
+    // MCP-origin interactive prompts (ask_user / request_review) reply via a
+    // oneshot, not the CLI — drop their channels so a suspended tool call gets a
+    // cancelled result instead of hanging after the user stops the session.
+    state.drain_mcp_replies_for_session(&chat_session_id).await;
     if let Some(ps) = interrupt_session {
         if let Err(err) = ps.interrupt_turn().await {
             tracing::warn!(
@@ -163,6 +167,8 @@ pub async fn reset_agent_session(
     if let Some((ref ps, drained)) = to_deny_reset {
         deny_drained_permissions(drained, ps, "Session reset.").await;
     }
+    // Cancel any in-flight MCP-origin prompts for this session (see stop_agent).
+    state.drain_mcp_replies_for_session(&chat_session_id).await;
     if let Some(pid) = pid_to_kill {
         let _ = agent::stop_agent(pid).await;
     }
@@ -380,6 +386,8 @@ pub async fn prepare_cross_harness_migration(
     if let Some((ps, drained)) = snapshot.drained_permissions {
         deny_drained_permissions(drained, &ps, "Session migrated to a different runtime.").await;
     }
+    // Cancel any in-flight MCP-origin prompts for this session (see stop_agent).
+    state.drain_mcp_replies_for_session(&chat_session_id).await;
     if let Some(pid) = snapshot.pid_to_kill {
         let _ = agent::stop_agent(pid).await;
     }

--- a/src-tauri/src/commands/chat/mod.rs
+++ b/src-tauri/src/commands/chat/mod.rs
@@ -1,5 +1,6 @@
 pub mod attachments;
 pub mod checkpoint;
+pub mod conclusions;
 pub mod interaction;
 pub mod lifecycle;
 mod naming;
@@ -198,9 +199,10 @@ pub(crate) async fn start_bridge_and_inject_mcp(
     workspace_id: &str,
     chat_session_id: &str,
     base_mcp_config: Option<String>,
+    interaction_enabled: bool,
 ) -> Result<(Arc<McpBridgeSession>, Option<String>), String> {
     let bridge = start_chat_bridge(app, db_path, workspace_id, chat_session_id).await?;
-    let merged = inject_claudette_mcp_entry(base_mcp_config, bridge.handle())?;
+    let merged = inject_claudette_mcp_entry(base_mcp_config, bridge.handle(), interaction_enabled)?;
     Ok((bridge, merged))
 }
 
@@ -275,6 +277,7 @@ fn windows_command_arg_quote(value: &str) -> String {
 fn inject_claudette_mcp_entry(
     base: Option<String>,
     handle: &BridgeHandle,
+    interaction_enabled: bool,
 ) -> Result<Option<String>, String> {
     let exe = std::env::current_exe()
         .map_err(|e| format!("current_exe: {e}"))?
@@ -288,6 +291,10 @@ fn inject_claudette_mcp_entry(
         "env": {
             claudette::agent_mcp::server::ENV_SOCKET_ADDR: handle.socket_addr,
             claudette::agent_mcp::server::ENV_TOKEN: handle.token,
+            // Tells the grandchild whether to advertise + accept the
+            // experimental interaction tools (it has no DB access of its own).
+            claudette::agent_mcp::server::ENV_INTERACTION_ENABLED:
+                if interaction_enabled { "true" } else { "false" },
         }
     });
 
@@ -365,7 +372,7 @@ mod mcp_inject_tests {
 
     #[test]
     fn inject_into_empty_config_creates_wrapper() {
-        let merged = inject_claudette_mcp_entry(None, &handle())
+        let merged = inject_claudette_mcp_entry(None, &handle(), true)
             .unwrap()
             .unwrap();
         let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
@@ -375,6 +382,21 @@ mod mcp_inject_tests {
         let env = &v["mcpServers"]["claudette"]["env"];
         assert_eq!(env["CLAUDETTE_MCP_SOCKET"], "/tmp/cmcp/abc.sock");
         assert_eq!(env["CLAUDETTE_MCP_TOKEN"], "secret");
+        assert_eq!(env["CLAUDETTE_MCP_INTERACTION"], "true");
+    }
+
+    #[test]
+    fn inject_marks_interaction_disabled_when_off() {
+        // The experimental flag flows to the grandchild via env. Off => "false",
+        // which the server reads to hide the interaction tools.
+        let merged = inject_claudette_mcp_entry(None, &handle(), false)
+            .unwrap()
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
+        assert_eq!(
+            v["mcpServers"]["claudette"]["env"]["CLAUDETTE_MCP_INTERACTION"],
+            "false"
+        );
     }
 
     #[test]
@@ -385,7 +407,7 @@ mod mcp_inject_tests {
             }
         })
         .to_string();
-        let merged = inject_claudette_mcp_entry(Some(base), &handle())
+        let merged = inject_claudette_mcp_entry(Some(base), &handle(), true)
             .unwrap()
             .unwrap();
         let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
@@ -407,7 +429,7 @@ mod mcp_inject_tests {
             }
         })
         .to_string();
-        let merged = inject_claudette_mcp_entry(Some(base), &handle())
+        let merged = inject_claudette_mcp_entry(Some(base), &handle(), true)
             .unwrap()
             .unwrap();
         let v: serde_json::Value = serde_json::from_str(&merged).unwrap();
@@ -417,7 +439,7 @@ mod mcp_inject_tests {
 
     #[test]
     fn inject_rejects_malformed_base_json() {
-        let res = inject_claudette_mcp_entry(Some("not-json".into()), &handle());
+        let res = inject_claudette_mcp_entry(Some("not-json".into()), &handle(), true);
         assert!(res.is_err());
     }
 

--- a/src-tauri/src/commands/chat/remote_control.rs
+++ b/src-tauri/src/commands/chat/remote_control.rs
@@ -467,20 +467,17 @@ async fn ensure_persistent_session_for_remote_control(
             .map_err(|e| e.to_string())?
     };
     let mcp_config = claudette::mcp::cli_config_from_rows(&db_rows);
-    let (send_to_user_enabled, agent_interaction_enabled, team_agent_session_tabs_enabled) = {
+    let (send_to_user_enabled, interaction_enabled, team_agent_session_tabs_enabled) = {
         let db = Database::open(db_path).map_err(|e| e.to_string())?;
         (
             claudette::agent_mcp::is_builtin_plugin_enabled(&db, "send_to_user"),
-            claudette::agent_mcp::is_builtin_plugin_enabled(
-                &db,
-                claudette::agent_mcp::AGENT_INTERACTION_PLUGIN,
-            ),
+            claudette::agent_mcp::claudette_mcp_enabled(&db),
             super::send::team_agent_session_tabs_enabled(&db),
         )
     };
-    // The send_to_user + interaction tools share one MCP server; inject it when
-    // either is enabled (the per-feature nudges stay independently gated).
-    let claudette_mcp_enabled = send_to_user_enabled || agent_interaction_enabled;
+    // send_to_user (default on) + the experimental interaction tools share one
+    // MCP server; inject it when either is enabled (nudges stay independent).
+    let claudette_server_enabled = send_to_user_enabled || interaction_enabled;
     let instructions = {
         let from_config = repo.as_ref().and_then(|r| {
             let path = r.path.clone();
@@ -491,12 +488,11 @@ async fn ensure_persistent_session_for_remote_control(
         });
         from_config.or_else(|| repo.as_ref().and_then(|r| r.custom_instructions.clone()))
     };
-    let nudge =
-        claudette::agent_mcp::compose_mcp_nudge(send_to_user_enabled, agent_interaction_enabled);
+    let nudge = claudette::agent_mcp::compose_mcp_nudge(send_to_user_enabled, interaction_enabled);
     // Remote-control sessions always launch through Claude CLI, so the
     // Claude-Code MCP rule block applies; it steers to our interaction tools
-    // when the Agent Interaction builtin is on (else the native fallback).
-    let claude_mcp_rules = claudette::agent_mcp::claude_code_mcp_rules(agent_interaction_enabled);
+    // when the experimental feature is on (else the native AskUserQuestion).
+    let claude_mcp_rules = claudette::agent_mcp::claude_code_mcp_rules(interaction_enabled);
     let custom_instructions = claudette::global_prompt::compose_system_prompt(
         instructions.as_deref(),
         nudge.as_deref(),
@@ -582,13 +578,14 @@ async fn ensure_persistent_session_for_remote_control(
         hook_bridge: None,
         extra_claude_flags,
     };
-    let bridge = if claudette_mcp_enabled {
+    let bridge = if claudette_server_enabled {
         let (bridge, mcp_with_claudette) = start_bridge_and_inject_mcp(
             app,
             &state.db_path,
             &workspace_id,
             &chat_session_id,
             agent_settings.mcp_config.clone(),
+            interaction_enabled,
         )
         .await?;
         agent_settings.mcp_config = mcp_with_claudette;

--- a/src-tauri/src/commands/chat/remote_control.rs
+++ b/src-tauri/src/commands/chat/remote_control.rs
@@ -467,13 +467,20 @@ async fn ensure_persistent_session_for_remote_control(
             .map_err(|e| e.to_string())?
     };
     let mcp_config = claudette::mcp::cli_config_from_rows(&db_rows);
-    let (send_to_user_enabled, team_agent_session_tabs_enabled) = {
+    let (send_to_user_enabled, agent_interaction_enabled, team_agent_session_tabs_enabled) = {
         let db = Database::open(db_path).map_err(|e| e.to_string())?;
         (
             claudette::agent_mcp::is_builtin_plugin_enabled(&db, "send_to_user"),
+            claudette::agent_mcp::is_builtin_plugin_enabled(
+                &db,
+                claudette::agent_mcp::AGENT_INTERACTION_PLUGIN,
+            ),
             super::send::team_agent_session_tabs_enabled(&db),
         )
     };
+    // The send_to_user + interaction tools share one MCP server; inject it when
+    // either is enabled (the per-feature nudges stay independently gated).
+    let claudette_mcp_enabled = send_to_user_enabled || agent_interaction_enabled;
     let instructions = {
         let from_config = repo.as_ref().and_then(|r| {
             let path = r.path.clone();
@@ -484,14 +491,16 @@ async fn ensure_persistent_session_for_remote_control(
         });
         from_config.or_else(|| repo.as_ref().and_then(|r| r.custom_instructions.clone()))
     };
-    let nudge = send_to_user_enabled.then_some(claudette::agent_mcp::SYSTEM_PROMPT_NUDGE);
+    let nudge =
+        claudette::agent_mcp::compose_mcp_nudge(send_to_user_enabled, agent_interaction_enabled);
     // Remote-control sessions always launch through Claude CLI, so the
-    // Claude-Code MCP rule block applies (AskUserQuestion / ExitPlanMode
-    // exist via the Claudette MCP bridge).
+    // Claude-Code MCP rule block applies; it steers to our interaction tools
+    // when the Agent Interaction builtin is on (else the native fallback).
+    let claude_mcp_rules = claudette::agent_mcp::claude_code_mcp_rules(agent_interaction_enabled);
     let custom_instructions = claudette::global_prompt::compose_system_prompt(
         instructions.as_deref(),
-        nudge,
-        Some(claudette::agent_mcp::CLAUDE_CODE_MCP_RULES),
+        nudge.as_deref(),
+        Some(claude_mcp_rules.as_str()),
     );
     let level = launch_options.permission_level.as_deref().unwrap_or("full");
     if !matches!(level, "readonly" | "standard" | "full") {
@@ -573,7 +582,7 @@ async fn ensure_persistent_session_for_remote_control(
         hook_bridge: None,
         extra_claude_flags,
     };
-    let bridge = if send_to_user_enabled {
+    let bridge = if claudette_mcp_enabled {
         let (bridge, mcp_with_claudette) = start_bridge_and_inject_mcp(
             app,
             &state.db_path,

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -1461,23 +1461,33 @@ pub async fn send_chat_message(
     }
     let session = agents.get_mut(&chat_session_id).ok_or("Session lost")?;
 
-    // The `send_to_user` built-in plugin is user-toggleable in Settings →
-    // Plugins. When disabled we skip both the synthetic MCP injection
-    // (further down, before spawn) and the system-prompt nudge here, so the
-    // agent has neither the tool nor any hint it exists.
+    // The `send_to_user` and `agent_interaction` built-in plugins are
+    // user-toggleable in Settings → Plugins. They share one MCP server, so the
+    // server is injected (further down, before spawn) when *either* is enabled;
+    // each feature's system-prompt nudge is gated on its own toggle so
+    // disabling one doesn't strip the other's guidance.
     let send_to_user_enabled = claudette::agent_mcp::is_builtin_plugin_enabled(&db, "send_to_user");
+    let agent_interaction_enabled = claudette::agent_mcp::is_builtin_plugin_enabled(
+        &db,
+        claudette::agent_mcp::AGENT_INTERACTION_PLUGIN,
+    );
+    let claudette_mcp_enabled = send_to_user_enabled || agent_interaction_enabled;
 
     // Compose the system prompt for fresh spawns: bundled global prompt →
-    // MCP nudge (so the model reaches for `mcp__claudette__send_to_user`
-    // when asked to deliver a file) → per-repo instructions. Resume turns
-    // reuse the persistent CLI process and never re-pass the prompt.
-    let nudge = send_to_user_enabled.then_some(claudette::agent_mcp::SYSTEM_PROMPT_NUDGE);
+    // MCP nudges (so the model reaches for `mcp__claudette__send_to_user` and
+    // the interaction tools when appropriate) → per-repo instructions. Resume
+    // turns reuse the persistent CLI process and never re-pass the prompt.
+    let nudge =
+        claudette::agent_mcp::compose_mcp_nudge(send_to_user_enabled, agent_interaction_enabled);
+    // Claude CLI exposes the interactive tools via the Claudette MCP bridge, so
+    // the rule block steers to ours (`mcp__claudette__ask_user`, …) when the
+    // Agent Interaction builtin is on, falling back to the native mandate when
+    // it's off.
+    let claude_mcp_rules = claudette::agent_mcp::claude_code_mcp_rules(agent_interaction_enabled);
     let custom_instructions = claudette::global_prompt::compose_system_prompt(
         session.custom_instructions.as_deref(),
-        nudge,
-        // Claude CLI exposes `AskUserQuestion` / `ExitPlanMode` via the
-        // Claudette MCP bridge, so those rules apply here.
-        Some(claudette::agent_mcp::CLAUDE_CODE_MCP_RULES),
+        nudge.as_deref(),
+        Some(claude_mcp_rules.as_str()),
     );
     // Pi runs without the Claudette MCP bridge, so we strip both the
     // send_to_user nudge *and* the AskUserQuestion / ExitPlanMode
@@ -2168,7 +2178,7 @@ pub async fn send_chat_message(
 
                 let mut respawn_settings = agent_settings.clone();
                 let bridge = match respawn_settings.backend_runtime.harness {
-                    AgentBackendRuntimeHarness::ClaudeCode => Some(if send_to_user_enabled {
+                    AgentBackendRuntimeHarness::ClaudeCode => Some(if claudette_mcp_enabled {
                         let (b, mcp_with_claudette) = start_bridge_and_inject_mcp(
                             &app,
                             &state.db_path,
@@ -2183,7 +2193,7 @@ pub async fn send_chat_message(
                         start_chat_bridge(&app, &state.db_path, &workspace_id, &chat_session_id)
                             .await?
                     }),
-                    AgentBackendRuntimeHarness::CodexAppServer if send_to_user_enabled => {
+                    AgentBackendRuntimeHarness::CodexAppServer if claudette_mcp_enabled => {
                         let (b, mcp_with_claudette) = start_bridge_and_inject_mcp(
                             &app,
                             &state.db_path,
@@ -2356,7 +2366,7 @@ pub async fn send_chat_message(
         // persistent CLI process.
         let mut spawn_settings = agent_settings.clone();
         let bridge = match spawn_settings.backend_runtime.harness {
-            AgentBackendRuntimeHarness::ClaudeCode => Some(if send_to_user_enabled {
+            AgentBackendRuntimeHarness::ClaudeCode => Some(if claudette_mcp_enabled {
                 let (b, mcp_with_claudette) = start_bridge_and_inject_mcp(
                     &app,
                     &state.db_path,
@@ -2370,7 +2380,7 @@ pub async fn send_chat_message(
             } else {
                 start_chat_bridge(&app, &state.db_path, &workspace_id, &chat_session_id).await?
             }),
-            AgentBackendRuntimeHarness::CodexAppServer if send_to_user_enabled => {
+            AgentBackendRuntimeHarness::CodexAppServer if claudette_mcp_enabled => {
                 let (b, mcp_with_claudette) = start_bridge_and_inject_mcp(
                     &app,
                     &state.db_path,

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -1461,29 +1461,25 @@ pub async fn send_chat_message(
     }
     let session = agents.get_mut(&chat_session_id).ok_or("Session lost")?;
 
-    // The `send_to_user` and `agent_interaction` built-in plugins are
-    // user-toggleable in Settings → Plugins. They share one MCP server, so the
-    // server is injected (further down, before spawn) when *either* is enabled;
-    // each feature's system-prompt nudge is gated on its own toggle so
-    // disabling one doesn't strip the other's guidance.
+    // `send_to_user` is a Settings → Plugins toggle (default on); the
+    // interaction tools are gated by the experimental "Claudette MCP" flag
+    // (Settings → Experimental, default OFF). They share one MCP server, so it's
+    // injected (further down, before spawn) when *either* is enabled; each
+    // feature's system-prompt nudge is gated independently.
     let send_to_user_enabled = claudette::agent_mcp::is_builtin_plugin_enabled(&db, "send_to_user");
-    let agent_interaction_enabled = claudette::agent_mcp::is_builtin_plugin_enabled(
-        &db,
-        claudette::agent_mcp::AGENT_INTERACTION_PLUGIN,
-    );
-    let claudette_mcp_enabled = send_to_user_enabled || agent_interaction_enabled;
+    let interaction_enabled = claudette::agent_mcp::claudette_mcp_enabled(&db);
+    let claudette_server_enabled = send_to_user_enabled || interaction_enabled;
 
     // Compose the system prompt for fresh spawns: bundled global prompt →
     // MCP nudges (so the model reaches for `mcp__claudette__send_to_user` and
     // the interaction tools when appropriate) → per-repo instructions. Resume
     // turns reuse the persistent CLI process and never re-pass the prompt.
-    let nudge =
-        claudette::agent_mcp::compose_mcp_nudge(send_to_user_enabled, agent_interaction_enabled);
+    let nudge = claudette::agent_mcp::compose_mcp_nudge(send_to_user_enabled, interaction_enabled);
     // Claude CLI exposes the interactive tools via the Claudette MCP bridge, so
     // the rule block steers to ours (`mcp__claudette__ask_user`, …) when the
-    // Agent Interaction builtin is on, falling back to the native mandate when
-    // it's off.
-    let claude_mcp_rules = claudette::agent_mcp::claude_code_mcp_rules(agent_interaction_enabled);
+    // experimental feature is on, falling back to the native AskUserQuestion
+    // mandate when it's off (the pre-feature behavior).
+    let claude_mcp_rules = claudette::agent_mcp::claude_code_mcp_rules(interaction_enabled);
     let custom_instructions = claudette::global_prompt::compose_system_prompt(
         session.custom_instructions.as_deref(),
         nudge.as_deref(),
@@ -2178,13 +2174,14 @@ pub async fn send_chat_message(
 
                 let mut respawn_settings = agent_settings.clone();
                 let bridge = match respawn_settings.backend_runtime.harness {
-                    AgentBackendRuntimeHarness::ClaudeCode => Some(if claudette_mcp_enabled {
+                    AgentBackendRuntimeHarness::ClaudeCode => Some(if claudette_server_enabled {
                         let (b, mcp_with_claudette) = start_bridge_and_inject_mcp(
                             &app,
                             &state.db_path,
                             &workspace_id,
                             &chat_session_id,
                             agent_settings.mcp_config.clone(),
+                            interaction_enabled,
                         )
                         .await?;
                         respawn_settings.mcp_config = mcp_with_claudette;
@@ -2193,13 +2190,14 @@ pub async fn send_chat_message(
                         start_chat_bridge(&app, &state.db_path, &workspace_id, &chat_session_id)
                             .await?
                     }),
-                    AgentBackendRuntimeHarness::CodexAppServer if claudette_mcp_enabled => {
+                    AgentBackendRuntimeHarness::CodexAppServer if claudette_server_enabled => {
                         let (b, mcp_with_claudette) = start_bridge_and_inject_mcp(
                             &app,
                             &state.db_path,
                             &workspace_id,
                             &chat_session_id,
                             agent_settings.mcp_config.clone(),
+                            interaction_enabled,
                         )
                         .await?;
                         respawn_settings.mcp_config = mcp_with_claudette;
@@ -2366,13 +2364,14 @@ pub async fn send_chat_message(
         // persistent CLI process.
         let mut spawn_settings = agent_settings.clone();
         let bridge = match spawn_settings.backend_runtime.harness {
-            AgentBackendRuntimeHarness::ClaudeCode => Some(if claudette_mcp_enabled {
+            AgentBackendRuntimeHarness::ClaudeCode => Some(if claudette_server_enabled {
                 let (b, mcp_with_claudette) = start_bridge_and_inject_mcp(
                     &app,
                     &state.db_path,
                     &workspace_id,
                     &chat_session_id,
                     agent_settings.mcp_config.clone(),
+                    interaction_enabled,
                 )
                 .await?;
                 spawn_settings.mcp_config = mcp_with_claudette;
@@ -2380,13 +2379,14 @@ pub async fn send_chat_message(
             } else {
                 start_chat_bridge(&app, &state.db_path, &workspace_id, &chat_session_id).await?
             }),
-            AgentBackendRuntimeHarness::CodexAppServer if claudette_mcp_enabled => {
+            AgentBackendRuntimeHarness::CodexAppServer if claudette_server_enabled => {
                 let (b, mcp_with_claudette) = start_bridge_and_inject_mcp(
                     &app,
                     &state.db_path,
                     &workspace_id,
                     &chat_session_id,
                     agent_settings.mcp_config.clone(),
+                    interaction_enabled,
                 )
                 .await?;
                 spawn_settings.mcp_config = mcp_with_claudette;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1090,6 +1090,7 @@ fn main() {
             commands::chat::attachments::load_attachments_for_session,
             commands::chat::attachments::load_attachment_data,
             commands::chat::attachments::read_file_as_base64,
+            commands::chat::conclusions::load_agent_conclusions_for_session,
             commands::chat::lifecycle::stop_agent,
             commands::chat::lifecycle::reset_agent_session,
             commands::chat::lifecycle::prepare_cross_harness_migration,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use claudette::agent::AgentSession;
-use tokio::sync::{RwLock, Semaphore};
+use tokio::sync::{RwLock, Semaphore, oneshot};
 
 use claudette::claude_help::ClaudeFlagDef;
 use claudette::env_provider::{EnvCache, EnvWatcher};
@@ -70,6 +70,24 @@ pub struct PendingPermission {
     /// Original tool input sent by the model — used verbatim as the base for
     /// `updatedInput` when approving (we layer user-collected answers on top).
     pub original_input: serde_json::Value,
+}
+
+/// A blocking interactive request that originated from a Claudette MCP tool
+/// (`ask_user` / `request_review`) rather than from a Claude-CLI control
+/// request. The agent's MCP tool call is suspended inside the bridge handler,
+/// which holds the paired [`oneshot::Receiver`]; the user's answer is delivered
+/// here by `submit_agent_answer` / `submit_plan_approval`, which routes to this
+/// sender instead of writing a `control_response` to the CLI's stdin.
+///
+/// Lives in [`AppState::mcp_pending_replies`] (keyed by `tool_use_id`) rather
+/// than on `AgentSessionState` so adding it doesn't churn the dozen-plus
+/// `AgentSessionState` construction sites. `chat_session_id` is retained so a
+/// session teardown can drop the matching senders, which unblocks the awaiting
+/// bridge handler with a `RecvError` (surfaced to the agent as a cancelled
+/// interaction).
+pub struct McpPendingReply {
+    pub chat_session_id: String,
+    pub reply: oneshot::Sender<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -735,6 +753,10 @@ pub struct AppState {
     /// deleted, or manually fired so the polling loop can recompute its next
     /// deadline immediately instead of waiting for the fallback tick.
     pub scheduler_notify: Arc<tokio::sync::Notify>,
+    /// In-flight blocking interactive requests from Claudette MCP tools
+    /// (`ask_user` / `request_review`), keyed by `tool_use_id`. See
+    /// [`McpPendingReply`].
+    pub mcp_pending_replies: RwLock<HashMap<String, McpPendingReply>>,
 }
 
 impl AppState {
@@ -791,6 +813,7 @@ impl AppState {
             bulk_cleanup_cancels: RwLock::new(HashMap::new()),
             workspace_creates_in_flight: Mutex::new(HashSet::new()),
             scheduler_notify: Arc::new(tokio::sync::Notify::new()),
+            mcp_pending_replies: RwLock::new(HashMap::new()),
         }
     }
 
@@ -838,6 +861,53 @@ impl AppState {
     /// the Plugins settings page from stalling while env loads.
     pub async fn plugins_snapshot(&self) -> Arc<PluginRegistry> {
         Arc::clone(&*self.plugins.read().await)
+    }
+
+    /// Register a blocking MCP interactive request and return the receiver the
+    /// bridge handler awaits. The matching answer is delivered by
+    /// [`Self::take_mcp_reply`]; an abandoned request is cleaned up by
+    /// [`Self::drain_mcp_replies_for_session`].
+    pub async fn register_mcp_reply(
+        &self,
+        tool_use_id: String,
+        chat_session_id: String,
+    ) -> oneshot::Receiver<serde_json::Value> {
+        let (tx, rx) = oneshot::channel();
+        self.mcp_pending_replies.write().await.insert(
+            tool_use_id,
+            McpPendingReply {
+                chat_session_id,
+                reply: tx,
+            },
+        );
+        rx
+    }
+
+    /// Non-destructive check used by the submit handlers to decide whether a
+    /// pending control is MCP-originated (reply via oneshot) or CLI-originated
+    /// (reply via `control_response`).
+    pub async fn is_mcp_pending(&self, tool_use_id: &str) -> bool {
+        self.mcp_pending_replies
+            .read()
+            .await
+            .contains_key(tool_use_id)
+    }
+
+    /// Remove and return the reply sender for `tool_use_id`, if present.
+    pub async fn take_mcp_reply(&self, tool_use_id: &str) -> Option<McpPendingReply> {
+        self.mcp_pending_replies.write().await.remove(tool_use_id)
+    }
+
+    /// Drop every pending MCP reply sender belonging to a session. Dropping the
+    /// sender unblocks the awaiting bridge handler with a `RecvError`, which it
+    /// surfaces to the agent as a cancelled interaction. Called from the
+    /// session teardown paths (stop / reset / migrate) so a blocked `ask_user`
+    /// can't hang after the user abandons it.
+    pub async fn drain_mcp_replies_for_session(&self, chat_session_id: &str) {
+        self.mcp_pending_replies
+            .write()
+            .await
+            .retain(|_, v| v.chat_session_id != chat_session_id);
     }
 }
 
@@ -1077,5 +1147,50 @@ mod create_slot_tests {
 
         // Releasing a repo that holds no slot is a harmless no-op.
         state.end_workspace_create("never-claimed");
+    }
+
+    #[tokio::test]
+    async fn mcp_reply_round_trip_delivers_answer() {
+        let (state, _dir) = test_state();
+        let rx = state.register_mcp_reply("tu1".into(), "sess".into()).await;
+        assert!(state.is_mcp_pending("tu1").await);
+
+        // The submit handler takes the sender and delivers the answer.
+        let pending = state.take_mcp_reply("tu1").await.expect("registered");
+        assert_eq!(pending.chat_session_id, "sess");
+        pending
+            .reply
+            .send(serde_json::json!({ "verdict": "approve" }))
+            .unwrap();
+
+        // The bridge handler awaiting `rx` receives it, and the entry is gone.
+        assert_eq!(rx.await.unwrap()["verdict"], "approve");
+        assert!(!state.is_mcp_pending("tu1").await);
+    }
+
+    #[tokio::test]
+    async fn drain_cancels_session_replies_but_spares_others() {
+        let (state, _dir) = test_state();
+        let rx_target = state
+            .register_mcp_reply("tu_target".into(), "sess".into())
+            .await;
+        let rx_other = state
+            .register_mcp_reply("tu_other".into(), "other".into())
+            .await;
+
+        // Tearing down "sess" drops its sender → the awaiting handler errors
+        // (surfaced to the agent as a cancelled interaction)…
+        state.drain_mcp_replies_for_session("sess").await;
+        assert!(rx_target.await.is_err());
+        assert!(!state.is_mcp_pending("tu_target").await);
+
+        // …while an unrelated session's pending reply is untouched.
+        assert!(state.is_mcp_pending("tu_other").await);
+        let pending = state.take_mcp_reply("tu_other").await.unwrap();
+        pending
+            .reply
+            .send(serde_json::json!({ "ok": true }))
+            .unwrap();
+        assert_eq!(rx_other.await.unwrap()["ok"], true);
     }
 }

--- a/src/agent_mcp/mod.rs
+++ b/src/agent_mcp/mod.rs
@@ -17,12 +17,15 @@ pub mod tools;
 
 use serde::Serialize;
 
-/// A built-in Claudette plugin — a Rust-implemented agent-callable tool
-/// surfaced via the in-process MCP bridge. Registered statically (no
-/// dynamic discovery) so the settings UI has a stable, hand-curated list.
+/// A built-in Claudette plugin — a Rust-implemented agent-callable surface
+/// exposed via the in-process MCP bridge. Registered statically (no dynamic
+/// discovery) so the settings UI has a stable, hand-curated list.
 #[derive(Debug, Clone, Copy, Serialize)]
 pub struct BuiltinPlugin {
-    /// Stable id, used as the setting key suffix and the MCP tool name.
+    /// Stable id, used as the setting-key suffix and the settings-UI key.
+    /// For single-tool plugins this is also the MCP tool name
+    /// (e.g. `send_to_user`); for a grouped plugin (e.g. `agent_interaction`)
+    /// it covers several related tools that toggle together.
     pub name: &'static str,
     /// One-line title for the settings UI.
     pub title: &'static str,
@@ -30,19 +33,36 @@ pub struct BuiltinPlugin {
     pub description: &'static str,
 }
 
+/// Setting-key suffix for the grouped interactive-prompt tools
+/// (`ask_user`, `request_review`, `present_conclusion`). Toggling it gates the
+/// system-prompt nudge; the tools are injected whenever any Claudette builtin
+/// is enabled (see [`claudette_mcp_server_enabled`]).
+pub const AGENT_INTERACTION_PLUGIN: &str = "agent_interaction";
+
 /// All built-in plugins shipped with Claudette. Add new ones here as the
 /// agent-tool surface grows.
-pub const BUILTIN_PLUGINS: &[BuiltinPlugin] = &[BuiltinPlugin {
-    name: "send_to_user",
-    title: "Agent Attachments",
-    description: "Lets the agent deliver images, screenshots, PDFs, and text/data \
+pub const BUILTIN_PLUGINS: &[BuiltinPlugin] = &[
+    BuiltinPlugin {
+        name: "send_to_user",
+        title: "Agent Attachments",
+        description: "Lets the agent deliver images, screenshots, PDFs, and text/data \
                   artifacts (plain text, CSV, JSON, Markdown) inline in chat. The agent \
                   reaches for this whenever you ask it to send, share, or show you a \
                   file — including artifacts produced by other tools (e.g. a Playwright \
                   screenshot, a generated CSV). Each type renders with a type-aware \
                   preview. Disable to remove the tool and stop the system prompt from \
                   nudging the agent to use it.",
-}];
+    },
+    BuiltinPlugin {
+        name: AGENT_INTERACTION_PLUGIN,
+        title: "Agent Interaction",
+        description: "Lets the agent ask you questions, request approval / feedback on a \
+                  plan or decision (approve, deny, or suggest changes), and present a \
+                  conclusion of completed work — each surfaced as an interactive card in \
+                  chat. Works across agent backends, not just Claude. Disable to stop \
+                  the system prompt from nudging the agent toward these tools.",
+    },
+];
 
 /// Settings key pattern: `builtin_plugin:{name}:enabled`. Absent key = enabled
 /// (the default), the literal string `"false"` = disabled. Mirrors the
@@ -90,17 +110,90 @@ Claudette to wake this chat later with a prompt. Use the cron tools for \
 recurring routines. Use `Monitor` to subscribe to future output from a \
 background Bash task instead of polling.";
 
-/// Claude-CLI-only rules that reference MCP tools shipped by the Claude
-/// Code runtime (`AskUserQuestion`, `ExitPlanMode`). These tools do not
-/// exist in the Pi SDK or the Codex app-server harnesses, so the rules
-/// only get appended for Claude CLI sessions — otherwise the model is
-/// told to use tools it doesn't have, which is both confusing for the
-/// model and a small step in the wrong direction for accuracy.
-pub const CLAUDE_CODE_MCP_RULES: &str = "\
-## Rules\n\
-\n\
-- Whenever you have a question for the user — no matter how minor — you MUST use the `AskUserQuestion` tool. No exceptions: do not ask questions in plain text output.\n\
-- Before complaining about a permissions error or denied tool call, check whether you are in plan mode. If you are in plan mode, you must exit plan mode (via `ExitPlanMode`) before retrying — many tools are intentionally blocked while planning.";
+/// System-prompt nudge for the interactive-prompt tools. Kept separate from
+/// [`SYSTEM_PROMPT_NUDGE`] so each feature's toggle gates only its own
+/// guidance — disabling Agent Attachments must not strip the interaction
+/// guidance, and vice versa.
+///
+/// Deliberately reiterates the mandate that [`claude_code_mcp_rules`] also
+/// states: the model strongly defaults to its native `AskUserQuestion`, so the
+/// steering toward our look-alike `mcp__claudette__ask_user` has to be repeated
+/// and explicit to win.
+pub const INTERACTION_PROMPT_NUDGE: &str = "\
+Interactive user prompts (REQUIRED tools): this Claudette workspace exposes \
+the MCP tools `mcp__claudette__ask_user`, `mcp__claudette__request_review`, \
+and `mcp__claudette__present_conclusion` (server `claudette`). These are the \
+required way to interact with the user in Claudette — use them in preference \
+to plain chat text and in preference to any similarly-named built-in tool. \
+- When you need the user to answer a question or choose between options, you \
+MUST call `mcp__claudette__ask_user` (NOT the native `AskUserQuestion`) and \
+wait for the answer; it renders interactive options and blocks until they \
+respond. \
+- Before acting on a plan or a consequential, hard-to-reverse decision, you \
+MUST call `mcp__claudette__request_review` and wait for the user's verdict \
+(approve / deny / suggest). \
+- When you finish a unit of work, call `mcp__claudette__present_conclusion` \
+with a concise summary of what you did — it is recorded in the transcript and \
+shown to the user as a conclusion card. \
+`ask_user` and `request_review` block on the user, so only call them when you \
+genuinely need input — do not call them to narrate progress.";
+
+/// Whether the Claudette MCP server should be injected into a spawned agent at
+/// all — true when *any* built-in plugin that lives on that server is enabled.
+/// The server lists all its tools together, so injection is all-or-nothing;
+/// per-feature toggles gate the system-prompt nudges (see
+/// [`compose_mcp_nudge`]).
+pub fn claudette_mcp_server_enabled(db: &crate::db::Database) -> bool {
+    BUILTIN_PLUGINS
+        .iter()
+        .any(|p| is_builtin_plugin_enabled(db, p.name))
+}
+
+/// Build the combined system-prompt nudge for the Claudette MCP tools, each
+/// section gated on its own builtin toggle. Returns `None` when every relevant
+/// builtin is disabled so the caller passes no nudge at all.
+pub fn compose_mcp_nudge(
+    send_to_user_enabled: bool,
+    agent_interaction_enabled: bool,
+) -> Option<String> {
+    let mut parts: Vec<&str> = Vec::new();
+    if send_to_user_enabled {
+        parts.push(SYSTEM_PROMPT_NUDGE);
+    }
+    if agent_interaction_enabled {
+        parts.push(INTERACTION_PROMPT_NUDGE);
+    }
+    (!parts.is_empty()).then(|| parts.join("\n\n"))
+}
+
+/// Claude-CLI-only prompt rules, appended for Claude Code sessions only (Pi /
+/// Codex pass `None` — they don't expose these tools, and pointing a qwen / GPT
+/// model at tools that aren't registered confuses its capability self-model).
+///
+/// The question / decision mandate is gated on `agent_interaction_enabled`:
+/// - **enabled** (default): the model is told to use *our* tools
+///   (`mcp__claudette__ask_user` / `request_review` / `present_conclusion`) and
+///   explicitly NOT the look-alike native `AskUserQuestion`. The model defaults
+///   hard to its native tool, so we both amend the old native mandate and state
+///   the new one imperatively here (and again in [`INTERACTION_PROMPT_NUDGE`]).
+/// - **disabled**: falls back to the native `AskUserQuestion` mandate so the
+///   model still asks via a tool rather than plain text.
+///
+/// The plan-mode rule is always present: `ExitPlanMode` is the real mechanism
+/// for leaving the CLI's `--permission-mode plan`, independent of (and not
+/// replaced by) our `request_review` tool.
+pub fn claude_code_mcp_rules(agent_interaction_enabled: bool) -> String {
+    let interaction_rules = if agent_interaction_enabled {
+        "- Whenever you need the user to answer a question or choose between options — no matter how minor — you MUST call the `mcp__claudette__ask_user` tool and wait for the answer. Do NOT ask in plain text, and do NOT use the native `AskUserQuestion` tool — `mcp__claudette__ask_user` is the required path.\n\
+- Before acting on a plan or any consequential, hard-to-reverse decision, you MUST call `mcp__claudette__request_review` and wait for the user's verdict (approve / deny / suggest).\n\
+- When you finish a unit of work, call `mcp__claudette__present_conclusion` with a concise summary so it is recorded for the user."
+    } else {
+        "- Whenever you have a question for the user — no matter how minor — you MUST use the `AskUserQuestion` tool. No exceptions: do not ask questions in plain text output."
+    };
+    format!(
+        "## Rules\n\n{interaction_rules}\n- Before complaining about a permissions error or denied tool call, check whether you are in plan mode. If you are in plan mode, you must exit plan mode (via `ExitPlanMode`) before retrying — many tools are intentionally blocked while planning."
+    )
+}
 
 #[cfg(test)]
 mod builtin_tests {
@@ -139,18 +232,63 @@ mod builtin_tests {
 
     #[test]
     fn registered_plugin_has_user_facing_name() {
-        // The settings UI shows `title`, not `name`. Make sure the title is
-        // human-readable (no underscores, capitalized).
-        let p = BUILTIN_PLUGINS
-            .iter()
-            .find(|p| p.name == "send_to_user")
-            .expect("send_to_user must be registered");
+        // The settings UI shows `title`, not `name`. Make sure every entry's
+        // title is human-readable (no underscores, capitalized).
+        for p in BUILTIN_PLUGINS {
+            assert!(
+                !p.title.contains('_'),
+                "title should be human-readable: {}",
+                p.title
+            );
+            assert!(p.title.starts_with(|c: char| c.is_uppercase()));
+            assert!(!p.description.is_empty());
+        }
+        assert!(BUILTIN_PLUGINS.iter().any(|p| p.name == "send_to_user"));
         assert!(
-            !p.title.contains('_'),
-            "title should be human-readable: {}",
-            p.title
+            BUILTIN_PLUGINS
+                .iter()
+                .any(|p| p.name == AGENT_INTERACTION_PLUGIN)
         );
-        assert!(p.title.starts_with(|c: char| c.is_uppercase()));
-        assert!(!p.description.is_empty());
+    }
+
+    #[test]
+    fn compose_mcp_nudge_gates_each_section_independently() {
+        // Both on → both sections present.
+        let both = compose_mcp_nudge(true, true).expect("both enabled");
+        assert!(both.contains("send_to_user"));
+        assert!(both.contains("ask_user"));
+
+        // Only interaction → no attachment nudge.
+        let only_interaction = compose_mcp_nudge(false, true).expect("interaction enabled");
+        assert!(only_interaction.contains("ask_user"));
+        assert!(!only_interaction.contains("Inline file delivery"));
+
+        // Only attachments → no interaction nudge.
+        let only_attach = compose_mcp_nudge(true, false).expect("attachments enabled");
+        assert!(only_attach.contains("send_to_user"));
+        assert!(!only_attach.contains("Interactive user prompts"));
+
+        // Neither → no nudge at all.
+        assert!(compose_mcp_nudge(false, false).is_none());
+    }
+
+    #[test]
+    fn server_enabled_when_any_builtin_enabled() {
+        let db = Database::open_in_memory().unwrap();
+        // All default-enabled → server should inject.
+        assert!(claudette_mcp_server_enabled(&db));
+        // Disable everything → server should not inject.
+        for p in BUILTIN_PLUGINS {
+            db.set_app_setting(&builtin_plugin_setting_key(p.name), "false")
+                .unwrap();
+        }
+        assert!(!claudette_mcp_server_enabled(&db));
+        // Re-enabling just one is enough to inject the shared server.
+        db.set_app_setting(
+            &builtin_plugin_setting_key(AGENT_INTERACTION_PLUGIN),
+            "true",
+        )
+        .unwrap();
+        assert!(claudette_mcp_server_enabled(&db));
     }
 }

--- a/src/agent_mcp/mod.rs
+++ b/src/agent_mcp/mod.rs
@@ -22,10 +22,8 @@ use serde::Serialize;
 /// discovery) so the settings UI has a stable, hand-curated list.
 #[derive(Debug, Clone, Copy, Serialize)]
 pub struct BuiltinPlugin {
-    /// Stable id, used as the setting-key suffix and the settings-UI key.
-    /// For single-tool plugins this is also the MCP tool name
-    /// (e.g. `send_to_user`); for a grouped plugin (e.g. `agent_interaction`)
-    /// it covers several related tools that toggle together.
+    /// Stable id, used as the setting-key suffix, the settings-UI key, and the
+    /// MCP tool name (each builtin plugin maps to one always-available tool).
     pub name: &'static str,
     /// One-line title for the settings UI.
     pub title: &'static str,
@@ -33,36 +31,35 @@ pub struct BuiltinPlugin {
     pub description: &'static str,
 }
 
-/// Setting-key suffix for the grouped interactive-prompt tools
-/// (`ask_user`, `request_review`, `present_conclusion`). Toggling it gates the
-/// system-prompt nudge; the tools are injected whenever any Claudette builtin
-/// is enabled (see [`claudette_mcp_server_enabled`]).
-pub const AGENT_INTERACTION_PLUGIN: &str = "agent_interaction";
+/// `app_settings` key for the experimental "Claudette MCP" feature, which gates
+/// the agent-initiated interaction tools (`ask_user`, `request_review`,
+/// `present_conclusion`) plus the system-prompt steering toward them. **Off by
+/// default** — only the literal string `"true"` enables it — so the feature can
+/// ship without changing behavior for anyone who hasn't opted in. Lives in the
+/// Experimental settings section (not Plugins).
+pub const CLAUDETTE_MCP_SETTING: &str = "claudette_mcp_enabled";
 
 /// All built-in plugins shipped with Claudette. Add new ones here as the
 /// agent-tool surface grows.
-pub const BUILTIN_PLUGINS: &[BuiltinPlugin] = &[
-    BuiltinPlugin {
-        name: "send_to_user",
-        title: "Agent Attachments",
-        description: "Lets the agent deliver images, screenshots, PDFs, and text/data \
+pub const BUILTIN_PLUGINS: &[BuiltinPlugin] = &[BuiltinPlugin {
+    name: "send_to_user",
+    title: "Agent Attachments",
+    description: "Lets the agent deliver images, screenshots, PDFs, and text/data \
                   artifacts (plain text, CSV, JSON, Markdown) inline in chat. The agent \
                   reaches for this whenever you ask it to send, share, or show you a \
                   file — including artifacts produced by other tools (e.g. a Playwright \
                   screenshot, a generated CSV). Each type renders with a type-aware \
                   preview. Disable to remove the tool and stop the system prompt from \
                   nudging the agent to use it.",
-    },
-    BuiltinPlugin {
-        name: AGENT_INTERACTION_PLUGIN,
-        title: "Agent Interaction",
-        description: "Lets the agent ask you questions, request approval / feedback on a \
-                  plan or decision (approve, deny, or suggest changes), and present a \
-                  conclusion of completed work — each surfaced as an interactive card in \
-                  chat. Works across agent backends, not just Claude. Disable to stop \
-                  the system prompt from nudging the agent toward these tools.",
-    },
-];
+}];
+
+/// Whether the experimental "Claudette MCP" feature is enabled. **Off by
+/// default**: absent or any value other than `"true"` reads as disabled, so the
+/// agent-interaction tools and their prompt steering stay dark until the user
+/// opts in via Settings → Experimental.
+pub fn claudette_mcp_enabled(db: &crate::db::Database) -> bool {
+    matches!(db.get_app_setting(CLAUDETTE_MCP_SETTING), Ok(Some(v)) if v == "true")
+}
 
 /// Settings key pattern: `builtin_plugin:{name}:enabled`. Absent key = enabled
 /// (the default), the literal string `"false"` = disabled. Mirrors the
@@ -138,20 +135,10 @@ shown to the user as a conclusion card. \
 `ask_user` and `request_review` block on the user, so only call them when you \
 genuinely need input — do not call them to narrate progress.";
 
-/// Whether the Claudette MCP server should be injected into a spawned agent at
-/// all — true when *any* built-in plugin that lives on that server is enabled.
-/// The server lists all its tools together, so injection is all-or-nothing;
-/// per-feature toggles gate the system-prompt nudges (see
-/// [`compose_mcp_nudge`]).
-pub fn claudette_mcp_server_enabled(db: &crate::db::Database) -> bool {
-    BUILTIN_PLUGINS
-        .iter()
-        .any(|p| is_builtin_plugin_enabled(db, p.name))
-}
-
-/// Build the combined system-prompt nudge for the Claudette MCP tools, each
-/// section gated on its own builtin toggle. Returns `None` when every relevant
-/// builtin is disabled so the caller passes no nudge at all.
+/// Build the combined system-prompt nudge for the Claudette MCP tools. The
+/// attachment section is gated on the `send_to_user` builtin toggle and the
+/// interaction section on the experimental `claudette_mcp_enabled` flag, so each
+/// is steered only when actually available. Returns `None` when neither is on.
 pub fn compose_mcp_nudge(
     send_to_user_enabled: bool,
     agent_interaction_enabled: bool,
@@ -170,14 +157,16 @@ pub fn compose_mcp_nudge(
 /// Codex pass `None` — they don't expose these tools, and pointing a qwen / GPT
 /// model at tools that aren't registered confuses its capability self-model).
 ///
-/// The question / decision mandate is gated on `agent_interaction_enabled`:
-/// - **enabled** (default): the model is told to use *our* tools
+/// The question / decision mandate is gated on `agent_interaction_enabled`
+/// (sourced from the experimental [`CLAUDETTE_MCP_SETTING`], **off by default**):
+/// - **enabled** (opt-in): the model is told to use *our* tools
 ///   (`mcp__claudette__ask_user` / `request_review` / `present_conclusion`) and
 ///   explicitly NOT the look-alike native `AskUserQuestion`. The model defaults
 ///   hard to its native tool, so we both amend the old native mandate and state
 ///   the new one imperatively here (and again in [`INTERACTION_PROMPT_NUDGE`]).
-/// - **disabled**: falls back to the native `AskUserQuestion` mandate so the
-///   model still asks via a tool rather than plain text.
+/// - **disabled** (default): falls back to the native `AskUserQuestion` mandate
+///   so the model still asks via a tool rather than plain text — i.e. exactly
+///   the pre-feature behavior.
 ///
 /// The plan-mode rule is always present: `ExitPlanMode` is the real mechanism
 /// for leaving the CLI's `--permission-mode plan`, independent of (and not
@@ -244,11 +233,18 @@ mod builtin_tests {
             assert!(!p.description.is_empty());
         }
         assert!(BUILTIN_PLUGINS.iter().any(|p| p.name == "send_to_user"));
-        assert!(
-            BUILTIN_PLUGINS
-                .iter()
-                .any(|p| p.name == AGENT_INTERACTION_PLUGIN)
-        );
+    }
+
+    #[test]
+    fn claudette_mcp_experimental_flag_defaults_off() {
+        let db = Database::open_in_memory().unwrap();
+        // Absent setting → feature is OFF (the whole point of the experimental gate).
+        assert!(!claudette_mcp_enabled(&db));
+        // Only the literal "true" turns it on.
+        db.set_app_setting(CLAUDETTE_MCP_SETTING, "false").unwrap();
+        assert!(!claudette_mcp_enabled(&db));
+        db.set_app_setting(CLAUDETTE_MCP_SETTING, "true").unwrap();
+        assert!(claudette_mcp_enabled(&db));
     }
 
     #[test]
@@ -270,25 +266,5 @@ mod builtin_tests {
 
         // Neither → no nudge at all.
         assert!(compose_mcp_nudge(false, false).is_none());
-    }
-
-    #[test]
-    fn server_enabled_when_any_builtin_enabled() {
-        let db = Database::open_in_memory().unwrap();
-        // All default-enabled → server should inject.
-        assert!(claudette_mcp_server_enabled(&db));
-        // Disable everything → server should not inject.
-        for p in BUILTIN_PLUGINS {
-            db.set_app_setting(&builtin_plugin_setting_key(p.name), "false")
-                .unwrap();
-        }
-        assert!(!claudette_mcp_server_enabled(&db));
-        // Re-enabling just one is enough to inject the shared server.
-        db.set_app_setting(
-            &builtin_plugin_setting_key(AGENT_INTERACTION_PLUGIN),
-            "true",
-        )
-        .unwrap();
-        assert!(claudette_mcp_server_enabled(&db));
     }
 }

--- a/src/agent_mcp/protocol.rs
+++ b/src/agent_mcp/protocol.rs
@@ -128,6 +128,30 @@ pub enum BridgePayload {
         task_id: String,
         until: Option<String>,
     },
+    /// Ask the user one or more questions and block until they answer. The
+    /// parent surfaces these through the same interactive card the native
+    /// `AskUserQuestion` uses, so any backend (not just the Claude CLI) can
+    /// prompt the user. `questions` is the validated question array, shaped
+    /// to match the `AskUserQuestion` tool input the frontend already renders.
+    /// The bridge response carries the user's answers (keyed by question text).
+    AskUser { questions: serde_json::Value },
+    /// Ask the user to review a plan or decision and block until they return a
+    /// verdict (approve / deny / suggest) with an optional note. Rendered
+    /// through the existing plan-approval card. `options` is reserved for a
+    /// future custom-verdict set; `None` means the default three verdicts.
+    RequestReview {
+        summary: String,
+        detail: Option<String>,
+        options: Option<serde_json::Value>,
+    },
+    /// Present a finished-work conclusion to the user. Persisted to the
+    /// transcript (so it survives reload/export) and surfaced as a conclusion
+    /// card. Non-blocking — returns as soon as the row is written.
+    PresentConclusion {
+        title: Option<String>,
+        summary: String,
+        artifacts: Option<Vec<String>>,
+    },
     /// Forward a Claude Code hook payload to the parent UI. Tool hooks fired
     /// inside subagents include `agent_id`, which lets the frontend attach the
     /// nested tool call to the parent Agent activity.
@@ -266,6 +290,87 @@ mod tests {
                 assert_eq!(caption.as_deref(), Some("look"));
             }
             _ => panic!("expected attachment payload"),
+        }
+    }
+
+    #[test]
+    fn bridge_ask_user_round_trips() {
+        let req = BridgeRequest {
+            token: "abc".into(),
+            payload: BridgePayload::AskUser {
+                questions: json!([{
+                    "question": "Ship it?",
+                    "header": "Deploy",
+                    "options": [{"label": "Yes", "description": "go"}],
+                    "multiSelect": false
+                }]),
+            },
+        };
+        let s = serde_json::to_string(&req).unwrap();
+        assert!(
+            s.contains("\"kind\":\"ask_user\""),
+            "tag should be snake_case: {s}"
+        );
+        let back: BridgeRequest = serde_json::from_str(&s).unwrap();
+        match back.payload {
+            BridgePayload::AskUser { questions } => {
+                assert_eq!(questions[0]["question"], "Ship it?");
+            }
+            _ => panic!("expected ask_user payload"),
+        }
+    }
+
+    #[test]
+    fn bridge_request_review_round_trips() {
+        let req = BridgeRequest {
+            token: "abc".into(),
+            payload: BridgePayload::RequestReview {
+                summary: "Refactor the auth module".into(),
+                detail: Some("Splits the god-file into three".into()),
+                options: None,
+            },
+        };
+        let s = serde_json::to_string(&req).unwrap();
+        assert!(s.contains("\"kind\":\"request_review\""), "{s}");
+        let back: BridgeRequest = serde_json::from_str(&s).unwrap();
+        match back.payload {
+            BridgePayload::RequestReview {
+                summary,
+                detail,
+                options,
+            } => {
+                assert_eq!(summary, "Refactor the auth module");
+                assert_eq!(detail.as_deref(), Some("Splits the god-file into three"));
+                assert!(options.is_none());
+            }
+            _ => panic!("expected request_review payload"),
+        }
+    }
+
+    #[test]
+    fn bridge_present_conclusion_round_trips() {
+        let req = BridgeRequest {
+            token: "abc".into(),
+            payload: BridgePayload::PresentConclusion {
+                title: Some("Done".into()),
+                summary: "Migrated 12 call sites and added tests.".into(),
+                artifacts: Some(vec!["/tmp/report.md".into()]),
+            },
+        };
+        let s = serde_json::to_string(&req).unwrap();
+        assert!(s.contains("\"kind\":\"present_conclusion\""), "{s}");
+        let back: BridgeRequest = serde_json::from_str(&s).unwrap();
+        match back.payload {
+            BridgePayload::PresentConclusion {
+                title,
+                summary,
+                artifacts,
+            } => {
+                assert_eq!(title.as_deref(), Some("Done"));
+                assert!(summary.contains("Migrated"));
+                assert_eq!(artifacts.unwrap().len(), 1);
+            }
+            _ => panic!("expected present_conclusion payload"),
         }
     }
 

--- a/src/agent_mcp/server.rs
+++ b/src/agent_mcp/server.rs
@@ -32,6 +32,11 @@ use crate::agent_mcp::tools::send_to_user::{
 
 pub const ENV_SOCKET_ADDR: &str = "CLAUDETTE_MCP_SOCKET";
 pub const ENV_TOKEN: &str = "CLAUDETTE_MCP_TOKEN";
+/// Set to `"true"` by the parent when the experimental "Claudette MCP" feature
+/// is on. The grandchild has no DB access, so this env var is how it learns
+/// whether to advertise + accept the interaction tools (`ask_user`,
+/// `request_review`, `present_conclusion`). Absent / any other value = off.
+pub const ENV_INTERACTION_ENABLED: &str = "CLAUDETTE_MCP_INTERACTION";
 pub const SEND_TO_USER_TOOL_NAME: &str = "send_to_user";
 pub const SCHEDULE_WAKEUP_TOOL_NAME: &str = "ScheduleWakeup";
 pub const CRON_CREATE_TOOL_NAME: &str = "CronCreate";
@@ -53,10 +58,18 @@ pub async fn run_stdio() -> io::Result<()> {
         .map_err(|_| io::Error::other(format!("{ENV_SOCKET_ADDR} not set")))?;
     let token =
         std::env::var(ENV_TOKEN).map_err(|_| io::Error::other(format!("{ENV_TOKEN} not set")))?;
+    let interaction_enabled = std::env::var(ENV_INTERACTION_ENABLED).as_deref() == Ok("true");
 
     let stdin = tokio::io::stdin();
     let mut stdout = tokio::io::stdout();
-    serve(BufReader::new(stdin), &mut stdout, &socket_addr, &token).await
+    serve(
+        BufReader::new(stdin),
+        &mut stdout,
+        &socket_addr,
+        &token,
+        interaction_enabled,
+    )
+    .await
 }
 
 /// Generic server loop, parameterised over the IO so we can unit-test it
@@ -66,6 +79,7 @@ pub async fn serve<R, W>(
     writer: &mut W,
     socket_addr: &str,
     token: &str,
+    interaction_enabled: bool,
 ) -> io::Result<()>
 where
     R: AsyncBufReadExt + Unpin,
@@ -89,7 +103,7 @@ where
                 error_codes::PARSE_ERROR,
                 format!("parse error: {e}"),
             )),
-            Ok(req) => handle_request(req, socket_addr, token).await,
+            Ok(req) => handle_request(req, socket_addr, token, interaction_enabled).await,
         };
 
         if let Some(resp) = response {
@@ -106,14 +120,23 @@ async fn handle_request(
     req: JsonRpcRequest,
     socket_addr: &str,
     token: &str,
+    interaction_enabled: bool,
 ) -> Option<JsonRpcResponse> {
     // Notifications carry no id and expect no response.
     let id = req.id.clone()?;
 
     match req.method.as_str() {
-        "initialize" => Some(JsonRpcResponse::success(id, initialize_result())),
-        "tools/list" => Some(JsonRpcResponse::success(id, tools_list_result())),
-        "tools/call" => Some(handle_tools_call(id, req.params, socket_addr, token).await),
+        "initialize" => Some(JsonRpcResponse::success(
+            id,
+            initialize_result(interaction_enabled),
+        )),
+        "tools/list" => Some(JsonRpcResponse::success(
+            id,
+            tools_list_result(interaction_enabled),
+        )),
+        "tools/call" => {
+            Some(handle_tools_call(id, req.params, socket_addr, token, interaction_enabled).await)
+        }
         _ => Some(JsonRpcResponse::error(
             id,
             error_codes::METHOD_NOT_FOUND,
@@ -122,12 +145,35 @@ async fn handle_request(
     }
 }
 
-fn initialize_result() -> Value {
+fn initialize_result(interaction_enabled: bool) -> Value {
     // The `instructions` field is the spec-blessed channel for telling the
     // host (and through it, the model) when this server is relevant. It
     // complements the per-tool description rather than duplicating it: the
     // tool description covers *how* to call `send_to_user`, this paragraph
     // covers *when* the whole server is the right tool to reach for.
+    let mut instructions = "The Claudette MCP server lets the agent deliver a \
+            file inline in the user's chat surface and gives agents native \
+            scheduling tools. Use `send_to_user` for deliverable artifacts. \
+            Do NOT use it for arbitrary binaries, archives, or oversized \
+            files; for those, tell the user the absolute path on disk. \
+            Use `ScheduleWakeup` for one-shot delayed re-entry, `CronCreate`, \
+            `CronList`, and `CronDelete` for recurring routines, and `Monitor` \
+            to subscribe to background task output without polling."
+        .to_string();
+    // Only advertise the interaction tools when the experimental feature is on
+    // — otherwise they aren't in `tools/list` and steering toward them would
+    // point the model at tools it can't call.
+    if interaction_enabled {
+        instructions.push_str(
+            " For interaction with the user, prefer these Claudette-native tools \
+            over plain chat text (and over harness-specific controls when \
+            present): `ask_user` to ask one or more questions and wait for the \
+            answer, `request_review` to have the user approve / deny / suggest \
+            changes to a plan or decision and wait for their verdict, and \
+            `present_conclusion` to deliver a final summary of completed work \
+            (it is recorded in the transcript).",
+        );
+    }
     json!({
         "protocolVersion": MCP_PROTOCOL_VERSION,
         "capabilities": {
@@ -137,25 +183,11 @@ fn initialize_result() -> Value {
             "name": SERVER_NAME,
             "version": env!("CARGO_PKG_VERSION"),
         },
-        "instructions": "The Claudette MCP server lets the agent deliver a \
-            file inline in the user's chat surface and gives agents native \
-            scheduling tools. Use `send_to_user` for deliverable artifacts. \
-            Do NOT use it for arbitrary binaries, archives, or oversized \
-            files; for those, tell the user the absolute path on disk. \
-            Use `ScheduleWakeup` for one-shot delayed re-entry, `CronCreate`, \
-            `CronList`, and `CronDelete` for recurring routines, and `Monitor` \
-            to subscribe to background task output without polling. \
-            For interaction with the user, prefer these Claudette-native tools \
-            over plain chat text (and over harness-specific controls when \
-            present): `ask_user` to ask one or more questions and wait for the \
-            answer, `request_review` to have the user approve / deny / suggest \
-            changes to a plan or decision and wait for their verdict, and \
-            `present_conclusion` to deliver a final summary of completed work \
-            (it is recorded in the transcript)."
+        "instructions": instructions,
     })
 }
 
-fn tools_list_result() -> Value {
+fn tools_list_result(interaction_enabled: bool) -> Value {
     let allowed_types: Vec<&str> = ALLOWED_IMAGE_TYPES
         .iter()
         .chain(ALLOWED_DOCUMENT_TYPES.iter())
@@ -163,7 +195,7 @@ fn tools_list_result() -> Value {
         .chain(allowed_text_types())
         .collect();
 
-    json!({
+    let mut result = json!({
         "tools": [{
             "name": SEND_TO_USER_TOOL_NAME,
             "description": "Deliver a file to the user inline in the Claudette chat surface. \
@@ -330,7 +362,21 @@ fn tools_list_result() -> Value {
                 "required": ["summary"]
             }
         }]
-    })
+    });
+
+    // Hide the interaction tools entirely when the experimental "Claudette MCP"
+    // feature is off, so the model never sees — or tries to call — ask_user /
+    // request_review / present_conclusion. Mirrors the env gate the grandchild
+    // was launched with; the base attachment + scheduling tools always remain.
+    if !interaction_enabled && let Some(tools) = result["tools"].as_array_mut() {
+        tools.retain(|t| {
+            !matches!(
+                t["name"].as_str(),
+                Some(ASK_USER_TOOL_NAME | REQUEST_REVIEW_TOOL_NAME | PRESENT_CONCLUSION_TOOL_NAME)
+            )
+        });
+    }
+    result
 }
 
 async fn handle_tools_call(
@@ -338,6 +384,7 @@ async fn handle_tools_call(
     params: Option<Value>,
     socket_addr: &str,
     token: &str,
+    interaction_enabled: bool,
 ) -> JsonRpcResponse {
     let params = match params {
         Some(p) => p,
@@ -352,6 +399,20 @@ async fn handle_tools_call(
 
     let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
     let args = params.get("arguments").cloned().unwrap_or(Value::Null);
+    // Defense in depth: the interaction tools aren't advertised when the
+    // experimental feature is off, but a stale/cached agent could still call
+    // one. Reject with method-not-found so it's treated as a non-existent tool.
+    let is_interaction_tool = matches!(
+        name,
+        ASK_USER_TOOL_NAME | REQUEST_REVIEW_TOOL_NAME | PRESENT_CONCLUSION_TOOL_NAME
+    );
+    if is_interaction_tool && !interaction_enabled {
+        return JsonRpcResponse::error(
+            id,
+            error_codes::METHOD_NOT_FOUND,
+            format!("no tool named {name:?}"),
+        );
+    }
     match name {
         SEND_TO_USER_TOOL_NAME => handle_send_to_user_tool(id, args, socket_addr, token).await,
         SCHEDULE_WAKEUP_TOOL_NAME => {
@@ -768,7 +829,12 @@ mod tests {
     /// Walk `serve` through a scripted set of input lines, collecting the
     /// JSON responses written back. The bridge connection is unused for
     /// inputs that don't reach `tools/call`.
-    async fn drive_serve(input: &str, socket_addr: &str, token: &str) -> Vec<Value> {
+    async fn drive_serve(
+        input: &str,
+        socket_addr: &str,
+        token: &str,
+        interaction_enabled: bool,
+    ) -> Vec<Value> {
         let (mut client, server) = duplex(64 * 1024);
         let (mut server_out, mut client_out) = duplex(64 * 1024);
 
@@ -783,9 +849,15 @@ mod tests {
         let token = token.to_string();
         let server_task = tokio::spawn(async move {
             let mut reader = BufReader::new(server);
-            super::serve(&mut reader, &mut server_out, &socket_addr, &token)
-                .await
-                .unwrap();
+            super::serve(
+                &mut reader,
+                &mut server_out,
+                &socket_addr,
+                &token,
+                interaction_enabled,
+            )
+            .await
+            .unwrap();
         });
 
         // Read all output.
@@ -810,7 +882,7 @@ mod tests {
             "params": {}
         });
         let input = format!("{req}\n");
-        let resps = drive_serve(&input, "ignored", "ignored").await;
+        let resps = drive_serve(&input, "ignored", "ignored", true).await;
         assert_eq!(resps.len(), 1);
         let r = &resps[0];
         assert_eq!(r["id"], 1);
@@ -843,7 +915,7 @@ mod tests {
             "method": "tools/list",
         });
         let input = format!("{req}\n");
-        let resps = drive_serve(&input, "ignored", "ignored").await;
+        let resps = drive_serve(&input, "ignored", "ignored", true).await;
         let tools = &resps[0]["result"]["tools"];
         assert!(tools.is_array());
         let names: Vec<&str> = tools
@@ -875,7 +947,7 @@ mod tests {
             "params": { "name": ASK_USER_TOOL_NAME, "arguments": {} }
         });
         let input = format!("{req}\n");
-        let resps = drive_serve(&input, "ignored", "ignored").await;
+        let resps = drive_serve(&input, "ignored", "ignored", true).await;
         assert_eq!(resps[0]["result"]["isError"], true);
         let text = resps[0]["result"]["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("questions is required"), "got: {text}");
@@ -890,8 +962,54 @@ mod tests {
             "params": { "name": REQUEST_REVIEW_TOOL_NAME, "arguments": { "summary": "  " } }
         });
         let input = format!("{req}\n");
-        let resps = drive_serve(&input, "ignored", "ignored").await;
+        let resps = drive_serve(&input, "ignored", "ignored", true).await;
         assert_eq!(resps[0]["result"]["isError"], true);
+    }
+
+    #[tokio::test]
+    async fn tools_list_hides_interaction_tools_when_disabled() {
+        // The whole point of the experimental gate: with interaction OFF, the
+        // 3 tools must not be advertised, but the base tools stay available.
+        let req = json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" });
+        let input = format!("{req}\n");
+        let resps = drive_serve(&input, "ignored", "ignored", false).await;
+        let names: Vec<&str> = resps[0]["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|t| t["name"].as_str())
+            .collect();
+        assert!(names.contains(&SEND_TO_USER_TOOL_NAME));
+        assert!(names.contains(&MONITOR_TOOL_NAME));
+        assert!(!names.contains(&ASK_USER_TOOL_NAME), "{names:?}");
+        assert!(!names.contains(&REQUEST_REVIEW_TOOL_NAME), "{names:?}");
+        assert!(!names.contains(&PRESENT_CONCLUSION_TOOL_NAME), "{names:?}");
+    }
+
+    #[tokio::test]
+    async fn interaction_tool_rejected_when_disabled() {
+        // Defense in depth: even if a stale agent calls ask_user with the
+        // feature off, it's treated as a non-existent method.
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 13,
+            "method": "tools/call",
+            "params": { "name": ASK_USER_TOOL_NAME, "arguments": { "questions": [] } }
+        });
+        let input = format!("{req}\n");
+        let resps = drive_serve(&input, "ignored", "ignored", false).await;
+        assert_eq!(resps[0]["error"]["code"], error_codes::METHOD_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn initialize_omits_interaction_guidance_when_disabled() {
+        let req = json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} });
+        let input = format!("{req}\n");
+        let resps = drive_serve(&input, "ignored", "ignored", false).await;
+        let instructions = resps[0]["result"]["instructions"].as_str().unwrap();
+        // Base guidance present, interaction guidance absent.
+        assert!(instructions.contains("send_to_user"));
+        assert!(!instructions.contains("ask_user"), "got: {instructions}");
     }
 
     #[tokio::test]
@@ -902,7 +1020,7 @@ mod tests {
             "method": "no/such/thing",
         });
         let input = format!("{req}\n");
-        let resps = drive_serve(&input, "ignored", "ignored").await;
+        let resps = drive_serve(&input, "ignored", "ignored", true).await;
         assert_eq!(resps[0]["error"]["code"], error_codes::METHOD_NOT_FOUND);
     }
 
@@ -913,14 +1031,14 @@ mod tests {
             "method": "notifications/initialized",
         });
         let input = format!("{req}\n");
-        let resps = drive_serve(&input, "ignored", "ignored").await;
+        let resps = drive_serve(&input, "ignored", "ignored", true).await;
         assert!(resps.is_empty(), "notifications must not get a response");
     }
 
     #[tokio::test]
     async fn parse_error_returns_jsonrpc_parse_error() {
         let input = "not-json\n";
-        let resps = drive_serve(input, "ignored", "ignored").await;
+        let resps = drive_serve(input, "ignored", "ignored", true).await;
         assert_eq!(resps[0]["error"]["code"], error_codes::PARSE_ERROR);
     }
 
@@ -964,7 +1082,7 @@ mod tests {
             }
         });
         let input = format!("{req}\n");
-        let resps = drive_serve(&input, &handle.socket_addr, &handle.token).await;
+        let resps = drive_serve(&input, &handle.socket_addr, &handle.token, true).await;
         assert_eq!(resps.len(), 1);
         let r = &resps[0];
         assert_eq!(r["id"], 7);
@@ -997,7 +1115,7 @@ mod tests {
             }
         });
         let input = format!("{req}\n");
-        let resps = drive_serve(&input, &handle.socket_addr, "wrong-token").await;
+        let resps = drive_serve(&input, &handle.socket_addr, "wrong-token", true).await;
         let r = &resps[0];
         assert_eq!(r["result"]["isError"], true);
         let text = r["result"]["content"][0]["text"].as_str().unwrap();

--- a/src/agent_mcp/server.rs
+++ b/src/agent_mcp/server.rs
@@ -25,6 +25,7 @@ use crate::agent_mcp::protocol::{
     BridgePayload, BridgeRequest, BridgeResponse, JsonRpcRequest, JsonRpcResponse,
     MCP_PROTOCOL_VERSION, error_codes,
 };
+use crate::agent_mcp::tools::interaction;
 use crate::agent_mcp::tools::send_to_user::{
     ALLOWED_DOCUMENT_TYPES, ALLOWED_IMAGE_TYPES, allowed_text_types,
 };
@@ -37,6 +38,9 @@ pub const CRON_CREATE_TOOL_NAME: &str = "CronCreate";
 pub const CRON_LIST_TOOL_NAME: &str = "CronList";
 pub const CRON_DELETE_TOOL_NAME: &str = "CronDelete";
 pub const MONITOR_TOOL_NAME: &str = "Monitor";
+pub const ASK_USER_TOOL_NAME: &str = "ask_user";
+pub const REQUEST_REVIEW_TOOL_NAME: &str = "request_review";
+pub const PRESENT_CONCLUSION_TOOL_NAME: &str = "present_conclusion";
 pub const SERVER_NAME: &str = "claudette";
 
 /// Run the stdio MCP server until stdin EOFs.
@@ -140,7 +144,14 @@ fn initialize_result() -> Value {
             files; for those, tell the user the absolute path on disk. \
             Use `ScheduleWakeup` for one-shot delayed re-entry, `CronCreate`, \
             `CronList`, and `CronDelete` for recurring routines, and `Monitor` \
-            to subscribe to background task output without polling."
+            to subscribe to background task output without polling. \
+            For interaction with the user, prefer these Claudette-native tools \
+            over plain chat text (and over harness-specific controls when \
+            present): `ask_user` to ask one or more questions and wait for the \
+            answer, `request_review` to have the user approve / deny / suggest \
+            changes to a plan or decision and wait for their verdict, and \
+            `present_conclusion` to deliver a final summary of completed work \
+            (it is recorded in the transcript)."
     })
 }
 
@@ -241,6 +252,83 @@ fn tools_list_result() -> Value {
                 },
                 "required": ["task_id"]
             }
+        }, {
+            "name": ASK_USER_TOOL_NAME,
+            "description": "REQUIRED way to ask the user a question in Claudette. Ask one or more \
+                           questions and BLOCK until they answer. Use this instead of asking in \
+                           plain chat text, and instead of any native/built-in question tool \
+                           (e.g. AskUserQuestion) — `mcp__claudette__ask_user` is the correct \
+                           tool here. Renders as interactive option buttons in the Claudette \
+                           chat surface (the user can also type a freeform answer). Returns the \
+                           user's answers keyed by question text.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "questions": {
+                        "type": "array",
+                        "description": "1–4 questions to ask.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "question": { "type": "string", "description": "The full question text." },
+                                "header": { "type": "string", "description": "Short label/chip for the question (optional)." },
+                                "multiSelect": { "type": "boolean", "description": "Allow selecting multiple options (optional)." },
+                                "options": {
+                                    "type": "array",
+                                    "description": "Up to 8 choices (optional). An 'Other'/freeform path always exists.",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "label": { "type": "string", "description": "The choice the user sees." },
+                                            "description": { "type": "string", "description": "Optional explanation of the choice." }
+                                        },
+                                        "required": ["label"]
+                                    }
+                                }
+                            },
+                            "required": ["question"]
+                        }
+                    }
+                },
+                "required": ["questions"]
+            }
+        }, {
+            "name": REQUEST_REVIEW_TOOL_NAME,
+            "description": "REQUIRED way to get the user's sign-off on a plan or decision in \
+                           Claudette. Ask the user to review and BLOCK until they respond with a \
+                           verdict: approve, deny, or suggest changes (with an optional note). \
+                           Call `mcp__claudette__request_review` (not plain chat) before acting \
+                           on a plan or any consequential, hard-to-reverse decision. Returns the \
+                           verdict and any note the user left.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "summary": { "type": "string", "description": "The plan or decision to review, as concise markdown." },
+                    "detail": { "type": "string", "description": "Optional additional detail / rationale shown below the summary." }
+                },
+                "required": ["summary"]
+            }
+        }, {
+            "name": PRESENT_CONCLUSION_TOOL_NAME,
+            "description": "Call `mcp__claudette__present_conclusion` when you finish a unit of \
+                           work to present a final summary. Recorded in the transcript and \
+                           surfaced to the user as a conclusion card. Does NOT block — use it as \
+                           you wrap up, not to ask a question. List any produced files in \
+                           `artifacts` (deliver them separately with send_to_user if the user \
+                           should see them inline).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "summary": { "type": "string", "description": "Markdown summary of what was done." },
+                    "title": { "type": "string", "description": "Optional short headline for the conclusion card." },
+                    "artifacts": {
+                        "type": "array",
+                        "description": "Optional list of file paths produced by the work.",
+                        "items": { "type": "string" }
+                    }
+                },
+                "required": ["summary"]
+            }
         }]
     })
 }
@@ -275,6 +363,11 @@ async fn handle_tools_call(
         }
         CRON_DELETE_TOOL_NAME => handle_cron_delete_tool(id, args, socket_addr, token).await,
         MONITOR_TOOL_NAME => handle_monitor_tool(id, args, socket_addr, token).await,
+        ASK_USER_TOOL_NAME => handle_ask_user_tool(id, args, socket_addr, token).await,
+        REQUEST_REVIEW_TOOL_NAME => handle_request_review_tool(id, args, socket_addr, token).await,
+        PRESENT_CONCLUSION_TOOL_NAME => {
+            handle_present_conclusion_tool(id, args, socket_addr, token).await
+        }
         _ => JsonRpcResponse::error(
             id,
             error_codes::METHOD_NOT_FOUND,
@@ -443,6 +536,88 @@ async fn handle_monitor_tool(
     .await
 }
 
+async fn handle_ask_user_tool(
+    id: Value,
+    args: Value,
+    socket_addr: &str,
+    token: &str,
+) -> JsonRpcResponse {
+    let questions = match args.get("questions") {
+        Some(q) => q.clone(),
+        None => return generic_tool_error_result(id, "questions is required"),
+    };
+    let questions = match interaction::validate_questions(&questions) {
+        Ok(q) => q,
+        Err(e) => return generic_tool_error_result(id, &e),
+    };
+    handle_simple_bridge_tool(id, BridgePayload::AskUser { questions }, socket_addr, token).await
+}
+
+async fn handle_request_review_tool(
+    id: Value,
+    args: Value,
+    socket_addr: &str,
+    token: &str,
+) -> JsonRpcResponse {
+    let summary = match args.get("summary").and_then(|v| v.as_str()) {
+        Some(s) => s.to_string(),
+        None => return generic_tool_error_result(id, "summary is required"),
+    };
+    if let Err(e) = interaction::validate_summary(&summary, "summary") {
+        return generic_tool_error_result(id, &e);
+    }
+    let detail = args
+        .get("detail")
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned);
+    handle_simple_bridge_tool(
+        id,
+        BridgePayload::RequestReview {
+            summary,
+            detail,
+            options: None,
+        },
+        socket_addr,
+        token,
+    )
+    .await
+}
+
+async fn handle_present_conclusion_tool(
+    id: Value,
+    args: Value,
+    socket_addr: &str,
+    token: &str,
+) -> JsonRpcResponse {
+    let summary = match args.get("summary").and_then(|v| v.as_str()) {
+        Some(s) => s.to_string(),
+        None => return generic_tool_error_result(id, "summary is required"),
+    };
+    if let Err(e) = interaction::validate_summary(&summary, "summary") {
+        return generic_tool_error_result(id, &e);
+    }
+    let title = args
+        .get("title")
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned);
+    let artifacts = args.get("artifacts").and_then(|v| v.as_array()).map(|arr| {
+        arr.iter()
+            .filter_map(|v| v.as_str().map(ToOwned::to_owned))
+            .collect::<Vec<_>>()
+    });
+    handle_simple_bridge_tool(
+        id,
+        BridgePayload::PresentConclusion {
+            title,
+            summary,
+            artifacts,
+        },
+        socket_addr,
+        token,
+    )
+    .await
+}
+
 async fn handle_simple_bridge_tool(
     id: Value,
     payload: BridgePayload,
@@ -462,9 +637,9 @@ async fn handle_simple_bridge_tool(
         }) => generic_tool_success_result(id, message.unwrap_or_else(|| "ok".to_string()), data),
         Ok(BridgeResponse {
             error: Some(msg), ..
-        }) => tool_error_result(id, &msg),
-        Ok(_) => tool_error_result(id, "bridge returned malformed response"),
-        Err(e) => tool_error_result(id, &format!("bridge IPC failed: {e}")),
+        }) => generic_tool_error_result(id, &msg),
+        Ok(_) => generic_tool_error_result(id, "bridge returned malformed response"),
+        Err(e) => generic_tool_error_result(id, &format!("bridge IPC failed: {e}")),
     }
 }
 
@@ -496,6 +671,19 @@ fn tool_error_result(id: Value, message: &str) -> JsonRpcResponse {
         id,
         json!({
             "content": [{ "type": "text", "text": format!("send_to_user failed: {message}") }],
+            "isError": true,
+        }),
+    )
+}
+
+/// Tool-result error without the `send_to_user`-specific prefix. Used by every
+/// tool that routes through [`handle_simple_bridge_tool`] (cron, scheduling,
+/// monitor, ask/review/conclude) so the message the model sees isn't mislabeled.
+fn generic_tool_error_result(id: Value, message: &str) -> JsonRpcResponse {
+    JsonRpcResponse::success(
+        id,
+        json!({
+            "content": [{ "type": "text", "text": message }],
             "isError": true,
         }),
     )
@@ -671,6 +859,39 @@ mod tests {
         assert!(names.contains(&SCHEDULE_WAKEUP_TOOL_NAME));
         assert!(names.contains(&CRON_CREATE_TOOL_NAME));
         assert!(names.contains(&MONITOR_TOOL_NAME));
+        assert!(names.contains(&ASK_USER_TOOL_NAME));
+        assert!(names.contains(&REQUEST_REVIEW_TOOL_NAME));
+        assert!(names.contains(&PRESENT_CONCLUSION_TOOL_NAME));
+    }
+
+    #[tokio::test]
+    async fn ask_user_rejects_missing_questions() {
+        // Validation happens in the grandchild before any bridge round trip,
+        // so a malformed call returns an isError result without a socket.
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "tools/call",
+            "params": { "name": ASK_USER_TOOL_NAME, "arguments": {} }
+        });
+        let input = format!("{req}\n");
+        let resps = drive_serve(&input, "ignored", "ignored").await;
+        assert_eq!(resps[0]["result"]["isError"], true);
+        let text = resps[0]["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("questions is required"), "got: {text}");
+    }
+
+    #[tokio::test]
+    async fn request_review_rejects_empty_summary() {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": { "name": REQUEST_REVIEW_TOOL_NAME, "arguments": { "summary": "  " } }
+        });
+        let input = format!("{req}\n");
+        let resps = drive_serve(&input, "ignored", "ignored").await;
+        assert_eq!(resps[0]["result"]["isError"], true);
     }
 
     #[tokio::test]

--- a/src/agent_mcp/tools/interaction.rs
+++ b/src/agent_mcp/tools/interaction.rs
@@ -1,0 +1,201 @@
+//! `ask_user`, `request_review`, `present_conclusion` — agent-callable MCP
+//! tools that let *any* backend surface an interactive prompt to the user
+//! through Claudette's own UI (not the Claude-CLI-only `AskUserQuestion` /
+//! `ExitPlanMode` controls).
+//!
+//! This module owns only the validation + input-shaping policy. The blocking
+//! round-trip (register a pending control, await the user's answer) lives
+//! parent-side in `agent_mcp_sink` (Tauri crate); the wire payloads are the
+//! `BridgePayload::{AskUser, RequestReview, PresentConclusion}` variants.
+//!
+//! Two seams import these helpers:
+//! - the MCP server (grandchild) calls the `validate_*` functions before it
+//!   ships a payload, so malformed agent input fails fast as a tool error
+//!   without a socket round-trip;
+//! - the sink (parent) calls the `*_card_input` shapers to build the
+//!   `original_input` the existing frontend cards already know how to render.
+
+use serde_json::{Value, json};
+
+/// Hard cap on questions per `ask_user` call. Mirrors the 1–4 range the
+/// native `AskUserQuestion` UI is designed around (see `AgentQuestionCard`).
+pub const MAX_QUESTIONS: usize = 4;
+/// Hard cap on options per question. The card renders these as buttons; an
+/// "Other"/freeform path always exists, so the model never needs more.
+pub const MAX_OPTIONS_PER_QUESTION: usize = 8;
+/// Bound on free-text fields so a prompt-injected or runaway call can't push
+/// a multi-megabyte string through the socket and into a DB row / UI label.
+pub const MAX_SUMMARY_LEN: usize = 16_384;
+
+/// Validate the agent-supplied `questions` argument for `ask_user`.
+///
+/// Returns the normalized question array on success (ready to embed in the
+/// `BridgePayload::AskUser`), or an `Err(reason)` the server surfaces back to
+/// the model so it can fix the call. Each question must have a non-empty
+/// `question` string; `options`, `header`, and `multiSelect` are optional and
+/// passed through so the existing card renders them.
+pub fn validate_questions(value: &Value) -> Result<Value, String> {
+    let arr = value
+        .as_array()
+        .ok_or("`questions` must be an array of question objects")?;
+    if arr.is_empty() {
+        return Err("`questions` must contain at least one question".into());
+    }
+    if arr.len() > MAX_QUESTIONS {
+        return Err(format!(
+            "`questions` may contain at most {MAX_QUESTIONS} questions, got {}",
+            arr.len()
+        ));
+    }
+    for (i, q) in arr.iter().enumerate() {
+        let obj = q
+            .as_object()
+            .ok_or_else(|| format!("question {i} must be an object"))?;
+        let text = obj
+            .get("question")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("question {i} is missing a `question` string"))?;
+        if text.trim().is_empty() {
+            return Err(format!("question {i} has an empty `question`"));
+        }
+        if text.len() > MAX_SUMMARY_LEN {
+            return Err(format!("question {i} `question` text is too long"));
+        }
+        if let Some(opts) = obj.get("options") {
+            let opts = opts
+                .as_array()
+                .ok_or_else(|| format!("question {i} `options` must be an array"))?;
+            if opts.len() > MAX_OPTIONS_PER_QUESTION {
+                return Err(format!(
+                    "question {i} may have at most {MAX_OPTIONS_PER_QUESTION} options"
+                ));
+            }
+            for (j, opt) in opts.iter().enumerate() {
+                let has_label = opt
+                    .as_object()
+                    .and_then(|o| o.get("label"))
+                    .and_then(Value::as_str)
+                    .is_some_and(|s| !s.trim().is_empty());
+                if !has_label {
+                    return Err(format!(
+                        "question {i} option {j} is missing a non-empty `label`"
+                    ));
+                }
+            }
+        }
+    }
+    Ok(value.clone())
+}
+
+/// Validate the `summary` shared by `request_review` and `present_conclusion`.
+pub fn validate_summary(summary: &str, field: &str) -> Result<(), String> {
+    if summary.trim().is_empty() {
+        return Err(format!("`{field}` must not be empty"));
+    }
+    if summary.len() > MAX_SUMMARY_LEN {
+        return Err(format!(
+            "`{field}` is too long ({} bytes, max {MAX_SUMMARY_LEN})",
+            summary.len()
+        ));
+    }
+    Ok(())
+}
+
+/// Shape an `ask_user` request into the `original_input` the existing
+/// `AgentQuestionCard` renders. The card keys off `questions`, exactly like
+/// the native `AskUserQuestion` tool input — so the same component works
+/// regardless of which backend asked.
+pub fn ask_card_input(questions: Value) -> Value {
+    json!({ "questions": questions })
+}
+
+/// Shape a `request_review` request into the `original_input` the existing
+/// `PlanApprovalCard` renders (which keys off `plan`). The `claudetteReview`
+/// marker lets the frontend distinguish a Claudette-native review (which
+/// offers the approve/deny/**suggest** verdicts) from a native `ExitPlanMode`
+/// (approve/deny only).
+pub fn review_card_input(summary: &str, detail: Option<&str>) -> Value {
+    let plan = match detail {
+        Some(d) if !d.trim().is_empty() => format!("{summary}\n\n{d}"),
+        _ => summary.to_string(),
+    };
+    json!({
+        "plan": plan,
+        "claudetteReview": true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_non_array_questions() {
+        assert!(validate_questions(&json!({"question": "x"})).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_questions() {
+        assert!(validate_questions(&json!([])).is_err());
+    }
+
+    #[test]
+    fn rejects_too_many_questions() {
+        let qs: Vec<Value> = (0..MAX_QUESTIONS + 1)
+            .map(|i| json!({"question": format!("q{i}")}))
+            .collect();
+        assert!(validate_questions(&Value::Array(qs)).is_err());
+    }
+
+    #[test]
+    fn rejects_question_without_text() {
+        assert!(validate_questions(&json!([{"header": "h"}])).is_err());
+        assert!(validate_questions(&json!([{"question": "   "}])).is_err());
+    }
+
+    #[test]
+    fn rejects_option_without_label() {
+        let v = json!([{"question": "q", "options": [{"description": "d"}]}]);
+        assert!(validate_questions(&v).is_err());
+    }
+
+    #[test]
+    fn accepts_well_formed_questions() {
+        let v = json!([{
+            "question": "Pick one",
+            "header": "Choice",
+            "multiSelect": false,
+            "options": [{"label": "A", "description": "first"}, {"label": "B"}]
+        }]);
+        assert_eq!(validate_questions(&v).unwrap(), v);
+    }
+
+    #[test]
+    fn summary_validation() {
+        assert!(validate_summary("", "summary").is_err());
+        assert!(validate_summary("   ", "summary").is_err());
+        assert!(validate_summary("ok", "summary").is_ok());
+        let huge = "x".repeat(MAX_SUMMARY_LEN + 1);
+        assert!(validate_summary(&huge, "summary").is_err());
+    }
+
+    #[test]
+    fn ask_card_input_wraps_questions() {
+        let qs = json!([{"question": "q"}]);
+        let input = ask_card_input(qs.clone());
+        assert_eq!(input["questions"], qs);
+    }
+
+    #[test]
+    fn review_card_input_merges_detail_and_marks_native() {
+        let input = review_card_input("Summary", Some("Detail"));
+        assert_eq!(input["claudetteReview"], true);
+        let plan = input["plan"].as_str().unwrap();
+        assert!(plan.contains("Summary"));
+        assert!(plan.contains("Detail"));
+
+        // No detail → plan is just the summary.
+        let input = review_card_input("Only summary", None);
+        assert_eq!(input["plan"], "Only summary");
+    }
+}

--- a/src/agent_mcp/tools/interaction.rs
+++ b/src/agent_mcp/tools/interaction.rs
@@ -110,17 +110,20 @@ pub fn ask_card_input(questions: Value) -> Value {
 }
 
 /// Shape a `request_review` request into the `original_input` the existing
-/// `PlanApprovalCard` renders (which keys off `plan`). The `claudetteReview`
-/// marker lets the frontend distinguish a Claudette-native review (which
-/// offers the approve/deny/**suggest** verdicts) from a native `ExitPlanMode`
-/// (approve/deny only).
+/// `PlanApprovalCard` renders. The card's inline preview reads the plan text
+/// from `codexPlanContent` (see the `ExitPlanMode` branch in
+/// `useAgentStream.ts`), so the merged summary/detail goes there — using `plan`
+/// would leave the card with no visible content. The `claudetteReview` marker
+/// lets the frontend distinguish a Claudette-native review (approve / deny /
+/// suggest) from a native `ExitPlanMode`. Note we do NOT set `codexSyntheticPlan`,
+/// so the card keeps `source: "claude"` and skips Codex's auto-message flow.
 pub fn review_card_input(summary: &str, detail: Option<&str>) -> Value {
     let plan = match detail {
         Some(d) if !d.trim().is_empty() => format!("{summary}\n\n{d}"),
         _ => summary.to_string(),
     };
     json!({
-        "plan": plan,
+        "codexPlanContent": plan,
         "claudetteReview": true,
     })
 }
@@ -188,14 +191,17 @@ mod tests {
 
     #[test]
     fn review_card_input_merges_detail_and_marks_native() {
+        // The plan text must land in `codexPlanContent` — the field the existing
+        // PlanApprovalCard inline preview actually renders. Using `plan` would
+        // leave the card blank.
         let input = review_card_input("Summary", Some("Detail"));
         assert_eq!(input["claudetteReview"], true);
-        let plan = input["plan"].as_str().unwrap();
+        let plan = input["codexPlanContent"].as_str().unwrap();
         assert!(plan.contains("Summary"));
         assert!(plan.contains("Detail"));
 
-        // No detail → plan is just the summary.
+        // No detail → content is just the summary.
         let input = review_card_input("Only summary", None);
-        assert_eq!(input["plan"], "Only summary");
+        assert_eq!(input["codexPlanContent"], "Only summary");
     }
 }

--- a/src/agent_mcp/tools/mod.rs
+++ b/src/agent_mcp/tools/mod.rs
@@ -1,1 +1,2 @@
+pub mod interaction;
 pub mod send_to_user;

--- a/src/db/chat.rs
+++ b/src/db/chat.rs
@@ -7,7 +7,9 @@
 
 use rusqlite::{OptionalExtension, params};
 
-use crate::model::{AgentStatus, Attachment, AttachmentOrigin, ChatMessage, ChatSession};
+use crate::model::{
+    AgentConclusion, AgentStatus, Attachment, AttachmentOrigin, ChatMessage, ChatSession,
+};
 
 use super::Database;
 
@@ -57,6 +59,73 @@ impl Database {
             ],
         )?;
         Ok(())
+    }
+
+    // --- Agent conclusions ---
+
+    /// Persist a conclusion presented by the agent via `present_conclusion`.
+    /// `artifacts` is stored as a JSON array string in `artifacts_json`.
+    pub fn insert_agent_conclusion(
+        &self,
+        conclusion: &AgentConclusion,
+    ) -> Result<(), rusqlite::Error> {
+        let artifacts_json = if conclusion.artifacts.is_empty() {
+            None
+        } else {
+            Some(
+                serde_json::to_string(&conclusion.artifacts)
+                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?,
+            )
+        };
+        self.conn.execute(
+            "INSERT INTO agent_conclusions (
+                id, chat_session_id, workspace_id, message_id, title, summary,
+                artifacts_json, created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                conclusion.id,
+                conclusion.chat_session_id,
+                conclusion.workspace_id,
+                conclusion.message_id,
+                conclusion.title,
+                conclusion.summary,
+                artifacts_json,
+                conclusion.created_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// List conclusions for a chat session, oldest first (transcript order).
+    pub fn list_agent_conclusions_for_session(
+        &self,
+        chat_session_id: &str,
+    ) -> Result<Vec<AgentConclusion>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, chat_session_id, workspace_id, message_id, title, summary, \
+                    artifacts_json, created_at \
+             FROM agent_conclusions WHERE chat_session_id = ?1 ORDER BY created_at ASC",
+        )?;
+        let rows = stmt.query_map(params![chat_session_id], Self::parse_agent_conclusion_row)?;
+        rows.collect()
+    }
+
+    fn parse_agent_conclusion_row(row: &rusqlite::Row) -> rusqlite::Result<AgentConclusion> {
+        let artifacts_json: Option<String> = row.get(6)?;
+        let artifacts = artifacts_json
+            .as_deref()
+            .and_then(|s| serde_json::from_str::<Vec<String>>(s).ok())
+            .unwrap_or_default();
+        Ok(AgentConclusion {
+            id: row.get(0)?,
+            chat_session_id: row.get(1)?,
+            workspace_id: row.get(2)?,
+            message_id: row.get(3)?,
+            title: row.get(4)?,
+            summary: row.get(5)?,
+            artifacts,
+            created_at: row.get(7)?,
+        })
     }
 
     pub(super) fn parse_chat_message_row(row: &rusqlite::Row) -> rusqlite::Result<ChatMessage> {
@@ -822,7 +891,7 @@ impl Database {
 mod tests {
     use super::*;
     use crate::db::test_support::*;
-    use crate::model::ChatRole;
+    use crate::model::{AgentConclusion, ChatRole};
 
     fn make_attachment(id: &str, message_id: &str, filename: &str) -> Attachment {
         Attachment {
@@ -859,6 +928,85 @@ mod tests {
         assert_eq!(msgs.len(), 2);
         assert_eq!(msgs[0].content, "hello");
         assert_eq!(msgs[1].content, "hi there");
+    }
+
+    // --- Agent conclusion tests ---
+
+    #[test]
+    fn insert_and_list_agent_conclusions() {
+        let db = setup_db_with_workspace();
+        let sid = db.default_session_id_for_workspace("w1").unwrap().unwrap();
+        // Anchor message (FK to chat_messages).
+        db.insert_chat_message(&make_chat_msg(
+            &db,
+            "m1",
+            "w1",
+            ChatRole::User,
+            "do the thing",
+        ))
+        .unwrap();
+
+        let c = AgentConclusion {
+            id: "c1".into(),
+            chat_session_id: sid.clone(),
+            workspace_id: "w1".into(),
+            message_id: Some("m1".into()),
+            title: Some("Done".into()),
+            summary: "Refactored 3 files.".into(),
+            artifacts: vec!["/tmp/report.md".into()],
+            created_at: "2026-06-11T00:00:00Z".into(),
+        };
+        db.insert_agent_conclusion(&c).unwrap();
+
+        let rows = db.list_agent_conclusions_for_session(&sid).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].summary, "Refactored 3 files.");
+        assert_eq!(rows[0].artifacts, vec!["/tmp/report.md".to_string()]);
+        assert_eq!(rows[0].title.as_deref(), Some("Done"));
+        assert_eq!(rows[0].message_id.as_deref(), Some("m1"));
+    }
+
+    #[test]
+    fn conclusion_without_artifacts_round_trips_empty() {
+        let db = setup_db_with_workspace();
+        let sid = db.default_session_id_for_workspace("w1").unwrap().unwrap();
+        let c = AgentConclusion {
+            id: "c1".into(),
+            chat_session_id: sid.clone(),
+            workspace_id: "w1".into(),
+            message_id: None,
+            title: None,
+            summary: "Nothing produced.".into(),
+            artifacts: vec![],
+            created_at: "2026-06-11T00:00:00Z".into(),
+        };
+        db.insert_agent_conclusion(&c).unwrap();
+
+        let rows = db.list_agent_conclusions_for_session(&sid).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].artifacts.is_empty());
+        assert!(rows[0].message_id.is_none());
+    }
+
+    #[test]
+    fn conclusion_cascades_when_session_deleted() {
+        let db = setup_db_with_workspace();
+        let sid = db.default_session_id_for_workspace("w1").unwrap().unwrap();
+        db.insert_agent_conclusion(&AgentConclusion {
+            id: "c1".into(),
+            chat_session_id: sid.clone(),
+            workspace_id: "w1".into(),
+            message_id: None,
+            title: None,
+            summary: "done".into(),
+            artifacts: vec![],
+            created_at: "2026-06-11T00:00:00Z".into(),
+        })
+        .unwrap();
+        // Deleting the workspace cascades chat_sessions → agent_conclusions.
+        db.delete_workspace("w1").unwrap();
+        let rows = db.list_agent_conclusions_for_session(&sid).unwrap();
+        assert!(rows.is_empty());
     }
 
     #[test]

--- a/src/global_prompt.rs
+++ b/src/global_prompt.rs
@@ -10,7 +10,7 @@ pub const GLOBAL_SYSTEM_PROMPT: &str = include_str!("global-system-prompt.md");
 /// when no layer contributes content, so the caller can skip the CLI
 /// flag entirely rather than pass an empty string.
 ///
-/// `claude_code_rules` should be `Some(CLAUDE_CODE_MCP_RULES)` for Claude
+/// `claude_code_rules` should be `Some(&claude_code_mcp_rules(...))` for Claude
 /// CLI runs and `None` for harnesses that don't expose those MCP tools
 /// (Pi SDK, Codex app-server) — telling a qwen / GPT model to call
 /// `AskUserQuestion` or `ExitPlanMode` instructs it to use tools that
@@ -155,10 +155,25 @@ mod tests {
     }
 
     #[test]
-    fn claude_cli_path_includes_claude_code_rules() {
-        let rules = crate::agent_mcp::CLAUDE_CODE_MCP_RULES;
-        let composed = compose_system_prompt(Some("REPO"), None, Some(rules)).unwrap();
-        assert!(composed.contains("AskUserQuestion"));
+    fn claude_cli_rules_steer_to_claudette_tools_when_enabled() {
+        // Default (Agent Interaction on): the question/decision mandate points
+        // at our MCP tools, not the look-alike native AskUserQuestion. The
+        // plan-mode lifecycle rule (ExitPlanMode) is always present.
+        let rules = crate::agent_mcp::claude_code_mcp_rules(true);
+        let composed = compose_system_prompt(Some("REPO"), None, Some(&rules)).unwrap();
+        assert!(composed.contains("mcp__claudette__ask_user"));
+        assert!(composed.contains("mcp__claudette__request_review"));
+        assert!(composed.contains("ExitPlanMode"));
+    }
+
+    #[test]
+    fn claude_cli_rules_fall_back_to_native_when_disabled() {
+        // With our interaction tools disabled, fall back to mandating the
+        // native AskUserQuestion so the model still asks via a tool.
+        let rules = crate::agent_mcp::claude_code_mcp_rules(false);
+        let composed = compose_system_prompt(Some("REPO"), None, Some(&rules)).unwrap();
+        assert!(composed.contains("`AskUserQuestion`"));
+        assert!(!composed.contains("mcp__claudette__ask_user"));
         assert!(composed.contains("ExitPlanMode"));
     }
 

--- a/src/migrations/20260611120000_agent_conclusions.sql
+++ b/src/migrations/20260611120000_agent_conclusions.sql
@@ -1,0 +1,18 @@
+-- Persisted "conclusion of the work" cards presented by the agent via the
+-- `present_conclusion` MCP tool. Kept in their own table (rather than as a new
+-- chat_messages kind) so the widely-constructed ChatMessage struct stays
+-- unchanged. Anchored to the user message that triggered the turn (nullable)
+-- so the FK cascade removes the conclusion when that turn is rolled back.
+CREATE TABLE IF NOT EXISTS agent_conclusions (
+    id              TEXT PRIMARY KEY,
+    chat_session_id TEXT NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+    workspace_id    TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    message_id      TEXT REFERENCES chat_messages(id) ON DELETE CASCADE,
+    title           TEXT,
+    summary         TEXT NOT NULL,
+    artifacts_json  TEXT,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_conclusions_session
+    ON agent_conclusions(chat_session_id, created_at);

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -264,4 +264,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260521212019_agent_scheduled_task_failures.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260611120000_agent_conclusions",
+        sql: include_str!("20260611120000_agent_conclusions.sql"),
+        legacy_version: None,
+    },
 ];

--- a/src/model/agent_conclusion.rs
+++ b/src/model/agent_conclusion.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+/// A finished-work conclusion the agent presented via the `present_conclusion`
+/// MCP tool. Persisted in `agent_conclusions` so it survives reload/export and
+/// can be rendered inline in the transcript as a conclusion card.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentConclusion {
+    pub id: String,
+    pub chat_session_id: String,
+    pub workspace_id: String,
+    /// User message that triggered the turn this conclusion belongs to, used
+    /// as the FK anchor so a rollback removes the conclusion too. `None` when
+    /// there was no in-flight turn to anchor against.
+    pub message_id: Option<String>,
+    pub title: Option<String>,
+    pub summary: String,
+    /// Paths the agent listed as artifacts of the work. Stored as a JSON array
+    /// in the `artifacts_json` column; always present (possibly empty) here.
+    pub artifacts: Vec<String>,
+    pub created_at: String,
+}

--- a/src/model/agent_conclusion.rs
+++ b/src/model/agent_conclusion.rs
@@ -3,8 +3,11 @@ use serde::Serialize;
 /// A finished-work conclusion the agent presented via the `present_conclusion`
 /// MCP tool. Persisted in `agent_conclusions` so it survives reload/export and
 /// can be rendered inline in the transcript as a conclusion card.
+///
+/// Serialized snake_case to match the rest of the chat domain (`ChatMessage`,
+/// `Attachment`) so the frontend `AgentConclusion` type and the
+/// `agent-conclusion-created` event payload share one field convention.
 #[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct AgentConclusion {
     pub id: String,
     pub chat_session_id: String,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,3 +1,4 @@
+mod agent_conclusion;
 mod attachment;
 pub mod cesp;
 mod chat_message;
@@ -12,6 +13,7 @@ mod repository_input;
 mod terminal_tab;
 mod workspace;
 
+pub use agent_conclusion::AgentConclusion;
 pub use attachment::{Attachment, AttachmentOrigin};
 pub use cesp::{
     CespCategorySounds, CespManifest, CespSound, InstalledPack, InstalledPackMeta, RegistryIndex,

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -73,6 +73,7 @@ function App() {
   const setSystemFonts = useAppStore((s) => s.setSystemFonts);
   const setDetectedApps = useAppStore((s) => s.setDetectedApps);
   const setUsageInsightsEnabled = useAppStore((s) => s.setUsageInsightsEnabled);
+  const setClaudetteMcpEnabled = useAppStore((s) => s.setClaudetteMcpEnabled);
   const setProjectViewIssuesPrsEnabled = useAppStore(
     (s) => s.setProjectViewIssuesPrsEnabled,
   );
@@ -382,6 +383,9 @@ function App() {
 
     getAppSetting("usage_insights_enabled")
       .then((val) => { if (val === "true") setUsageInsightsEnabled(true); })
+      .catch(() => {});
+    getAppSetting("claudette_mcp_enabled")
+      .then((val) => { if (val === "true") setClaudetteMcpEnabled(true); })
       .catch(() => {});
     getAppSetting("project_view_issues_prs_enabled")
       .then((val) => { if (val === "true") setProjectViewIssuesPrsEnabled(true); })
@@ -958,7 +962,7 @@ function App() {
       unlistenMissingCli.then((fn) => fn());
       unlistenMissingWorktree.then((fn) => fn());
     };
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultTerminalAppId, setWorkspaceAppsMenuShown, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setProjectViewIssuesPrsEnabled, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setToolDisplayMode, setExtendedToolCallOutput, setAlternativeBackendsAvailable, setPiSdkAvailable, setAlternativeBackendsEnabled, setCodexEnabled, setAgentBackends, setDefaultAgentBackendId, setClaudeAuthMethod, setEditorGitGutterBase, setEditorMinimapEnabled, setRevealActiveFileInTree, setEditorWordWrap, setEditorLineNumbersEnabled, setEditorFontZoom, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings, setManualWorkspaceOrderByRepo, hydrateWorkspaceScmLinks]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultTerminalAppId, setWorkspaceAppsMenuShown, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setClaudetteMcpEnabled, setProjectViewIssuesPrsEnabled, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setToolDisplayMode, setExtendedToolCallOutput, setAlternativeBackendsAvailable, setPiSdkAvailable, setAlternativeBackendsEnabled, setCodexEnabled, setAgentBackends, setDefaultAgentBackendId, setClaudeAuthMethod, setEditorGitGutterBase, setEditorMinimapEnabled, setRevealActiveFileInTree, setEditorWordWrap, setEditorLineNumbersEnabled, setEditorFontZoom, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings, setManualWorkspaceOrderByRepo, hydrateWorkspaceScmLinks]);
 
   // Live freshness for LM Studio's `loaded_context_length`.
   //

--- a/src/ui/src/components/chat/ConclusionCard.module.css
+++ b/src/ui/src/components/chat/ConclusionCard.module.css
@@ -1,0 +1,103 @@
+/* Conclusion card — shares visual language with PlanApprovalCard, but is
+   purely presentational: the markdown body is always expanded (no
+   click-to-reveal), and there are no permissions or actions.
+
+   Prose styling is intentionally NOT re-cloned here: <MessageMarkdown> ships
+   its own typography (the `.body` wrapper in MessageMarkdown.module.css), so
+   the conclusion renders identically to assistant messages. */
+.card {
+  background: var(--chat-system-bg);
+  border: 1px solid var(--accent-bg-strong);
+  border-left: 3px solid var(--accent-primary);
+  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+  padding: var(--space-4) var(--space-5);
+  margin: var(--space-3) 0;
+  box-shadow: var(--shadow-md);
+}
+
+.label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent-primary);
+  margin-bottom: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Completion cue — distinguishes a conclusion at a glance from the plan /
+   question cards, which carry no leading glyph (or a "?"). */
+.label::before {
+  content: "\2713"; /* ✓ */
+  font-size: 13px;
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.4;
+  margin-bottom: 10px;
+}
+
+.content {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-primary);
+}
+
+.artifacts {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--divider);
+}
+
+.artifactsLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-bottom: 6px;
+}
+
+.artifactsList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+}
+
+.artifactItem {
+  margin: 0;
+  max-width: 100%;
+}
+
+.artifactLink {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background: var(--hover-bg-subtle);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  color: var(--accent-primary);
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.artifactLink:hover {
+  border-color: rgba(var(--accent-primary-rgb), 0.3);
+  background: rgba(var(--accent-primary-rgb), 0.05);
+}

--- a/src/ui/src/components/chat/ConclusionCard.tsx
+++ b/src/ui/src/components/chat/ConclusionCard.tsx
@@ -1,0 +1,63 @@
+import { useTranslation } from "react-i18next";
+import type { AgentConclusion } from "../../types";
+import { MessageMarkdown } from "./MessageMarkdown";
+import { useWorkspaceFileOpener } from "./useWorkspaceFileOpener";
+import styles from "./ConclusionCard.module.css";
+
+interface ConclusionCardProps {
+  conclusion: AgentConclusion;
+  /** Owning workspace, so file-path links in the summary (and the artifact
+   *  list) route into this workspace's Monaco tab — same as PlanApprovalCard. */
+  workspaceId: string;
+}
+
+/**
+ * Renders a finished-work conclusion the agent presented via
+ * `mcp__claudette__present_conclusion`. Takes its visual cues from
+ * `PlanApprovalCard` but is purely presentational: the markdown body is
+ * expanded by default (no click-to-reveal) and there are no permissions or
+ * approve/deny actions.
+ */
+export function ConclusionCard({ conclusion, workspaceId }: ConclusionCardProps) {
+  const { t } = useTranslation("chat");
+  const { openFile, resolveFilePath } = useWorkspaceFileOpener(workspaceId);
+  const title = conclusion.title?.trim();
+  const artifacts = conclusion.artifacts.filter((p) => p.trim() !== "");
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.label}>{t("conclusion_label")}</div>
+      {title && <div className={styles.title}>{title}</div>}
+      <div className={styles.content}>
+        <MessageMarkdown
+          content={conclusion.summary}
+          onOpenFile={openFile}
+          resolveFilePath={resolveFilePath}
+        />
+      </div>
+      {artifacts.length > 0 && (
+        <div className={styles.artifacts}>
+          <div className={styles.artifactsLabel}>
+            {t("conclusion_artifacts")}
+          </div>
+          <ul className={styles.artifactsList}>
+            {artifacts.map((path, i) => (
+              <li key={`${path}-${i}`} className={styles.artifactItem}>
+                <button
+                  type="button"
+                  className={styles.artifactLink}
+                  onClick={() => {
+                    openFile(path);
+                  }}
+                  title={path}
+                >
+                  {path}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/MessagesWithTurns.test.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.test.tsx
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useAppStore, type CompletedTurn, type ToolActivity } from "../../stores/useAppStore";
-import type { ChatMessage } from "../../types/chat";
+import type { AgentConclusion, ChatMessage } from "../../types/chat";
 import { MessagesWithTurns } from "./MessagesWithTurns";
 
 const serviceMocks = vi.hoisted(() => ({
@@ -778,5 +778,69 @@ describe("MessagesWithTurns edit summaries", () => {
     expect(container.textContent).toContain("1 file changed");
     expect(container.textContent).toContain("src/app.ts");
     expect(container.textContent).not.toContain("dirty-from-other-session.ts");
+  });
+});
+
+describe("MessagesWithTurns conclusion gating", () => {
+  function conclusion(summary: string): AgentConclusion {
+    return {
+      id: "conclusion-1",
+      chat_session_id: SESSION_ID,
+      workspace_id: WORKSPACE_ID,
+      // Anchored to the user message that triggered the turn; routes to the
+      // turn's assistant message for rendering (see conclusionsByMessage).
+      message_id: "user-1",
+      title: null,
+      summary,
+      artifacts: [],
+      created_at: "2026-05-08T00:00:00.000Z",
+    };
+  }
+
+  const messages = [
+    message("user-1", "User", "Wrap it up"),
+    message("assistant-1", "Assistant", "On it."),
+  ];
+
+  it("renders conclusion cards when the Claudette MCP flag is on", async () => {
+    useAppStore.setState({
+      claudetteMcpEnabled: true,
+      chatConclusions: { [SESSION_ID]: [conclusion("Shipped the migration.")] },
+    });
+
+    const container = await render(
+      <MessagesWithTurns
+        messages={messages}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        isRunning={false}
+        searchQuery=""
+        toolDisplayMode="grouped"
+      />,
+    );
+
+    expect(container.textContent).toContain("Shipped the migration.");
+  });
+
+  it("hides already-loaded conclusion cards when the flag is off", async () => {
+    // Mirrors flipping the experimental flag off mid-session: the conclusions
+    // are still in the store, but the feature must stay fully dark.
+    useAppStore.setState({
+      claudetteMcpEnabled: false,
+      chatConclusions: { [SESSION_ID]: [conclusion("Shipped the migration.")] },
+    });
+
+    const container = await render(
+      <MessagesWithTurns
+        messages={messages}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        isRunning={false}
+        searchQuery=""
+        toolDisplayMode="grouped"
+      />,
+    );
+
+    expect(container.textContent).not.toContain("Shipped the migration.");
   });
 });

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -164,6 +164,11 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   const chatConclusions = useAppStore(
     (s) => s.chatConclusions[sessionId] ?? EMPTY_CONCLUSIONS,
   );
+  // Conclusions only render when the experimental "Claudette MCP" flag is on.
+  // History load already skips fetching them when off, but a session that had
+  // them loaded (flag toggled off mid-session) or a stray live event must also
+  // stay dark — so we gate the render below, not just the fetch.
+  const claudetteMcpEnabled = useAppStore((s) => s.claudetteMcpEnabled);
   const worktreePath = useAppStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.worktree_path,
   );
@@ -253,9 +258,9 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   // *user* message that triggered the turn; re-route each to that turn's
   // *assistant* message so the card renders at the end of the turn. Mirrors the
   // attachment routing above (kept separate so its dependency set is just
-  // conclusions + messages).
+  // conclusions + messages + the experimental flag gate).
   const conclusionsByMessage = useMemo(() => {
-    if (chatConclusions.length === 0)
+    if (!claudetteMcpEnabled || chatConclusions.length === 0)
       return new Map<string, AgentConclusion[]>();
     const userToNextAssistant = new Map<string, string>();
     const loadedMessageIds = new Set<string>();
@@ -297,7 +302,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
       else map.set(targetId, [c]);
     }
     return map;
-  }, [chatConclusions, messages]);
+  }, [chatConclusions, messages, claudetteMcpEnabled]);
 
   // CompletedTurn.afterMessageIndex is GLOBAL (counts from message 0 of the
   // session, not from the loaded window). Shift to local before indexing into

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -4,7 +4,7 @@ import { useAppStore } from "../../stores/useAppStore";
 import type { ToolDisplayMode } from "../../stores/slices/settingsSlice";
 import type { CompletedTurn, ToolActivity } from "../../stores/useAppStore";
 import { loadAttachmentData } from "../../services/tauri";
-import type { ChatMessage, ChatAttachment } from "../../types/chat";
+import type { AgentConclusion, ChatMessage, ChatAttachment } from "../../types/chat";
 import { roleClassKey, shouldRenderAsMarkdown } from "./messageRendering";
 import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
 import { HighlightedPlainText } from "./HighlightedPlainText";
@@ -67,8 +67,10 @@ import {
   EMPTY_ATTACHMENTS,
   EMPTY_CHECKPOINTS,
   EMPTY_COMPLETED_TURNS,
+  EMPTY_CONCLUSIONS,
   type RollbackModalData,
 } from "./chatConstants";
+import { ConclusionCard } from "./ConclusionCard";
 
 /**
  * Renders all messages interleaved with completed turn summaries at the correct
@@ -159,6 +161,9 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   const chatAttachments = useAppStore(
     (s) => s.chatAttachments[sessionId] ?? EMPTY_ATTACHMENTS,
   );
+  const chatConclusions = useAppStore(
+    (s) => s.chatConclusions[sessionId] ?? EMPTY_CONCLUSIONS,
+  );
   const worktreePath = useAppStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.worktree_path,
   );
@@ -243,6 +248,56 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     }
     return map;
   }, [chatAttachments, messages]);
+
+  // Conclusions are agent-authored and anchored (like agent attachments) to the
+  // *user* message that triggered the turn; re-route each to that turn's
+  // *assistant* message so the card renders at the end of the turn. Mirrors the
+  // attachment routing above (kept separate so its dependency set is just
+  // conclusions + messages).
+  const conclusionsByMessage = useMemo(() => {
+    if (chatConclusions.length === 0)
+      return new Map<string, AgentConclusion[]>();
+    const userToNextAssistant = new Map<string, string>();
+    const loadedMessageIds = new Set<string>();
+    let nextAssistantId: string | null = null;
+    let firstAssistantInWindow: string | null = null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i];
+      loadedMessageIds.add(m.id);
+      if (m.role === "Assistant") {
+        nextAssistantId = m.id;
+        firstAssistantInWindow = m.id;
+      } else if (m.role === "User" && nextAssistantId) {
+        userToNextAssistant.set(m.id, nextAssistantId);
+      }
+    }
+    const firstNonSystem = messages.find((m) => m.role !== "System");
+    const startsMidTurn = firstNonSystem?.role === "Assistant";
+    const map = new Map<string, AgentConclusion[]>();
+    for (const c of chatConclusions) {
+      // A null anchor (no in-flight turn when presented) or an anchor whose
+      // turn is fully out of view won't route; fall back to the carry-over
+      // assistant on a mid-turn page, else skip (matches attachment behavior).
+      const anchor = c.message_id;
+      let targetId: string | null = null;
+      if (anchor && userToNextAssistant.has(anchor)) {
+        targetId = userToNextAssistant.get(anchor)!;
+      } else if (
+        (!anchor || !loadedMessageIds.has(anchor)) &&
+        firstAssistantInWindow !== null &&
+        startsMidTurn
+      ) {
+        targetId = firstAssistantInWindow;
+      } else if (anchor) {
+        targetId = anchor;
+      }
+      if (targetId === null) continue;
+      const list = map.get(targetId);
+      if (list) list.push(c);
+      else map.set(targetId, [c]);
+    }
+    return map;
+  }, [chatConclusions, messages]);
 
   // CompletedTurn.afterMessageIndex is GLOBAL (counts from message 0 of the
   // session, not from the loaded window). Shift to local before indexing into
@@ -1031,6 +1086,16 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                 </div>
               </div>
             )}
+            {conclusionsByMessage.has(msg.id) &&
+              conclusionsByMessage
+                .get(msg.id)!
+                .map((c) => (
+                  <ConclusionCard
+                    key={c.id}
+                    conclusion={c}
+                    workspaceId={workspaceId}
+                  />
+                ))}
             {renderPlainTurnFooter(idx + 1)}
           </React.Fragment>
         );

--- a/src/ui/src/components/chat/chatConstants.ts
+++ b/src/ui/src/components/chat/chatConstants.ts
@@ -1,5 +1,5 @@
 import type { CompletedTurn, ToolActivity } from "../../stores/useAppStore";
-import type { ChatAttachment } from "../../types/chat";
+import type { AgentConclusion, ChatAttachment } from "../../types/chat";
 import type { ConversationCheckpoint } from "../../types/checkpoint";
 
 // Stable empty arrays to avoid Zustand selector re-renders when data is undefined.
@@ -12,6 +12,7 @@ import type { ConversationCheckpoint } from "../../types/checkpoint";
 export const EMPTY_COMPLETED_TURNS: readonly CompletedTurn[] = Object.freeze([]);
 export const EMPTY_ACTIVITIES: readonly ToolActivity[] = Object.freeze([]);
 export const EMPTY_ATTACHMENTS: readonly ChatAttachment[] = Object.freeze([]);
+export const EMPTY_CONCLUSIONS: readonly AgentConclusion[] = Object.freeze([]);
 export const EMPTY_CHECKPOINTS: readonly ConversationCheckpoint[] = Object.freeze([]);
 
 export type RollbackModalData = {

--- a/src/ui/src/components/chat/useChatPanelSessionLifecycle.ts
+++ b/src/ui/src/components/chat/useChatPanelSessionLifecycle.ts
@@ -12,6 +12,7 @@ import {
 import {
   getAppSetting,
   listCheckpoints,
+  loadAgentConclusionsForSession,
   loadChatHistoryPage,
   loadCompletedTurns,
   sendRemoteCommand,
@@ -247,6 +248,19 @@ export function useChatPanelSessionLifecycle({
             });
           })
           .catch((e) => console.error("Failed to load chat history:", e));
+        // Agent-presented conclusions persist in their own table; load them
+        // alongside history so the inline conclusion cards survive reload.
+        // Live conclusions append separately via `agent-conclusion-created`.
+        // Gated on the experimental "Claudette MCP" flag so the feature stays
+        // fully dark when off (no card renders, even for past conclusions).
+        if (useAppStore.getState().claudetteMcpEnabled) {
+          loadAgentConclusionsForSession(sessionId)
+            .then((conclusions) => {
+              if (cancelled || !isCurrentHistoryLoad()) return;
+              useAppStore.getState().setChatConclusions(sessionId, conclusions);
+            })
+            .catch((e) => console.error("Failed to load conclusions:", e));
+        }
       }
     } else {
       sendRemoteCommand(currentWs!.remote_connection_id!, "load_chat_history", {

--- a/src/ui/src/components/settings/sections/ExperimentalSettings.test.tsx
+++ b/src/ui/src/components/settings/sections/ExperimentalSettings.test.tsx
@@ -149,13 +149,17 @@ describe("ExperimentalSettings — Usage Insights consent gate", () => {
       "false",
     );
   });
-  it("does not render the removed OpenRouter balance toggle", async () => {
+  it("renders the usage + Claudette MCP toggles (not the removed OpenRouter one)", async () => {
     const container = await renderSettings();
-    const switches = Array.from(container.querySelectorAll('[role="switch"]'));
+    const labels = Array.from(
+      container.querySelectorAll('[role="switch"]'),
+    ).map((s) => s.getAttribute("aria-label"));
 
-    expect(switches).toHaveLength(1);
-    expect(switches[0]?.getAttribute("aria-label")).toBe(
+    // Exactly the two experimental toggles, in render order — the long-removed
+    // OpenRouter balance toggle must not reappear.
+    expect(labels).toEqual([
       "experimental_claude_code_usage_aria",
-    );
+      "experimental_claudette_mcp_aria",
+    ]);
   });
 });

--- a/src/ui/src/components/settings/sections/ExperimentalSettings.tsx
+++ b/src/ui/src/components/settings/sections/ExperimentalSettings.tsx
@@ -17,6 +17,8 @@ export function ExperimentalSettings() {
   const clearSettingsFocus = useAppStore((s) => s.clearSettingsFocus);
   const usageInsightsEnabled = useAppStore((s) => s.usageInsightsEnabled);
   const setUsageInsightsEnabled = useAppStore((s) => s.setUsageInsightsEnabled);
+  const claudetteMcpEnabled = useAppStore((s) => s.claudetteMcpEnabled);
+  const setClaudetteMcpEnabled = useAppStore((s) => s.setClaudetteMcpEnabled);
   const [error, setError] = useState<string | null>(null);
   const [usageConfirmOpen, setUsageConfirmOpen] = useState(false);
   const usageRowRef = useRef<HTMLDivElement>(null);
@@ -64,6 +66,18 @@ export function ExperimentalSettings() {
     await applyUsageInsights(false);
   };
 
+  const handleClaudetteMcpToggle = async () => {
+    const next = !claudetteMcpEnabled;
+    setClaudetteMcpEnabled(next);
+    try {
+      setError(null);
+      await setAppSetting("claudette_mcp_enabled", next ? "true" : "false");
+    } catch (e) {
+      setClaudetteMcpEnabled(!next); // revert optimistic update on failure
+      setError(String(e));
+    }
+  };
+
   return (
     <div>
       <h2 className={styles.sectionTitle}>{t("experimental_title")}</h2>
@@ -91,6 +105,27 @@ export function ExperimentalSettings() {
             aria-label={t("experimental_claude_code_usage_aria")}
             data-checked={usageInsightsEnabled}
             onClick={handleUsageToggle}
+          >
+            <div className={styles.toggleKnob} />
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.settingRow} id="claudette-mcp-setting">
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>{t("experimental_claudette_mcp")}</div>
+          <div className={styles.settingDescription}>
+            {t("experimental_claudette_mcp_desc")}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.toggle}
+            role="switch"
+            aria-checked={claudetteMcpEnabled}
+            aria-label={t("experimental_claudette_mcp_aria")}
+            data-checked={claudetteMcpEnabled}
+            onClick={handleClaudetteMcpToggle}
           >
             <div className={styles.toggleKnob} />
           </button>

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -13,7 +13,7 @@ import type {
   AgentApprovalKind,
   AgentToolCall,
 } from "../stores/useAppStore";
-import type { ChatMessage } from "../types/chat";
+import type { AgentConclusionEvent, ChatMessage } from "../types/chat";
 import type { ConversationCheckpoint } from "../types/checkpoint";
 import type { TerminalTab } from "../types/terminal";
 import { extractToolSummary } from "./toolSummary";
@@ -1193,6 +1193,27 @@ export function useAgentStream() {
       unlisten.then((fn) => fn());
     };
   }, [addChatAttachments]);
+
+  // Listen for agent-presented conclusions delivered via the
+  // `mcp__claudette__present_conclusion` tool. The Rust bridge has already
+  // persisted the row; we mirror it into the store so the inline conclusion
+  // card renders live. The event payload IS the serialized AgentConclusion.
+  const addChatConclusions = useAppStore((s) => s.addChatConclusions);
+  useEffect(() => {
+    let active = true;
+    const unlisten = listen<AgentConclusionEvent>(
+      "agent-conclusion-created",
+      (event) => {
+        if (!active) return;
+        const conclusion = event.payload;
+        addChatConclusions(conclusion.chat_session_id, [conclusion]);
+      },
+    );
+    return () => {
+      active = false;
+      unlisten.then((fn) => fn());
+    };
+  }, [addChatConclusions]);
 
   useEffect(() => {
     let active = true;

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -131,6 +131,8 @@
   "plan_approval_or_feedback": "Or provide feedback below",
   "plan_approval_feedback_placeholder": "Request changes or ask for a revision…",
   "plan_approval_send": "Send",
+  "conclusion_label": "Conclusion",
+  "conclusion_artifacts": "Artifacts",
   "agent_approval_label": "Approval Required",
   "agent_approval_details": "Details",
   "agent_approval_commandExecution_title": "Run command",

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -480,6 +480,9 @@
   "experimental_claude_code_usage": "Claude Code Usage",
   "experimental_claude_code_usage_desc": "Surface Claude Pro / Max subscription quotas (5-hour session, weekly all-model, weekly Sonnet/Opus, extra usage) in the chat composer's usage meter. Requires a standard Pro or Max login — does not apply to API-key sessions or to Codex / OpenAI / OpenRouter / Pi backends, which already show local-aggregate token totals.",
   "experimental_claude_code_usage_aria": "Claude Code Usage",
+  "experimental_claudette_mcp": "Claudette MCP",
+  "experimental_claudette_mcp_desc": "Let agents interact with you through Claudette's own UI: ask questions, request approval / feedback on a plan or decision (approve, deny, or suggest changes), and present a conclusion of completed work — each shown as an interactive card in chat. Works across agent backends. Experimental and off by default while the experience is polished.",
+  "experimental_claudette_mcp_aria": "Claudette MCP",
   "usage_indicator_disabled_tooltip": "Claude Code Usage is off — click to enable",
 
   "plugins_title": "Plugins",

--- a/src/ui/src/services/tauri/chat.ts
+++ b/src/ui/src/services/tauri/chat.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
+  AgentConclusion,
   AttachmentInput,
   ChatAttachment,
   ChatHistoryPage,
@@ -83,6 +84,14 @@ export function loadAttachmentData(
   attachmentId: string,
 ): Promise<string> {
   return invoke("load_attachment_data", { attachmentId });
+}
+
+/** Load every conclusion the agent presented in a session (oldest first),
+ *  persisted via the `present_conclusion` MCP tool. */
+export function loadAgentConclusionsForSession(
+  sessionId: string,
+): Promise<AgentConclusion[]> {
+  return invoke("load_agent_conclusions_for_session", { sessionId });
 }
 
 export function readFileAsBase64(path: string): Promise<ChatAttachment> {

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -1,5 +1,10 @@
 import type { StateCreator } from "zustand";
-import type { ChatMessage, ChatAttachment, ChatPaginationState } from "../../types";
+import type {
+  ChatMessage,
+  ChatAttachment,
+  ChatPaginationState,
+  AgentConclusion,
+} from "../../types";
 import type { StoredAttachment } from "../../types/chat";
 import { debugChat } from "../../utils/chatDebug";
 import type { CompactionEvent } from "../../utils/compactionSentinel";
@@ -100,6 +105,12 @@ export interface ChatSlice {
   chatAttachments: Record<string, ChatAttachment[]>;
   setChatAttachments: (sessionId: string, attachments: ChatAttachment[]) => void;
   addChatAttachments: (sessionId: string, attachments: ChatAttachment[]) => void;
+  /** Agent-presented conclusions (`present_conclusion`), keyed by session id.
+   *  Mirrors `chatAttachments`: loaded on session open + appended live from
+   *  the `agent-conclusion-created` event. */
+  chatConclusions: Record<string, AgentConclusion[]>;
+  setChatConclusions: (sessionId: string, conclusions: AgentConclusion[]) => void;
+  addChatConclusions: (sessionId: string, conclusions: AgentConclusion[]) => void;
   streamingContent: Record<string, string>;
   streamingThinking: Record<string, string>;
   pendingTypewriter: Record<string, { messageId: string; text: string } | null>;
@@ -273,6 +284,26 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
         [sessionId]: [...(s.chatAttachments[sessionId] ?? []), ...attachments],
       },
     })),
+  chatConclusions: {},
+  setChatConclusions: (sessionId, conclusions) =>
+    set((s) => ({
+      chatConclusions: { ...s.chatConclusions, [sessionId]: conclusions },
+    })),
+  addChatConclusions: (sessionId, conclusions) =>
+    set((s) => {
+      // Dedupe by id so a live event that races the initial load (or a
+      // double-mount) can't render the same conclusion twice.
+      const existing = s.chatConclusions[sessionId] ?? [];
+      const seen = new Set(existing.map((c) => c.id));
+      const fresh = conclusions.filter((c) => !seen.has(c.id));
+      if (fresh.length === 0) return {};
+      return {
+        chatConclusions: {
+          ...s.chatConclusions,
+          [sessionId]: [...existing, ...fresh],
+        },
+      };
+    }),
   chatPagination: {},
   setChatPagination: (sessionId, state) =>
     set((s) => ({

--- a/src/ui/src/stores/slices/settingsSlice.ts
+++ b/src/ui/src/stores/slices/settingsSlice.ts
@@ -72,6 +72,10 @@ export interface SettingsSlice {
   // Experimental
   usageInsightsEnabled: boolean;
   setUsageInsightsEnabled: (enabled: boolean) => void;
+  /** Experimental "Claudette MCP": agent-initiated interaction tools
+   *  (ask_user / request_review / present_conclusion). Off by default. */
+  claudetteMcpEnabled: boolean;
+  setClaudetteMcpEnabled: (enabled: boolean) => void;
   disable1mContext: boolean;
   setDisable1mContext: (v: boolean) => void;
   alternativeBackendsAvailable: boolean;
@@ -201,6 +205,8 @@ export const createSettingsSlice: StateCreator<
     set({ projectViewIssuesPrsEnabled: enabled }),
   usageInsightsEnabled: false,
   setUsageInsightsEnabled: (enabled) => set({ usageInsightsEnabled: enabled }),
+  claudetteMcpEnabled: false,
+  setClaudetteMcpEnabled: (enabled) => set({ claudetteMcpEnabled: enabled }),
   disable1mContext: false,
   setDisable1mContext: (v) => set({ disable1mContext: v }),
   alternativeBackendsAvailable: false,

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useAppStore } from "./useAppStore";
 import type { AgentApproval, AgentQuestion, PlanApproval } from "./useAppStore";
-import type { ChatMessage, ChatSession } from "../types/chat";
+import type { AgentConclusion, ChatMessage, ChatSession } from "../types/chat";
 import type { ConversationCheckpoint } from "../types/checkpoint";
 import type { Workspace } from "../types/workspace";
 import { applyPlanModeMountDefault } from "../components/chat/planModePersistence";
@@ -122,6 +122,48 @@ describe("Claudette terminal setting", () => {
 
     useAppStore.getState().setClaudetteTerminalEnabled(true);
     expect(useAppStore.getState().claudetteTerminalEnabled).toBe(true);
+  });
+});
+
+describe("chat conclusions", () => {
+  beforeEach(() => {
+    useAppStore.setState({ chatConclusions: {} });
+  });
+
+  const makeConclusion = (id: string): AgentConclusion => ({
+    id,
+    chat_session_id: "s1",
+    workspace_id: "w1",
+    message_id: "m1",
+    title: null,
+    summary: "done",
+    artifacts: [],
+    created_at: "2026-06-16T00:00:00Z",
+  });
+
+  it("setChatConclusions replaces the session list", () => {
+    useAppStore.getState().setChatConclusions("s1", [makeConclusion("c1")]);
+    useAppStore.getState().setChatConclusions("s1", [makeConclusion("c2")]);
+    expect(
+      useAppStore.getState().chatConclusions["s1"].map((c) => c.id),
+    ).toEqual(["c2"]);
+  });
+
+  it("addChatConclusions appends and dedupes by id", () => {
+    useAppStore.getState().setChatConclusions("s1", [makeConclusion("c1")]);
+    useAppStore
+      .getState()
+      .addChatConclusions("s1", [makeConclusion("c1"), makeConclusion("c2")]);
+    expect(
+      useAppStore.getState().chatConclusions["s1"].map((c) => c.id),
+    ).toEqual(["c1", "c2"]);
+  });
+
+  it("keeps sessions independent", () => {
+    useAppStore.getState().addChatConclusions("s1", [makeConclusion("c1")]);
+    useAppStore.getState().addChatConclusions("s2", [makeConclusion("c1")]);
+    expect(useAppStore.getState().chatConclusions["s1"]).toHaveLength(1);
+    expect(useAppStore.getState().chatConclusions["s2"]).toHaveLength(1);
   });
 });
 

--- a/src/ui/src/types/chat.ts
+++ b/src/ui/src/types/chat.ts
@@ -72,6 +72,30 @@ export interface AgentAttachmentEvent {
   attachment: ChatAttachment & { caption?: string | null };
 }
 
+/** A finished-work conclusion the agent presented via the
+ *  `mcp__claudette__present_conclusion` MCP tool. Persisted in the
+ *  `agent_conclusions` table and rendered inline as a conclusion card.
+ *
+ *  Snake_case to match the rest of the chat domain (`ChatMessage`,
+ *  `ChatAttachment`). `message_id` is the user message that triggered the turn
+ *  (the FK anchor); like agent attachments it's re-routed to that turn's
+ *  assistant message at render time. */
+export interface AgentConclusion {
+  id: string;
+  chat_session_id: string;
+  workspace_id: string;
+  message_id: string | null;
+  title: string | null;
+  summary: string;
+  artifacts: string[];
+  created_at: string;
+}
+
+/** Payload of the `agent-conclusion-created` Tauri event — emitted whenever the
+ *  agent calls `mcp__claudette__present_conclusion`. The payload IS the
+ *  `AgentConclusion` itself (the Rust bridge emits the serialized row). */
+export type AgentConclusionEvent = AgentConclusion;
+
 /** Payload shape for sending attachment data to the backend. */
 export interface AttachmentInput {
   filename: string;

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -16,6 +16,8 @@ export type {
   SessionStatus,
   SessionAttentionKind,
   SessionAgentStatus,
+  AgentConclusion,
+  AgentConclusionEvent,
 } from "./chat";
 export type {
   DiffFile,


### PR DESCRIPTION
### Summary

Adds agent-initiated user interaction to Claudette via three new tools on the built-in `claudette` MCP server, so **any MCP-capable backend** can drive Claudette's own UI instead of relying on the Claude-CLI-only `AskUserQuestion` / `ExitPlanMode` controls. This is **Phase 1 (Rust backend), scoped to the Claude backend** to prove the approach.

- **`ask_user`** — blocks until the user answers (renders via the existing `AgentQuestionCard`).
- **`request_review`** — blocks until the user returns an approve / deny / suggest verdict (renders via the existing `PlanApprovalCard`; "suggest" is the existing deny-with-feedback path).
- **`present_conclusion`** — non-blocking; persists a finished-work summary to a new `agent_conclusions` table and emits `agent-conclusion-created`.

The key design choice: **reuse the existing pending-control machinery**. The blocking happens parent-side in the bridge sink, which registers a pending control through the existing `pending_permissions`/attention path and awaits a `oneshot`. The reply is delivered by the existing `submit_agent_answer` / `submit_plan_approval` commands, which now route MCP-origin requests to the oneshot. Because of this reuse, `ask_user` and `request_review` are **end-to-end functional for Claude with no frontend changes** — and the existing CLI responders (`claudette chat answer` / `approve-plan` / `deny-plan`) resolve them too.

```mermaid
sequenceDiagram
    participant M as Model
    participant CLI as Claude CLI
    participant G as agent-mcp grandchild
    participant S as Bridge sink (Tauri parent)
    participant UI as Chat UI / CLI responder
    M->>CLI: tools/call mcp__claudette__ask_user
    CLI->>G: stdio MCP
    G->>S: BridgePayload::AskUser (socket)
    S->>S: register pending control + oneshot
    S->>UI: emit agent-permission-prompt (origin=claudette_mcp)
    Note over S: await oneshot (blocks, no timeout)
    UI->>S: submit_agent_answer -> oneshot.send(answers)
    S-->>G: BridgeResponse(answers)
    G-->>CLI: tool_result
    CLI-->>M: resume turn
```

### Complexity Notes

- **Reply-routing fork** (`submit_agent_answer` / `submit_approval_response` in `interaction.rs`): MCP-origin requests reply via a `oneshot`; CLI-origin requests keep the existing `control_response` path. This is the one genuinely new branch.
- **Reply channels live on `AppState`** (`mcp_pending_replies`, keyed by `tool_use_id`) rather than `AgentSessionState`, to avoid churning the 12+ session construction sites. They're drained on stop/reset/migrate so a blocked tool call can't hang (dropping the sender surfaces a cancelled result to the agent).
- **Shared MCP server injection gate** changed from `send_to_user_enabled` to `claudette_mcp_enabled = send_to_user || agent_interaction`, so disabling Agent Attachments no longer also removes the interaction tools. Per-feature system-prompt nudges stay independently gated.
- **`CLAUDE_CODE_MCP_RULES` const → `claude_code_mcp_rules(agent_interaction_enabled)` fn**: mandates the new tools (and tells the model *not* to use the look-alike native `AskUserQuestion`) when enabled; falls back to the native mandate when disabled. The `ExitPlanMode` plan-mode rule is retained either way — it's the real plan-mode-exit mechanism, distinct from `request_review`.
- **`request_review` reuses `ExitPlanMode` rendering** but deliberately does **not** set `session_exited_plan`, so it does not trigger the CLI plan-mode teardown.
- **`present_conclusion` renders a non-interactive `ConclusionCard`** — it persists the summary + emits `agent-conclusion-created`, and the inline card is now shown in chat (added in a follow-up commit on this branch). The whole feature — card included — is gated behind the new experimental **Claudette MCP** flag (off by default).

Follow-ups (intentionally out of scope here): Codex backend injection and user-facing docs.

### Test Steps

Requires a **dev build of this branch** (the installed app won't have these tools). `./scripts/dev.sh`.

1. In a workspace's Claude session, prompt: *"Ask me whether to proceed."* → an `ask_user` question card should render. Confirm it's ours, not native, by tailing logs: `grep claudette::agent_mcp ~/.claudette/logs/claudette.<date>.log` → `MCP interactive prompt registered`.
2. Answer via the card **or** the CLI: `claudette chat answer <session> <tool_use_id> --answers-json '{"...":"..."}'` (tool_use_id is in the log line). The agent should resume with the answer; log shows `answered — resuming agent`.
3. Prompt: *"Propose a one-line plan and get my review."* → `request_review` renders the plan card; approve / deny-with-feedback returns the verdict to the agent.
4. Prompt: *"Summarize what you did with present_conclusion."* → verify persistence: `sqlite3 ~/.claudette/claudette.db "SELECT title, summary FROM agent_conclusions ORDER BY created_at DESC LIMIT 1;"`.
5. Settings → Plugins → disable **Agent Interaction**, start a fresh turn, and confirm the rule block falls back to the native `AskUserQuestion` mandate (no regression).
6. Backend sanity: `cargo test -p claudette --all-features` (1538 pass), `cargo fmt --all --check`, `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features`.

### Checklist

- [x] Tests added/updated (protocol round-trips, tool validation + reject, `tools/list`, nudge/server-enable gating, `claude_code_mcp_rules` steer/fallback, conclusion DB insert/list/cascade, AppState oneshot round-trip + session-scoped drain)
- [ ] Documentation updated — deferred to a follow-up (settings reference + feature page), per scope
