### PR TITLE
feat(models): add Claude Opus 5 and fix stale Opus/Fable pricing

### DIFF
--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -14,14 +14,13 @@ Select a model from the dropdown in the chat header. Available models:
 
 | Model | ID | Description |
 |-------|-----|-------------|
-| **Opus 4.8 1M** | `opus` | Opus 4.8 with a 1M context window |
-| **Opus 4.8** | `claude-opus-4-8` | Standard Opus 4.8 (200K context) |
+| **Opus 5** | `opus` | Latest Opus; native 1M context window (no extra usage), full effort support incl. XHigh — Anthropic's recommended default for everyday, complex tasks |
 | **Sonnet 5** | `sonnet` | Fast and capable; native 1M context window (no extra usage), full effort support incl. XHigh |
 | **Haiku 4.5** | `haiku` | Fastest, most affordable |
 | **Fable 5** | `claude-fable-5` | Opus-class model with full effort support, incl. XHigh (200K context) |
 | **Fable 5 1M** | `claude-fable-5[1m]` | Fable 5 with a 1M context window |
 
-Earlier-generation models (Opus 4.7, Opus 4.7 1M, Opus 4.6, Opus 4.6 1M, Opus 4.5, Sonnet 4.6, Sonnet 4.6 1M, Sonnet 4.5, Haiku 3.5) remain selectable in the picker as legacy entries.
+Earlier-generation models (Opus 4.8, Opus 4.8 1M, Opus 4.7, Opus 4.7 1M, Opus 4.6, Opus 4.6 1M, Opus 4.5, Sonnet 4.6, Sonnet 4.6 1M, Sonnet 4.5, Haiku 3.5) remain selectable in the picker as legacy entries.
 
 The model selection is per-workspace — you can use different models for different tasks.
 
@@ -31,12 +30,12 @@ Set the default model for new sessions in `Settings > Models > Default model`.
 
 You can change the model on an active chat at any time — from the toolbar dropdown or with the `/model` slash command. Whether the conversation continues depends on whether the swap stays inside the same runtime:
 
-- **Same runtime (no context loss)** — Switching between models that resolve to the same harness keeps the full transcript. The very next turn streams from the new model with every prior message available. This covers the common cases: Sonnet 5 ↔ Opus 4.8 on the Anthropic Claude Code path, two Ollama models on the same Ollama card, and so on. Claudette tears down the persistent agent subprocess and respawns it with the new `--model` flag while reusing the existing session id, so the new turn resumes the prior transcript.
+- **Same runtime (no context loss)** — Switching between models that resolve to the same harness keeps the full transcript. The very next turn streams from the new model with every prior message available. This covers the common cases: Sonnet 5 ↔ Opus 5 on the Anthropic Claude Code path, two Ollama models on the same Ollama card, and so on. Claudette tears down the persistent agent subprocess and respawns it with the new `--model` flag while reusing the existing session id, so the new turn resumes the prior transcript.
 - **Different runtime (context migrated as a prelude)** — Switching to a model whose backend uses a different runtime — e.g., Anthropic Claude Code to Codex Native — preserves the conversation by injecting the prior history into the new harness's very first turn. Claudette reads every persisted message on the session, wraps it in a `<conversation-history>` block, and prepends that block to the user's next message before sending it to the new harness. The persisted chat history in the UI is unchanged; the prelude is only visible to the model on the next turn. Tool calls in the history are rendered as text — the new harness reads them for context but does not re-execute them. The first turn after a cross-runtime switch will be slower and use more input tokens than usual because the whole prior conversation is part of its input.
 
 ### When the model's context window is too small
 
