### PR TITLE
feat(models): add Sonnet 5 and demote Sonnet 4.6 to the "More" menu

### DIFF
--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -16,13 +16,12 @@ Select a model from the dropdown in the chat header. Available models:
 |-------|-----|-------------|
 | **Opus 4.8 1M** | `opus` | Opus 4.8 with a 1M context window |
 | **Opus 4.8** | `claude-opus-4-8` | Standard Opus 4.8 (200K context) |
-| **Sonnet 4.6** | `sonnet` | Fast and capable |
-| **Sonnet 4.6 1M** | `claude-sonnet-4-6[1m]` | Sonnet 4.6 with a 1M context window (extra usage) |
+| **Sonnet 5** | `sonnet` | Fast and capable; native 1M context window (no extra usage), full effort support incl. XHigh |
 | **Haiku 4.5** | `haiku` | Fastest, most affordable |
 | **Fable 5** | `claude-fable-5` | Opus-class model with full effort support, incl. XHigh (200K context) |
 | **Fable 5 1M** | `claude-fable-5[1m]` | Fable 5 with a 1M context window |
 
-Earlier-generation models (Opus 4.7, Opus 4.7 1M, Opus 4.6, Opus 4.6 1M, Opus 4.5, Sonnet 4.5, Haiku 3.5) remain selectable in the picker as legacy entries.
+Earlier-generation models (Opus 4.7, Opus 4.7 1M, Opus 4.6, Opus 4.6 1M, Opus 4.5, Sonnet 4.6, Sonnet 4.6 1M, Sonnet 4.5, Haiku 3.5) remain selectable in the picker as legacy entries.
 
 The model selection is per-workspace — you can use different models for different tasks.
 
@@ -32,14 +31,14 @@ Set the default model for new sessions in `Settings > Models > Default model`.
 
 You can change the model on an active chat at any time — from the toolbar dropdown or with the `/model` slash command. Whether the conversation continues depends on whether the swap stays inside the same runtime:
 
-- **Same runtime (no context loss)** — Switching between models that resolve to the same harness keeps the full transcript. The very next turn streams from the new model with every prior message available. This covers the common cases: Sonnet 4.6 ↔ Opus 4.8 on the Anthropic Claude Code path, two Pi-routed Ollama models on the same Pi card, and so on. Claudette tears down the persistent agent subprocess and respawns it with the new `--model` flag while reusing the existing session id, so the new turn resumes the prior transcript.
+- **Same runtime (no context loss)** — Switching between models that resolve to the same harness keeps the full transcript. The very next turn streams from the new model with every prior message available. This covers the common cases: Sonnet 5 ↔ Opus 4.8 on the Anthropic Claude Code path, two Pi-routed Ollama models on the same Pi card, and so on. Claudette tears down the persistent agent subprocess and respawns it with the new `--model` flag while reusing the existing session id, so the new turn resumes the prior transcript.
 - **Different runtime (context migrated as a prelude)** — Switching to a model whose backend uses a different runtime — e.g., Anthropic Claude Code to Codex Native, or anything to a Pi SDK target — preserves the conversation by injecting the prior history into the new harness's very first turn. Claudette reads every persisted message on the session, wraps it in a `<conversation-history>` block, and prepends that block to the user's next message before sending it to the new harness. The persisted chat history in the UI is unchanged; the prelude is only visible to the model on the next turn. Tool calls in the history are rendered as text — the new harness reads them for context but does not re-execute them. The first turn after a cross-runtime switch will be slower and use more input tokens than usual because the whole prior conversation is part of its input.
 
 You can see which runtime a model uses from the "via …" badge next to its row in the model picker. Models on a runtime that matches the picker section's default carry no badge (e.g., Pi-card models on the Pi runtime, Anthropic Claude Code models on the Claude CLI runtime).
 
 ### When the model's context window is too small
 
