### PR TITLE
fix(agent): place attachments before prompt text (longform data first)

### DIFF
--- a/src/agent/args.rs
+++ b/src/agent/args.rs
@@ -290,9 +290,11 @@ pub(super) fn build_settings_json(settings: &AgentSettings) -> Option<String> {
 
 /// Build a single-line JSON payload for stdin when using `--input-format stream-json`.
 ///
-/// Produces an `SDKUserMessage` with content blocks: one text block for the
-/// prompt, then one block per attachment — text files become `"text"` blocks,
-/// PDFs become `"document"` blocks, and images become `"image"` blocks.
+/// Produces an `SDKUserMessage` with content blocks: one block per attachment
+/// first — text files become `"text"` blocks, PDFs become `"document"` blocks,
+/// and images become `"image"` blocks — followed by a trailing text block for
+/// the prompt. Attachments lead so the model reads the longform data before the
+/// user's query (Anthropic "longform data at the top" guidance).
 pub fn build_stdin_message(prompt: &str, attachments: &[FileAttachment]) -> String {
     build_stdin_message_with_uuid(prompt, attachments, &uuid::Uuid::new_v4().to_string())
 }
@@ -327,12 +329,11 @@ fn build_stdin_message_inner(
 ) -> String {
     let mut content_blocks = Vec::new();
 
-    // Only add a text block if the prompt is non-empty — the API rejects
-    // empty text content blocks with "text content blocks must be non-empty".
-    if !prompt.trim().is_empty() {
-        content_blocks.push(serde_json::json!({"type": "text", "text": prompt}));
-    }
-
+    // Attachments go BEFORE the prompt text so the model sees the longform data
+    // (documents, images) first and the user's query/instructions last. This
+    // follows Anthropic's prompt-engineering guidance ("put longform data at the
+    // top … above your query") and the vision guidance to place images before
+    // text. See build_codex_user_input for the sibling ordering on the Codex path.
     for att in attachments {
         if let Some(ref text) = att.text_content {
             let label = att.filename.as_deref().unwrap_or("file");
@@ -357,6 +358,12 @@ fn build_stdin_message_inner(
                 }
             }));
         }
+    }
+
+    // Only add a text block if the prompt is non-empty — the API rejects
+    // empty text content blocks with "text content blocks must be non-empty".
+    if !prompt.trim().is_empty() {
+        content_blocks.push(serde_json::json!({"type": "text", "text": prompt}));
     }
 
     let mut payload = serde_json::json!({
@@ -889,12 +896,13 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
         let content = parsed["message"]["content"].as_array().unwrap();
         assert_eq!(content.len(), 2);
-        assert_eq!(content[0]["type"], "text");
-        assert_eq!(content[0]["text"], "describe this");
-        assert_eq!(content[1]["type"], "image");
-        assert_eq!(content[1]["source"]["type"], "base64");
-        assert_eq!(content[1]["source"]["media_type"], "image/png");
-        assert_eq!(content[1]["source"]["data"], "iVBORw0KGgo=");
+        // Attachment leads, prompt trails (longform data at the top).
+        assert_eq!(content[0]["type"], "image");
+        assert_eq!(content[0]["source"]["type"], "base64");
+        assert_eq!(content[0]["source"]["media_type"], "image/png");
+        assert_eq!(content[0]["source"]["data"], "iVBORw0KGgo=");
+        assert_eq!(content[1]["type"], "text");
+        assert_eq!(content[1]["text"], "describe this");
     }
 
     #[test]
@@ -922,10 +930,13 @@ mod tests {
         let msg = build_stdin_message("compare these", &attachments);
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
         let content = parsed["message"]["content"].as_array().unwrap();
-        assert_eq!(content.len(), 4); // 1 text + 3 images
-        assert_eq!(content[1]["source"]["media_type"], "image/png");
-        assert_eq!(content[2]["source"]["media_type"], "image/jpeg");
-        assert_eq!(content[3]["source"]["media_type"], "image/webp");
+        assert_eq!(content.len(), 4); // 3 images + 1 text prompt
+        assert_eq!(content[0]["source"]["media_type"], "image/png");
+        assert_eq!(content[1]["source"]["media_type"], "image/jpeg");
+        assert_eq!(content[2]["source"]["media_type"], "image/webp");
+        // Prompt trails the attachments.
+        assert_eq!(content[3]["type"], "text");
+        assert_eq!(content[3]["text"], "compare these");
     }
 
     #[test]
@@ -940,12 +951,12 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
         let content = parsed["message"]["content"].as_array().unwrap();
         assert_eq!(content.len(), 2);
-        assert_eq!(content[0]["type"], "text");
-        // PDFs must use "document" type, not "image".
-        assert_eq!(content[1]["type"], "document");
-        assert_eq!(content[1]["source"]["type"], "base64");
-        assert_eq!(content[1]["source"]["media_type"], "application/pdf");
-        assert_eq!(content[1]["source"]["data"], "JVBERi0xLjQ=");
+        // PDFs must use "document" type, not "image", and lead the prompt.
+        assert_eq!(content[0]["type"], "document");
+        assert_eq!(content[0]["source"]["type"], "base64");
+        assert_eq!(content[0]["source"]["media_type"], "application/pdf");
+        assert_eq!(content[0]["source"]["data"], "JVBERi0xLjQ=");
+        assert_eq!(content[1]["type"], "text");
     }
 
     #[test]