-If you switch to a model whose context window can't hold the current conversation, the agent's send fails with a "context length" / "input is too long" error. Claudette detects that error class and inlines a **"Choose a larger-context model →"** link directly into the chat error banner. Clicking it opens the toolbar's model picker so you can pick one of the 1M-context models (Opus 4.8 1M, Sonnet 5 — which is natively 1M) or another model the registry shows with a larger window. The conversation is not lost — it stays in the chat panel, and your next send under the new model will resume it via the same in-place or cross-runtime path described above.
+If you switch to a model whose context window can't hold the current conversation, the agent's send fails with a "context length" / "input is too long" error. Claudette detects that error class and inlines a **"Choose a larger-context model →"** link directly into the chat error banner. Clicking it opens the toolbar's model picker so you can pick one of the 1M-context models (Opus 5, Sonnet 5 — both natively 1M) or another model the registry shows with a larger window. The conversation is not lost — it stays in the chat panel, and your next send under the new model will resume it via the same in-place or cross-runtime path described above.
 
 ## Reasoning Effort
 

--- a/site/src/content/docs/features/cli-client.mdx
+++ b/site/src/content/docs/features/cli-client.mdx
@@ -154,7 +154,7 @@ Boolean flags are tri-state — pass `--plan` to force on, `--no-plan` to force 
 | `--model` | `opus`, `sonnet`, `haiku`, `claude-opus-4-8`, `claude-fable-5`, ... | Override model for this turn |
 | `--plan` / `--no-plan` | — | Plan mode (read-only until approved) |
 | `--thinking` / `--no-thinking` | — | Extended thinking |
