### PR TITLE
fix(chat): clear the Workflow status pill when a run ends or is killed

### DIFF
--- a/site/src/content/docs/features/workflows.mdx
+++ b/site/src/content/docs/features/workflows.mdx
@@ -22,13 +22,17 @@ The card is expanded by default. Collapsing it hides the agent tree but keeps th
 
 Workflows run in the background. The tool returns "launched in background" within a second, the agent finishes its turn, and the run keeps going for minutes — so the card is usually well above the fold by the time anything interesting happens.
 
-A pill above the message composer keeps each in-flight run visible: workflow name, current phase, and agents completed. Click it to scroll its card back into view. The pill disappears when the run finishes. Concurrent workflows each get their own pill.
+A pill above the message composer keeps each in-flight run visible: workflow name, current phase, and agents completed. Click it to scroll its card back into view. Concurrent workflows each get their own pill.
+
+The pill disappears when the run ends — whether it completed, failed, or was terminated. Terminated runs count: a workflow you stop, or one killed when its session is interrupted or reset, resolves the same way rather than leaving an indicator behind.
 
 ## Persistence
 
 A completed run's tree is stored with the turn, so it renders the same after an app restart, in [forked sessions](/claudette/features/checkpoints-and-forking/), and when history is replayed from disk.
 
-Because a workflow typically finishes long after its turn was saved, Claudette writes the final tree back to that turn when the completion notification arrives. If you restart Claudette while a workflow is still running, its card shows the tree as of the moment the turn ended — the run itself continues inside Claude Code, but Claudette is no longer listening for its progress.
+Because a workflow typically finishes long after its turn was saved, Claudette writes the final tree back to that turn when the completion notification arrives.
+
+A workflow runs inside the Claude Code process that started it, so it does not survive that process going away — quitting Claudette, stopping the agent, or resetting the session ends the run. Claudette marks those runs stopped rather than leaving them mid-flight: any still marked running when Claudette starts belongs to a process that is gone, and is resolved at launch. Their cards keep the tree as of the last progress update before the process ended.
 
 ## Limits
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -44,32 +44,46 @@ fn chrono_iso_now() -> String {
     chrono::Utc::now().to_rfc3339()
 }
 
-/// Best-effort warning when another live Claudette dev instance is
-/// likely running against the same database. We do **not** block the
-/// second launch — multi-instance dev is a supported workflow — but
-/// two processes against the same SQLite file is the most plausible
-/// origin of cross-session message bleed-through (insert paths race
-/// on `chat_messages.chat_session_id`, transcript JSONLs in
-/// `~/.claude/projects/<encoded-cwd>/<sid>.jsonl` interleave). Surfacing
-/// the collision in the log lets postmortems start with "two PIDs were
-/// alive at the same time" rather than guessing.
+/// Other live Claudette processes likely running against the same
+/// database. We do **not** block the second launch — multi-instance dev is
+/// a supported workflow — but two processes against the same SQLite file
+/// is the most plausible origin of cross-session message bleed-through
+/// (insert paths race on `chat_messages.chat_session_id`, transcript
+/// JSONLs in `~/.claude/projects/<encoded-cwd>/<sid>.jsonl` interleave).
 ///
 /// `scripts/dev.sh` drops `${TMPDIR}/claudette-dev/<pid>.json` when it