@@ -967,9 +978,10 @@ mod tests {
         let msg = build_stdin_message("here are files", &attachments);
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
         let content = parsed["message"]["content"].as_array().unwrap();
-        assert_eq!(content.len(), 3); // 1 text + 1 image + 1 document
-        assert_eq!(content[1]["type"], "image");
-        assert_eq!(content[2]["type"], "document");
+        assert_eq!(content.len(), 3); // 1 image + 1 document + 1 text prompt
+        assert_eq!(content[0]["type"], "image");
+        assert_eq!(content[1]["type"], "document");
+        assert_eq!(content[2]["type"], "text");
     }
 
     #[test]
@@ -984,12 +996,13 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
         let content = parsed["message"]["content"].as_array().unwrap();
         assert_eq!(content.len(), 2);
+        // Attachment (text file) leads, prompt trails.
         assert_eq!(content[0]["type"], "text");
-        assert_eq!(content[0]["text"], "review this");
-        assert_eq!(content[1]["type"], "text");
-        let text = content[1]["text"].as_str().unwrap();
+        let text = content[0]["text"].as_str().unwrap();
         assert!(text.contains("main.rs"));
         assert!(text.contains("fn main() {}"));
+        assert_eq!(content[1]["type"], "text");
+        assert_eq!(content[1]["text"], "review this");
     }
 
     #[test]
@@ -1017,13 +1030,34 @@ mod tests {
         let msg = build_stdin_message("check these", &attachments);
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
         let content = parsed["message"]["content"].as_array().unwrap();
-        assert_eq!(content.len(), 4); // 1 prompt + 1 text file + 1 image + 1 document
+        assert_eq!(content.len(), 4); // 1 text file + 1 image + 1 document + 1 prompt
+        // Attachments lead in slice order; the prompt trails as the last block.
         assert_eq!(content[0]["type"], "text");
-        assert_eq!(content[0]["text"], "check these");
-        assert_eq!(content[1]["type"], "text");
-        assert!(content[1]["text"].as_str().unwrap().contains("readme.txt"));
-        assert_eq!(content[2]["type"], "image");
-        assert_eq!(content[3]["type"], "document");
+        assert!(content[0]["text"].as_str().unwrap().contains("readme.txt"));
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[2]["type"], "document");
+        assert_eq!(content[3]["type"], "text");
+        assert_eq!(content[3]["text"], "check these");
+    }
+
+    #[test]
+    fn test_build_stdin_message_attachments_precede_prompt() {
+        // Contract: longform attachment blocks come first, the user's prompt is
+        // the trailing block (Anthropic "put longform data at the top" guidance).
+        let attachments = vec![FileAttachment {
+            media_type: "image/png".into(),
+            data_base64: "png_data".into(),
+            text_content: None,
+            filename: None,
+        }];
+        let msg = build_stdin_message("what is in this image?", &attachments);
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let content = parsed["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["type"], "image");
+        let last = content.last().unwrap();
+        assert_eq!(last["type"], "text");
+        assert_eq!(last["text"], "what is in this image?");
     }
 
     #[test]

--- a/src/agent/codex_app_server.rs
+++ b/src/agent/codex_app_server.rs
@@ -1811,12 +1811,9 @@ fn validate_codex_attachments(attachments: &[FileAttachment]) -> Result<(), Stri
 fn build_codex_user_input(prompt: &str, attachments: &[FileAttachment]) -> Vec<Value> {
     let mut input = Vec::with_capacity(attachments.len() + 1);
 
-    input.push(json!({
-        "type": "text",
-        "text": prompt,
-        "textElements": [],
-    }));
-
+    // Attachments lead so the model reads the longform data (documents, images)
+    // before the user's query/instructions, per Anthropic's "put longform data
+    // at the top" guidance. Mirrors build_stdin_message_inner on the Claude path.
     for attachment in attachments {
         if let Some(text) = attachment.text_content.as_deref() {
             let label = attachment.filename.as_deref().unwrap_or("file");
@@ -1835,6 +1832,12 @@ fn build_codex_user_input(prompt: &str, attachments: &[FileAttachment]) -> Vec<V
             }));
         }
     }
+
+    input.push(json!({
+        "type": "text",
+        "text": prompt,
+        "textElements": [],
+    }));
 
     input
 }
@@ -3715,18 +3718,20 @@ mod tests {
         });
         let value = serde_json::to_value(request).unwrap();
 