-If you switch to a model whose context window can't hold the current conversation, the agent's send fails with a "context length" / "input is too long" error. Claudette detects that error class and inlines a **"Choose a larger-context model →"** link directly into the chat error banner. Clicking it opens the toolbar's model picker so you can pick one of the 1M-context variants (Opus 4.8 1M, Sonnet 4.6 1M) or another model the registry shows with a larger window. The conversation is not lost — it stays in the chat panel, and your next send under the new model will resume it via the same in-place or cross-runtime path described above.
+If you switch to a model whose context window can't hold the current conversation, the agent's send fails with a "context length" / "input is too long" error. Claudette detects that error class and inlines a **"Choose a larger-context model →"** link directly into the chat error banner. Clicking it opens the toolbar's model picker so you can pick one of the 1M-context models (Opus 4.8 1M, Sonnet 5 — which is natively 1M) or another model the registry shows with a larger window. The conversation is not lost — it stays in the chat panel, and your next send under the new model will resume it via the same in-place or cross-runtime path described above.
 
 ## Reasoning Effort
 
@@ -51,7 +50,7 @@ Control how much reasoning the agent applies to each response:
 | **Low** | Fast, minimal reasoning | Opus, Sonnet, Fable 5 |
 | **Medium** | Balanced | Opus, Sonnet, Fable 5 |
 | **High** | Deep reasoning | Opus, Sonnet, Fable 5 |
-| **XHigh** | Extended reasoning budget | Opus 4.7+, Fable 5 |
+| **XHigh** | Extended reasoning budget | Opus 4.7+, Fable 5, Sonnet 5 |
 | **Max** | Maximum reasoning budget | Opus, Sonnet, Fable 5 (effort-capable models) |
 
 Select the effort level from the dropdown in the chat header, next to the model selector.

--- a/site/src/content/docs/features/cli-client.mdx
+++ b/site/src/content/docs/features/cli-client.mdx
@@ -155,7 +155,7 @@ Boolean flags are tri-state — pass `--plan` to force on, `--no-plan` to force 
 | `--plan` / `--no-plan` | — | Plan mode (read-only until approved) |
 | `--thinking` / `--no-thinking` | — | Extended thinking |
 | `--fast` / `--no-fast` | — | Fast mode (built-in support: Opus 4.6) |
