### PR TITLE
fix(agent): stop forwarding remote MCP servers into Codex thread config

### DIFF
--- a/src/agent/codex_app_server.rs
+++ b/src/agent/codex_app_server.rs
@@ -1699,6 +1699,24 @@ fn codex_thread_config(reasoning_effort: Option<&str>, mcp_config: Option<&str>)
     (!config.is_empty()).then_some(Value::Object(config))
 }
 
+/// Translate Claude Code's `--mcp-config` shape into Codex's `mcp_servers`
+/// config override, forwarding only `stdio` (command-based) servers.
+///
+/// Remote servers (`"type": "http"` / `"sse"`, keyed on `url` rather than
+/// `command`) are deliberately dropped rather than translated. Codex's
+/// `config` override is deep-merged on top of the user's own
+/// `~/.codex/config.toml` (and project `.codex/config.toml`) layers keyed by
+/// server name — see `merge_toml_values` in codex's config crate. If the user
+/// already has a `command`-based entry for that name (e.g. an `mcp-remote`
+/// stdio bridge to the same remote server, which is how Codex natively
+/// supports non-streamable-http remotes), merging our `url`-based override on
+/// top produces a hybrid entry with both `command` and `url` set, which
+/// Codex's config loader rejects outright (`url is not supported for
+/// stdio`), aborting the whole `thread/start`/`thread/resume` call. Even
+/// without a name collision, Claude's remote-server shape uses `headers`
+/// where Codex expects `http_headers`/`bearer_token_env_var`, so forwarding
+/// it verbatim silently drops auth headers. Remote MCP access for Codex
+/// should be configured natively in Codex's own config instead.
 fn codex_mcp_servers_from_claude_config(mcp_config: &str) -> Option<Value> {
     let parsed: Value = serde_json::from_str(mcp_config).ok()?;
     let servers = parsed
@@ -1709,6 +1727,13 @@ fn codex_mcp_servers_from_claude_config(mcp_config: &str) -> Option<Value> {
     for (name, server) in servers {
         let mut server = server.clone();
         if let Value::Object(ref mut object) = server {
+            let is_remote = matches!(
+                object.get("type").and_then(Value::as_str),
+                Some("http") | Some("sse")
+            );
+            if is_remote {
+                continue;
+            }
             object.remove("type");
         }
         codex_servers.insert(name.clone(), server);
@@ -3847,6 +3872,39 @@ mod tests {
         assert_eq!(server["env"]["CLAUDETTE_AGENT_MCP_TOKEN"], "secret");
         assert!(server.get("type").is_none());
         assert_eq!(value["params"]["config"]["model_reasoning_effort"], "high");
+    }
+
+    #[test]
+    fn thread_start_request_drops_remote_mcp_servers_for_codex() {
+        // Regression test: a `"type": "http"`/`"sse"` (remote/url-based)
+        // Claude MCP server must not be forwarded into Codex's config
+        // override. Codex deep-merges this override onto the user's own
+        // `~/.codex/config.toml` layers by server name; if the user already
+        // has a `command`-based (stdio) entry under the same name — e.g. an
+        // `mcp-remote` bridge, which is how Codex natively reaches non-
+        // streamable-http remotes — merging in a `url` field produces a
+        // hybrid entry with both `command` and `url` set, which Codex's
+        // config loader rejects with `url is not supported for stdio`,
+        // aborting `thread/start` entirely.
+        let request = build_thread_start_request(
+            8,
+            CodexThreadRequestParams {
+                model: Some("gpt-5.4"),
+                cwd: Path::new("/tmp/work"),
+                permission_level: CodexPermissionLevel::Readonly,
+                fast_mode: false,
+                reasoning_effort: None,
+                custom_instructions: None,
+                mcp_config: Some(
+                    r#"{"mcpServers":{"datadog":{"type":"http","url":"https://mcp.us3.datadoghq.com/api/unstable/mcp-server/mcp","headers":{"DD_API_KEY":"secret"}},"puppeteer":{"type":"stdio","command":"npx","args":["-y","@modelcontextprotocol/server-puppeteer"]}}}"#,
+                ),
+            },
+        );
+        let value = serde_json::to_value(request).unwrap();
+
+        let mcp_servers = &value["params"]["config"]["mcp_servers"];
+        assert!(mcp_servers.get("datadog").is_none());
+        assert_eq!(mcp_servers["puppeteer"]["command"], "npx");
     }
 
     #[test]

--- a/src/agent/codex_app_server.rs
+++ b/src/agent/codex_app_server.rs
@@ -1725,20 +1725,16 @@ fn codex_mcp_servers_from_claude_config(mcp_config: &str) -> Option<Value> {
         .as_object()?;
     let mut codex_servers = serde_json::Map::new();
     for (name, server) in servers {
-        let mut server = server.clone();
-        if let Value::Object(ref mut object) = server {
-            let is_remote = matches!(
-                object.get("type").and_then(Value::as_str),
-                Some("http") | Some("sse")
-            );
-            if is_remote {
-                continue;
-            }
-            object.remove("type");
+        let Some(mut object) = server.as_object().cloned() else {
+            continue;
+        };
+        if object.get("command").and_then(Value::as_str).is_none() {
+            continue;
         }
-        codex_servers.insert(name.clone(), server);
+        object.remove("type");
+        codex_servers.insert(name.clone(), Value::Object(object));
     }
-    Some(Value::Object(codex_servers))
+    (!codex_servers.is_empty()).then_some(Value::Object(codex_servers))
 }
 
 pub struct CodexTurnStartRequest<'a> {
@@ -3896,7 +3892,7 @@ mod tests {
                 reasoning_effort: None,
                 custom_instructions: None,
                 mcp_config: Some(
-                    r#"{"mcpServers":{"datadog":{"type":"http","url":"https://mcp.us3.datadoghq.com/api/unstable/mcp-server/mcp","headers":{"DD_API_KEY":"secret"}},"puppeteer":{"type":"stdio","command":"npx","args":["-y","@modelcontextprotocol/server-puppeteer"]}}}"#,
+                    r#"{"mcpServers":{"datadog":{"type":"http","url":"https://mcp.us3.datadoghq.com/api/unstable/mcp-server/mcp","headers":{"DD_API_KEY":"secret"}},"legacy-remote":{"url":"https://example.com/mcp"},"malformed":"not-an-object","puppeteer":{"command":"npx","args":["-y","@modelcontextprotocol/server-puppeteer"]}}}"#,
                 ),
             },
         );
@@ -3904,7 +3900,28 @@ mod tests {
 
         let mcp_servers = &value["params"]["config"]["mcp_servers"];
         assert!(mcp_servers.get("datadog").is_none());
+        assert!(mcp_servers.get("legacy-remote").is_none());
+        assert!(mcp_servers.get("malformed").is_none());
         assert_eq!(mcp_servers["puppeteer"]["command"], "npx");
+    }
+
+    #[test]
+    fn thread_start_request_omits_mcp_override_when_no_stdio_servers_remain() {
+        let request = build_thread_start_request(
+            8,
+            CodexThreadRequestParams {
+                model: Some("gpt-5.4"),
+                cwd: Path::new("/tmp/work"),
+                permission_level: CodexPermissionLevel::Readonly,
+                fast_mode: false,
+                reasoning_effort: None,
+                custom_instructions: None,
+                mcp_config: Some(r#"{"mcpServers":{"remote":{"url":"https://example.com/mcp"}}}"#),
+            },
+        );
+        let value = serde_json::to_value(request).unwrap();
+
+        assert!(value["params"]["config"].is_null());
     }
 
     #[test]

--- a/src/cesp.rs
+++ b/src/cesp.rs
@@ -45,17 +45,13 @@ pub fn resolve_category<'a>(manifest: &'a CespManifest, category: &str) -> Optio
     }
     let mut target = category.to_string();
     for _ in 0..MAX_ALIAS_DEPTH {
-        match manifest.category_aliases.get(&target) {
-            Some(alias_target) => {
-                if let Some(cat) = manifest.categories.get(alias_target)
-                    && !cat.sounds.is_empty()
-                {
-                    return Some(&cat.sounds);
-                }
-                target = alias_target.clone();
-            }
-            None => return None,
+        let alias_target = manifest.category_aliases.get(&target)?;
+        if let Some(cat) = manifest.categories.get(alias_target)
+            && !cat.sounds.is_empty()
+        {
+            return Some(&cat.sounds);
         }
+        target = alias_target.clone();
     }
     None
 }

--- a/src/ops/workspace.rs
+++ b/src/ops/workspace.rs
@@ -460,19 +460,11 @@ pub async fn resolve_and_run_setup_streaming(
         Ok(Some(cfg)) => {
             if let Some(setup) = cfg.scripts.and_then(|s| s.setup) {
                 (setup, "repo")
-            } else if let Some(fallback) = settings_script {
-                (fallback.to_string(), "settings")
             } else {
-                return None;
+                (settings_script?.to_string(), "settings")
             }
         }
-        Ok(None) => {
-            if let Some(fallback) = settings_script {
-                (fallback.to_string(), "settings")
-            } else {
-                return None;
-            }
-        }
+        Ok(None) => (settings_script?.to_string(), "settings"),
         Err(parse_err) => {
             tracing::warn!(
                 target: "claudette::workspace",
@@ -649,19 +641,11 @@ pub async fn resolve_and_run_archive(
         Ok(Some(cfg)) => {
             if let Some(archive) = cfg.scripts.and_then(|s| s.archive) {
                 (archive, "repo")
-            } else if let Some(fallback) = settings_script {
-                (fallback.to_string(), "settings")
             } else {
-                return None;
+                (settings_script?.to_string(), "settings")
             }
         }
-        Ok(None) => {
-            if let Some(fallback) = settings_script {
-                (fallback.to_string(), "settings")
-            } else {
-                return None;
-            }
-        }
+        Ok(None) => (settings_script?.to_string(), "settings"),
         Err(parse_err) => {
             tracing::warn!(
                 target: "claudette::workspace",


### PR DESCRIPTION
## Summary

- Codex's per-thread `config` override (sent via `thread/start`/`thread/resume`) is deep-merged onto the user's own `~/.codex/config.toml` (and project/repo `.codex/config.toml`) layers, keyed by MCP server name — Codex merges tables field-by-field, not by whole-entry replacement.
- Claudette's `codex_mcp_servers_from_claude_config` (`src/agent/codex_app_server.rs`) was translating *every* Claude Code MCP server into that override, including remote (`"type": "http"`/`"sse"`, `url`-based) ones. If the user already has a `command`-based (stdio) entry under the same server name in their native Codex config — e.g. an `mcp-remote` stdio bridge, which is how Codex natively reaches non-streamable-http remotes — merging in the `url`-based override produces a hybrid entry with both `command` and `url` set. Codex's config loader rejects that outright with `url is not supported for stdio`, aborting the entire `thread/start` call and blocking the whole Codex session from starting (not just disabling that one tool).
- Even without a name collision, Claude's remote-server shape uses a `headers` field where Codex expects `http_headers`/`bearer_token_env_var`, so forwarding it verbatim was already silently dropping auth headers.
- Fix: only forward `stdio` (command-based) MCP servers into Codex's session config. Remote MCP access for Codex should be configured natively in Codex's own config (`codex mcp add <name> --url <url>` or `~/.codex/config.toml`), which is how affected users already work around this.

Root cause was confirmed against OpenAI's actual Codex source (`codex-rs/config/src/merge.rs`'s `merge_toml_values`, `codex-rs/config/src/mcp_types.rs`'s `TryFrom<RawMcpServerConfig>`) and reproduced against a real-world config pairing: a Claude Code `datadog` entry (`type: http`, `url`, `headers`) alongside a native Codex `datadog` entry (`command: npx` running `mcp-remote` against the same URL).

```mermaid
sequenceDiagram
    participant Claudette
    participant Codex as Codex app-server
    participant Layers as ~/.codex/config.toml layers

    Note over Claudette,Codex: Before fix
    Claudette->>Codex: thread/start { config.mcp_servers.datadog = { url, headers } }
    Codex->>Layers: deep-merge override onto file config
    Layers-->>Codex: mcp_servers.datadog = { command, args, env, url } (hybrid, invalid)
    Codex--xClaudette: "url is not supported for stdio" — thread/start fails

    Note over Claudette,Codex: After fix
    Claudette->>Codex: thread/start { config.mcp_servers omits remote "datadog" }
    Codex->>Layers: deep-merge override onto file config
    Layers-->>Codex: mcp_servers.datadog = { command, args, env } (untouched, valid)
    Codex-->>Claudette: thread/start succeeds
```

## Complexity Notes

- The fix is intentionally narrow: it excludes remote/`url`-based servers entirely rather than attempting to translate them into Codex's `http_headers`/`bearer_token_env_var` shape, because even a correctly-shaped `url`-based override would still collide with a pre-existing `command`-based entry of the same name (Codex's merge can't retract a field the base layer already set). Users who want Codex to reach the same remote MCP server should configure it natively in Codex's own config, which is what the reporting user had already done.
- Stdio-to-stdio name collisions (e.g. a server configured in both tools, such as `puppeteer`) remain unaffected — Codex's validator only errors on the `command`+`url` mismatch, not on merging two compatible stdio shapes, so those keep being forwarded as before.

## Test Steps

1. `cargo test -p claudette --lib agent::codex_app_server::tests::thread_start_request` — confirms the new regression test (`thread_start_request_drops_remote_mcp_servers_for_codex`) and the existing stdio-translation test both pass.
2. Manually: configure a Claude Code MCP server with `"type": "http"` and a `url`, plus a same-named `command`-based entry in `~/.codex/config.toml` pointing at the same remote endpoint (e.g. via `mcp-remote`). Start a Codex Native session in Claudette against that project — it should start successfully instead of failing with `failed to load configuration: url is not supported for stdio`.
3. Confirm a purely `stdio`-type Claude MCP server (no native Codex equivalent) is still visible/usable inside the Codex session.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable) — not applicable; internal session-start plumbing fix, no user-facing setting/flag/command changed.