### PR TITLE
fix(chat): show days and hours in agent run durations

### DIFF
--- a/src/ui/src/components/chat/chatHelpers.test.ts
+++ b/src/ui/src/components/chat/chatHelpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatDurationMs, formatElapsedSeconds } from "./chatHelpers";
+
+describe("formatElapsedSeconds", () => {
+  it("formats sub-minute durations as seconds only", () => {
+    expect(formatElapsedSeconds(0)).toBe("0s");
+    expect(formatElapsedSeconds(15)).toBe("15s");
+    expect(formatElapsedSeconds(59)).toBe("59s");
+  });
+
+  it("formats sub-hour durations as minutes and seconds", () => {
+    expect(formatElapsedSeconds(60)).toBe("1m 0s");
+    expect(formatElapsedSeconds(154)).toBe("2m 34s");
+    expect(formatElapsedSeconds(3599)).toBe("59m 59s");
+  });
+
+  it("formats sub-day durations as hours, minutes, and seconds", () => {
+    expect(formatElapsedSeconds(3600)).toBe("1h 0m 0s");
+    // 1369m 33s, the long-running example this format was extended for
+    expect(formatElapsedSeconds(82173)).toBe("22h 49m 33s");
+    expect(formatElapsedSeconds(86399)).toBe("23h 59m 59s");
+  });
+
+  it("formats multi-day durations as days, hours, minutes, and seconds", () => {
+    expect(formatElapsedSeconds(86400)).toBe("1d 0h 0m 0s");
+    expect(formatElapsedSeconds(90061)).toBe("1d 1h 1m 1s");
+    expect(formatElapsedSeconds(200000)).toBe("2d 7h 33m 20s");
+  });
+});
+
+describe("formatDurationMs", () => {
+  it("delegates to formatElapsedSeconds, rounding sub-second durations up to 1s", () => {
+    expect(formatDurationMs(400)).toBe("1s");
+    expect(formatDurationMs(2500)).toBe("2s");
+    expect(formatDurationMs(82_173_000)).toBe("22h 49m 33s");
+  });
+});

--- a/src/ui/src/components/chat/chatHelpers.ts
+++ b/src/ui/src/components/chat/chatHelpers.ts
@@ -6,12 +6,18 @@ export function shouldDisable1mContext(modelId: string | null): boolean {
   return entry ? entry.contextWindowTokens < 1_000_000 : false;
 }
 
-/** Format a duration in seconds as "15s" or "2m 34s". */
+/** Format a duration in seconds as "15s", "2m 34s", "3h 2m 34s", or "1d 3h 2m 34s". */
 export function formatElapsedSeconds(secs: number): string {
   if (secs < 60) return `${secs}s`;
-  const m = Math.floor(secs / 60);
   const s = secs % 60;
-  return `${m}m ${s}s`;
+  const totalMinutes = Math.floor(secs / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m ${s}s`;
+  const m = totalMinutes % 60;
+  const totalHours = Math.floor(totalMinutes / 60);
+  if (totalHours < 24) return `${totalHours}h ${m}m ${s}s`;
+  const h = totalHours % 24;
+  const d = Math.floor(totalHours / 24);
+  return `${d}d ${h}h ${m}m ${s}s`;
 }
 
 /** Format a duration in milliseconds as "15s" or "2m 34s". Sub-second turns


### PR DESCRIPTION
## Summary

- `formatElapsedSeconds` (in `src/ui/src/components/chat/chatHelpers.ts`) previously capped its output at unbounded minutes, so a long-running agent turn read as something like `1369m 33s`. It now escalates through minutes → hours → days, so the same duration reads as `22h 49m 33s`, and multi-day runs get a leading `Xd`.
- This single helper backs every duration display in the app, so the fix covers both surfaces in one place:
  - **Chat UI**: the live "processing…" timer and aria-label in `ChatPanelSessionView.tsx`, the completed-turn duration in `TurnFooter.tsx` (via `formatDurationMs`), and `VoiceMeter.tsx`.
  - **Dashboard UI**: the per-workspace running-time indicator in `Dashboard.tsx`.
- Short-duration formatting is unchanged: sub-minute durations still show as `15s`, sub-hour as `2m 34s` — no leading zero-units are introduced for shorter runs.

## Test Steps

1. `cd src/ui && bun run test -- chatHelpers.test.ts` — new unit tests pin sub-minute, sub-hour, sub-day, and multi-day formatting (including the `1369m 33s` → `22h 49m 33s` example).
2. In the app, start a long-running agent turn (or use `/claudette-debug eval` to simulate a large elapsed value) and confirm the chat panel's processing timer and the dashboard card's running-time label both show hours/days instead of large minute counts.
3. `cd src/ui && bunx tsc -b && bun run test && bun run lint` — full typecheck, test suite (2791 tests), and lint all pass with no new warnings.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (if applicable) — no user-facing docs describe this display format, so none needed