### PR TITLE
fix(env): fall back to login-only shell probe when interactive probe fails

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -194,9 +194,18 @@ pub fn apply_denylist(
 /// testability — callers usually go through [`probe_shell_env`] which
 /// resolves `$SHELL` automatically.
 ///
-/// Spawns `<shell> -l -i -c '<emit-script>'` with a 5-second timeout,
-/// stdin closed, no console window. Returns `None` on timeout,
-/// non-zero exit, missing/relative shell path, or parse failure.
+/// First attempts `<shell> -l -i -c '<emit-script>'` (login + interactive)
+/// so that both `.zprofile`/`.bash_profile` (login) and `.zshrc`/`.bashrc`
+/// (interactive) are sourced, capturing tools like `nvm`, `pyenv`, and
+/// `rbenv` that only add themselves to PATH for interactive sessions.
+///
+/// If the interactive probe exits non-zero or times out — which happens on
+/// systems whose `.zshrc` contains terminal-dependent initialization (e.g.
+/// Powerlevel10k instant prompt, `compinit`, or `read` calls) — the probe
+/// falls back to `<shell> -l -c '<emit-script>'` (login-only). The
+/// login-only probe matches the behaviour of the previous
+/// `login_shell_path_probe` implementation and reliably captures PATH
+/// additions from `.zprofile` / `.bash_profile`.
 ///
 /// Fish has no `env -0`, so we build the NUL-delimited stream by
 /// hand using `set -nx` (lists exported var names) and `$$var`
@@ -224,8 +233,24 @@ pub fn probe_shell_env_with_shell(shell: &std::path::Path) -> Option<BTreeMap<St
         r#"printf '\0'; env -0"#
     };
 
+    // Try the interactive+login probe first to capture .zshrc/.bashrc additions.
+    // Fall back to login-only when the interactive probe fails (e.g. .zshrc has
+    // terminal-dependent init that exits non-zero without a real TTY).
+    run_shell_probe(shell, &["-l", "-i", "-c", emit_script]).or_else(|| {
+        tracing::debug!(
+            target: "claudette::env",
+            shell = %shell.display(),
+            "interactive shell probe failed; retrying with login-only probe",
+        );
+        run_shell_probe(shell, &["-l", "-c", emit_script])
+    })
+}
+
+/// Spawn `shell` with `args`, drain stdout, and return the parsed env dump.
+/// Returns `None` on spawn failure, timeout, non-zero exit, or empty parse.
+fn run_shell_probe(shell: &std::path::Path, args: &[&str]) -> Option<BTreeMap<String, String>> {
     let mut child = crate::process::std_command(shell)
-        .args(["-l", "-i", "-c", emit_script])
+        .args(args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -1468,12 +1493,48 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         let tmp = tempfile::tempdir().unwrap();
         let shim = tmp.path().join("badshell");
+        // Exits 7 regardless of args — both the interactive and login-only
+        // probes will fail, so the function must return None.
         std::fs::write(&shim, "#!/bin/sh\nexit 7\n").unwrap();
         let mut perm = std::fs::metadata(&shim).unwrap().permissions();
         perm.set_mode(0o755);
         std::fs::set_permissions(&shim, perm).unwrap();
         let probed = probe_shell_env_with_shell(shim.as_path());
         assert!(probed.is_none(), "non-zero shell exit must yield None");
+    }
+
+    /// Verify the interactive-probe fallback: a shell that fails when run with
+    /// `-i` (simulating a `.zshrc` that requires a real TTY) but succeeds with
+    /// login-only args must still return valid results via the fallback probe.
+    #[cfg(unix)]
+    #[test]
+    fn probe_falls_back_to_login_only_when_interactive_fails() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let shim = tmp.path().join("pickyshell");
+        // Fails when invoked with -i (interactive), succeeds otherwise.
+        // grep for the literal flag to distinguish the two probe attempts.
+        std::fs::write(
+            &shim,
+            "#!/bin/sh\ncase \"$*\" in *-i*) exit 2;; esac\nprintf 'FALLBACK_VAR=yes\\0PATH=/fallback/bin\\0'\n",
+        )
+        .unwrap();
+        let mut perm = std::fs::metadata(&shim).unwrap().permissions();
+        perm.set_mode(0o755);
+        std::fs::set_permissions(&shim, perm).unwrap();
+
+        let probed = probe_shell_env_with_shell(shim.as_path());
+        let env = probed.expect("fallback login-only probe must succeed");
+        assert_eq!(
+            env.get("FALLBACK_VAR").map(String::as_str),
+            Some("yes"),
+            "login-only fallback must capture env vars",
+        );
+        assert_eq!(
+            env.get("PATH").map(String::as_str),
+            Some("/fallback/bin"),
+            "login-only fallback must capture PATH",
+        );
     }
 
     #[test]

