### PR TITLE
fix(chat): render insight callouts wrapped in a code fence

### DIFF
--- a/src/ui/src/utils/callouts.test.ts
+++ b/src/ui/src/utils/callouts.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { preprocessCallouts } from "./callouts";
+
+/** Box-drawing rule of the length Claude actually emits. */
+const RULE = "─".repeat(49);
+const HEADER_RULE = "─".repeat(45);
+
+describe("preprocessCallouts — inline-backtick form", () => {
+  it("converts a complete backtick-wrapped callout to a styled block", () => {
+    const out = preprocessCallouts(
+      `\`★ Insight ${HEADER_RULE}\`\nWorktrees are cheap.\n\`${RULE}\``,
+    );
+    expect(out).toContain('<div class="cc-callout">');
+    expect(out).toContain(
+      '<div class="cc-callout-header"><span class="cc-callout-icon">★</span> Insight</div>',
+    );
+    expect(out).toContain("Worktrees are cheap.");
+    expect(out).toContain("</div>");
+  });
+
+  it("keeps a label without a leading icon intact", () => {
+    const out = preprocessCallouts(
+      `\`Warning ${HEADER_RULE}\`\nBe careful.\n\`${RULE}\``,
+    );
+    expect(out).toContain('<div class="cc-callout-header">Warning</div>');
+    expect(out).not.toContain("cc-callout-icon");
+  });
+
+  it("promotes an orphaned header when no closing rule arrived yet", () => {
+    const out = preprocessCallouts(`\`★ Insight ${HEADER_RULE}\`\nStill streaming`);
+    expect(out).toContain(
+      '<div class="cc-callout-header"><span class="cc-callout-icon">★</span> Insight</div>',
+    );
+    expect(out).not.toContain('<div class="cc-callout">');
+  });
+
+  it("turns an orphaned closing rule into a horizontal rule", () => {
+    const out = preprocessCallouts(`Some prose.\n\`${RULE}\``);
+    expect(out).toContain('<hr class="cc-callout-rule" />');
+  });
+});
+
+describe("preprocessCallouts — bare-lines form", () => {
+  it("converts standalone rule lines to a styled block", () => {
+    const out = preprocessCallouts(
+      `★ Insight ${HEADER_RULE}\nNo backticks here.\n${RULE}`,
+    );
+    expect(out).toContain('<div class="cc-callout">');
+    expect(out).toContain("No backticks here.");
+  });
+
+  it("leaves an indented-code-block callout alone", () => {
+    const src = [
+      "Example output:",
+      "",
+      `    ★ Insight ${HEADER_RULE}`,
+      "    indented sample",
+      `    ${RULE}`,
+    ].join("\n");
+    expect(preprocessCallouts(src)).toBe(src);
+  });
+});
+
+describe("preprocessCallouts — fenced code blocks", () => {
+  it("unwraps a bare fence whose whole body is a callout", () => {
+    const src = [
+      "It's inverted: the fix creates the flaw it claims to remove.",
+      "",
+      "```",
+      `★ Insight ${HEADER_RULE}`,
+      "This is the classic mock-sentinel pattern, and it reads as a bug",
+      'to anyone who scans for "assertion matches input."',
+      RULE,
+      "```",
+      "",
+      "Two smaller things: ...",
+    ].join("\n");
+
+    const out = preprocessCallouts(src);
+    // The regression: HTML source leaking into a code block.
+    expect(out).not.toContain("```");
+    expect(out).toContain('<div class="cc-callout">');
+    expect(out).toContain(
+      '<div class="cc-callout-header"><span class="cc-callout-icon">★</span> Insight</div>',
+    );
+    expect(out).toContain("This is the classic mock-sentinel pattern");
+    expect(out).toContain("Two smaller things: ...");
+  });
+
+  it("unwraps a fence padded with blank lines around the callout", () => {
+    const out = preprocessCallouts(
+      ["```", "", `★ Insight ${HEADER_RULE}`, "Padded.", RULE, "", "```"].join("\n"),
+    );
+    expect(out).toContain('<div class="cc-callout">');
+    expect(out).toContain("Padded.");
+  });
+
+  it("leaves a language-tagged fence untouched", () => {
+    const src = [
+      "```text",
+      `★ Insight ${HEADER_RULE}`,
+      "Shown verbatim on purpose.",
+      RULE,
+      "```",
+    ].join("\n");
+    expect(preprocessCallouts(src)).toBe(src);
+  });
+
+  it("leaves a fence that mixes a callout with other content untouched", () => {
+    const src = [
+      "```",
+      "$ claudette ws list",
+      `★ Insight ${HEADER_RULE}`,
+      "Part of a larger sample.",
+      RULE,
+      "```",
+    ].join("\n");
+    expect(preprocessCallouts(src)).toBe(src);
+  });
+
+  it("does not rewrite callout syntax inside an ordinary code sample", () => {
+    const src = [
+      "Here is how the raw output looks:",
+      "",
+      "```",
+      "some code",
+      `★ Insight ${HEADER_RULE}`,
+      "more code",
+      "```",
+    ].join("\n");
+    expect(preprocessCallouts(src)).toBe(src);
+  });
+
+  it("handles tilde fences", () => {
+    const src = ["~~~", `★ Insight ${HEADER_RULE}`, "Tilde-fenced.", RULE, "~~~"].join(
+      "\n",
+    );
+    const out = preprocessCallouts(src);
+    expect(out).toContain('<div class="cc-callout">');
+    expect(out).not.toContain("~~~");
+  });
+
+  it("leaves an unterminated fence alone", () => {
+    const src = ["```", `★ Insight ${HEADER_RULE}`, "Still streaming in"].join("\n");
+    expect(preprocessCallouts(src)).toBe(src);
+  });
+
+  it("does not let a callout match span a fence boundary", () => {
+    const src = [
+      `\`★ Insight ${HEADER_RULE}\``,
+      "",
+      "```",
+      "code in between",
+      "```",
+      "",
+      `\`${RULE}\``,
+    ].join("\n");
+    const out = preprocessCallouts(src);
+    // Fence survives verbatim; the two orphans degrade independently.
+    expect(out).toContain("```\ncode in between\n```");
+    expect(out).toContain('<div class="cc-callout-header">');
+    expect(out).toContain('<hr class="cc-callout-rule" />');
+  });
+});
+
+describe("preprocessCallouts — pass-through", () => {
+  it("returns text with no callouts unchanged", () => {
+    const src = "Just a paragraph.\n\n- a list item\n- another\n\n```js\nconst a = 1;\n```\n";
+    expect(preprocessCallouts(src)).toBe(src);
+  });
+
+  it("preserves trailing newlines", () => {
+    expect(preprocessCallouts("hello\n\n")).toBe("hello\n\n");
+  });
+
+  it("handles an empty string", () => {
+    expect(preprocessCallouts("")).toBe("");
+  });
+});

