### PR TITLE
fix(models): stop warning about retired Pi / LM Studio backend entries

### DIFF
--- a/src-tauri/src/commands/agent_backends/config.rs
+++ b/src-tauri/src/commands/agent_backends/config.rs
@@ -345,18 +345,42 @@ pub(super) fn read_unknown_passthrough(db: &Database) -> Result<Vec<Value>, Stri
 /// JSON, never a reparse, so unrelated unknown-kind passthrough and any
 /// additive fields written by a newer build survive untouched.
 ///
+/// An unreadable blob makes this a whole no-op, including the id-keyed
+/// settings — see the state table in the body for why.
+///
 /// A DB write failure is returned to the caller rather than swallowed —
 /// the alternative is silently reintroducing the warning-free-but-still-
 /// stored state this is meant to clear.
 pub(super) fn purge_retired_backend_settings(db: &Database) -> Result<(), String> {
-    // A missing or corrupt blob reads as "nothing to purge" rather than an
-    // error: recovering a corrupt blob is `save_backend_configs`'s job, and
-    // this pass must not be the thing that overwrites it.
-    let stored: Vec<Value> = db
+    // The stored blob has three states, and only two are safe to act on:
+    //
+    //   key absent          -> known-empty. Nothing is stored, so an
+    //                          id-keyed setting naming a retired backend
+    //                          is a genuine orphan and can go.
+    //   key present, parses -> known. `live_ids` below is trustworthy.
+    //   key present, corrupt-> unknown. Bail out entirely.
+    //
+    // The corrupt case must not fall through to the id-keyed purge: an
+    // empty `live_ids` there means "couldn't read", not "nothing claims
+    // this id", which would defeat the collision guard below and delete
+    // the default selection of a user-defined backend still sitting in
+    // that unreadable JSON. Repairing a corrupt blob is
+    // `save_backend_configs`' job — the tolerant loader deliberately
+    // leaves it in place for external recovery, so this pass leaves every
+    // related setting alone until the blob is readable again.
+    let Some(raw) = db
         .get_app_setting(SETTINGS_KEY)
         .map_err(|e| e.to_string())?
-        .and_then(|raw| serde_json::from_str::<Vec<Value>>(&raw).ok())
-        .unwrap_or_default();
+    else {
+        return purge_retired_id_keyed_settings(db, &HashSet::new());
+    };
+    let Ok(stored) = serde_json::from_str::<Vec<Value>>(&raw) else {
+        tracing::warn!(
+            target: "agent_backends",
+            "skipping retired-backend purge: stored blob is unreadable"
+        );
+        return Ok(());
+    };
 
     if stored.iter().any(is_retired_backend_entry) {
         let kept: Vec<&Value> = stored
@@ -372,16 +396,23 @@ pub(super) fn purge_retired_backend_settings(db: &Database) -> Result<(), String
         );
     }
 
-    // `default_agent_backend` and the auto-detect opt-out are keyed by id,
-    // and a retired id is not reserved — nothing stops a user-defined
-    // backend from also being called `pi`. Only purge an id-keyed setting
-    // when no surviving entry claims that id, so a custom backend that
-    // happens to reuse the name keeps its default selection and opt-out.
     let live_ids: HashSet<&str> = stored
         .iter()
         .filter(|entry| !is_retired_backend_entry(entry))
         .filter_map(|entry| entry.get("id").and_then(Value::as_str))
         .collect();