-/// launches; we scan that directory, cross-reference with the live
-/// process table, and emit a `tracing::warn!` if any other live PID is
-/// found. Stale files from crashed dev runs are ignored (PID not
-/// alive). Release builds without `dev.sh` simply find an empty
-/// directory and log nothing.
-fn warn_if_concurrent_dev_instance(db_path: &Path) {
+/// launches; we scan that directory and cross-reference with the live
+/// process table. Stale files from crashed dev runs are ignored (PID not
+/// alive).
+///
+/// Two callers: [`warn_if_concurrent_dev_instance`], so a postmortem can
+/// start from "two PIDs were alive at the same time" rather than guessing,
+/// and the orphaned-workflow sweep, which must not rewrite rows a peer may
+/// still own.
+///
+/// Note the coverage this gives. A peer is only visible if it wrote a
+/// discovery file, which means `dev.sh` launches and nothing else — two
+/// *release* builds against one database produce an empty result here. An
+/// empty return means "no peer we can see", not "no peer".
+fn live_peer_instances(db_path: &Path) -> Vec<PeerInstance> {
+    peer_instances_in(&std::env::temp_dir().join("claudette-dev"), db_path)
+}
+
+/// The scan itself, with the discovery directory injected.
+///
+/// Split out from [`live_peer_instances`] so it can be tested against a
+/// fixture directory: this result now gates a database mutation (the
+/// orphaned-workflow sweep), not just a log line, so a false "no peers"
+/// has consequences beyond a missing warning.
+fn peer_instances_in(dir: &Path, db_path: &Path) -> Vec<PeerInstance> {
     use std::fs;
 
-    let dir = std::env::temp_dir().join("claudette-dev");
-    let Ok(entries) = fs::read_dir(&dir) else {
-        return;
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
     };
     let our_pid = std::process::id();
     let our_data_dir = db_path.parent().map(normalize_dev_data_dir);
-    let mut peers: Vec<(u32, String, Option<PathBuf>)> = Vec::new();
+    let mut peers: Vec<PeerInstance> = Vec::new();
 
     for entry in entries.flatten() {
         let path = entry.path();
@@ -105,10 +119,26 @@ fn warn_if_concurrent_dev_instance(db_path: &Path) {
         if peer_data_dir.is_some() && peer_data_dir != our_data_dir {
             continue;
         }
-        peers.push((pid, cwd, peer_data_dir));
+        peers.push(PeerInstance {
+            pid,
+            cwd,
+            data_dir: peer_data_dir,
+        });
     }
 
-    for (pid, cwd, peer_data_dir) in &peers {
+    peers
+}
+
+/// A live Claudette process that may be sharing our database.
+struct PeerInstance {
+    pid: u32,
+    cwd: String,
+    data_dir: Option<PathBuf>,
+}
+
+fn warn_if_concurrent_dev_instance(peers: &[PeerInstance], db_path: &Path) {
+    let our_pid = std::process::id();
+    for peer in peers {
         // Modern `scripts/dev.sh` discovery files include the effective
         // `CLAUDETTE_DATA_DIR`, so we skip peers that are clearly isolated.
         // Older discovery files do not have it; keep warning for those because
@@ -116,9 +146,9 @@ fn warn_if_concurrent_dev_instance(db_path: &Path) {
         tracing::warn!(
             target: "claudette::startup",
             our_pid,
-            peer_pid = pid,
-            peer_cwd = %cwd,
-            peer_data_dir = peer_data_dir.as_ref().map(|p| p.display().to_string()),
+            peer_pid = peer.pid,
+            peer_cwd = %peer.cwd,
+            peer_data_dir = peer.data_dir.as_ref().map(|p| p.display().to_string()),
             our_db_path = %db_path.display(),
             "another Claudette dev instance is alive — if it's running \
              against the same DB, concurrent SQLite writers can cross-pollute \
@@ -439,7 +469,8 @@ fn main() {
     // most plausible source of cross-session message bleed-through.
     // The dev launcher (`scripts/dev.sh`) drops a discovery file at
     // `${TMPDIR}/claudette-dev/<pid>.json` we can scan here.
-    warn_if_concurrent_dev_instance(&db_path);
+    let peer_instances = live_peer_instances(&db_path);
+    warn_if_concurrent_dev_instance(&peer_instances, &db_path);
 
     // Ensure DB exists and migrations are applied. Stamp the install date on
     // first-ever startup so lifetime stats ("days using Claudette") have an
@@ -457,20 +488,47 @@ fn main() {
     // can never report again. Left alone, each one pins a status pill above
     // the composer on every reload, forever. Non-fatal: a failure here costs
     // a stale pill, not a broken boot.
-    if let Ok(db) = Database::open(&db_path) {
-        match db.resolve_orphaned_workflow_activities() {
-            Ok(0) => {}
-            Ok(count) => tracing::info!(
-                target: "claudette::chat",
-                count,
-                "resolved orphaned workflow activities from a previous session"
-            ),
-            Err(e) => tracing::warn!(
-                target: "claudette::chat",
-                error = %e,
-                "failed to resolve orphaned workflow activities"
-            ),
+    //
+    // Skipped when a peer instance is alive, because the inference above
+    // ("nothing can still be running") only holds for a process lifecycle we
+    // own. A peer may be running workflows against this same database right
+    // now, and sweeping them to `stopped` would blank a live run's pill the
+    // next time that instance re-hydrates from disk.
+    //
+    // The asymmetry is what makes skipping the right default: not sweeping
+    // leaves a stale pill — the status quo this fix targets, recoverable on
+    // the next clean start — whereas sweeping wrongly blanks a run that is
+    // genuinely in flight.
+    //
+    // This does not close the hole, and is not meant to read as if it does:
+    // peers are discovered through `scripts/dev.sh` discovery files, so two
+    // *release* builds sharing a database remain undetectable here. That
+    // configuration is already documented as unsupported for worse reasons —
+    // concurrent SQLite writers cross-pollute `chat_messages` and corrupt
+    // resumed CLI transcripts, per the warning above.
+    if peer_instances.is_empty() {
+        if let Ok(db) = Database::open(&db_path) {
+            match db.resolve_orphaned_workflow_activities() {
+                Ok(0) => {}
+                Ok(count) => tracing::info!(
+                    target: "claudette::chat",
+                    count,
+                    "resolved orphaned workflow activities from a previous session"
+                ),
+                Err(e) => tracing::warn!(
+                    target: "claudette::chat",
+                    error = %e,
+                    "failed to resolve orphaned workflow activities"
+                ),
+            }
         }
+    } else {
+        tracing::info!(
+            target: "claudette::chat",
+            peer_count = peer_instances.len(),
+            "skipped resolving orphaned workflow activities — a peer instance \
+             is alive and may own runs that are still in flight"
+        );
     }
 
     // Load worktree base dir from settings, or use default.
@@ -1678,6 +1736,127 @@ mod tests {
             normalize_dev_data_dir(&spelled),
             normalize_dev_data_dir(&data)
         );
+    }
+
+    /// Peer detection gates the orphaned-workflow sweep, so a wrong
+    /// "no peers" answer now costs a database mutation against rows another
+    /// live instance may still own — not just a missing warning.
+    ///
+    /// Unix-only: `is_pid_alive` is a stub returning `false` on Windows,
+    /// where `scripts/dev.sh` writes no discovery files anyway. PID 1 is the
+    /// fixture's "alive but not us" peer — always present, and `kill(1, 0)`
+    /// reports EPERM rather than ESRCH for an unprivileged caller, which
+    /// `is_pid_alive` correctly reads as alive.
+    #[cfg(unix)]
+    mod peer_instances {
+        use super::super::peer_instances_in;
+        use std::path::Path;
+        use tempfile::tempdir;
+
+        const ALIVE_NOT_US: u32 = 1;
+
+        fn write_peer(dir: &Path, name: &str, contents: &str) {
+            std::fs::write(dir.join(name), contents).unwrap();
+        }
+
+        /// A discovery file for a live peer sharing our data directory.
+        fn peer_json(pid: u32, data_dir: &Path) -> String {
+            format!(
+                r#"{{"pid":{pid},"cwd":"/tmp/peer","claudette_data_dir":"{}"}}"#,
+                data_dir.display()
+            )
+        }
+
+        #[test]
+        fn reports_a_live_peer_sharing_our_data_dir() {
+            let discovery = tempdir().unwrap();
+            let data = tempdir().unwrap();
+            let db_path = data.path().join("claudette.db");
+            write_peer(
+                discovery.path(),
+                "peer.json",
+                &peer_json(ALIVE_NOT_US, data.path()),
+            );
+
+            let peers = peer_instances_in(discovery.path(), &db_path);
+            assert_eq!(peers.len(), 1);
+            assert_eq!(peers[0].pid, ALIVE_NOT_US);
+        }
+
+        /// The isolation `scripts/dev.sh` provides: a peer pointed at its own
+        /// data dir shares no database with us, so it must not suppress the
+        /// sweep.
+        #[test]
+        fn ignores_a_peer_with_a_different_data_dir() {
+            let discovery = tempdir().unwrap();
+            let ours = tempdir().unwrap();
+            let theirs = tempdir().unwrap();
+            let db_path = ours.path().join("claudette.db");
+            write_peer(
+                discovery.path(),
+                "peer.json",
+                &peer_json(ALIVE_NOT_US, theirs.path()),
+            );
+
+            assert!(peer_instances_in(discovery.path(), &db_path).is_empty());
+        }
+
+        /// Legacy discovery files predate `claudette_data_dir` and shared the
+        /// default database by construction, so an absent field counts as a
+        /// peer rather than as isolation.
+        #[test]
+        fn treats_a_peer_without_a_data_dir_as_sharing() {
+            let discovery = tempdir().unwrap();
+            let data = tempdir().unwrap();
+            let db_path = data.path().join("claudette.db");
+            write_peer(
+                discovery.path(),
+                "legacy.json",
+                &format!(r#"{{"pid":{ALIVE_NOT_US},"cwd":"/tmp/peer"}}"#),
+            );
+
+            assert_eq!(peer_instances_in(discovery.path(), &db_path).len(), 1);
+        }
+
+        /// Our own discovery file is always present once `dev.sh` launched
+        /// us. Counting it would make every dev run skip its own sweep.
+        #[test]
+        fn ignores_our_own_discovery_file() {
+            let discovery = tempdir().unwrap();
+            let data = tempdir().unwrap();
+            let db_path = data.path().join("claudette.db");
+            write_peer(
+                discovery.path(),
+                "self.json",
+                &peer_json(std::process::id(), data.path()),
+            );
+
+            assert!(peer_instances_in(discovery.path(), &db_path).is_empty());
+        }
+
+        #[test]
+        fn ignores_non_json_and_unparseable_files() {
+            let discovery = tempdir().unwrap();
+            let data = tempdir().unwrap();
+            let db_path = data.path().join("claudette.db");
+            write_peer(discovery.path(), "notes.txt", "not a discovery file");
+            write_peer(discovery.path(), "broken.json", "{ this is not json");
+            write_peer(discovery.path(), "no-pid.json", r#"{"cwd":"/tmp/peer"}"#);
+
+            assert!(peer_instances_in(discovery.path(), &db_path).is_empty());
+        }
+
+        /// The common case by far — no dev launcher has ever run, so the
+        /// directory does not exist and the sweep must proceed.
+        #[test]
+        fn reports_no_peers_when_the_directory_is_missing() {
+            let data = tempdir().unwrap();
+            let db_path = data.path().join("claudette.db");
+
+            assert!(
+                peer_instances_in(Path::new("/nonexistent/claudette-dev"), &db_path).is_empty()
+            );
+        }
     }
 
     /// Migration is idempotent: a second run after a successful first

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -451,6 +451,28 @@ fn main() {
         let _ = db.set_app_setting("install_date", &now);
     }
 
+    // Resolve `Workflow` activities that a previous app session left mid-run.
+    // Background tasks live inside the Claude CLI process and none survive a
+    // restart, so anything still marked in-flight here belongs to a run that
+    // can never report again. Left alone, each one pins a status pill above
+    // the composer on every reload, forever. Non-fatal: a failure here costs
+    // a stale pill, not a broken boot.
+    if let Ok(db) = Database::open(&db_path) {
+        match db.resolve_orphaned_workflow_activities() {
+            Ok(0) => {}
+            Ok(count) => tracing::info!(
+                target: "claudette::chat",
+                count,
+                "resolved orphaned workflow activities from a previous session"
+            ),
+            Err(e) => tracing::warn!(
+                target: "claudette::chat",
+                error = %e,
+                "failed to resolve orphaned workflow activities"
+            ),
+        }
+    }
+
     // Load worktree base dir from settings, or use default.
     let worktree_base_dir = {
         let default = claudette::path::claudette_home().join("workspaces");

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -924,6 +924,51 @@ impl Database {
         )
     }
 
+    /// Resolve `Workflow` activities left mid-run by a previous app session.
+    ///
+    /// A workflow's background task lives inside the Claude CLI process, so
+    /// none of them survive a Claudette restart. Any row still claiming to
+    /// be in flight when we boot is therefore describing a run that can
+    /// never report again: its terminal `task_notification` was lost when
+    /// the process went away (app quit, crash, kill), and `agent_status`
+    /// stayed at `"running"` — or at `NULL`, for a run checkpointed before
+    /// its first progress tick.
+    ///
+    /// The frontend reads those rows back as still-running and pins a
+    /// status pill above the composer for each one, permanently: the pill
+    /// is sourced from persisted turns, so it returns on every reload and
+    /// accumulates one entry per historical run.
+    ///
+    /// Runs at startup rather than as a migration because the wedge is not
+    /// a one-time backlog — a SIGKILL'd app never gets to run the
+    /// frontend's `ProcessExited` reaper, so fresh orphans can appear at
+    /// any time. Idempotent, and safe to run unconditionally: at boot,
+    /// there is by definition no live CLI process from a previous run.
+    ///
+    /// Scoped to `Workflow`. `Task` / `Agent` activities can wedge the same
+    /// way, but they render as a status word inside a collapsed turn rather
+    /// than as a persistent floating indicator, so rewriting their
+    /// historical status is not worth the blast radius here.
+    ///
+    /// Returns the number of rows resolved.
+    pub fn resolve_orphaned_workflow_activities(&self) -> Result<usize, rusqlite::Error> {
+        // Keep the terminal set in sync with `isTerminalBackgroundTaskStatus`
+        // in `src/ui/src/types/backgroundTaskStatus.ts`, which is where the
+        // vocabulary is documented. `"stopped"` is the CLI's own value for a
+        // task that ended without completing, so a resolved row needs no
+        // special-casing on the read side.
+        self.conn.execute(
+            "UPDATE turn_tool_activities
+                SET agent_status = 'stopped'
+              WHERE tool_name = 'Workflow'
+                AND (agent_status IS NULL
+                     OR LOWER(agent_status) NOT IN
+                        ('completed', 'failed', 'stopped', 'killed',
+                         'error', 'cancelled', 'canceled'))",
+            [],
+        )
+    }
+
     /// Load all completed turns for a workspace: checkpoints joined with their
     /// tool activities, grouped by checkpoint and ordered by turn_index.
     pub fn list_completed_turns(
@@ -1507,6 +1552,62 @@ mod tests {
         let activity = &turns[0].activities[0];
         assert_eq!(activity.workflow_progress_json, tree);
         assert_eq!(activity.agent_status.as_deref(), Some("failed"));
+    }
+
+    /// The startup sweep resolves workflows a previous session left mid-run
+    /// (`"running"`, or `NULL` for a run checkpointed before its first
+    /// progress tick) while leaving already-resolved runs alone. Without it
+    /// each wedged row pins a status pill above the composer on every
+    /// reload, forever.
+    #[test]
+    fn test_resolve_orphaned_workflow_activities() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+
+        let mut running = make_tool_activity("a1", "cp1", "Workflow", 0);
+        running.agent_status = Some("running".into());
+        let mut never_reported = make_tool_activity("a2", "cp1", "Workflow", 1);
+        never_reported.agent_status = None;
+        let mut completed = make_tool_activity("a3", "cp1", "Workflow", 2);
+        completed.agent_status = Some("completed".into());
+        // Mixed case: the CLI's vocabulary is lowercase, but the comparison
+        // is case-insensitive so a differently-cased value can't slip past
+        // and get rewritten as if it were still in flight.
+        let mut stopped = make_tool_activity("a4", "cp1", "Workflow", 3);
+        stopped.agent_status = Some("Stopped".into());
+        // A non-workflow activity with the same wedged status is out of
+        // scope — it renders as a status word inside a collapsed turn, not
+        // as a floating indicator.
+        let mut agent_task = make_tool_activity("a5", "cp1", "Task", 4);
+        agent_task.agent_status = Some("running".into());
+
+        db.insert_turn_tool_activities(&[running, never_reported, completed, stopped, agent_task])
+            .unwrap();
+
+        let resolved = db.resolve_orphaned_workflow_activities().unwrap();
+        assert_eq!(resolved, 2, "only the two in-flight workflows are swept");
+
+        let turns = db.list_completed_turns("w1").unwrap();
+        let by_id = |id: &str| {
+            turns[0]
+                .activities
+                .iter()
+                .find(|a| a.tool_use_id == id)
+                .unwrap()
+                .agent_status
+                .clone()
+        };
+        assert_eq!(by_id("tu_a1").as_deref(), Some("stopped"));
+        assert_eq!(by_id("tu_a2").as_deref(), Some("stopped"));
+        assert_eq!(by_id("tu_a3").as_deref(), Some("completed"));
+        assert_eq!(by_id("tu_a4").as_deref(), Some("Stopped"));
+        assert_eq!(by_id("tu_a5").as_deref(), Some("running"));
+
+        // Idempotent: a second boot has nothing left to do.
+        assert_eq!(db.resolve_orphaned_workflow_activities().unwrap(), 0);
     }
 
     /// An unknown `tool_use_id` is normal (the turn may never have been

--- a/src/ui/src/components/chat/WorkflowCard.tsx
+++ b/src/ui/src/components/chat/WorkflowCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
 import type { ToolActivity } from "../../stores/useAppStore";
+import { isTerminalBackgroundTaskStatus } from "../../types/backgroundTaskStatus";
 import {
   isAgentTerminal,
   phaseTitleOf,
@@ -36,25 +37,6 @@ function workflowScript(inputJson: string): string | null {
   } catch {
     return null;
   }
-}
-
-/** Statuses that mean the background task itself has ended.
- *
- *  These arrive on the `task-notification` the CLI emits when a workflow
- *  finishes — `useAgentStream` copies the notification's `status` onto
- *  `agentStatus`. While the run is in flight the same field reads
- *  `"running"` (set by the `task_progress` branch). */
-const TERMINAL_WORKFLOW_STATUSES = new Set([
-  "completed",
-  "failed",
-  "error",
-  "killed",
-  "cancelled",
-  "canceled",
-]);
-
-function isTerminalWorkflowStatus(status: string | null | undefined): boolean {
-  return TERMINAL_WORKFLOW_STATUSES.has((status ?? "").toLowerCase());
 }
 
 function stateIcon(state: string): string {
@@ -291,7 +273,7 @@ export function WorkflowCard({
   // launched in background. Task ID: …"); the run itself takes minutes.
   // Completion arrives much later as a task-notification, which
   // `useAgentStream` maps onto `agentStatus`.
-  const finished = isTerminalWorkflowStatus(activity.agentStatus);
+  const finished = isTerminalBackgroundTaskStatus(activity.agentStatus);
   // `live` gates the interpolated clock. A run that was still going when
   // the app closed replays with non-terminal agents forever; without this
   // its elapsed times would tick upward on every reload, reporting minutes

--- a/src/ui/src/components/chat/WorkflowStatusPill.test.tsx
+++ b/src/ui/src/components/chat/WorkflowStatusPill.test.tsx
@@ -125,6 +125,61 @@ describe("WorkflowStatusPill", () => {
     expect(container.textContent).toBe("");
   });
 
+  // The regression this file exists to pin. `"stopped"` is what the CLI's
+  // `task_notification` reports for a *terminated* run — its status enum is
+  // exactly `["completed", "failed", "stopped"]` — but the terminal set
+  // here was hand-written and omitted it, so killing a workflow left its
+  // pill above the composer for the rest of the session. Worse, the status
+  // is persisted, so it came back on every reload.
+  it.each(["stopped", "failed", "completed", "killed"])(
+    "hides a run that ended with status %s",
+    async (agentStatus) => {
+      useAppStore.setState({
+        completedTurns: {
+          [SESSION]: [
+            turn("turn-1", [workflowActivity("toolu_wf1", { agentStatus })]),
+          ],
+        },
+      });
+      const container = await render(<WorkflowStatusPill sessionId={SESSION} />);
+      expect(container.textContent).toBe("");
+    },
+  );
+
+  // Case-insensitive, so an upper/mixed-case value from a future CLI build
+  // degrades to "finished" rather than to a pill that never leaves.
+  it("hides a run whose terminal status is differently cased", async () => {
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION]: [
+          turn("turn-1", [
+            workflowActivity("toolu_wf1", { agentStatus: "Stopped" }),
+          ]),
+        ],
+      },
+    });
+    const container = await render(<WorkflowStatusPill sessionId={SESSION} />);
+    expect(container.textContent).toBe("");
+  });
+
+  // A workflow checkpointed before its first `task_progress` tick has no
+  // status yet and is genuinely still starting — absence must NOT read as
+  // an ending, or a just-launched run would never show a pill at all.
+  it("still shows a run that has not reported a status yet", async () => {
+    useAppStore.setState({
+      toolActivities: {
+        [SESSION]: [
+          workflowActivity("toolu_wf1", {
+            agentStatus: undefined,
+            workflowProgress: undefined,
+          }),
+        ],
+      },
+    });
+    const container = await render(<WorkflowStatusPill sessionId={SESSION} />);
+    expect(container.textContent).toContain("review-changes");
+  });
+
   it("does not double-count a workflow present in both lanes", async () => {
     useAppStore.setState({
       toolActivities: { [SESSION]: [workflowActivity()] },

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "../stores/useAppStore";
 import { findToolActivity } from "../stores/findToolActivity";
+import { collectInFlightWorkflows } from "../stores/inFlightWorkflows";
+import { REAPED_BACKGROUND_TASK_STATUS } from "../types/backgroundTaskStatus";
 import {
   loadChatHistory,
   saveTurnToolActivities,
@@ -14,6 +16,7 @@ import type {
   AgentApprovalDetail,
   AgentApprovalKind,
   AgentToolCall,
+  ToolActivity,
 } from "../stores/useAppStore";
 import type { AgentConclusionEvent, ChatMessage } from "../types/chat";
 import type { ConversationCheckpoint } from "../types/checkpoint";
@@ -47,6 +50,76 @@ const ASK_USER_QUESTION_TOOL = "AskUserQuestion";
 const CODEX_COMMAND_APPROVAL_TOOL = "CodexCommandApproval";
 const CODEX_FILE_CHANGE_APPROVAL_TOOL = "CodexFileChangeApproval";
 const CODEX_PERMISSIONS_APPROVAL_TOOL = "CodexPermissionsApproval";
+
+/**
+ * Resolve every workflow a session's CLI process was still running when it
+ * exited.
+ *
+ * A `Workflow` run lives *inside* the CLI process — nothing can move it
+ * forward once that process is gone, and nothing will report on it either.
+ * The CLI states the same invariant for its own `background_tasks_changed`
+ * level signal: "The level is per-process: nothing is emitted at startup,
+ * so consumers must reset to the empty set whenever the session's CLI
+ * process (re)starts." `AgentSessionState` holds a single `active_pid` per
+ * chat session, so `ProcessExited` is unambiguous — there is no second
+ * process that could still own these tasks.
+ *
+ * On the happy path this reaps nothing: the run's terminal
+ * `task_notification` arrived minutes earlier and the activity already
+ * reads as finished. It fires on the paths that never produce a
+ * notification at all — the user hitting stop, a crash, a session reset —
+ * which used to leave `agentStatus` pinned at `"running"` (or unset) with
+ * no way out. That wedged the status pill above the composer for the rest
+ * of the session, and since the status is persisted, every later reload
+ * brought the pill back.
+ *
+ * Persisted as well as applied in-store. `checkpoint-created` fires before
+ * the `result` event, so the row exists by the time we get here; when it
+ * doesn't (a stop before any checkpoint) the UPDATE matches nothing, which
+ * is exactly right — there is no row to resurrect the pill from.
+ *
+ * Takes `updateToolActivity` rather than closing over it so it can live at
+ * module scope: a helper defined in the hook body would be a new reference
+ * every render and would have to be threaded through the stream effect's
+ * dependency array, which already lists the store action.
+ */
+function reapInFlightWorkflows(
+  sessionId: string,
+  updateToolActivity: (
+    sessionId: string,
+    toolUseId: string,
+    updates: Partial<ToolActivity>,
+  ) => void,
+): void {
+  const state = useAppStore.getState();
+  const orphaned = collectInFlightWorkflows(
+    state.toolActivities[sessionId] ?? [],
+    state.completedTurns[sessionId] ?? [],
+  );
+  if (orphaned.length === 0) return;
+  debugChat("stream", "reap in-flight workflows", {
+    sessionId,
+    toolUseIds: orphaned.map((a) => a.toolUseId),
+  });
+  for (const activity of orphaned) {
+    updateToolActivity(sessionId, activity.toolUseId, {
+      agentStatus: REAPED_BACKGROUND_TASK_STATUS,
+    });
+    // `null` for the tree: whatever the last `task_progress` tick left in
+    // the store is already the stored value, and both columns COALESCE, so
+    // a status-only write can't blank a good tree.
+    void updateTurnToolActivityProgress(
+      activity.toolUseId,
+      null,
+      REAPED_BACKGROUND_TASK_STATUS,
+    ).catch((err) => {
+      debugChat("stream", "persist reaped workflow status failed", {
+        toolUseId: activity.toolUseId,
+        error: String(err),
+      });
+    });
+  }
+}
 
 function isCodexApprovalTool(toolName: string): boolean {
   return (
@@ -253,6 +326,9 @@ export function useAgentStream() {
             turnCheckpointIdRef.current[sessionId]
           );
         }
+        // After `finalizeTurn`, so the activity sits in exactly one lane
+        // (`completedTurns`) and the update has one place to land.
+        reapInFlightWorkflows(sessionId, updateToolActivity);
         turnMessageCountRef.current[sessionId] = 0;
         turnFinalizedRef.current[sessionId] = false;
         turnCheckpointIdRef.current[sessionId] = undefined;

--- a/src/ui/src/hooks/useAgentStream.workflowReap.test.tsx
+++ b/src/ui/src/hooks/useAgentStream.workflowReap.test.tsx
@@ -1,0 +1,309 @@
+// @vitest-environment happy-dom
+
+/**
+ * Regression tests for resolving workflows whose CLI process went away
+ * without ever reporting an outcome.
+ *
+ * A `Workflow` run lives inside the Claude CLI process. On the happy path
+ * it ends with a `task_notification` carrying `status: "completed"`, and
+ * everything downstream reads it as finished. But nothing emits that
+ * notification when the process is killed — the user hitting stop, a
+ * crash, a session reset — and the activity was left pinned at
+ * `agentStatus: "running"` (or at no status at all, for a run checkpointed
+ * before its first progress tick).
+ *
+ * The visible symptom: the status pill above the composer never went away.
+ * Because `agentStatus` is persisted to `turn_tool_activities`, it also
+ * came back on every reload of the session, accumulating one dead pill per
+ * abandoned run.
+ *
+ * `ProcessExited` is the authoritative signal here — `AgentSessionState`
+ * holds a single `active_pid` per chat session, so a session's process
+ * exiting means every background task it owned is gone.
+ */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type HandlerRecord = (event: { payload: unknown }) => void;
+const registeredHandlers = new Map<string, HandlerRecord[]>();
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (eventName: string, handler: HandlerRecord) => {
+    const list = registeredHandlers.get(eventName) ?? [];
+    list.push(handler);
+    registeredHandlers.set(eventName, list);
+    return Promise.resolve(() => {
+      const after =
+        registeredHandlers.get(eventName)?.filter((h) => h !== handler) ?? [];
+      registeredHandlers.set(eventName, after);
+    });
+  },
+}));
+
+const persistSpy = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../services/tauri", async () => {
+  const actual = await vi.importActual<typeof import("../services/tauri")>(
+    "../services/tauri",
+  );
+  return {
+    ...actual,
+    loadChatHistory: vi.fn().mockResolvedValue([]),
+    saveTurnToolActivities: vi.fn().mockResolvedValue(undefined),
+    setSessionCliInvocation: vi.fn().mockResolvedValue(undefined),
+    updateTurnToolActivityProgress: persistSpy,
+  };
+});
+
+import { useAgentStream } from "./useAgentStream";
+import {
+  useAppStore,
+  type CompletedTurn,
+  type ToolActivity,
+} from "../stores/useAppStore";
+import { findToolActivity } from "../stores/findToolActivity";
+import type { WorkflowProgressEntry } from "../types/workflow";
+
+const WS_ID = "ws-1";
+const SESSION_ID = "session-1";
+const WF_ID = "toolu_wf1";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function mountHook(): Promise<void> {
+  function Probe() {
+    useAgentStream();
+    return null;
+  }
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(<Probe />);
+  });
+}
+
+async function fireProcessExited(): Promise<void> {
+  const handlers = registeredHandlers.get("agent-stream") ?? [];
+  expect(handlers.length).toBeGreaterThan(0);
+  await act(async () => {
+    for (const handler of handlers) {
+      handler({
+        payload: {
+          workspace_id: WS_ID,
+          chat_session_id: SESSION_ID,
+          event: { ProcessExited: { exit_code: 0 } },
+        },
+      });
+    }
+  });
+}
+
+const TREE: WorkflowProgressEntry[] = [
+  { type: "workflow_phase", index: 1, title: "Investigate" },
+  {
+    type: "workflow_agent",
+    index: 1,
+    label: "investigate:a",
+    state: "progress",
+    phaseTitle: "Investigate",
+  },
+];
+
+function workflowActivity(overrides: Partial<ToolActivity> = {}): ToolActivity {
+  return {
+    toolUseId: WF_ID,
+    toolName: "Workflow",
+    inputJson: JSON.stringify({ script: "export const meta = {}" }),
+    resultText: "Workflow launched in background. Task ID: w4stpeffj",
+    collapsed: false,
+    summary: "trner-labs-fifo-violation",
+    agentStatus: "running",
+    workflowProgress: TREE,
+    ...overrides,
+  };
+}
+
+function turn(id: string, activities: ToolActivity[]): CompletedTurn {
+  return {
+    id,
+    activities,
+    messageCount: 1,
+    collapsed: true,
+    afterMessageIndex: 1,
+  };
+}
+
+function statusOf(toolUseId: string): string | null | undefined {
+  return findToolActivity(useAppStore.getState(), SESSION_ID, toolUseId)
+    ?.agentStatus;
+}
+
+beforeEach(() => {
+  registeredHandlers.clear();
+  persistSpy.mockClear();
+  useAppStore.setState({
+    agentQuestions: {},
+    toolActivities: {},
+    completedTurns: {},
+    streamingContent: {},
+    streamingThinking: {},
+    promptStartTime: {},
+    sessionsByWorkspace: {},
+  });
+});
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
+describe("useAgentStream — reaping orphaned workflows on ProcessExited", () => {
+  // The common shape: the workflow's launching turn ended minutes ago, so
+  // the activity lives in `completedTurns`, and the run was still going
+  // when the process died.
+  it("resolves a running workflow held in a completed turn", async () => {
+    useAppStore.setState({
+      completedTurns: { [SESSION_ID]: [turn("turn-1", [workflowActivity()])] },
+    });
+    await mountHook();
+
+    await fireProcessExited();
+
+    expect(statusOf(WF_ID)).toBe("stopped");
+  });
+
+  // Persisted as well as applied in-store: the store copy dies with the
+  // session view, and it is the stale DB row that resurrects the pill on
+  // the next load. `null` for the tree so the COALESCE keeps whatever the
+  // last progress tick stored.
+  it("persists the resolved status so a reload cannot resurrect the pill", async () => {
+    useAppStore.setState({
+      completedTurns: { [SESSION_ID]: [turn("turn-1", [workflowActivity()])] },
+    });
+    await mountHook();
+
+    await fireProcessExited();
+
+    expect(persistSpy).toHaveBeenCalledTimes(1);
+    expect(persistSpy).toHaveBeenCalledWith(WF_ID, null, "stopped");
+  });
+
+  // A run checkpointed before its first `task_progress` tick has no status
+  // at all. That reads as in-flight everywhere (correctly, while live), so
+  // it needs resolving too or it wedges exactly the same way.
+  it("resolves a workflow that never reported a status", async () => {
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION_ID]: [
+          turn("turn-1", [
+            workflowActivity({
+              agentStatus: undefined,
+              workflowProgress: undefined,
+            }),
+          ]),
+        ],
+      },
+    });
+    await mountHook();
+
+    await fireProcessExited();
+
+    expect(statusOf(WF_ID)).toBe("stopped");
+  });
+
+  // The happy path must be untouched: the terminal notification landed
+  // minutes ago and already says how the run ended. Overwriting that with
+  // "stopped" would misreport every successful run.
+  it.each(["completed", "failed", "stopped"])(
+    "leaves a run that already ended with status %s alone",
+    async (agentStatus) => {
+      useAppStore.setState({
+        completedTurns: {
+          [SESSION_ID]: [turn("turn-1", [workflowActivity({ agentStatus })])],
+        },
+      });
+      await mountHook();
+
+      await fireProcessExited();
+
+      expect(statusOf(WF_ID)).toBe(agentStatus);
+      expect(persistSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  // Scoped to workflows. `Task` / `Agent` activities carry `agentStatus`
+  // too, but they are not what pins a pill above the composer, and
+  // rewriting their status here would be an unrelated behavior change.
+  it("does not touch non-workflow activities", async () => {
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION_ID]: [
+          turn("turn-1", [
+            workflowActivity({
+              toolUseId: "toolu_task1",
+              toolName: "Task",
+            }),
+          ]),
+        ],
+      },
+    });
+    await mountHook();
+
+    await fireProcessExited();
+
+    expect(statusOf("toolu_task1")).toBe("running");
+    expect(persistSpy).not.toHaveBeenCalled();
+  });
+
+  // Another session's workflow is owned by a different CLI process and
+  // must survive this one exiting.
+  it("does not reap workflows belonging to another session", async () => {
+    useAppStore.setState({
+      completedTurns: {
+        "session-2": [turn("turn-1", [workflowActivity()])],
+      },
+    });
+    await mountHook();
+
+    await fireProcessExited();
+
+    expect(
+      findToolActivity(useAppStore.getState(), "session-2", WF_ID)?.agentStatus,
+    ).toBe("running");
+    expect(persistSpy).not.toHaveBeenCalled();
+  });
+
+  // Concurrent runs each get resolved — the pill stack renders one entry
+  // per workflow, so missing any one of them leaves a stuck pill behind.
+  it("resolves every in-flight workflow in the session", async () => {
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION_ID]: [
+          turn("turn-1", [
+            workflowActivity(),
+            workflowActivity({ toolUseId: "toolu_wf2" }),
+          ]),
+        ],
+      },
+    });
+    await mountHook();
+
+    await fireProcessExited();
+
+    expect(statusOf(WF_ID)).toBe("stopped");
+    expect(statusOf("toolu_wf2")).toBe("stopped");
+    expect(persistSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/ui/src/hooks/useLiveWorkflows.ts
+++ b/src/ui/src/hooks/useLiveWorkflows.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useAppStore } from "../stores/useAppStore";
 import type { CompletedTurn, ToolActivity } from "../stores/useAppStore";
+import { collectInFlightWorkflows } from "../stores/inFlightWorkflows";
 import { workflowDisplayName } from "../components/chat/workflowMeta";
 import {
   summarizeWorkflowProgress,
@@ -17,33 +18,15 @@ const EMPTY_ACTIVITIES: ToolActivity[] = [];
 const EMPTY_TURNS: CompletedTurn[] = [];
 const EMPTY_WORKFLOWS: LiveWorkflow[] = [];
 
-/** Statuses meaning the background task has ended. Mirrors the set in
- *  `WorkflowCard`; kept local rather than shared because the two consume it
- *  for different questions ("is this card live" vs "should the pill show"). */
-const TERMINAL_STATUSES = new Set([
-  "completed",
-  "failed",
-  "error",
-  "killed",
-  "cancelled",
-  "canceled",
-]);
-
-function isInFlight(activity: ToolActivity): boolean {
-  if (activity.toolName !== "Workflow") return false;
-  return !TERMINAL_STATUSES.has((activity.agentStatus ?? "").toLowerCase());
-}
-
 /**
  * Workflows still running in this session.
  *
- * Scans completed turns as well as the live turn, because a workflow
- * routinely outlives the turn that launched it — that is the normal case,
- * not an edge one, and a pill that only looked at `toolActivities` would go
- * dark for most of a run's duration.
- *
- * Ordered oldest-first so a second workflow launched later appears after
- * the one already running, matching transcript order.
+ * The two-lane scan and the in-flight predicate live in
+ * `stores/inFlightWorkflows` because the reaper in `useAgentStream` has to
+ * answer the identical question when a session's CLI process exits. This
+ * used to carry its own copy of the terminal-status set, which drifted from
+ * `WorkflowCard`'s copy and from the CLI's actual vocabulary — both omitted
+ * `"stopped"`, so a terminated run pinned its pill here forever.
  */
 export function useLiveWorkflows(sessionId: string | null): LiveWorkflow[] {
   const toolActivities = useAppStore(
@@ -56,21 +39,10 @@ export function useLiveWorkflows(sessionId: string | null): LiveWorkflow[] {
   return useMemo(() => {
     if (!sessionId) return EMPTY_WORKFLOWS;
 
-    // De-dupe by toolUseId: an activity can briefly appear in both lanes
-    // around the turn boundary. The live copy is the fresher one, so it
-    // wins.
-    const byId = new Map<string, ToolActivity>();
-    for (const turn of completedTurns) {
-      for (const activity of turn.activities) {
-        if (isInFlight(activity)) byId.set(activity.toolUseId, activity);
-      }
-    }
-    for (const activity of toolActivities) {
-      if (isInFlight(activity)) byId.set(activity.toolUseId, activity);
-    }
-    if (byId.size === 0) return EMPTY_WORKFLOWS;
+    const inFlight = collectInFlightWorkflows(toolActivities, completedTurns);
+    if (inFlight.length === 0) return EMPTY_WORKFLOWS;
 
-    return [...byId.values()].map((activity) => ({
+    return inFlight.map((activity) => ({
       toolUseId: activity.toolUseId,
       name: workflowDisplayName(activity.inputJson),
       summary: summarizeWorkflowProgress(activity.workflowProgress),

--- a/src/ui/src/stores/inFlightWorkflows.test.ts
+++ b/src/ui/src/stores/inFlightWorkflows.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { collectInFlightWorkflows } from "./inFlightWorkflows";
+import type { CompletedTurn, ToolActivity } from "./useAppStore";
+
+function activity(
+  toolUseId: string,
+  overrides: Partial<ToolActivity> = {},
+): ToolActivity {
+  return {
+    toolUseId,
+    toolName: "Workflow",
+    inputJson: "{}",
+    resultText: "Workflow launched in background.",
+    collapsed: false,
+    summary: toolUseId,
+    agentStatus: "running",
+    ...overrides,
+  };
+}
+
+function turn(id: string, activities: ToolActivity[]): CompletedTurn {
+  return {
+    id,
+    activities,
+    messageCount: 1,
+    collapsed: true,
+    afterMessageIndex: 1,
+  };
+}
+
+describe("collectInFlightWorkflows", () => {
+  it("finds workflows in both lanes", () => {
+    const found = collectInFlightWorkflows(
+      [activity("live")],
+      [turn("t1", [activity("done-turn")])],
+    );
+    expect(found.map((a) => a.toolUseId)).toEqual(["done-turn", "live"]);
+  });
+
+  it("skips runs that already reported an ending", () => {
+    const found = collectInFlightWorkflows(
+      [],
+      [
+        turn("t1", [
+          activity("finished", { agentStatus: "completed" }),
+          activity("terminated", { agentStatus: "stopped" }),
+          activity("still-going"),
+        ]),
+      ],
+    );
+    expect(found.map((a) => a.toolUseId)).toEqual(["still-going"]);
+  });
+
+  it("ignores non-workflow activities", () => {
+    const found = collectInFlightWorkflows(
+      [activity("task", { toolName: "Task" }), activity("bash", { toolName: "Bash" })],
+      [],
+    );
+    expect(found).toEqual([]);
+  });
+
+  // An activity is briefly in both lanes around the turn boundary. The live
+  // copy is the fresher one and must win, but the entry keeps the position
+  // it had in transcript order — `Map.set` on an existing key updates in
+  // place rather than moving it to the end.
+  it("prefers the live copy without disturbing transcript order", () => {
+    const found = collectInFlightWorkflows(
+      [activity("wf1", { summary: "fresh" })],
+      [
+        turn("t1", [activity("wf1", { summary: "stale" })]),
+        turn("t2", [activity("wf2")]),
+      ],
+    );
+    expect(found.map((a) => a.toolUseId)).toEqual(["wf1", "wf2"]);
+    expect(found[0].summary).toBe("fresh");
+  });
+
+  it("returns nothing when every run has ended", () => {
+    const found = collectInFlightWorkflows(
+      [activity("wf1", { agentStatus: "stopped" })],
+      [turn("t1", [activity("wf2", { agentStatus: "completed" })])],
+    );
+    expect(found).toEqual([]);
+  });
+});

--- a/src/ui/src/stores/inFlightWorkflows.ts
+++ b/src/ui/src/stores/inFlightWorkflows.ts
@@ -1,0 +1,46 @@
+import type { CompletedTurn, ToolActivity } from "./useAppStore";
+import { isTerminalBackgroundTaskStatus } from "../types/backgroundTaskStatus";
+
+/** A `Workflow` activity whose background task has not reported an ending.
+ *
+ *  Note this is a claim about what Claudette has been *told*, not about
+ *  what is actually running: a run whose CLI process died without emitting
+ *  a `task_notification` still looks in-flight here. Resolving that is the
+ *  reaper's job (`useAgentStream`'s `ProcessExited` handler) and the
+ *  startup sweep's; this predicate stays honest about the recorded state. */
+export function isInFlightWorkflow(activity: ToolActivity): boolean {
+  return (
+    activity.toolName === "Workflow" &&
+    !isTerminalBackgroundTaskStatus(activity.agentStatus)
+  );
+}
+
+/**
+ * Every workflow in a session that has not reported an ending, across both
+ * places a tool activity can live.
+ *
+ * A backgrounded workflow routinely outlives the turn that launched it —
+ * that is the normal case, not an edge one — so it spends most of its life
+ * in `completedTurns` rather than the live `toolActivities` lane. Anything
+ * asking "what is still running" has to scan both.
+ *
+ * Ordered oldest-first: `Map.set` on an existing key updates the value
+ * without moving it, so seeding from completed turns first fixes each
+ * workflow's position at its transcript order, and the second pass only
+ * swaps in the fresher live copy for anything sitting on the turn boundary.
+ */
+export function collectInFlightWorkflows(
+  liveActivities: ToolActivity[],
+  completedTurns: CompletedTurn[],
+): ToolActivity[] {
+  const byId = new Map<string, ToolActivity>();
+  for (const turn of completedTurns) {
+    for (const activity of turn.activities) {
+      if (isInFlightWorkflow(activity)) byId.set(activity.toolUseId, activity);
+    }
+  }
+  for (const activity of liveActivities) {
+    if (isInFlightWorkflow(activity)) byId.set(activity.toolUseId, activity);
+  }
+  return [...byId.values()];
+}

--- a/src/ui/src/types/backgroundTaskStatus.test.ts
+++ b/src/ui/src/types/backgroundTaskStatus.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REAPED_BACKGROUND_TASK_STATUS,
+  isTerminalBackgroundTaskStatus,
+} from "./backgroundTaskStatus";
+
+describe("isTerminalBackgroundTaskStatus", () => {
+  // The CLI's `task_notification` schema declares a closed enum:
+  //   status: z.enum(["completed", "failed", "stopped"])
+  // All three have to read as terminal. `"stopped"` is the one that was
+  // missing, and it is the value a *terminated* run reports — so killing a
+  // workflow left its status pill up for the rest of the session.
+  it.each(["completed", "failed", "stopped"])(
+    "treats the task_notification status %s as terminal",
+    (status) => {
+      expect(isTerminalBackgroundTaskStatus(status)).toBe(true);
+    },
+  );
+
+  // From `task_updated.patch.status`, a channel not consumed yet. Listed so
+  // wiring it up later cannot reintroduce the same wedge.
+  it("treats killed as terminal", () => {
+    expect(isTerminalBackgroundTaskStatus("killed")).toBe(true);
+  });
+
+  // Also from `task_updated` — but a paused task has not ended, so it must
+  // keep reading as in-flight.
+  it.each(["pending", "running", "paused"])(
+    "treats the non-terminal status %s as in flight",
+    (status) => {
+      expect(isTerminalBackgroundTaskStatus(status)).toBe(false);
+    },
+  );
+
+  it("is case-insensitive", () => {
+    expect(isTerminalBackgroundTaskStatus("Stopped")).toBe(true);
+    expect(isTerminalBackgroundTaskStatus("COMPLETED")).toBe(true);
+  });
+
+  // A workflow checkpointed before its first `task_progress` tick has no
+  // status yet and is genuinely still starting. Reading absence as an
+  // ending would hide a just-launched run's pill entirely.
+  it.each([null, undefined, "", "   "])(
+    "does not treat %p as terminal",
+    (status) => {
+      expect(isTerminalBackgroundTaskStatus(status as string | null)).toBe(
+        false,
+      );
+    },
+  );
+
+  it("closes the loop on the status the reaper writes", () => {
+    expect(isTerminalBackgroundTaskStatus(REAPED_BACKGROUND_TASK_STATUS)).toBe(
+      true,
+    );
+  });
+});

--- a/src/ui/src/types/backgroundTaskStatus.ts
+++ b/src/ui/src/types/backgroundTaskStatus.ts
@@ -1,0 +1,72 @@
+/**
+ * Terminal statuses for a Claude Code background task.
+ *
+ * `useAgentStream` copies `task_notification.status` onto an activity's
+ * `agentStatus`, and writes `"running"` itself on every `task_progress`
+ * tick. Asking "has this run ended?" therefore means asking this set.
+ *
+ * The CLI declares a closed enum for the notification that ends a run:
+ *
+ * ```
+ * subtype: "task_notification", status: z.enum(["completed", "failed", "stopped"])
+ * ```
+ *
+ * `"stopped"` is what a *terminated* run reports — `TaskStop`, an
+ * interrupt, or the task being killed out from under the agent. It was
+ * missing from the two copies of this set that used to live in
+ * `useLiveWorkflows` and `WorkflowCard`, so a stopped workflow never read
+ * as finished: its status pill stayed pinned above the composer for the
+ * rest of the session, and because the wedged status is persisted to
+ * `turn_tool_activities.agent_status`, it came back on every reload.
+ *
+ * `"killed"` belongs to a different channel — `task_updated.patch.status`
+ * (`pending | running | completed | failed | killed | paused`), which
+ * Claudette does not consume today. It is listed anyway so wiring that
+ * channel up later can't reintroduce the same wedge. `"paused"` is
+ * deliberately absent: a paused task has not ended.
+ *
+ * `"error"` / `"cancelled"` / `"canceled"` appear in neither schema. They
+ * are kept as tolerated aliases because the cost of a false positive here
+ * (a finished run stops being advertised) is much lower than the cost of a
+ * false negative (an indicator that never goes away), which is the exact
+ * failure this set exists to prevent.
+ */
+const TERMINAL_BACKGROUND_TASK_STATUSES = new Set([
+  // Emitted on `task_notification` — the authoritative closed set.
+  "completed",
+  "failed",
+  "stopped",
+  // Emitted on `task_updated.patch.status`, not consumed yet.
+  "killed",
+  // Not emitted by any current schema; tolerated aliases.
+  "error",
+  "cancelled",
+  "canceled",
+]);
+
+/**
+ * Whether a background task's status means the task itself has ended.
+ *
+ * `null` / `undefined` / `""` are NOT terminal. A workflow whose row was
+ * checkpointed before its first `task_progress` tick has no status yet and
+ * is genuinely still starting — the pill renders it as "starting", which is
+ * correct. Orphaned rows in that state are resolved by the reaper on
+ * `ProcessExited` and by the startup sweep, not by treating absence as an
+ * ending.
+ */
+export function isTerminalBackgroundTaskStatus(
+  status: string | null | undefined,
+): boolean {
+  return TERMINAL_BACKGROUND_TASK_STATUSES.has((status ?? "").toLowerCase());
+}
+
+/**
+ * Status recorded for a background task whose owning CLI process went away
+ * without ever reporting an outcome.
+ *
+ * Deliberately `"stopped"` rather than a Claudette-specific sentinel: it is
+ * a real value in the CLI's own `task_notification` enum with exactly this
+ * meaning ("ended without completing"), so it needs no special-casing at
+ * any read site and reads correctly in the card's status line.
+ */
+export const REAPED_BACKGROUND_TASK_STATUS = "stopped";


### PR DESCRIPTION
Workflow status pills above the composer never went away — they survived the run finishing, being terminated, and every subsequent reload, stacking up one per historical run.

Three separate causes. All were reproducible against a real database, which had two stuck pills at the time of investigation plus three more wedged rows in other sessions.

## 1. `"stopped"` was never treated as terminal

Claude Code's `task_notification` schema declares a **closed** enum:

```js
subtype: z.literal("task_notification"),
status: z.enum(["completed", "failed", "stopped"])
```

`"stopped"` is what a *terminated* run reports. Both hand-written copies of the terminal-status set — one in `useLiveWorkflows`, one in `WorkflowCard` — omitted it, while including four values (`error`, `cancelled`, `canceled`, and `killed` on this channel) that appear on no schema at all.

The rest of the pipeline was already correct. A stopped run is on disk right now with `agent_status='stopped'`: Rust parsed the notification, the frontend applied it, and the targeted DB write landed. Only the vocabulary was wrong, so the pill simply never believed the run had ended.

The two copies are now a single module that documents what each value is and which channel emits it. `"killed"` is kept because it is real on `task_updated.patch.status` (a channel not consumed yet, so wiring it up later can't reintroduce the wedge); `"paused"` is deliberately excluded, since a paused task has not ended.

## 2. A killed process never sends a notification at all

A workflow runs *inside* the CLI process. Stop, crash, or session reset ends the run with nothing on the wire, leaving `agentStatus` pinned at `"running"` — or unset entirely, for a run checkpointed before its first progress tick.

`ProcessExited` now resolves those, in the store and on disk. `AgentSessionState` holds a single `active_pid` per chat session, so that signal is unambiguous: no second process could still own the tasks. Claude Code states the same invariant for its own `background_tasks_changed` level signal — the level is per-process, and consumers must reset when the process restarts.

On the happy path this reaps nothing, because the terminal notification landed minutes earlier.

## 3. Rows already wedged stayed wedged

No background task survives an app restart, so anything still marked in-flight at boot describes a run that can never report again. Those rows re-rendered a pill on **every** load, forever, accumulating one per historical run.

A startup sweep resolves them. Startup rather than a migration because this is not a one-time backlog: a SIGKILL'd app never reaches the `ProcessExited` reaper, so fresh orphans keep appearing. Safe to run unconditionally — at boot there is by definition no live CLI process from a previous run.

Scoped to `Workflow`. `Task` / `Agent` rows can wedge identically, but they render as a status word inside a collapsed turn rather than a floating indicator, so their historical status is left alone rather than rewritten.

## Docs

`workflows.mdx` was wrong on two counts and is corrected:

- "The pill disappears when the run finishes" — now covers terminated runs explicitly, which is the case that was broken.
- The Persistence section claimed an interrupted run "continues inside Claude Code". It does not survive the process that owns it, and Claudette could never observe the outcome either way.

## Verification

- Dry-ran the sweep against a **copy** of a real database: resolved exactly the 5 wedged workflow rows (3 `running` + 2 null), left all 12 `completed` and the pre-existing `stopped` row untouched, and did not touch any `Task`/`Agent` row. The live database was not modified.
- Schemas quoted above were read out of the installed CLI binary (2.1.220) rather than inferred.

## Tests

- Pill hides for each real terminal status and is case-insensitive; **still shows** for a run that has not reported yet, since absence of a status is not an ending.
- Reaper resolves and persists on `ProcessExited`, and leaves alone: already-resolved runs, other sessions' workflows, and non-workflow activities.
- Sweep is idempotent, case-insensitive, and correctly scoped.

The behavioral tests were verified to fail against the previous code — 2 in the pill suite, 4 in the reaper suite.

`cargo fmt`, `clippy` (`claudette` / `-server` / `-cli` clean; `claudette-tauri` compiles with only its 13 pre-existing warnings, none in `main.rs`), full backend suite, `tsc -b`, `lint:css`, and all 2920 frontend tests pass. No new ESLint warnings.