--- a/src/ui/src/utils/callouts.ts
+++ b/src/ui/src/utils/callouts.ts
@@ -1,0 +1,195 @@
+/**
+ * Claude Code's decorative callout blocks → styled block-level HTML.
+ *
+ * Claude emits these in two spellings. Inline-backtick, which is what the
+ * output-style contract asks for:
+ *
+ *   `★ Insight ─────────────────────────────────────`
+ *   [content]
+ *   `─────────────────────────────────────────────────`
+ *
+ * …and bare lines with no backticks at all. Both look great in a terminal but
+ * render as inline `<code>` (or as nothing at all) in markdown, so we rewrite
+ * them into `<div class="cc-callout">` blocks that react-markdown + rehype-raw
+ * pass through and `MessageMarkdown.module.css` styles.
+ *
+ * This is a text-level pass that runs *before* the markdown parser, which
+ * means it has to do a slice of the parser's job itself: recognise the regions
+ * where markdown syntax is inert. Without that, the bare-lines pattern happily
+ * fires inside a fenced code block, the fence survives the rewrite, and the
+ * reader gets a code box full of raw `<div class="cc-callout">` source.
+ * `splitFences` carves the text into code / non-code segments so the rewrite
+ * only ever touches prose.
+ *
+ * Models also sometimes wrap the whole callout in a bare fence — presumably to
+ * protect the box-drawing characters from reflowing. `unwrapFencedCallout`
+ * recognises that shape and promotes it to a real callout, so an insight
+ * renders the same way regardless of which spelling the model reached for.
+ */
+
+/** Split a leading single-character icon off the label, e.g. "★ Insight". */
+function calloutHeader(rawLabel: string): string {
+  const label = rawLabel.trim();
+  const match = label.match(/^(\S)\s+(.*)/);
+  if (match) {
+    return `<span class="cc-callout-icon">${match[1]}</span> ${match[2]}`;
+  }
+  return label;
+}
+
+/** The block-level HTML a matched callout becomes. */
+function calloutHtml(label: string, content: string): string {
+  return `\n\n<div class="cc-callout"><div class="cc-callout-header">${calloutHeader(label)}</div>\n\n${content.trim()}\n\n</div>\n\n`;
+}
+
+/**
+ * Rewrite callout syntax within a single non-code segment.
+ *
+ * Kept as sequential `String.replace` passes (rather than one grammar) because
+ * each pass handles a distinct degradation: complete blocks first, then the
+ * orphaned header / rule fragments that a truncated or interrupted stream
+ * leaves behind.
+ */
+function rewriteCallouts(text: string): string {
+  // Full callout blocks (backtick-wrapped): `Label ───` ... content ... `───`
+  // [^─`] matches any character that isn't a dash or backtick — captures the label.
+  text = text.replace(
+    /`([^─`]+?)─{3,}`([\s\S]*?)`─{5,}`/g,
+    (_m, label: string, content: string) => calloutHtml(label, content),
+  );
+
+  // Full callout blocks (no backticks, standalone lines). The leading
+  // lookahead keeps this off indented code blocks: under CommonMark a line
+  // indented four or more spaces is code, not a paragraph, so a rule drawn
+  // that far in is decoration inside a code sample rather than a callout.
+  text = text.replace(
+    /^(?! {4}|\t)([^─\n]+?)─{3,}\s*$([\s\S]*?)^─{5,}\s*$/gm,
+    (_m, label: string, content: string) => calloutHtml(label, content),
+  );
+
+  // Leftover unmatched backtick-wrapped headers (no closing rule found)
+  text = text.replace(
+    /`([^─`]+?)─{3,}`/g,
+    (_m, label: string) =>
+      `\n\n<div class="cc-callout-header">${calloutHeader(label)}</div>\n\n`,
+  );
+
+  // Leftover unmatched backtick-wrapped horizontal rules
+  text = text.replace(
+    /`─{5,}`/g,
+    '\n\n<hr class="cc-callout-rule" />\n\n',
+  );
+
+  return text;
+}
+
+type Segment =
+  | { kind: "text"; lines: string[] }
+  | {
+      kind: "fence";
+      open: string;
+      /** Info string after the opening marker, trimmed ("" for a bare fence). */
+      info: string;
+      body: string[];
+      /** null when the fence is never closed (runs to end of input). */
+      close: string | null;
+    };
+
+/** Opening fence: up to three spaces of indent, then 3+ backticks or tildes. */
+const FENCE_OPEN_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+
+/**
+ * Partition `text` into alternating prose and fenced-code segments, following
+ * CommonMark's fence rules closely enough for chat content: a closing fence
+ * uses the same character, is at least as long as the opener, and carries
+ * nothing but trailing whitespace. Every input line lands in exactly one
+ * segment, so joining the rendered segments with "\n" reproduces the original
+ * text when nothing matches.
+ */
+function splitFences(text: string): Segment[] {
+  const lines = text.split("\n");
+  const segments: Segment[] = [];
+  let buf: string[] = [];
+
+  const flushText = () => {
+    if (buf.length > 0) {
+      segments.push({ kind: "text", lines: buf });
+      buf = [];
+    }
+  };
+
+  let i = 0;
+  while (i < lines.length) {
+    const open = lines[i].match(FENCE_OPEN_RE);
+    // A backtick fence's info string may not itself contain a backtick —
+    // otherwise `` `foo` `` at the start of a line would read as a fence.
+    const isFence =
+      open != null && !(open[2].startsWith("`") && open[3].includes("`"));
+
+    if (!isFence || open == null) {
+      buf.push(lines[i]);
+      i += 1;
+      continue;
+    }
+
+    flushText();
+    const marker = open[2];
+    const closeRe = new RegExp(
+      `^ {0,3}[${marker[0]}]{${marker.length},}[ \\t]*$`,
+    );
+    const openLine = lines[i];
+    const body: string[] = [];
+    let close: string | null = null;
+    i += 1;
+    while (i < lines.length) {
+      if (closeRe.test(lines[i])) {
+        close = lines[i];
+        i += 1;
+        break;
+      }
+      body.push(lines[i]);
+      i += 1;
+    }
+    segments.push({ kind: "fence", open: openLine, info: open[3].trim(), body, close });
+  }
+
+  flushText();
+  return segments;
+}
+
+/** A fence body that is nothing but a callout: header rule, content, closing rule. */
+const FENCED_CALLOUT_RE =
+  /^([^─\n]+?)─{3,}[ \t]*\n([\s\S]*)\n[ \t]*─{5,}[ \t]*$/;
+
+/**
+ * Promote a fence whose entire body is a callout back into a real callout.
+ *
+ * Deliberately conservative: only bare fences qualify. A fence tagged with a
+ * language (```text, ```js) is a code sample the author chose to show
+ * verbatim, and unwrapping it would destroy content rather than style it.
+ */
+function unwrapFencedCallout(seg: Extract<Segment, { kind: "fence" }>): string | null {
+  if (seg.info !== "") return null;
+  if (seg.close == null) return null;
+  const match = seg.body.join("\n").trim().match(FENCED_CALLOUT_RE);
+  if (!match) return null;
+  if (!match[1].trim()) return null;
+  return calloutHtml(match[1], match[2]);
+}
+
+function renderSegment(seg: Segment): string {
+  if (seg.kind === "text") return rewriteCallouts(seg.lines.join("\n"));
+  const unwrapped = unwrapFencedCallout(seg);
+  if (unwrapped != null) return unwrapped;
+  const parts = [seg.open, ...seg.body];
+  if (seg.close != null) parts.push(seg.close);
+  return parts.join("\n");
+}
+
+/**
+ * Pre-process Claude Code's decorative callout blocks into styled HTML,
+ * leaving the contents of fenced code blocks alone.
+ */
+export function preprocessCallouts(text: string): string {
+  return splitFences(text).map(renderSegment).join("\n");
+}

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -25,6 +25,7 @@ import {
   isLikelyFilePathTarget,
   isLikelyRelativeFileReference,
 } from "./filePathLinks";