-| `--fast` / `--no-fast` | — | Fast mode (built-in support: Opus 4.6) |
+| `--fast` / `--no-fast` | — | Fast mode (built-in support: Opus 5, Opus 4.8) |
 | `--effort` | `low`, `medium`, `high`, `xhigh`, `max` | Reasoning effort (`xhigh` requires Opus 4.7+, Fable 5, or Sonnet 5) |
 | `--chrome` / `--no-chrome` | — | Chrome browser tool |
 | `--disable-1m-context` | — | Suppress Max-plan auto-upgrade to a 1M context window |

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -33,7 +33,7 @@ Default values applied to all new agent sessions. Per-workspace overrides are av
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| Default model | Model for new chats (Opus 4.8 1M, Opus 4.8, Sonnet 5, Haiku 4.5, Fable 5, Fable 5 1M; older models such as Opus 4.7 / 4.6 / 4.5 and Sonnet 4.6 / 4.6 1M remain selectable behind the picker's "More" disclosure) | — |
+| Default model | Model for new chats (Opus 5, Sonnet 5, Haiku 4.5, Fable 5, Fable 5 1M; older models such as Opus 4.8 / 4.7 / 4.6 / 4.5 and Sonnet 4.6 / 4.6 1M remain selectable behind the picker's "More" disclosure) | — |
 | Default effort / Codex intelligence | Claude models use effort levels (`auto`, `low`, `medium`, `high`, `xhigh`, `max` where supported). Codex uses intelligence levels (`low`, `medium`, `high`, `xhigh`). | Auto / High |
 | Default thinking | Enable extended thinking for Claude models. Codex does not expose a reasoning on/off toggle; use Codex intelligence instead. | Off |
 | Show thinking / reasoning blocks | Display Claude thinking blocks or Codex reasoning summaries in the chat UI. | Off |

--- a/src/ui/src/components/chat/applySelectedModel.test.ts
+++ b/src/ui/src/components/chat/applySelectedModel.test.ts
@@ -247,11 +247,26 @@ describe("applySelectedModel", () => {
       appStore.selectedModel["sess-1"] = "claude-opus-4-7";
       appStore.selectedModelProvider["sess-1"] = "anthropic";
 
-      await applySelectedModel("sess-1", "opus", "anthropic");
+      await applySelectedModel("sess-1", "claude-opus-4-8[1m]", "anthropic");
 
       expect(appStore.setSelectedModel).toHaveBeenCalledWith(
         "sess-1",
         "claude-opus-4-8",
+        "anthropic",
+      );
+      expect(serviceMocks.resetAgentSession).not.toHaveBeenCalled();
+    });
+
+    it("does NOT substitute the `opus` alias (Opus 5 is natively 1M, no 200K variant)", async () => {
+      appStore.disable1mContext = true;
+      appStore.selectedModel["sess-1"] = "claude-opus-4-7";
+      appStore.selectedModelProvider["sess-1"] = "anthropic";
+
+      await applySelectedModel("sess-1", "opus", "anthropic");
+
+      expect(appStore.setSelectedModel).toHaveBeenCalledWith(
+        "sess-1",
+        "opus",
         "anthropic",
       );
       expect(serviceMocks.resetAgentSession).not.toHaveBeenCalled();

--- a/src/ui/src/components/chat/modelCapabilities.test.ts
+++ b/src/ui/src/components/chat/modelCapabilities.test.ts
@@ -2,23 +2,31 @@ import { describe, it, expect } from "vitest";
 import { isFastSupported, isEffortSupported, isXhighEffortAllowed, isMaxEffortAllowed } from "./modelCapabilities";
 
 describe("isFastSupported", () => {
-  it("returns true for claude-opus-4-6", () => {
-    expect(isFastSupported("claude-opus-4-6")).toBe(true);
+  it("returns true for opus alias (now Opus 5)", () => {
+    expect(isFastSupported("opus")).toBe(true);
   });
 
-  it("returns true for claude-opus-4-6[1m]", () => {
-    expect(isFastSupported("claude-opus-4-6[1m]")).toBe(true);
+  it("returns true for claude-opus-4-8 (demoted but still fast-capable)", () => {
+    expect(isFastSupported("claude-opus-4-8")).toBe(true);
   });
 
-  it("returns false for opus alias", () => {
-    expect(isFastSupported("opus")).toBe(false);
+  it("returns true for claude-opus-4-8[1m]", () => {
+    expect(isFastSupported("claude-opus-4-8[1m]")).toBe(true);
+  });
+
+  it("returns false for claude-opus-4-6 (fast mode is Opus 5 / Opus 4.8 only)", () => {
+    expect(isFastSupported("claude-opus-4-6")).toBe(false);
+  });
+
+  it("returns false for claude-opus-4-6[1m]", () => {
+    expect(isFastSupported("claude-opus-4-6[1m]")).toBe(false);
   });
 
   it("returns false for claude-opus-4-7", () => {
     expect(isFastSupported("claude-opus-4-7")).toBe(false);
   });
 
-  it("returns false for claude-fable-5 (Opus-class but fast is Opus-4.6-only)", () => {
+  it("returns false for claude-fable-5 (Opus-class but fast is Opus 5 / Opus 4.8 only)", () => {
     expect(isFastSupported("claude-fable-5")).toBe(false);
   });
 
@@ -38,6 +46,10 @@ describe("isEffortSupported", () => {
 
   it("returns true for claude-opus-4-8", () => {
     expect(isEffortSupported("claude-opus-4-8")).toBe(true);
+  });
+
+  it("returns true for claude-opus-4-8[1m]", () => {
+    expect(isEffortSupported("claude-opus-4-8[1m]")).toBe(true);
   });
 
   it("returns true for claude-fable-5", () => {
@@ -90,6 +102,10 @@ describe("isXhighEffortAllowed", () => {
     expect(isXhighEffortAllowed("claude-opus-4-8")).toBe(true);
   });
 
+  it("returns true for claude-opus-4-8[1m]", () => {
+    expect(isXhighEffortAllowed("claude-opus-4-8[1m]")).toBe(true);
+  });
+
   it("returns true for claude-fable-5", () => {
     expect(isXhighEffortAllowed("claude-fable-5")).toBe(true);
   });
@@ -127,6 +143,10 @@ describe("isMaxEffortAllowed", () => {
 
   it("returns true for claude-opus-4-8", () => {
     expect(isMaxEffortAllowed("claude-opus-4-8")).toBe(true);
+  });
+
+  it("returns true for claude-opus-4-8[1m]", () => {
+    expect(isMaxEffortAllowed("claude-opus-4-8[1m]")).toBe(true);
   });
 
   it("returns true for claude-fable-5", () => {

--- a/src/ui/src/components/chat/modelCapabilities.ts
+++ b/src/ui/src/components/chat/modelCapabilities.ts
@@ -1,16 +1,18 @@
-/** Built-in Claude models that support fast mode. Provider models use backend capabilities. */
-const FAST_SUPPORTED_MODELS = new Set(["claude-opus-4-6", "claude-opus-4-6[1m]"]);
+/** Built-in Claude models that support fast mode (research preview: Claude Opus 5 / Opus 4.8 only).
+ *  `opus` now resolves to Opus 5; the demoted `claude-opus-4-8` ids keep the
+ *  capability they had when `opus` pointed at them. */
+const FAST_SUPPORTED_MODELS = new Set(["opus", "claude-opus-4-8", "claude-opus-4-8[1m]"]);
 
 /** Models that support effort levels. */
-const EFFORT_SUPPORTED_MODELS = new Set(["opus", "claude-opus-4-8", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6", "claude-sonnet-4-6[1m]"]);
+const EFFORT_SUPPORTED_MODELS = new Set(["opus", "claude-opus-4-8", "claude-opus-4-8[1m]", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6", "claude-sonnet-4-6[1m]"]);
 
 /** Models that support the "xhigh" effort level (Opus 4.7+, Fable 5, and Sonnet 5).
  *  Sonnet 5 (the `sonnet` alias, natively 1M) gained xhigh — the demoted
  *  Sonnet 4.6 ids deliberately stay out. */
-const XHIGH_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "sonnet"]);
+const XHIGH_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-opus-4-8[1m]", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "sonnet"]);
 
 /** Models that support the "max" effort level. */
-const MAX_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6", "claude-sonnet-4-6[1m]"]);
+const MAX_EFFORT_MODELS = new Set(["opus", "claude-opus-4-8", "claude-opus-4-8[1m]", "claude-fable-5", "claude-fable-5[1m]", "claude-opus-4-7", "claude-opus-4-7[1m]", "claude-opus-4-6", "claude-opus-4-6[1m]", "sonnet", "claude-sonnet-4-6", "claude-sonnet-4-6[1m]"]);
 
 export function isFastSupported(model: string): boolean {
   return FAST_SUPPORTED_MODELS.has(model);

--- a/src/ui/src/components/chat/modelRegistry.test.ts
+++ b/src/ui/src/components/chat/modelRegistry.test.ts
@@ -61,13 +61,19 @@ describe("modelRegistry", () => {
 
   describe("get1mFallback", () => {
     it("maps 1M models to their 200K equivalents", () => {
-      expect(get1mFallback("opus")).toBe("claude-opus-4-8");
       expect(get1mFallback("claude-fable-5[1m]")).toBe("claude-fable-5");
+      // Opus 4.8 1M now falls back to the pinned 200K id, not the `opus`
+      // alias (which moved to Opus 5).
+      expect(get1mFallback("claude-opus-4-8[1m]")).toBe("claude-opus-4-8");
       expect(get1mFallback("claude-opus-4-7[1m]")).toBe("claude-opus-4-7");
       // Sonnet 4.6 1M now falls back to the pinned 200K id, not the `sonnet`
       // alias (which moved to Sonnet 5).
       expect(get1mFallback("claude-sonnet-4-6[1m]")).toBe("claude-sonnet-4-6");
       expect(get1mFallback("claude-opus-4-6[1m]")).toBe("claude-opus-4-6");
+    });
+
+    it("returns the `opus` alias unchanged (Opus 5 is natively 1M, no 200K variant)", () => {
+      expect(get1mFallback("opus")).toBe("opus");
     });
 
     it("returns the `sonnet` alias unchanged (Sonnet 5 is natively 1M, no 200K variant)", () => {

--- a/src/ui/src/components/chat/modelRegistry.ts
+++ b/src/ui/src/components/chat/modelRegistry.ts
@@ -39,10 +39,12 @@ export function is1mContextModel(modelId: string): boolean {
 }
 
 const NON_1M_FALLBACKS: Record<string, string> = {
-  "opus": "claude-opus-4-8",
+  // No `opus` entry: Opus 5 is natively 1M with no 200K variant to fall back
+  // to, so `get1mFallback("opus")` correctly returns "opus" unchanged.
   // No `sonnet` entry: Sonnet 5 is natively 1M with no 200K variant to fall
   // back to, so `get1mFallback("sonnet")` correctly returns "sonnet" unchanged.
   "claude-fable-5[1m]": "claude-fable-5",
+  "claude-opus-4-8[1m]": "claude-opus-4-8",
   "claude-opus-4-7[1m]": "claude-opus-4-7",
   "claude-sonnet-4-6[1m]": "claude-sonnet-4-6",
   "claude-opus-4-6[1m]": "claude-opus-4-6",
@@ -54,16 +56,21 @@ export function get1mFallback(modelId: string): string {
 
 export const MODELS: readonly Model[] = [
   // 1M context billing per Anthropic's Claude Code docs (Model configuration → Extended context):
-  //   Max/Team/Enterprise → Opus 1M included with subscription; legacy Sonnet 4.6 1M is extra usage.
-  //   Pro                → both Opus 1M and legacy Sonnet 4.6 1M are extra usage.
-  // Sonnet 5 is the exception: its 1M window is native and included at standard pricing on
-  // every plan, so it carries no `extraUsage` indicator (see the `sonnet` row below).
+  //   Max/Team/Enterprise → legacy Opus 4.8 1M is included with subscription; legacy Sonnet 4.6 1M is extra usage.
+  //   Pro                → both legacy Opus 4.8 1M and legacy Sonnet 4.6 1M are extra usage.
+  // Opus 5 and Sonnet 5 are both exceptions: their 1M windows are native and included at
+  // standard pricing on every plan, so neither carries an `extraUsage` indicator (see the
+  // `opus` and `sonnet` rows below).
   // The `extraUsage` flag tracks subscription-quota inclusion, not per-token API price.
   // We optimize for Max/Team/Enterprise (Claudette's primary audience), so only legacy
-  // Sonnet 4.6 1M carries the indicator; Pro users selecting Opus 1M see no warning even
-  // though it counts against their extra-usage allotment.
-  { id: "opus", label: "Opus 4.8 1M", group: "Claude Code", extraUsage: false, contextWindowTokens: 1_000_000 },
-  { id: "claude-opus-4-8", label: "Opus 4.8", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
+  // Sonnet 4.6 1M carries the indicator; Pro users selecting legacy Opus 4.8 1M see no
+  // warning even though it counts against their extra-usage allotment.
+  // `opus` is the bare alias the Claude CLI resolves to the latest Opus — now Opus 5,
+  // which (like Sonnet 5) runs natively at 1M context with no 200K variant, no `[1m]`
+  // suffix to select, and no usage credits on any plan — Anthropic recommends it as
+  // Claude Code's default. So unlike Opus 4.8, there is no separate concrete
+  // `claude-opus-5` row: the alias itself is the 1M model.
+  { id: "opus", label: "Opus 5", group: "Claude Code", extraUsage: false, contextWindowTokens: 1_000_000 },
   // `sonnet` is the bare alias the Claude CLI resolves to the latest Sonnet — now Sonnet 5,
   // which runs natively at 1M context (no 200K variant, no `[1m]` suffix to select, no usage
   // credits on any plan — Claude Code model-config docs, "Sonnet 5 context window"). So unlike
@@ -76,6 +83,11 @@ export const MODELS: readonly Model[] = [
   // uses the `[1m]` suffix convention so `is1mContextModel` detects it without a special case.
   { id: "claude-fable-5", label: "Fable 5", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
   { id: "claude-fable-5[1m]", label: "Fable 5 1M", group: "Claude Code", extraUsage: false, contextWindowTokens: 1_000_000 },
+  // Opus 4.8 demoted to the "More" disclosure when `opus` moved to Opus 5. Both the
+  // 200K default and 1M variant are pinned here (the paths the `opus` alias used to
+  // resolve to for each context size) so they survive the alias move.
+  { id: "claude-opus-4-8", label: "Opus 4.8", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
+  { id: "claude-opus-4-8[1m]", label: "Opus 4.8 1M", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 1_000_000 },
   { id: "claude-opus-4-7", label: "Opus 4.7", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
   { id: "claude-opus-4-7[1m]", label: "Opus 4.7 1M", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 1_000_000 },
   { id: "claude-opus-4-6", label: "Opus 4.6", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },

--- a/src/usage/pricing.rs
+++ b/src/usage/pricing.rs
@@ -98,36 +98,45 @@ const PRICING_TABLE: &[(&str, ModelPricing)] = &[
     (
         "claude-fable-5",
         ModelPricing {
-            prompt_per_mtok_usd: 30.00,
-            completion_per_mtok_usd: 150.00,
+            prompt_per_mtok_usd: 10.00,
+            completion_per_mtok_usd: 50.00,
+        },
+    ),
+    // Opus 5 is the current flagship; the `opus` alias resolves here.
+    // The `[1m]` gateway form matches via `starts_with`.
+    (
+        "claude-opus-5",
+        ModelPricing {
+            prompt_per_mtok_usd: 5.00,
+            completion_per_mtok_usd: 25.00,
         },
     ),
     (
         "claude-opus-4-8",
         ModelPricing {
-            prompt_per_mtok_usd: 15.00,
-            completion_per_mtok_usd: 75.00,
+            prompt_per_mtok_usd: 5.00,
+            completion_per_mtok_usd: 25.00,
         },
     ),
     (
         "claude-opus-4-7",
         ModelPricing {
-            prompt_per_mtok_usd: 15.00,
-            completion_per_mtok_usd: 75.00,
+            prompt_per_mtok_usd: 5.00,
+            completion_per_mtok_usd: 25.00,
         },
     ),
     (
         "claude-opus-4-6",
         ModelPricing {
-            prompt_per_mtok_usd: 15.00,
-            completion_per_mtok_usd: 75.00,
+            prompt_per_mtok_usd: 5.00,
+            completion_per_mtok_usd: 25.00,
         },
     ),
     (
         "claude-opus-4-5",
         ModelPricing {
-            prompt_per_mtok_usd: 15.00,
-            completion_per_mtok_usd: 75.00,
+            prompt_per_mtok_usd: 5.00,
+            completion_per_mtok_usd: 25.00,
         },
     ),
     // Sonnet 5 standard list price ($3/$15 per Mtok) — same as Sonnet 4.6.
@@ -171,11 +180,21 @@ mod tests {
     #[test]
     fn lookup_fable_5_priced_at_2x_opus() {
         let p = lookup("claude-fable-5").expect("claude-fable-5 has pricing");
-        assert!((p.prompt_per_mtok_usd - 30.00).abs() < f64::EPSILON);
-        assert!((p.completion_per_mtok_usd - 150.00).abs() < f64::EPSILON);
+        assert!((p.prompt_per_mtok_usd - 10.00).abs() < f64::EPSILON);
+        assert!((p.completion_per_mtok_usd - 50.00).abs() < f64::EPSILON);
         // The 1M variant shares the bare prefix via `starts_with`.
         let one_m = lookup("claude-fable-5[1m]").expect("1M variant resolves to same pricing");
-        assert!((one_m.prompt_per_mtok_usd - 30.00).abs() < f64::EPSILON);
+        assert!((one_m.prompt_per_mtok_usd - 10.00).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lookup_opus_5() {
+        let p = lookup("claude-opus-5").expect("claude-opus-5 has pricing");
+        assert!((p.prompt_per_mtok_usd - 5.00).abs() < f64::EPSILON);
+        assert!((p.completion_per_mtok_usd - 25.00).abs() < f64::EPSILON);
+        // The 1M gateway form shares the bare prefix via `starts_with`.
+        let one_m = lookup("claude-opus-5[1m]").expect("1M variant resolves to same pricing");
+        assert!((one_m.prompt_per_mtok_usd - 5.00).abs() < f64::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds Claude Opus 5 as a selectable model and makes it the default, per Anthropic's own recommendation ("Opus 5 with 1M context · Best for everyday, complex tasks").

- Retargets the bare `opus` alias — which the Claude CLI always resolves to the latest Opus, and which is Claudette's actual default-model value everywhere (`DEFAULT_CLAUDE_MODEL`, the Rust `default_model` default, chat toolbar fallbacks) — from Opus 4.8 to **Opus 5**. Opus 5 runs natively at 1M context with no 200K/extra-usage split, so this mirrors exactly how `sonnet` moved to Sonnet 5 previously.
- Demotes Opus 4.8 to a legacy entry (both its 200K and 1M variants get their own pinned ids) behind the model picker's "More" disclosure, so it stays selectable.
- Fixes two pre-existing data bugs discovered while placing the new entries:
  - `src/usage/pricing.rs` had Opus 4.5–4.8 hardcoded at $15/$75 per Mtok and Fable 5 at $30/$150 — stale values ~3x the current published pricing ($5/$25 and $10/$50 respectively). Corrected all of them and added the new `claude-opus-5` entry.
  - `modelCapabilities.ts`'s fast-mode capability set gated in `claude-opus-4-6` (which doesn't support fast mode) while omitting Opus 5 / Opus 4.8 (which do, per Anthropic's docs). Corrected the set.

```mermaid
flowchart LR
    A["opus" alias] -->|was| B[Opus 4.8]
    A -->|now| C[Opus 5]
    B -->|demoted to legacy| D["claude-opus-4-8 / claude-opus-4-8[1m]"]
```

## Complexity Notes

- The `opus`/`sonnet` aliases act as rolling pointers that get retargeted at each flagship release, while dated ids become permanent pinned snapshots. Because everything downstream (Rust defaults, Zustand store fallbacks, command palette) just passes the string `"opus"` through, this change is almost entirely a metadata edit in `modelRegistry.ts` rather than a rewire of chat/session code.
- The pricing and fast-mode corrections are scope additions beyond "add Opus 5" — they were confirmed with the requester before implementing, since they change previously-displayed cost estimates and capability gating for existing (non-Opus-5) models.

## Test Steps

1. `cd src/ui && bun install && bunx tsc -b` — type-check passes.
2. `cd src/ui && bun run test -- --run` — full vitest suite passes (2798 passed, 6 skipped).
3. `cargo test -p claudette usage::pricing` — pricing table unit tests pass (8/8), including the new `lookup_opus_5` case.
4. `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` — zero warnings.
5. In the running app: open the chat toolbar model picker for an Anthropic-backed workspace and confirm the top entry reads "Opus 5" and is selected by default for new sessions; expand "More" and confirm "Opus 4.8" / "Opus 4.8 1M" are still there and selectable.
6. Toggle Fast Mode for Opus 5 in the composer and confirm the toggle is now available (it wasn't before, for either Opus 4.8 or Opus 5).

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (agent-configuration.mdx, settings.mdx, cli-client.mdx)