-        assert_eq!(value["params"]["input"][0]["type"], "text");
-        assert_eq!(value["params"]["input"][0]["text"], "inspect this");
-        assert_eq!(value["params"]["input"][1]["type"], "image");
+        // Attachments lead in slice order; the prompt is the trailing block
+        // (longform data at the top, query last).
+        assert_eq!(value["params"]["input"][0]["type"], "image");
         assert_eq!(
-            value["params"]["input"][1]["url"],
+            value["params"]["input"][0]["url"],
             "data:image/png;base64,iVBORw0KGgo="
         );
-        assert_eq!(value["params"]["input"][2]["type"], "text");
+        assert_eq!(value["params"]["input"][1]["type"], "text");
         assert_eq!(
-            value["params"]["input"][2]["text"],
+            value["params"]["input"][1]["text"],
             "Content of `note.txt`:\n```\nhello from a file\n```"
         );
+        assert_eq!(value["params"]["input"][2]["type"], "text");
+        assert_eq!(value["params"]["input"][2]["text"], "inspect this");
     }
 
     #[test]
@@ -3744,12 +3749,13 @@ mod tests {
         assert_eq!(value["method"], "turn/steer");
         assert_eq!(value["params"]["threadId"], "thread-1");
         assert_eq!(value["params"]["expectedTurnId"], "turn-1");
-        assert_eq!(value["params"]["input"][0]["text"], "also inspect this");
-        assert_eq!(value["params"]["input"][1]["type"], "image");
+        // Attachment leads, prompt trails.
+        assert_eq!(value["params"]["input"][0]["type"], "image");
         assert_eq!(
-            value["params"]["input"][1]["url"],
+            value["params"]["input"][0]["url"],
             "data:image/jpeg;base64,/9j/4AAQ"
         );
+        assert_eq!(value["params"]["input"][1]["text"], "also inspect this");
     }
 
     #[test]


### PR DESCRIPTION
### Summary

Reorders user-turn content blocks so **attachment content leads and the user's query/instructions trail**, matching Anthropic's prompt-engineering guidance to "put longform data at the top … above your query, instructions, and examples," and the vision guidance to place images before text.

Previously both attachment-carrying harnesses built the payload as `[prompt, att0, att1, …]` — query first, longform data last. This flips that to `[att0, att1, …, prompt]`.

The ordering lives in a single builder per harness, and every send path (one-shot, persistent, mid-turn steering) funnels through it, so this is a focused change:

- **Claude CLI** (`src/agent/args.rs`, `build_stdin_message_inner`) — attachment blocks now pushed before the trailing prompt text block. The empty/whitespace-prompt omission is preserved (the API rejects empty text blocks).
- **Codex app-server** (`src/agent/codex_app_server.rs`, `build_codex_user_input`) — prompt push relocated to after the attachment loop; still unconditional (Codex's prior behavior), just trailing.

No change needed elsewhere:
- **Pi harness** rejects attachments at the Rust boundary, so there is no ordering to set.
- **Frontend / MCP send path** never reorders — it forwards `content` and `attachments` as separate values, leaving the two Rust builders as the sole authority.

```mermaid
flowchart LR
    subgraph before["Before"]
        direction LR
        b0["prompt (query)"] --> b1["attachment 0"] --> b2["attachment 1"]
    end
    subgraph after["After (longform-first)"]
        direction LR
        a0["attachment 0"] --> a1["attachment 1"] --> a2["prompt (query)"]
    end
    before -.reorder.-> after
```

### Complexity Notes

- **Empty-prompt asymmetry (intentional, preserved):** the Claude path *omits* a blank prompt block entirely, while Codex still emits an (empty) trailing text block. Each harness's pre-existing empty-prompt behavior was preserved rather than unified — the diff is strictly about ordering.
- **Steering inherits the fix for free:** `build_steering_stdin_message` and `build_turn_steer_request` delegate to the same builders, so mid-turn attachment injection is also now data-first.
- Attachment slice order within the group is unchanged; only the prompt moved relative to the group.

### Test Steps

1. `cargo test -p claudette --all-features` — all backend tests pass (1543 + integration + doctests).
2. Targeted: `cargo test -p claudette --lib --all-features stdin_message` and `cargo test -p claudette --lib --all-features codex` — ordering tests assert attachments precede the prompt; see the new `test_build_stdin_message_attachments_precede_prompt`.
3. `cargo clippy -p claudette --all-features --lib` — zero warnings; `cargo fmt --all --check` — clean.
4. Manual: attach an image or PDF plus a short prompt in the GUI and send. The model receives the document/image block(s) first and the query as the final block (verify via the CLI invocation banner / stream-json payload).

### Checklist
- [x] Tests added/updated
- [ ] Documentation updated (if applicable) — internal prompt-construction with no user-facing setting/flag, so no docs-site change applies.