-| `--effort` | `low`, `medium`, `high`, `xhigh`, `max` | Reasoning effort (`xhigh` requires Opus 4.7+ or Fable 5) |
+| `--effort` | `low`, `medium`, `high`, `xhigh`, `max` | Reasoning effort (`xhigh` requires Opus 4.7+, Fable 5, or Sonnet 5) |
 | `--chrome` / `--no-chrome` | — | Chrome browser tool |
 | `--disable-1m-context` | — | Suppress Max-plan auto-upgrade to a 1M context window |
 | `--permission` | `default`, `acceptEdits`, `bypassPermissions` | Permission level |

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -33,7 +33,7 @@ Default values applied to all new agent sessions. Per-workspace overrides are av
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| Default model | Model for new chats (Opus 4.8 1M, Opus 4.8, Sonnet 4.6, Sonnet 4.6 1M, Haiku 4.5, Fable 5, Fable 5 1M; older models such as Opus 4.7 / 4.6 / 4.5 remain selectable behind the picker's "More" disclosure) | — |
+| Default model | Model for new chats (Opus 4.8 1M, Opus 4.8, Sonnet 5, Haiku 4.5, Fable 5, Fable 5 1M; older models such as Opus 4.7 / 4.6 / 4.5 and Sonnet 4.6 / 4.6 1M remain selectable behind the picker's "More" disclosure) | — |
 | Default effort / Codex intelligence | Claude models use effort levels (`auto`, `low`, `medium`, `high`, `xhigh`, `max` where supported). Codex uses intelligence levels (`low`, `medium`, `high`, `xhigh`). | Auto / High |
 | Default thinking | Enable extended thinking for Claude models. Codex does not expose a reasoning on/off toggle; use Codex intelligence instead. | Off |
 | Show thinking / reasoning blocks | Display Claude thinking blocks or Codex reasoning summaries in the chat UI. | Off |

--- a/src-cli/src/commands/chat.rs
+++ b/src-cli/src/commands/chat.rs
@@ -149,7 +149,7 @@ pub enum Action {
         #[arg(long = "no-fast", overrides_with = "fast", hide = true)]
         no_fast: bool,
         /// Effort level: `low`, `medium`, `high`, `xhigh`, `max`
-        /// (`xhigh` requires Opus 4.7+ or Fable 5).
+        /// (`xhigh` requires Opus 4.7+, Fable 5, or Sonnet 5).
         #[arg(long)]
         effort: Option<String>,
         /// Enable Chrome browser mode for this session. Pair: `--no-chrome`

--- a/src/ui/src/components/chat/applySelectedModel.ts
+++ b/src/ui/src/components/chat/applySelectedModel.ts
@@ -30,7 +30,7 @@ import {
  *
  * Session-handling rule, by swap kind:
  *
- * - **Same harness** (e.g. Sonnet 4.6 <-> Opus 4.8 on the Anthropic Claude
+ * - **Same harness** (e.g. Sonnet 5 <-> Opus 4.8 on the Anthropic Claude
  *   Code path, or two Pi-routed Ollama models): preserve
  *   `chat_sessions.session_id` so the next turn resumes the prior
  *   transcript via `claude --resume` (Claude CLI) or its harness-native

--- a/src/ui/src/components/chat/modelCapabilities.test.ts
+++ b/src/ui/src/components/chat/modelCapabilities.test.ts
@@ -64,6 +64,10 @@ describe("isEffortSupported", () => {
     expect(isEffortSupported("sonnet")).toBe(true);
   });
 
+  it("returns true for claude-sonnet-4-6 (demoted but still effort-capable)", () => {
+    expect(isEffortSupported("claude-sonnet-4-6")).toBe(true);
+  });
+
   it("returns true for claude-sonnet-4-6[1m]", () => {
     expect(isEffortSupported("claude-sonnet-4-6[1m]")).toBe(true);
   });
@@ -102,8 +106,13 @@ describe("isXhighEffortAllowed", () => {
     expect(isXhighEffortAllowed("claude-opus-4-6[1m]")).toBe(false);
   });
 
-  it("returns false for sonnet", () => {
-    expect(isXhighEffortAllowed("sonnet")).toBe(false);
+  it("returns true for sonnet (Sonnet 5 gained xhigh)", () => {
+    expect(isXhighEffortAllowed("sonnet")).toBe(true);
+  });
+
+  it("returns false for the demoted Sonnet 4.6 ids (no xhigh)", () => {
+    expect(isXhighEffortAllowed("claude-sonnet-4-6")).toBe(false);
+    expect(isXhighEffortAllowed("claude-sonnet-4-6[1m]")).toBe(false);
   });
 
   it("returns false for haiku", () => {
@@ -138,6 +147,10 @@ describe("isMaxEffortAllowed", () => {
 
   it("returns true for sonnet", () => {
     expect(isMaxEffortAllowed("sonnet")).toBe(true);
+  });
+
+  it("returns true for claude-sonnet-4-6", () => {
+    expect(isMaxEffortAllowed("claude-sonnet-4-6")).toBe(true);
   });
 
   it("returns true for claude-sonnet-4-6[1m]", () => {

--- a/src/ui/src/components/chat/modelCapabilities.ts
+++ b/src/ui/src/components/chat/modelCapabilities.ts
@@ -2,13 +2,15 @@
 const FAST_SUPPORTED_MODELS = new Set(["claude-opus-4-6", "claude-opus-4-6[1m]"]);
 
 /** Models that support effort levels. */
-const EFFORT_SUPPORTED_MODELS = new Set(["opus", "claude-opus-4-8", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6[1m]"]);
+const EFFORT_SUPPORTED_MODELS = new Set(["opus", "claude-opus-4-8", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6", "claude-sonnet-4-6[1m]"]);
 
-/** Models that support the "xhigh" effort level (Opus 4.7+ and Fable 5). */
-const XHIGH_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]"]);
+/** Models that support the "xhigh" effort level (Opus 4.7+, Fable 5, and Sonnet 5).
+ *  Sonnet 5 (the `sonnet` alias, natively 1M) gained xhigh — the demoted
+ *  Sonnet 4.6 ids deliberately stay out. */
+const XHIGH_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "sonnet"]);
 
 /** Models that support the "max" effort level. */
-const MAX_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6[1m]"]);
+const MAX_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6", "claude-sonnet-4-6[1m]"]);
 
 export function isFastSupported(model: string): boolean {
   return FAST_SUPPORTED_MODELS.has(model);

--- a/src/ui/src/components/chat/modelRegistry.test.ts
+++ b/src/ui/src/components/chat/modelRegistry.test.ts
@@ -20,11 +20,12 @@ describe("modelRegistry", () => {
     }
   });
 
-  // `"opus"` is the 1M alias of Opus 4.8 whose id lacks the `[1m]` suffix
-  // other 1M variants use. Keep the explicit `id === "opus"` check — removing
-  // it would silently misclassify the alias as a 200k model.
+  // `"opus"` and `"sonnet"` are bare 1M aliases whose ids lack the `[1m]`
+  // suffix other 1M variants use (opus auto-upgrades to 1M; Sonnet 5 is
+  // natively 1M). Keep the explicit id checks — removing either would
+  // silently misclassify the alias as a 200k model.
   it("1M-context variants report 1_000_000", () => {
-    const oneM = MODELS.filter((m) => m.id === "opus" || m.id.endsWith("[1m]"));
+    const oneM = MODELS.filter((m) => m.id === "opus" || m.id === "sonnet" || m.id.endsWith("[1m]"));
     expect(oneM.length).toBeGreaterThan(0);
     for (const m of oneM) {
       expect(m.contextWindowTokens, m.id).toBe(1_000_000);
@@ -32,7 +33,7 @@ describe("modelRegistry", () => {
   });
 
   it("standard variants report 200_000", () => {
-    const standard = MODELS.filter((m) => m.id !== "opus" && !m.id.endsWith("[1m]"));
+    const standard = MODELS.filter((m) => m.id !== "opus" && m.id !== "sonnet" && !m.id.endsWith("[1m]"));
     expect(standard.length).toBeGreaterThan(0);
     for (const m of standard) {
       expect(m.contextWindowTokens, m.id).toBe(200_000);
@@ -66,12 +67,18 @@ describe("modelRegistry", () => {
       expect(get1mFallback("opus")).toBe("claude-opus-4-8");
       expect(get1mFallback("claude-fable-5[1m]")).toBe("claude-fable-5");
       expect(get1mFallback("claude-opus-4-7[1m]")).toBe("claude-opus-4-7");
-      expect(get1mFallback("claude-sonnet-4-6[1m]")).toBe("sonnet");
+      // Sonnet 4.6 1M now falls back to the pinned 200K id, not the `sonnet`
+      // alias (which moved to Sonnet 5).
+      expect(get1mFallback("claude-sonnet-4-6[1m]")).toBe("claude-sonnet-4-6");
       expect(get1mFallback("claude-opus-4-6[1m]")).toBe("claude-opus-4-6");
     });
 
-    it("returns non-1M models unchanged", () => {
+    it("returns the `sonnet` alias unchanged (Sonnet 5 is natively 1M, no 200K variant)", () => {
       expect(get1mFallback("sonnet")).toBe("sonnet");
+    });
+
+    it("returns non-1M models unchanged", () => {
+      expect(get1mFallback("claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
       expect(get1mFallback("claude-opus-4-7")).toBe("claude-opus-4-7");
       expect(get1mFallback("haiku")).toBe("haiku");
     });
@@ -86,7 +93,12 @@ describe("modelRegistry", () => {
         const fallback = get1mFallback(m.id);
         const target = MODELS.find((t) => t.id === fallback);
         expect(target, `${m.id} → ${fallback} not in MODELS`).toBeDefined();
-        expect(target!.contextWindowTokens, `${m.id} → ${fallback} should be non-1M`).toBeLessThan(1_000_000);
+        // The fallback is either a strictly-smaller (200K) model, or the model
+        // itself when it is natively 1M with no 200K variant (Sonnet 5 — the CLI
+        // caps it to 200K under the same id rather than swapping to another model).
+        if (fallback !== m.id) {
+          expect(target!.contextWindowTokens, `${m.id} → ${fallback} should be non-1M`).toBeLessThan(1_000_000);
+        }
       }
     });
   });

--- a/src/ui/src/components/chat/modelRegistry.ts
+++ b/src/ui/src/components/chat/modelRegistry.ts
@@ -58,9 +58,11 @@ export function is1mContextModel(modelId: string): boolean {
 
 const NON_1M_FALLBACKS: Record<string, string> = {
   "opus": "claude-opus-4-8",
+  // No `sonnet` entry: Sonnet 5 is natively 1M with no 200K variant to fall
+  // back to, so `get1mFallback("sonnet")` correctly returns "sonnet" unchanged.
   "claude-fable-5[1m]": "claude-fable-5",
   "claude-opus-4-7[1m]": "claude-opus-4-7",
-  "claude-sonnet-4-6[1m]": "sonnet",
+  "claude-sonnet-4-6[1m]": "claude-sonnet-4-6",
   "claude-opus-4-6[1m]": "claude-opus-4-6",
 };
 
@@ -70,16 +72,21 @@ export function get1mFallback(modelId: string): string {
 
 export const MODELS: readonly Model[] = [
   // 1M context billing per Anthropic's Claude Code docs (Model configuration → Extended context):
-  //   Max/Team/Enterprise → Opus 1M included with subscription; Sonnet 1M is extra usage.
-  //   Pro                → both Opus 1M and Sonnet 1M are extra usage.
+  //   Max/Team/Enterprise → Opus 1M included with subscription; legacy Sonnet 4.6 1M is extra usage.
+  //   Pro                → both Opus 1M and legacy Sonnet 4.6 1M are extra usage.
+  // Sonnet 5 is the exception: its 1M window is native and included at standard pricing on
+  // every plan, so it carries no `extraUsage` indicator (see the `sonnet` row below).
   // The `extraUsage` flag tracks subscription-quota inclusion, not per-token API price.
-  // We optimize for Max/Team/Enterprise (Claudette's primary audience), so only Sonnet 1M
-  // carries the indicator; Pro users selecting Opus 1M see no warning even though it
-  // counts against their extra-usage allotment.
+  // We optimize for Max/Team/Enterprise (Claudette's primary audience), so only legacy
+  // Sonnet 4.6 1M carries the indicator; Pro users selecting Opus 1M see no warning even
+  // though it counts against their extra-usage allotment.
   { id: "opus", label: "Opus 4.8 1M", group: "Claude Code", extraUsage: false, contextWindowTokens: 1_000_000 },
   { id: "claude-opus-4-8", label: "Opus 4.8", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
-  { id: "sonnet", label: "Sonnet 4.6", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
-  { id: "claude-sonnet-4-6[1m]", label: "Sonnet 4.6 1M", group: "Claude Code", extraUsage: true, contextWindowTokens: 1_000_000 },
+  // `sonnet` is the bare alias the Claude CLI resolves to the latest Sonnet — now Sonnet 5,
+  // which runs natively at 1M context (no 200K variant, no `[1m]` suffix to select, no usage
+  // credits on any plan — Claude Code model-config docs, "Sonnet 5 context window"). So unlike
+  // Sonnet 4.6, there is no separate 1M row: the alias itself is the 1M model.
+  { id: "sonnet", label: "Sonnet 5", group: "Claude Code", extraUsage: false, contextWindowTokens: 1_000_000 },
   { id: "haiku", label: "Haiku 4.5", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
   // Fable 5 is an Opus-class Anthropic model (effort incl. xhigh/max, 1M variant).
   // It has no bare alias — the concrete id carries through to the Claude CLI `--model`
@@ -92,6 +99,11 @@ export const MODELS: readonly Model[] = [
   { id: "claude-opus-4-6", label: "Opus 4.6", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
   { id: "claude-opus-4-6[1m]", label: "Opus 4.6 1M", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 1_000_000 },
   { id: "claude-opus-4-5", label: "Opus 4.5", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
+  // Sonnet 4.6 demoted to the "More" disclosure when `sonnet` moved to Sonnet 5.
+  // The 200K id is pinned here (the path the `sonnet` alias used to resolve to)
+  // so it survives the alias move; the 1M variant keeps its `extraUsage` flag.
+  { id: "claude-sonnet-4-6", label: "Sonnet 4.6", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
+  { id: "claude-sonnet-4-6[1m]", label: "Sonnet 4.6 1M", group: "Claude Code", extraUsage: true, legacy: true, contextWindowTokens: 1_000_000 },
   { id: "claude-sonnet-4-5", label: "Sonnet 4.5", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
   { id: "claude-haiku-3-5", label: "Haiku 3.5", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
 ];

--- a/src/ui/src/components/command-palette/commands.ts
+++ b/src/ui/src/components/command-palette/commands.ts
@@ -234,7 +234,7 @@ export function buildEffortCommands(
     { id: "low", label: "Low", description: "Fast, minimal reasoning" },
     { id: "medium", label: "Medium", description: "Balanced" },
     { id: "high", label: "High", description: "Deep reasoning" },
-    { id: "xhigh", label: "Extra High", description: "Extended reasoning (Opus 4.7+, Fable 5)" },
+    { id: "xhigh", label: "Extra High", description: "Extended reasoning (Opus 4.7+, Fable 5, Sonnet 5)" },
     { id: "max", label: "Max", description: "Full budget" },
   ];
   const levels = !isEffortSupported(selectedModel)

--- a/src/usage/pricing.rs
+++ b/src/usage/pricing.rs
@@ -130,6 +130,18 @@ const PRICING_TABLE: &[(&str, ModelPricing)] = &[
             completion_per_mtok_usd: 75.00,
         },
     ),
+    // Sonnet 5 standard list price ($3/$15 per Mtok) — same as Sonnet 4.6.
+    // (The launch promo of $2/$10 through 2026-08-31 is intentionally not
+    // encoded; this table is a durable reference, not a billing source — the
+    // Anthropic Claude CLI path reports cost directly and bypasses this table.)
+    // A `[1m]`-suffixed gateway form (`claude-sonnet-5[1m]`) matches via `starts_with`.
+    (
+        "claude-sonnet-5",
+        ModelPricing {
+            prompt_per_mtok_usd: 3.00,
+            completion_per_mtok_usd: 15.00,
+        },
+    ),
     (
         "claude-sonnet-4-6",
         ModelPricing {
@@ -164,6 +176,16 @@ mod tests {
         // The 1M variant shares the bare prefix via `starts_with`.
         let one_m = lookup("claude-fable-5[1m]").expect("1M variant resolves to same pricing");
         assert!((one_m.prompt_per_mtok_usd - 30.00).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lookup_sonnet_5_priced_same_as_sonnet_4_6() {
+        let p = lookup("claude-sonnet-5").expect("claude-sonnet-5 has pricing");
+        assert!((p.prompt_per_mtok_usd - 3.00).abs() < f64::EPSILON);
+        assert!((p.completion_per_mtok_usd - 15.00).abs() < f64::EPSILON);
+        // The 1M variant shares the bare prefix via `starts_with`.
+        let one_m = lookup("claude-sonnet-5[1m]").expect("1M variant resolves to same pricing");
+        assert!((one_m.prompt_per_mtok_usd - 3.00).abs() < f64::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
### Summary

Adds **Claude Sonnet 5** to the model picker and moves **Sonnet 4.6** behind the picker's "More" (legacy) disclosure, following the established Opus 4.8 (#993) / Fable 5 (#995) transition pattern — adapted to Sonnet 5's *native-1M* context model.

Key points:

- **`sonnet` alias → "Sonnet 5".** The Claude CLI resolves the bare `sonnet` alias to the latest Sonnet, so it now runs Sonnet 5. Per the [Claude Code model-config docs](https://code.claude.com/docs/en/model-config) ("Sonnet 5 context window"), Sonnet 5 runs **natively at 1M context — no 200K variant, no `[1m]` suffix to select, and no usage credits on any plan**. So the `sonnet` row is now `1_000_000` / `extraUsage: false`, and there is **no separate 1M entry** (unlike Opus, whose bare alias pairs with a pinned 200K id).
- **Sonnet 4.6 demoted.** Split into pinned `claude-sonnet-4-6` (200K) + `claude-sonnet-4-6[1m]`, both `legacy: true` (→ behind "More"). This preserves every path the `sonnet` alias used to serve. `claude-sonnet-4-6[1m]`'s 200K fallback was rewired from `sonnet` → `claude-sonnet-4-6`.
- **xhigh effort.** Sonnet 5 (`sonnet`) gains `xhigh` (Sonnet 4.6 did not support it); the demoted 4.6 ids keep effort + max but stay out of xhigh.
- **Pricing.** `claude-sonnet-5` at **$3/$15** per Mtok (standard list, == Sonnet 4.6). The $2/$10 launch promo through 2026-08-31 is intentionally not encoded — the table is a durable reference and the Anthropic Claude CLI path reports cost directly.
- **Docs + help strings** updated: model table, default-model row, effort table, legacy list, and the CLI `--effort` / command-palette xhigh descriptions.

No Rust routing change is needed — `claude-sonnet-5` and the `sonnet` alias pass the existing `claude-`/alias gate unchanged. The app's default model is **not** changed.

### Complexity Notes

- **Sonnet 5 is the registry's first natively-1M model with no 200K sibling.** This breaks the prior implicit invariant "every 1M model has a strictly-smaller fallback." `get1mFallback("sonnet")` intentionally returns `"sonnet"` (the CLI caps it to 200K under the *same* id when 1M is disabled, rather than swapping models). The fallback-invariant test was updated to allow a self-fallback for 1M-native models while still catching a fallback that wrongly points at a *different* 1M model. `sonnet` also joins `opus` as a bare-alias 1M special-case in the 1M/200K classification tests.
- **Easy-to-miss trap:** naively mirroring Sonnet 4.6's registry shape (200K base + opt-in *extra-usage* 1M) would carry the wrong billing/context contract onto Sonnet 5. The first implementation did exactly that; it was corrected after checking the authoritative Claude Code docs.

### Test Steps

1. `cd src/ui && bunx tsc -b && bun run test` — type-check + full vitest suite (**2818 pass**). Focused suites: `bun run test -- --run modelRegistry modelCapabilities`.
2. `cargo test -p claudette --lib usage::pricing` — confirms `claude-sonnet-5` / `claude-sonnet-5[1m]` resolve to $3/$15.
3. In the app: open the chat model picker → **Sonnet 5** appears in the primary list; **Sonnet 4.6** and **Sonnet 4.6 1M** appear only after expanding **More**.
4. Select **Sonnet 5** → the effort dropdown offers **Extra High (xhigh)**. Select the demoted **Sonnet 4.6** → xhigh is not offered.
5. Select **Sonnet 5** → the context meter reflects a **1M** window with no "extra usage" billing badge.

### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