--- a/src/env.rs
+++ b/src/env.rs
@@ -199,13 +199,15 @@ pub fn apply_denylist(
 /// (interactive) are sourced, capturing tools like `nvm`, `pyenv`, and
 /// `rbenv` that only add themselves to PATH for interactive sessions.
 ///
-/// If the interactive probe exits non-zero or times out — which happens on
-/// systems whose `.zshrc` contains terminal-dependent initialization (e.g.
-/// Powerlevel10k instant prompt, `compinit`, or `read` calls) — the probe
-/// falls back to `<shell> -l -c '<emit-script>'` (login-only). The
-/// login-only probe matches the behaviour of the previous
-/// `login_shell_path_probe` implementation and reliably captures PATH
-/// additions from `.zprofile` / `.bash_profile`.
+/// If the interactive probe fails for any reason — spawn error, non-zero
+/// exit, timeout, or an empty/unparseable stdout dump — the probe falls back
+/// to `<shell> -l -c '<emit-script>'` (login-only). The most common trigger
+/// is `.zshrc` containing terminal-dependent initialization (e.g.
+/// Powerlevel10k instant prompt, `compinit`, or `read` calls) that causes
+/// the shell to exit non-zero without a real TTY. The login-only probe
+/// matches the behaviour of the previous `login_shell_path_probe`
+/// implementation and reliably captures PATH additions from
+/// `.zprofile` / `.bash_profile`.
 ///
 /// Fish has no `env -0`, so we build the NUL-delimited stream by
 /// hand using `set -nx` (lists exported var names) and `$$var`

--- a/src/git.rs
+++ b/src/git.rs
@@ -23,10 +23,11 @@ pub fn resolve_git_path_blocking() -> OsString {
         return cached.clone();
     }
     // On Unix, `enriched_path()` reads the PATH from the cached shell env;
-    // the initial probe spawns `$SHELL -l -i -c env -0` with a 5 s timeout.
-    // `resolve_git_path_blocking` is called inline from async code paths
-    // (every `run_git`), so we must not pay that probe cost on a Tokio
-    // worker. When the cache is cold we fall back to the process PATH —
+    // the initial probe tries `$SHELL -l -i -c '...'` then falls back to
+    // `$SHELL -l -c '...'` (up to 5 s each). `resolve_git_path_blocking`
+    // is called inline from async code paths (every `run_git`), so we must
+    // not pay that probe cost on a Tokio worker. When the cache is cold we
+    // fall back to the process PATH —
     // git is almost always in `/usr/bin` or
     // `/usr/local/bin` (both in process PATH on macOS/Linux), and the
     // well-known fallbacks below cover nix profiles, Homebrew, etc.


### PR DESCRIPTION
## Summary

The shell-env feature (#990, shipped in 558b6869) changed the environment probe from `$SHELL -l -c` (login-only) to `$SHELL -l -i -c` (login + interactive) to capture tools like `nvm`, `pyenv`, and `rbenv` that only add themselves to `PATH` in `.zshrc`/`.bashrc`. However, many `.zshrc` files contain terminal-dependent initialization — Powerlevel10k instant prompt, `compinit`, or `read` calls — that cause the shell to **exit non-zero when run without a real TTY**.

When the probe fails:
- `SHELL_ENV` cache stays empty → `shell_env_is_cached()` returns `false`
- The dispatcher never injects the shell-env source
- `enriched_path()` falls back to the minimal launchd PATH (`/usr/bin:/bin:/usr/sbin:/sbin`)
- Claude CLI reports `sf isn't on the non-interactive PATH` / `gh isn't on the non-interactive PATH`

**Fix:** Extract the subprocess-run logic into a private `run_shell_probe(shell, args)` helper and have `probe_shell_env_with_shell` try the interactive probe first, then silently fall back to the login-only probe on non-zero exit or timeout.

- Well-behaved shells get the full interactive env capture (`.zshrc`/`.bashrc` additions preserved)
- Shells with TTY-sensitive init scripts fall back to the pre-#990 login-only behavior and retain PATH enrichment from `.zprofile`/`.bash_profile`
- A `tracing::debug!` event is emitted when the fallback fires, so it's visible in logs

## Complexity Notes

**Worst-case timing:** If both probes timeout, the background prewarm thread blocks for up to 10s (5s per probe) instead of 5s. This is acceptable because:
1. The probe runs on a detached `std::thread::spawn`, never on the Tokio runtime or UI thread
2. The common interactive-probe failure (`.zshrc` exits non-zero fast, e.g. Powerlevel10k guard) is milliseconds, not a timeout
3. A shell that hangs under *both* `-i` and `-l` modes would have hung the old code too

## Test Steps

1. On a Mac with a `.zshrc` that includes Powerlevel10k or similar TTY-requiring setup, install the nightly build from this branch.
2. Open Claudette and start a new agent session in any workspace.
3. Ask the agent to run `which sf` or `which gh` — the tools should be found.
4. Optionally check Settings → Environment → Shell environment to confirm the probe captured vars from the shell profile.

To reproduce the regression locally: add `exit 1` at the top of `~/.zshrc` and confirm the old code breaks while this fix falls back correctly.

## Checklist
- [x] Tests added/updated (`probe_falls_back_to_login_only_when_interactive_fails`)
- [x] `probe_returns_none_when_shell_exits_nonzero` updated with comment clarifying both probes now run
- [x] `src/git.rs` comment updated to reflect the new worst-case probe timing (up to 5s each)
- [ ] Documentation updated (no user-visible behavior change — the fallback is transparent)