+import { preprocessCallouts } from "./callouts";
 import { classifyAgentFile } from "./agentFiles";
 import { getCachedHighlight, highlightCode } from "./highlight";
 import { rehypeFilePathLinks } from "./rehypeFilePathLinks";
@@ -39,61 +40,9 @@ export function ansiToHtml(text: string): string {
   return ansiUp.ansi_to_html(text);
 }
 
-/**
- * Build callout header HTML, splitting a leading icon from the label text.
- * e.g. "★ Insight" → icon span + "Insight", "Warning" → just "Warning"
- */
-function calloutHeader(rawLabel: string): string {
-  const label = rawLabel.trim();
-  const match = label.match(/^(\S)\s+(.*)/);
-  if (match) {
-    return `<span class="cc-callout-icon">${match[1]}</span> ${match[2]}`;
-  }
-  return label;
-}
-
-/**
- * Pre-process Claude Code's decorative callout blocks into styled HTML.
- * Claude outputs patterns like:
- *   `★ Insight ─────────────────────────────────────`
- *   [content]
- *   `─────────────────────────────────────────────────`
- *
- * These look great in a terminal but render as inline <code> in markdown.
- * Convert them to block-level HTML elements that react-markdown + rehype-raw
- * will pass through as styled callout blocks.
- */
-export function preprocessCallouts(text: string): string {
-  // Full callout blocks (backtick-wrapped): `Label ───` ... content ... `───`
-  // [^─`] matches any character that isn't a dash or backtick — captures the label.
-  text = text.replace(
-    /`([^─`]+?)─{3,}`([\s\S]*?)`─{5,}`/g,
-    (_m, label: string, content: string) =>
-      `\n\n<div class="cc-callout"><div class="cc-callout-header">${calloutHeader(label)}</div>\n\n${content.trim()}\n\n</div>\n\n`,
-  );
-
-  // Full callout blocks (no backticks, standalone lines)
-  text = text.replace(
-    /^([^─\n]+?)─{3,}\s*$([\s\S]*?)^─{5,}\s*$/gm,
-    (_m, label: string, content: string) =>
-      `\n\n<div class="cc-callout"><div class="cc-callout-header">${calloutHeader(label)}</div>\n\n${content.trim()}\n\n</div>\n\n`,
-  );
-
-  // Leftover unmatched backtick-wrapped headers (no closing rule found)
-  text = text.replace(
-    /`([^─`]+?)─{3,}`/g,
-    (_m, label: string) =>
-      `\n\n<div class="cc-callout-header">${calloutHeader(label)}</div>\n\n`,
-  );
-
-  // Leftover unmatched backtick-wrapped horizontal rules
-  text = text.replace(
-    /`─{5,}`/g,
-    '\n\n<hr class="cc-callout-rule" />\n\n',
-  );
-
-  return text;
-}
+// Re-exported so the long-standing `utils/markdown` import path keeps working
+// for callers (and tests) that reach for the callout pass directly.
+export { preprocessCallouts };
 
 /** Full pre-processing pipeline for assistant message content. */
 export function preprocessContent(text: string): string {


### PR DESCRIPTION
### Summary

Insight callouts stopped rendering as styled blocks and started showing up as a code block full of raw `<div class="cc-callout">` HTML source.

`preprocessCallouts` rewrites Claude's decorative callout syntax into block-level HTML *before* the markdown parser runs, but it had no notion of where markdown syntax is inert. Claude emits callouts in two spellings — inline-backtick (what the output-style contract asks for) and bare lines — and when it wrapped an insight in a bare ` ``` ` fence instead, the bare-lines pattern fired on the fence's *contents*. The fence itself survived the rewrite, so react-markdown correctly rendered it as a code block whose text happened to be HTML.

Nothing in this repo changed to cause it (`git log -S preprocessCallouts` → #176, #109). It's a latent bug that a shift in model output exposed, which is why it appears and disappears seemingly at random.

The fix moves the callout pass out of the already-large `markdown.ts` into `utils/callouts.ts` (re-exported, so existing import paths are unchanged) and teaches it to partition text into prose and fenced-code segments before rewriting anything:

```mermaid
flowchart LR
    A[raw message] --> B[ansiToHtml]
    B --> C[splitFences]
    C -->|prose segment| D[rewriteCallouts<br/>4 regex passes]
    C -->|fenced segment| E{bare fence whose<br/>body is entirely<br/>a callout?}
    E -->|yes| F[unwrap to<br/>cc-callout HTML]
    E -->|no| G[emit verbatim]
    D --> H[react-markdown<br/>+ rehype-raw]
    F --> H
    G --> H
```

Net effect: an insight renders as a styled callout regardless of which spelling the model reached for, and code samples that *contain* callout-looking text are no longer corrupted.

### Complexity Notes

Three deliberate behavior decisions, each pinned by a test — worth a close look since they're judgment calls, not forced moves:

| case | behavior | rationale |
|---|---|---|
| language-tagged fence (` ```text `, ` ```js `) containing a callout | left as code | a tagged fence is a sample the author chose to show verbatim; unwrapping destroys content |
| fence mixing a callout with other content | left as code | unwrapping would lose the rest of the block |
| callout markers straddling a fence boundary | no longer matches across it | latent bug fixed as a side effect of segmenting |

**Behavior change worth flagging:** bare-lines matching now skips lines indented four or more spaces. Under CommonMark such a line is code, not a paragraph, so the previous behavior was wrong — but a callout nested four spaces deep inside a list would previously have been styled and will now render as code. Judged the rarer of the two failure modes.

**`splitFences` is a second, partial implementation of CommonMark's fence grammar.** It handles backtick and tilde fences, up-to-3-space indents, matching-or-longer closing markers, info strings, and unterminated fences. It's bounded and tested, but it can drift from the real parser. The structurally immune alternative is a remark plugin operating on the mdast (where a fence is a `code` node a visitor simply never descends into) — that was considered and rejected as too much regression surface in a hot render path for a bug fix. Flagging it as the natural next step if callout handling grows further.

`preprocessCallouts` previously had **zero** test coverage — no test file referenced it at all, which is precisely why this shipped unnoticed. That gap is now closed.

### Test Steps

1. Run the new tests:
   ```bash
   cd src/ui && bunx vitest run src/utils/callouts.test.ts
   ```
   Expect 17 passing.

2. Confirm no regressions across the suite and type-check:
   ```bash
   cd src/ui && bunx vitest run && bunx tsc -b && bun run lint:css
   ```
   Expect 2937 passing / 6 skipped, clean `tsc`, clean CSS token check.

3. Verify in the running app (`./scripts/dev.sh`) — ask an agent a question in a workspace where the explanatory output style is active, and confirm the `★ Insight` block renders as a styled callout (icon + header + bordered body), **not** as a code block containing HTML.

4. Regression check the code-sample path: send a message containing a fenced block that itself contains box-drawing rules, e.g.

   ````
   ```text
   ★ Insight ─────────────────────
   shown verbatim
   ─────────────────────────────────
   ```
   ````

   It must still render as a plain code block with the box-drawing intact.

5. Regression check the original spelling: an insight written with the inline-backtick form (`` `★ Insight ───` `` … `` `─────` ``) must still render as a styled callout exactly as before.

### Checklist

- [x] Tests added/updated — 17 new tests in `src/ui/src/utils/callouts.test.ts`, covering a previously untested function
- [ ] Documentation updated (if applicable) — **N/A and intentional.** No page in `site/` documents callout rendering, and this adds no setting, command, flag, or shortcut. It's a rendering bug fix, so there's no settings-reference row or feature page to update.