+    purge_retired_id_keyed_settings(db, &live_ids)
+}
+
+/// Clear the id-keyed settings (`default_agent_backend`, the auto-detect
+/// opt-out) belonging to a retired backend.
+///
+/// `live_ids` must be the set of ids the *readable* stored blob still
+/// claims — a retired id is not reserved, so nothing stops a user-defined
+/// backend from also being called `pi`, and any id in this set is spared.
+/// Callers must never pass an empty set to mean "couldn't read the blob";
+/// see [`purge_retired_backend_settings`].
+fn purge_retired_id_keyed_settings(db: &Database, live_ids: &HashSet<&str>) -> Result<(), String> {
     let purgeable_ids: Vec<&str> = RETIRED_BACKEND_IDS
         .iter()
         .copied()

--- a/src-tauri/src/commands/agent_backends/config.rs
+++ b/src-tauri/src/commands/agent_backends/config.rs
@@ -17,6 +17,7 @@ use claudette::plugin::load_secure_secret;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use super::auto_detect::auto_detect_disabled_key;
 use super::codex_gate::{
     LEGACY_CODEX_SUBSCRIPTION_BACKEND_ID, LEGACY_NATIVE_CODEX_BACKEND_ID, NATIVE_CODEX_BACKEND_ID,
     codex_backend_hidden_by_gate, default_backends_for_gate, is_codex_gate_backend_id,
@@ -26,6 +27,37 @@ use super::codex_gate::{
 pub(super) const SETTINGS_KEY: &str = "agent_backends_config";
 pub(super) const SECRET_BUCKET: &str = "agentBackendSecrets";
 const BACKEND_RUNTIME_ENV_VERSION: u8 = 2;
+
+/// Backend `kind` values that shipped in an earlier build and have since
+/// been removed for good (Pi + LM Studio, dropped in #1007).
+///
+/// These are deliberately *not* treated like an unrecognized kind from a
+/// newer build. The unknown-entry path assumes forward compatibility — it
+/// warns the user and preserves the entry so it revives on a build that
+/// understands it. No such build is coming for these, so a stored entry is
+/// simply dead config: the tolerant loader skips it without a user-visible
+/// warning, [`read_unknown_passthrough`] stops splicing it back on save,
+/// and [`purge_retired_backend_settings`] removes it from the stored blob.
+const RETIRED_BACKEND_KINDS: &[&str] = &["pi_sdk", "lm_studio"];
+
+/// Backend ids that belonged to [`RETIRED_BACKEND_KINDS`]. Tracked
+/// separately because id-keyed settings (`default_agent_backend`, the
+/// auto-detect opt-out keys) never record a `kind`.
+const RETIRED_BACKEND_IDS: &[&str] = &["pi", "lm-studio"];
+
+/// True when a stored JSON entry carries a retired `kind`. Reads the raw
+/// value rather than a parsed config because retired kinds are exactly the
+/// ones this build can no longer deserialize.
+fn is_retired_backend_entry(entry: &Value) -> bool {
+    entry
+        .get("kind")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| RETIRED_BACKEND_KINDS.contains(&kind))
+}
+
+fn is_retired_backend_id(id: &str) -> bool {
+    RETIRED_BACKEND_IDS.contains(&id)
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BackendStatus {
@@ -179,6 +211,18 @@ pub(super) fn load_backend_configs_tolerant(db: &Database) -> Result<LoadedBacke
                                 .get("kind")
                                 .and_then(Value::as_str)
                                 .unwrap_or("<no kind>");
+                            // Retired kinds are dead config, not a
+                            // forward-compat entry — nothing for the user
+                            // to act on, so no warning. `list_agent_backends`
+                            // purges them from storage on the next load.
+                            if is_retired_backend_entry(&entry) {
+                                tracing::debug!(
+                                    target: "agent_backends",
+                                    id, kind,
+                                    "tolerant load: dropping retired backend entry"
+                                );
+                                continue;
+                            }
                             warnings.push(format!(
                                 "Skipped backend entry id=`{id}` kind=`{kind}`: {err}. \
                                  Entry preserved and will be reapplied on a build that supports it."
@@ -232,6 +276,17 @@ pub(super) fn resolve_backend_list_default(
     if backends.iter().any(|backend| backend.id == aliased_default) {
         return aliased_default;
     }
+    // A default pointing at a retired backend isn't a config the user can
+    // repair by switching builds — fall back silently and let
+    // `purge_retired_backend_settings` clear the stored key.
+    if is_retired_backend_id(&stored_default) {
+        tracing::debug!(
+            target: "agent_backends",
+            stored_default = %stored_default,
+            "default backend setting points at a retired backend; using anthropic"
+        );
+        return "anthropic".to_string();
+    }
     warnings.push(format!(
         "Default backend `{stored_default}` is not available in this build; \
          falling back to `anthropic` for this session. \
@@ -268,8 +323,92 @@ pub(super) fn read_unknown_passthrough(db: &Database) -> Result<Vec<Value>, Stri
     };
     Ok(entries
         .into_iter()
-        .filter(|entry| serde_json::from_value::<AgentBackendConfig>(entry.clone()).is_err())
+        .filter(|entry| {
+            // Retired kinds are excluded from passthrough on purpose: they
+            // are unparseable here and always will be, so preserving them
+            // would carry dead config forward on every write.
+            !is_retired_backend_entry(entry)
+                && serde_json::from_value::<AgentBackendConfig>(entry.clone()).is_err()
+        })
         .collect())
+}
+
+/// Drop every trace of a retired backend from persisted settings: the
+/// entry in the backend blob, a `default_agent_backend` still pointing at
+/// it, and its auto-detect opt-out key.
+///
+/// Called from `list_agent_backends` (which runs at app boot and whenever
+/// the Models panel mounts) so the cleanup is deterministic rather than
+/// waiting for the user's next backend edit. Self-limiting: once the
+/// retired entries are gone there is nothing to rewrite, so it stops
+/// touching the DB. Surviving entries are re-persisted from their raw
+/// JSON, never a reparse, so unrelated unknown-kind passthrough and any
+/// additive fields written by a newer build survive untouched.
+///
+/// A DB write failure is returned to the caller rather than swallowed —
+/// the alternative is silently reintroducing the warning-free-but-still-
+/// stored state this is meant to clear.
+pub(super) fn purge_retired_backend_settings(db: &Database) -> Result<(), String> {
+    // A missing or corrupt blob reads as "nothing to purge" rather than an
+    // error: recovering a corrupt blob is `save_backend_configs`'s job, and
+    // this pass must not be the thing that overwrites it.
+    let stored: Vec<Value> = db
+        .get_app_setting(SETTINGS_KEY)
+        .map_err(|e| e.to_string())?
+        .and_then(|raw| serde_json::from_str::<Vec<Value>>(&raw).ok())
+        .unwrap_or_default();
+
+    if stored.iter().any(is_retired_backend_entry) {
+        let kept: Vec<&Value> = stored
+            .iter()
+            .filter(|entry| !is_retired_backend_entry(entry))
+            .collect();
+        let cleaned = serde_json::to_string(&kept).map_err(|e| e.to_string())?;
+        db.set_app_setting(SETTINGS_KEY, &cleaned)
+            .map_err(|e| e.to_string())?;
+        tracing::info!(
+            target: "agent_backends",
+            "purged retired backend entries from stored settings"
+        );
+    }
+
+    // `default_agent_backend` and the auto-detect opt-out are keyed by id,
+    // and a retired id is not reserved — nothing stops a user-defined
+    // backend from also being called `pi`. Only purge an id-keyed setting
+    // when no surviving entry claims that id, so a custom backend that
+    // happens to reuse the name keeps its default selection and opt-out.
+    let live_ids: HashSet<&str> = stored
+        .iter()
+        .filter(|entry| !is_retired_backend_entry(entry))
+        .filter_map(|entry| entry.get("id").and_then(Value::as_str))
+        .collect();
+    let purgeable_ids: Vec<&str> = RETIRED_BACKEND_IDS
+        .iter()
+        .copied()
+        .filter(|id| !live_ids.contains(id))
+        .collect();
+
+    if db
+        .get_app_setting("default_agent_backend")
+        .map_err(|e| e.to_string())?
+        .is_some_and(|stored| purgeable_ids.contains(&stored.as_str()))
+    {
+        db.delete_app_setting("default_agent_backend")
+            .map_err(|e| e.to_string())?;
+    }
+
+    for id in purgeable_ids {
+        let key = auto_detect_disabled_key(id);
+        if db
+            .get_app_setting(&key)
+            .map_err(|e| e.to_string())?
+            .is_some()
+        {
+            db.delete_app_setting(&key).map_err(|e| e.to_string())?;
+        }
+    }
+
+    Ok(())
 }
 
 pub(super) fn canonical_backend_id(id: &str) -> &str {

--- a/src-tauri/src/commands/agent_backends/mod.rs
+++ b/src-tauri/src/commands/agent_backends/mod.rs
@@ -52,7 +52,7 @@ pub use config::{BackendListResponse, BackendSecretUpdate, BackendStatus};
 use config::{
     SECRET_BUCKET, apply_discovered_models, canonical_backend_id, find_backend,
     load_backend_configs, load_backend_configs_tolerant, normalize_backend,
-    resolve_backend_list_default, save_backend_configs,
+    purge_retired_backend_settings, resolve_backend_list_default, save_backend_configs,
 };
 use discovery::{codex_cli_command, discover_models, test_backend_connectivity};
 
@@ -71,6 +71,7 @@ pub async fn list_agent_backends(
     state: State<'_, AppState>,
 ) -> Result<BackendListResponse, String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    purge_retired_backend_settings(&db)?;
     let stored_default = db
         .get_app_setting("default_agent_backend")
         .map_err(|e| e.to_string())?
@@ -1102,6 +1103,211 @@ mod tests {
             warning.contains("future-thing") && warning.contains("totally_new_backend"),
             "warning should name the offending entry: {warning}"
         );
+    }
+
+    /// Seed the stored blob with the two retired kinds plus a genuinely
+    /// unknown one, so every assertion can check that "retired" and
+    /// "unknown" stay on different code paths.
+    fn seed_retired_and_unknown_entries(db: &Database) {
+        let raw = serde_json::Value::Array(vec![
+            json!({ "id": "pi", "label": "Pi", "kind": "pi_sdk", "enabled": true }),
+            json!({ "id": "lm-studio", "label": "LM Studio", "kind": "lm_studio", "enabled": true }),
+            json!({ "id": "future-thing", "label": "Future", "kind": "totally_new_backend" }),
+        ]);
+        db.set_app_setting(SETTINGS_KEY, &raw.to_string())
+            .expect("seed should save");
+    }
+
+    #[test]
+    fn tolerant_load_drops_retired_kinds_without_warning() {
+        // Pi / LM Studio were removed for good, so a stored entry is dead
+        // config rather than a forward-compat passthrough. It must not
+        // raise the "some saved backend entries weren't loaded" banner —
+        // there is no build coming that would revive it. A genuinely
+        // unknown kind in the same blob must still warn.
+        let db = Database::open_in_memory().expect("test db should open");
+        seed_retired_and_unknown_entries(&db);
+
+        let loaded = load_backend_configs_tolerant(&db).expect("tolerant load should succeed");
+
+        assert!(!loaded.backends.iter().any(|b| b.id == "pi"));
+        assert!(!loaded.backends.iter().any(|b| b.id == "lm-studio"));
+        assert_eq!(
+            loaded.warnings.len(),
+            1,
+            "only the unknown kind should warn: {:?}",
+            loaded.warnings
+        );
+        assert!(loaded.warnings[0].contains("future-thing"));
+
+        // Retired kinds are excluded from passthrough; the unknown one is not.
+        let passthrough = read_unknown_passthrough(&db).expect("passthrough read should succeed");
+        assert_eq!(passthrough.len(), 1);
+        assert_eq!(
+            passthrough[0].get("id").and_then(Value::as_str),
+            Some("future-thing")
+        );
+    }
+
+    #[test]
+    fn save_drops_retired_kinds_but_keeps_unknown_passthrough() {
+        let db = Database::open_in_memory().expect("test db should open");
+        seed_retired_and_unknown_entries(&db);
+
+        let mut ollama = AgentBackendConfig::builtin_ollama();
+        ollama.enabled = true;
+        save_backend_configs(&db, &[ollama]).expect("save should succeed");
+
+        let raw = db
+            .get_app_setting(SETTINGS_KEY)
+            .expect("read should succeed")
+            .expect("blob should exist");
+        let entries: Vec<Value> = serde_json::from_str(&raw).expect("blob should parse");
+        let ids: Vec<&str> = entries
+            .iter()
+            .filter_map(|entry| entry.get("id").and_then(Value::as_str))
+            .collect();
+        assert!(ids.contains(&"ollama"));
+        assert!(
+            ids.contains(&"future-thing"),
+            "unknown kind still preserved"
+        );
+        assert!(!ids.contains(&"pi"));
+        assert!(!ids.contains(&"lm-studio"));
+    }
+
+    #[test]
+    fn purge_retired_backend_settings_clears_every_stored_trace() {
+        let db = Database::open_in_memory().expect("test db should open");
+        seed_retired_and_unknown_entries(&db);
+        db.set_app_setting("default_agent_backend", "pi")
+            .expect("default should save");
+        db.set_app_setting(&auto_detect_disabled_key("lm-studio"), "true")
+            .expect("opt-out should save");
+
+        purge_retired_backend_settings(&db).expect("purge should succeed");
+
+        let raw = db
+            .get_app_setting(SETTINGS_KEY)
+            .expect("read should succeed")
+            .expect("blob should exist");
+        let entries: Vec<Value> = serde_json::from_str(&raw).expect("blob should parse");
+        assert_eq!(entries.len(), 1, "only the unknown entry survives");
+        assert_eq!(
+            entries[0].get("id").and_then(Value::as_str),
+            Some("future-thing")
+        );
+        assert_eq!(
+            db.get_app_setting("default_agent_backend")
+                .expect("read should succeed"),
+            None
+        );
+        assert_eq!(
+            db.get_app_setting(&auto_detect_disabled_key("lm-studio"))
+                .expect("read should succeed"),
+            None
+        );
+
+        // Idempotent: a second pass has nothing left to rewrite.
+        purge_retired_backend_settings(&db).expect("second purge should succeed");
+        let after = db
+            .get_app_setting(SETTINGS_KEY)
+            .expect("read should succeed")
+            .expect("blob should exist");
+        assert_eq!(after, raw);
+    }
+
+    #[test]
+    fn purge_leaves_unrelated_settings_alone() {
+        let db = Database::open_in_memory().expect("test db should open");
+        let mut ollama = AgentBackendConfig::builtin_ollama();
+        ollama.enabled = true;
+        save_backend_configs(&db, &[ollama]).expect("save should succeed");
+        db.set_app_setting("default_agent_backend", "ollama")
+            .expect("default should save");
+        let before = db
+            .get_app_setting(SETTINGS_KEY)
+            .expect("read should succeed");
+
+        purge_retired_backend_settings(&db).expect("purge should succeed");
+
+        assert_eq!(
+            db.get_app_setting(SETTINGS_KEY)
+                .expect("read should succeed"),
+            before
+        );
+        assert_eq!(
+            db.get_app_setting("default_agent_backend")
+                .expect("read should succeed"),
+            Some("ollama".to_string())
+        );
+    }
+
+    #[test]
+    fn purge_spares_a_live_backend_that_reuses_a_retired_id() {
+        // `pi` is a dead *kind*, not a reserved *id*. A user-defined
+        // backend is free to be named `pi`, and the id-keyed settings
+        // (default selection, auto-detect opt-out) must survive for it.
+        let db = Database::open_in_memory().expect("test db should open");
+        let raw = serde_json::Value::Array(vec![
+            json!({ "id": "pi", "label": "Pi", "kind": "pi_sdk", "enabled": true }),
+            json!({
+                "id": "pi",
+                "label": "My Pi Proxy",
+                "kind": "custom_openai",
+                "enabled": true
+            }),
+        ]);
+        db.set_app_setting(SETTINGS_KEY, &raw.to_string())
+            .expect("seed should save");
+        db.set_app_setting("default_agent_backend", "pi")
+            .expect("default should save");
+        db.set_app_setting(&auto_detect_disabled_key("pi"), "true")
+            .expect("opt-out should save");
+
+        purge_retired_backend_settings(&db).expect("purge should succeed");
+
+        let stored = db
+            .get_app_setting(SETTINGS_KEY)
+            .expect("read should succeed")
+            .expect("blob should exist");
+        let entries: Vec<Value> = serde_json::from_str(&stored).expect("blob should parse");
+        assert_eq!(entries.len(), 1, "only the retired-kind entry is dropped");
+        assert_eq!(
+            entries[0].get("kind").and_then(Value::as_str),
+            Some("custom_openai")
+        );
+        assert_eq!(
+            db.get_app_setting("default_agent_backend")
+                .expect("read should succeed"),
+            Some("pi".to_string()),
+            "the live `pi` backend keeps its default selection"
+        );
+        assert_eq!(
+            db.get_app_setting(&auto_detect_disabled_key("pi"))
+                .expect("read should succeed"),
+            Some("true".to_string())
+        );
+    }
+
+    #[test]
+    fn retired_default_backend_falls_back_without_warning() {
+        let backends = vec![AgentBackendConfig::builtin_anthropic()];
+        let mut warnings = Vec::new();
+
+        let resolved =
+            resolve_backend_list_default(&backends, &mut warnings, "lm-studio".to_string());
+
+        assert_eq!(resolved, "anthropic");
+        assert!(warnings.is_empty(), "retired default should not warn");
+
+        // A non-retired missing default still warns — the silent path is
+        // scoped to backends we removed on purpose, not to typos or to a
+        // backend hidden by a feature gate.
+        let resolved =
+            resolve_backend_list_default(&backends, &mut warnings, "some-other".to_string());
+        assert_eq!(resolved, "anthropic");
+        assert_eq!(warnings.len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/commands/agent_backends/mod.rs
+++ b/src-tauri/src/commands/agent_backends/mod.rs
@@ -1291,6 +1291,67 @@ mod tests {
     }
 
     #[test]
+    fn purge_is_a_no_op_while_the_stored_blob_is_unreadable() {
+        // A corrupt blob means we cannot tell which ids are live, and an
+        // empty live-id set must not be read as "nothing claims `pi`" —
+        // the user's custom `pi` backend may be sitting in that very JSON,
+        // which the tolerant loader deliberately leaves in place for
+        // external recovery. Nothing may be deleted until it parses again.
+        let db = Database::open_in_memory().expect("test db should open");
+        db.set_app_setting(SETTINGS_KEY, "{ not valid json")
+            .expect("seed should save");
+        db.set_app_setting("default_agent_backend", "pi")
+            .expect("default should save");
+        db.set_app_setting(&auto_detect_disabled_key("pi"), "true")
+            .expect("opt-out should save");
+
+        purge_retired_backend_settings(&db).expect("purge should succeed");
+
+        assert_eq!(
+            db.get_app_setting(SETTINGS_KEY)
+                .expect("read should succeed"),
+            Some("{ not valid json".to_string()),
+            "corrupt blob is left untouched for recovery"
+        );
+        assert_eq!(
+            db.get_app_setting("default_agent_backend")
+                .expect("read should succeed"),
+            Some("pi".to_string()),
+            "id-keyed settings survive while the blob is unreadable"
+        );
+        assert_eq!(
+            db.get_app_setting(&auto_detect_disabled_key("pi"))
+                .expect("read should succeed"),
+            Some("true".to_string())
+        );
+    }
+
+    #[test]
+    fn purge_clears_orphaned_id_keyed_settings_when_no_blob_is_stored() {
+        // No blob at all is a *known*-empty state, unlike a corrupt one:
+        // nothing is stored, so a default naming a retired backend is a
+        // genuine orphan and should go.
+        let db = Database::open_in_memory().expect("test db should open");
+        db.set_app_setting("default_agent_backend", "lm-studio")
+            .expect("default should save");
+        db.set_app_setting(&auto_detect_disabled_key("lm-studio"), "true")
+            .expect("opt-out should save");
+
+        purge_retired_backend_settings(&db).expect("purge should succeed");
+
+        assert_eq!(
+            db.get_app_setting("default_agent_backend")
+                .expect("read should succeed"),
+            None
+        );
+        assert_eq!(
+            db.get_app_setting(&auto_detect_disabled_key("lm-studio"))
+                .expect("read should succeed"),
+            None
+        );
+    }
+
+    #[test]
     fn retired_default_backend_falls_back_without_warning() {
         let backends = vec![AgentBackendConfig::builtin_anthropic()];
         let mut warnings = Vec::new();

--- a/src/ui/src/components/settings/sections/ModelSettings.tsx
+++ b/src/ui/src/components/settings/sections/ModelSettings.tsx
@@ -61,11 +61,14 @@ export function ModelSettings() {
   const [defaultEffort, setDefaultEffort] = useState("auto");
   const [defaultShowThinking, setDefaultShowThinking] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Tolerant-loader diagnostics: non-fatal warnings emitted when
-  // stored backend entries have a `kind` this build doesn't recognize
-  // (e.g. a removed kind like `pi_sdk` / `lm_studio` left in the DB).
-  // Backend keeps the entries as opaque passthrough; user just needs
-  // to know they aren't active in this session.
+  // Tolerant-loader diagnostics: non-fatal warnings emitted when stored
+  // backend entries have a `kind` this build doesn't recognize — i.e. a
+  // newer build wrote them, or the user downgraded. The backend keeps
+  // those entries as opaque passthrough, so the banner's job is only to
+  // say they aren't active this session.
+  // Kinds retired for good (`pi_sdk` / `lm_studio`) deliberately do NOT
+  // land here: the loader drops them silently and purges them from
+  // storage, because no future build will revive them.
   const [backendWarnings, setBackendWarnings] = useState<string[]>([]);
   const alternativeBackendsEnabled = useAppStore((s) => s.alternativeBackendsEnabled);
   const alternativeBackendsAvailable = useAppStore((s) => s.alternativeBackendsAvailable);


### PR DESCRIPTION
### Summary

The Models panel showed a permanent, unclearable warning banner to anyone who had ever configured Pi or LM Studio:

> **Some saved backend entries weren't loaded**
> Skipped backend entry id=`pi` kind=`pi_sdk`: unknown variant `pi_sdk` … Entry preserved and will be reapplied on a build that supports it.

The tolerant backend loader has one bucket for "a `kind` I can't deserialize" and assumes every such entry is **forward-compatible** — a newer build wrote it, or the user downgraded. So it warns and keeps the entry as opaque passthrough, splicing it back into the blob on every write.

Pi and LM Studio (removed in #1007) break that assumption. No future build will understand `pi_sdk` / `lm_studio` again, so the promise in the banner is false and the user has no action available.

This teaches the loader a second category. Retired kinds are **dead config**, not passthrough:

| | Unknown kind (e.g. `totally_new_backend`) | Retired kind (`pi_sdk`, `lm_studio`) |
|---|---|---|
| Warning banner | shown | **silent** |
| Passthrough on save | preserved | **dropped** |
| Stored blob | untouched | **purged** |

Genuinely unknown kinds keep the existing warn + passthrough behavior — the banner still does its job for a real forward-compat entry.

```mermaid
flowchart TD
    A[Stored entry in agent_backends_config] --> B{Deserializes as<br/>AgentBackendConfig?}
    B -->|yes| C[Active backend]
    B -->|no| D{kind in<br/>RETIRED_BACKEND_KINDS?}
    D -->|no — forward compat| E[Warn in UI banner<br/>+ keep as passthrough<br/>+ re-splice on save]
    D -->|yes — dead config| F[Silent skip<br/>+ drop from passthrough<br/>+ purge from storage]
```

**Where the purge runs.** `list_agent_backends` calls `purge_retired_backend_settings` first. That command fires at app boot (`App.tsx`) and on Models-panel mount, so cleanup is deterministic rather than waiting for the user's next backend edit. It is self-limiting: once nothing retired remains, there is no DB write. Surviving entries are re-persisted from their **raw JSON** rather than a reparse, so unrelated unknown-kind passthrough and any additive fields written by a newer build survive byte-for-byte.

### Complexity Notes

Three things worth a close look:

1. **Retired *kinds* and retired *ids* are different namespaces.** The backend blob is keyed by `kind`, but `default_agent_backend` and `agent_backend_auto_detect_disabled:*` are keyed by **id** — and `pi` was never a reserved id. A naive purge would delete the default-backend setting for anyone whose *custom* backend happens to be named `pi`. The purge computes surviving ids from the cleaned blob and spares any id-keyed setting a live backend still claims. Pinned by `purge_spares_a_live_backend_that_reuses_a_retired_id`.

2. **This is a data deletion, so the blast radius matters.** Only entries whose `kind` is exactly `pi_sdk` or `lm_studio` are removed. The stored blob has three states and the purge treats them differently (this was tightened in f93d58a8 after review feedback):

   | Blob state | Meaning | Behavior |
   |---|---|---|
   | key absent | *known*-empty | clear orphaned id-keyed settings |
   | key present, parses | known | full purge; `live_ids` is trustworthy |
   | key present, corrupt | *unknown* | whole pass is a no-op |

   The corrupt case matters: an empty `live_ids` there means "couldn't read", not "nothing claims this id", so falling through would defeat the collision guard in (1) and delete the default selection of a user-defined backend still sitting in that unreadable JSON. The tolerant loader deliberately leaves a corrupt blob in place for external recovery, so this pass must not delete related settings behind it. Pinned by `purge_is_a_no_op_while_the_stored_blob_is_unreadable`, `purge_clears_orphaned_id_keyed_settings_when_no_blob_is_stored`, and `purge_leaves_unrelated_settings_alone`.

3. **A SQL migration was considered and rejected.** Editing the JSON blob via `json_each` / `json_group_array` has a trap: `json_extract(value,'$.kind')` returns `NULL` for an entry with no `kind`, and `NULL NOT IN (...)` evaluates to `NULL`, not true — the filter would have silently deleted every kind-less entry. Migrations are also unfixable in place once released. Rust with `Database::open_in_memory()` tests is the safer home.

**Intentionally not purged:** keychain secrets under `agentBackendSecrets` for `pi` / `lm-studio`. Deleting credentials without asking is the worse failure mode; the orphaned entries are inert.

**No docs change.** Pi / LM Studio were already scrubbed from `site/` in #1007, and the warning banner itself is undocumented and unchanged for its remaining (forward-compat) purpose.

### Test Steps

Automated — 6 new tests in `src-tauri/src/commands/agent_backends/mod.rs`:

```bash
cargo test -p claudette-tauri --no-default-features \
  --features devtools,server,alternative-backends agent_backends
```

Covers: retired kinds load without warning; a genuinely unknown kind in the *same* blob still warns; save drops retired entries but keeps unknown passthrough; the purge clears every stored trace and is idempotent; the purge spares a live backend reusing a retired id; a retired default falls back silently while a non-retired missing default still warns.

Manual, to reproduce the original bug and confirm the fix:

1. With the app closed, seed a retired entry into your dev DB (`~/.claudette/claudette.db`):
   ```sql
   UPDATE app_settings
   SET value = '[{"id":"pi","label":"Pi","kind":"pi_sdk","enabled":true}]'
   WHERE key = 'agent_backends_config';
   ```
2. Launch `./scripts/dev.sh` and open **Settings → Models**. On `main` you get the orange "Some saved backend entries weren't loaded" banner; on this branch the panel is clean.
3. Confirm the entry is actually gone, not just hidden:
   ```sql
   SELECT value FROM app_settings WHERE key = 'agent_backends_config';
   ```
   The `pi` entry should no longer be present.
4. Verify the forward-compat path still works — seed `'[{"id":"future-thing","label":"Future","kind":"totally_new_backend"}]'`, relaunch, and confirm the banner **does** appear and the entry survives in the DB after editing an unrelated backend.
5. Sanity-check that Anthropic / Ollama / Codex still load, are selectable, and that switching the default backend persists across a restart.

### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable) — n/a, see Complexity Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
