### PR TITLE
fix(scm): don't auto-archive a workspace that inherited a merged PR

### DIFF
--- a/plugins/scm-github/init.lua
+++ b/plugins/scm-github/init.lua
@@ -18,7 +18,10 @@ function M.list_pull_requests(args)
     local limit = tostring(args.limit or 30)
     local gh_args = {
         "pr", "list",
-        "--json", "number,title,state,url,author,headRefName,baseRefName,isDraft,statusCheckRollup",
+        -- mergedAt lets the host tell a merge that belongs to the polling
+        -- workspace from one it inherited via a branch-name collision (see
+        -- src/scm/auto_archive.rs). It is null for unmerged PRs.
+        "--json", "number,title,state,url,author,headRefName,baseRefName,isDraft,statusCheckRollup,mergedAt",
         "--limit", limit,
     }
     if args.branch then
@@ -65,7 +68,7 @@ function M.list_pull_requests(args)
             elseif all_pass then ci = "success"
             else ci = "pending" end
         end
-        table.insert(prs, {
+        local pr = {
             number = item.number,
             title = item.title,
             state = item.isDraft and "draft" or string.lower(item.state),
@@ -75,7 +78,14 @@ function M.list_pull_requests(args)
             base = item.baseRefName,
             draft = item.isDraft,
             ci_status = ci,
-        })
+        }
+        -- Assigned conditionally rather than inline: an unmerged PR's
+        -- mergedAt is JSON null, and leaving the key absent is the shape the
+        -- host's Option<String> expects regardless of how null decodes.
+        if type(item.mergedAt) == "string" and #item.mergedAt > 0 then
+            pr.merged_at = item.mergedAt
+        end
+        table.insert(prs, pr)
     end
     return prs
 end
@@ -155,7 +165,7 @@ end
 function M.get_pull_request(args)
     local data = gh({
         "pr", "view", tostring(args.number),
-        "--json", "number,title,state,url,author,headRefName,baseRefName,isDraft,statusCheckRollup",
+        "--json", "number,title,state,url,author,headRefName,baseRefName,isDraft,statusCheckRollup,mergedAt",
     })
     local ci = nil
     if data.statusCheckRollup and #data.statusCheckRollup > 0 then
@@ -177,7 +187,7 @@ function M.get_pull_request(args)
         elseif all_pass then ci = "success"
         else ci = "pending" end
     end
-    return {
+    local pr = {
         number = data.number,
         title = data.title,
         state = data.isDraft and "draft" or string.lower(data.state),
@@ -188,6 +198,10 @@ function M.get_pull_request(args)
         draft = data.isDraft,
         ci_status = ci,
     }
+    if type(data.mergedAt) == "string" and #data.mergedAt > 0 then
+        pr.merged_at = data.mergedAt
+    end
+    return pr
 end
 
 function M.create_pull_request(args)

--- a/plugins/scm-gitlab/init.lua
+++ b/plugins/scm-gitlab/init.lua
@@ -8,6 +8,19 @@ local function glab(args)
     return host.json_decode(result.stdout)
 end
 
+-- Copy glab's merged_at onto a canonical PullRequest table, if present.
+-- The host uses it to tell a merge that belongs to the polling workspace
+-- from one it inherited via a branch-name collision (see
+-- src/scm/auto_archive.rs). Assigned conditionally rather than inline so an
+-- unmerged MR leaves the key absent, which is what the host's
+-- Option<String> expects regardless of how JSON null decodes.
+local function with_merged_at(pr, data)
+    if type(data.merged_at) == "string" and #data.merged_at > 0 then
+        pr.merged_at = data.merged_at
+    end
+    return pr
+end
+
 function M.list_pull_requests(args)
     -- Two call-sites: per-branch sidebar lookup (args.branch) and the
     -- repo-wide project-view aggregation (args.scope). Match the
@@ -38,7 +51,7 @@ function M.list_pull_requests(args)
     local data = glab(glab_args)
     local prs = {}
     for _, item in ipairs(data) do
-        table.insert(prs, {
+        table.insert(prs, with_merged_at({
             number = item.iid,
             title = item.title,
             state = item.state == "opened" and "open" or item.state,
@@ -47,7 +60,7 @@ function M.list_pull_requests(args)
             branch = item.source_branch,
             base = item.target_branch,
             draft = item.draft or false,
-        })
+        }, item))
     end
     return prs
 end
@@ -128,7 +141,7 @@ function M.get_pull_request(args)
         "mr", "view", tostring(args.number),
         "--output-format", "json",
     })
-    return {
+    return with_merged_at({
         number = data.iid,
         title = data.title,
         state = data.state == "opened" and "open" or data.state,
@@ -137,12 +150,12 @@ function M.get_pull_request(args)
         branch = data.source_branch,
         base = data.target_branch,
         draft = data.draft or false,
-    }
+    }, data)
 end
 
 -- Normalize glab's MR JSON shape to our canonical PullRequest fields.
 local function normalize_mr(data)
-    return {
+    return with_merged_at({
         number = data.iid,
         title = data.title,
         state = data.state == "opened" and "open" or data.state,
@@ -151,7 +164,7 @@ local function normalize_mr(data)
         branch = data.source_branch or "",
         base = data.target_branch or "",
         draft = data.draft or false,
-    }
+    }, data)
 end
 
 function M.create_pull_request(args)

--- a/site/src/content/docs/features/scm-providers.mdx
+++ b/site/src/content/docs/features/scm-providers.mdx
@@ -47,6 +47,21 @@ If the CLI isn't installed or authenticated, the SCM tab shows a helpful status 
 
 Enable [**Settings > General > Archive on merge**](/claudette/features/settings/#general) to automatically archive a workspace when its PR is detected as merged. The sidebar cleans itself up without manual intervention.
 
+### How Claudette decides the merge is yours
+
+A workspace's PR is resolved by **branch name** — and merged PRs keep resolving for their branch forever, so the sidebar badge still renders after a merge. That creates a trap: a brand-new workspace whose branch happens to match an older, already-merged PR would otherwise be archived within a minute of its first prompt. Branch names collide more easily than you'd expect, because the first prompt of a workspace auto-renames its branch to a slug derived from that prompt — ask for something twice and you get the same slug twice.
+
+Claudette therefore archives only when at least one of these holds:
+
+- **The PR merged at or after the workspace was created.** The merge plausibly came from this workspace's work.
+- **Claudette watched the transition.** This app session polled the *same PR number* and saw it go from open or draft to merged.
+
+Either signal is enough, which keeps the feature working in both directions: providers that report no merge timestamp are covered by the observed transition, and merges that happened while the app was closed are covered by the timestamp. A merged PR inherited purely through a branch-name collision satisfies neither, so the workspace is left alone and a `declining auto-archive` line is written to the log.
+
+This matters most when [**Settings > Git > Auto-delete branch on archive**](/claudette/features/settings/#git) is also on, since that upgrades the archive into a hard delete of the workspace record, worktree, and local branch.
+
+Custom SCM plugins should return `merged_at` (RFC 3339) on merged pull requests so the timestamp check applies. Plugins that omit it still work — they just fall back to the observed-transition check.
+
 ## Auto-Fix on CI Failure
 
 Enable [**Settings > Git > Auto-fix CI failures**](/claudette/features/settings/#git) to automatically create a new agent session when a workspace's CI changes from passing or running to failed. Claudette waits until checks have finished, applies the per-workspace cooldown, then opens a session with a prompt containing failed check names, links, branch and PR context, and failed log output when the provider supports it.

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -12,7 +12,7 @@ Open settings with `⌘/Ctrl + ,` or from the sidebar. Settings are organized in
 | App version | Shows the installed version and an inline **Check for updates** button. When an update is available, **Install now** / **When idle** buttons replace it. | — |
 | Update channel | Build channel the updater follows: **Stable** or **Nightly**. Opting into Nightly is gated behind a confirmation dialog. Locked while an install is downloading or queued. | Stable |
 | Worktree base directory | Directory where new workspaces are created | `~/.claudette/workspaces` |
-| Archive on merge | Automatically archive a workspace when its pull request is merged. See [SCM Providers](/claudette/features/scm-providers/). | Off |
+| Archive on merge | Automatically archive a workspace when its pull request is merged. Only fires when the merge is attributable to that workspace — see [Auto-Archive on Merge](/claudette/features/scm-providers/#auto-archive-on-merge). | Off |
 | Claudette Terminal | Show a read-only terminal tab that mirrors workspace provisioning (env-providers + setup script), agent shell commands, and background task output. | On |
 | System tray | Enable/disable system tray integration | Enabled |
 | Tray icon style | Tray icon rendering: `Auto`, `Light`, `Dark`, or `Color`. Disabled when the system tray is off. | Auto |

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -10,6 +10,7 @@ use claudette::db::{Database, RepoScmListCacheRow, WorkspaceScmLinkRow};
 use claudette::mcp_supervisor::McpSupervisor;
 use claudette::plugin_runtime::PluginError;
 use claudette::plugin_runtime::host_api::WorkspaceInfo;
+use claudette::scm::auto_archive::{self, AutoArchiveVerdict, ObservedPr};
 use claudette::scm::detect;
 use claudette::scm::types::{
     CiCheck, CiCheckStatus, CiFailureLog, CiOverallStatus, Issue, IssueScope, PullRequest,
@@ -48,6 +49,9 @@ const SCM_FETCH_LOCK_TTL: Duration = Duration::from_secs(10 * 60);
 
 struct ScmPollSettingsSnapshot {
     workspace_ids: Vec<(String, String)>,
+    /// `workspace_id` → `created_at`, so the auto-archive gate can reject a
+    /// merged PR that predates the workspace without a second DB round-trip.
+    workspace_created_at: HashMap<String, String>,
     global_archive: bool,
     per_repo_archive: HashMap<String, bool>,
     global_ci_auto_fix: bool,
@@ -1639,7 +1643,7 @@ fn parse_ci_auto_fix_cooldown_seconds(raw: Option<String>) -> u64 {
 }
 
 fn load_scm_poll_settings_snapshot(db: &Database) -> ScmPollSettingsSnapshot {
-    let active: Vec<(String, String)> = db
+    let active_workspaces: Vec<claudette::model::Workspace> = db
         .list_workspaces()
         .unwrap_or_default()
         .into_iter()
@@ -1650,6 +1654,13 @@ fn load_scm_poll_settings_snapshot(db: &Database) -> ScmPollSettingsSnapshot {
                     .as_deref()
                     .is_some_and(|path| !path.trim().is_empty())
         })
+        .collect();
+    let workspace_created_at: HashMap<String, String> = active_workspaces
+        .iter()
+        .map(|ws| (ws.id.clone(), ws.created_at.clone()))
+        .collect();
+    let active: Vec<(String, String)> = active_workspaces
+        .into_iter()
         .map(|ws| (ws.id, ws.repository_id))
         .collect();
     let global_archive = db
@@ -1750,6 +1761,7 @@ fn load_scm_poll_settings_snapshot(db: &Database) -> ScmPollSettingsSnapshot {
 
     ScmPollSettingsSnapshot {
         workspace_ids: active,
+        workspace_created_at,
         global_archive,
         per_repo_archive,
         global_ci_auto_fix,
@@ -1883,15 +1895,62 @@ pub fn start_scm_polling(app_handle: tauri::AppHandle) {
                         .copied()
                         .unwrap_or(settings.global_archive);
 
-                    if should_archive
-                        && detail
-                            .pull_request
-                            .as_ref()
-                            .is_some_and(|pr| pr.state == claudette::scm::types::PrState::Merged)
+                    // Read the prior observation *before* recording this
+                    // poll's, so a non-merged→merged transition is still
+                    // visible to the gate below.
+                    let observed_before =
+                        app_state.pr_last_observed.read().await.get(&ws_id).cloned();
                     {
-                        tracing::info!(target: "claudette::scm", workspace_id = %ws_id, "PR merged — auto-archiving workspace");
-                        let pr_number = detail.pull_request.as_ref().map(|pr| pr.number);
-                        auto_archive_workspace(&handle, &app_state, &ws_id, pr_number).await;
+                        let mut observed = app_state.pr_last_observed.write().await;
+                        match detail.pull_request.as_ref() {
+                            Some(pr) => {
+                                observed.insert(ws_id.clone(), ObservedPr::from_pr(pr));
+                            }
+                            None => {
+                                observed.remove(&ws_id);
+                            }
+                        }
+                    }
+
+                    if should_archive && let Some(pr) = detail.pull_request.as_ref() {
+                        let created_at = settings
+                            .workspace_created_at
+                            .get(&ws_id)
+                            .map(String::as_str)
+                            .unwrap_or_default();
+                        match auto_archive::evaluate(pr, created_at, observed_before.as_ref()) {
+                            AutoArchiveVerdict::Archive => {
+                                tracing::info!(target: "claudette::scm", workspace_id = %ws_id, pr_number = pr.number, "PR merged — auto-archiving workspace");
+                                auto_archive_workspace(
+                                    &handle,
+                                    &app_state,
+                                    &ws_id,
+                                    Some(pr.number),
+                                )
+                                .await;
+                            }
+                            AutoArchiveVerdict::NotMerged => {}
+                            verdict => {
+                                // Only on the first sighting of this merged
+                                // PR — a workspace parked on an adopted
+                                // merged PR would otherwise log every tick.
+                                let already_seen_merged =
+                                    observed_before.as_ref().is_some_and(|prev| {
+                                        prev.number == pr.number
+                                            && prev.state == claudette::scm::types::PrState::Merged
+                                    });
+                                if !already_seen_merged {
+                                    tracing::info!(
+                                        target: "claudette::scm",
+                                        workspace_id = %ws_id,
+                                        pr_number = pr.number,
+                                        branch = %pr.branch,
+                                        ?verdict,
+                                        "declining auto-archive — merged PR is not this workspace's work"
+                                    );
+                                }
+                            }
+                        }
                     }
 
                     // CI auto-fix: detect failure transitions
@@ -2472,6 +2531,7 @@ mod tests {
             base: "main".into(),
             draft: false,
             ci_status: None,
+            merged_at: None,
         }
     }
 
@@ -3029,6 +3089,7 @@ mod ci_auto_fix_tests {
             base: "main".to_string(),
             draft: false,
             ci_status: Some(CiOverallStatus::Failure),
+            merged_at: None,
         };
         let template = "Branch: {{branch}}, PR: {{pr_title}} {{pr_url}} #{{pr_number}}\n{{failed_checks}}\n{{failure_logs}}\n{{all_checks}}";
         let result = format_ci_auto_fix_prompt(template, &checks, &logs, "fix-branch", Some(&pr));

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -11,6 +11,7 @@ use claudette::claude_help::ClaudeFlagDef;
 use claudette::env_provider::{EnvCache, EnvWatcher};
 use claudette::file_watcher::FileWatcher;
 use claudette::plugin_runtime::PluginRegistry;
+use claudette::scm::auto_archive::ObservedPr;
 use claudette::scm::types::{CiCheck, CiOverallStatus, PullRequest};
 use serde::{Deserialize, Serialize};
 
@@ -690,6 +691,14 @@ pub struct AppState {
     pub diff_load_locks: RwLock<HashMap<String, AsyncGateEntry>>,
     /// Per-workspace CI transition state for auto-fix triggering.
     pub ci_last_status: RwLock<HashMap<String, CiTransitionState>>,
+    /// Per-workspace pull-request state as of the last SCM poll, keyed by
+    /// workspace id. Lets auto-archive-on-merge require a witnessed
+    /// non-merged→merged transition when the provider reports no merge
+    /// timestamp. Deliberately keyed by workspace rather than by branch, so a
+    /// branch rename starts fresh instead of inheriting the previous branch's
+    /// history. In-memory only: a restart simply falls back to the merge-time
+    /// check in `claudette::scm::auto_archive`.
+    pub pr_last_observed: RwLock<HashMap<String, ObservedPr>>,
     /// Limits concurrent SCM CLI invocations.
     pub scm_semaphore: Arc<Semaphore>,
     /// The workspace the user is currently viewing. The polling loop reads
@@ -800,6 +809,7 @@ impl AppState {
             merge_base_cache: MergeBaseCache::new(),
             diff_load_locks: RwLock::new(HashMap::new()),
             ci_last_status: RwLock::new(HashMap::new()),
+            pr_last_observed: RwLock::new(HashMap::new()),
             scm_semaphore: Arc::new(Semaphore::new(4)),
             selected_workspace_id: RwLock::new(None),
             workspace_activity: RwLock::new(HashMap::new()),

--- a/src/scm/auto_archive.rs
+++ b/src/scm/auto_archive.rs
@@ -1,0 +1,338 @@
+//! Decides whether a merged pull request actually authorizes archiving the
+//! workspace that resolved it.
+//!
+//! The SCM poller resolves a workspace's PR by branch name alone
+//! (`gh pr list --state all --head <branch>` — `--state all` is deliberate so
+//! the sidebar badge still renders for merged/closed PRs). A merged PR
+//! therefore keeps resolving for its branch name forever, including for a
+//! *different* workspace that later lands on the same branch name — which the
+//! first-prompt branch auto-rename makes easy, since two similar prompts
+//! produce the same slug. Combined with `git_delete_branch_on_archive`, which
+//! erases both the local branch and the workspace row that name allocation
+//! checks against, a brand-new workspace could inherit a days-old merged PR
+//! and be hard-deleted seconds after its first prompt, killing the running
+//! agent with it.
+//!
+//! Two independent signals can authorize archiving here, and **either one is
+//! sufficient**:
+//!
+//! 1. **Merge time** — the PR merged at or after the workspace was created,
+//!    so the merge plausibly came from this workspace's work.
+//! 2. **Observed transition** — this process watched the *same PR number* go
+//!    from a non-merged state to merged while polling this workspace.
+//!
+//! Requiring only one keeps the feature working where the other can't apply:
+//! signal 2 covers providers that report no merge timestamp (third-party
+//! plugins, older cached rows), and signal 1 covers app restarts, where no
+//! transition can have been observed. A merged PR adopted through a branch
+//! name collision satisfies neither.
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+
+use super::types::{PrState, PullRequest};
+
+/// The pull request state the SCM poller last saw for a workspace.
+///
+/// Tracked per workspace (not per branch) so a branch rename resets the
+/// history rather than inheriting the previous branch's observations.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObservedPr {
+    pub number: u64,
+    pub state: PrState,
+}
+
+impl ObservedPr {
+    pub fn from_pr(pr: &PullRequest) -> Self {
+        Self {
+            number: pr.number,
+            state: pr.state.clone(),
+        }
+    }
+}
+
+/// Outcome of [`evaluate`]. Non-`Archive` variants name the reason so the
+/// poller can log why it declined rather than silently doing nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoArchiveVerdict {
+    /// The merge belongs to this workspace — go ahead and archive.
+    Archive,
+    /// The PR isn't merged. Not a skip, just the common case.
+    NotMerged,
+    /// The PR merged before this workspace existed and no transition was
+    /// observed: the workspace adopted someone else's PR via its branch name.
+    PrPredatesWorkspace,
+    /// No usable merge timestamp and no observed transition, so there's no
+    /// evidence tying the merge to this workspace. Declining is the safe
+    /// default — archiving is destructive and not reliably reversible.
+    Unverifiable,
+}
+
+/// Decide whether `pr` being merged authorizes archiving the workspace.
+///
+/// `workspace_created_at` accepts any of the shapes this codebase produces:
+/// SQLite `datetime('now')` (`"YYYY-MM-DD HH:MM:SS"`, UTC — what the
+/// `workspaces.created_at` column default actually writes), RFC 3339, or
+/// epoch seconds. `previously_observed` is the last state this process saw
+/// for the *same workspace*, or `None` if it has never seen a PR there.
+pub fn evaluate(
+    pr: &PullRequest,
+    workspace_created_at: &str,
+    previously_observed: Option<&ObservedPr>,
+) -> AutoArchiveVerdict {
+    if pr.state != PrState::Merged {
+        return AutoArchiveVerdict::NotMerged;
+    }
+
+    // Same PR number is required: a stale observation of a *different* PR
+    // (from the branch this workspace had before it was auto-renamed) says
+    // nothing about whether this merge is ours.
+    let observed_transition = previously_observed
+        .is_some_and(|prev| prev.number == pr.number && prev.state != PrState::Merged);
+
+    let merged_at = parse_timestamp(pr.merged_at.as_deref());
+    let created_at = parse_timestamp(Some(workspace_created_at));
+
+    match (merged_at, created_at) {
+        (Some(merged), Some(created)) => {
+            if merged >= created || observed_transition {
+                AutoArchiveVerdict::Archive
+            } else {
+                AutoArchiveVerdict::PrPredatesWorkspace
+            }
+        }
+        _ => {
+            if observed_transition {
+                AutoArchiveVerdict::Archive
+            } else {
+                AutoArchiveVerdict::Unverifiable
+            }
+        }
+    }
+}
+
+/// Parse the timestamp shapes that reach this module.
+///
+/// Providers emit RFC 3339 (`gh --json mergedAt`, `glab`'s `merged_at`);
+/// `workspaces.created_at` comes from SQLite's `datetime('now')` column
+/// default, which is space-separated UTC with no offset marker; and
+/// `ops::workspace::create` builds an epoch-seconds string in memory for the
+/// struct it hands back before the row is read again.
+fn parse_timestamp(raw: Option<&str>) -> Option<DateTime<Utc>> {
+    let raw = raw?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    if let Ok(dt) = DateTime::parse_from_rfc3339(raw) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    if let Ok(naive) = NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S") {
+        return Some(naive.and_utc());
+    }
+    if let Ok(secs) = raw.parse::<i64>() {
+        return DateTime::from_timestamp(secs, 0);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pr(number: u64, state: PrState, merged_at: Option<&str>) -> PullRequest {
+        PullRequest {
+            number,
+            title: "t".into(),
+            state,
+            url: "https://example.test/pr".into(),
+            author: "someone".into(),
+            branch: "doomspork/fix-insights-rendering".into(),
+            base: "main".into(),
+            draft: false,
+            ci_status: None,
+            merged_at: merged_at.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn open_pr_is_not_merged() {
+        assert_eq!(
+            evaluate(&pr(1, PrState::Open, None), "2026-08-07 17:06:00", None),
+            AutoArchiveVerdict::NotMerged
+        );
+    }
+
+    /// The reported regression: a workspace created on Aug 7 adopts a PR that
+    /// merged on Aug 5 purely because the auto-rename gave it the same branch
+    /// name as an earlier, already-deleted workspace.
+    #[test]
+    fn merged_before_workspace_existed_is_refused() {
+        assert_eq!(
+            evaluate(
+                &pr(1016, PrState::Merged, Some("2026-08-05T22:54:34Z")),
+                "2026-08-07 17:06:00",
+                None,
+            ),
+            AutoArchiveVerdict::PrPredatesWorkspace
+        );
+    }
+
+    #[test]
+    fn merged_after_workspace_created_is_archived() {
+        assert_eq!(
+            evaluate(
+                &pr(1016, PrState::Merged, Some("2026-08-07T18:30:00Z")),
+                "2026-08-07 17:06:00",
+                None,
+            ),
+            AutoArchiveVerdict::Archive
+        );
+    }
+
+    /// A clock skewed such that the local created_at lands after the remote
+    /// merge time must not block an archive we actually watched happen.
+    #[test]
+    fn observed_transition_overrides_timestamp_skew() {
+        let observed = ObservedPr {
+            number: 1016,
+            state: PrState::Open,
+        };
+        assert_eq!(
+            evaluate(
+                &pr(1016, PrState::Merged, Some("2026-08-05T22:54:34Z")),
+                "2026-08-07 17:06:00",
+                Some(&observed),
+            ),
+            AutoArchiveVerdict::Archive
+        );
+    }
+
+    /// Providers that report no merge timestamp still work via the observed
+    /// open→merged transition.
+    #[test]
+    fn transition_authorizes_archive_without_timestamp() {
+        let observed = ObservedPr {
+            number: 42,
+            state: PrState::Open,
+        };
+        assert_eq!(
+            evaluate(
+                &pr(42, PrState::Merged, None),
+                "2026-08-07 17:06:00",
+                Some(&observed),
+            ),
+            AutoArchiveVerdict::Archive
+        );
+    }
+
+    #[test]
+    fn draft_to_merged_counts_as_a_transition() {
+        let observed = ObservedPr {
+            number: 42,
+            state: PrState::Draft,
+        };
+        assert_eq!(
+            evaluate(
+                &pr(42, PrState::Merged, None),
+                "2026-08-07 17:06:00",
+                Some(&observed),
+            ),
+            AutoArchiveVerdict::Archive
+        );
+    }
+
+    /// An observation of a *different* PR — the one on the branch this
+    /// workspace had before it was auto-renamed — is not a transition.
+    #[test]
+    fn observation_of_a_different_pr_is_not_a_transition() {
+        let observed = ObservedPr {
+            number: 900,
+            state: PrState::Open,
+        };
+        assert_eq!(
+            evaluate(
+                &pr(1016, PrState::Merged, None),
+                "2026-08-07 17:06:00",
+                Some(&observed),
+            ),
+            AutoArchiveVerdict::Unverifiable
+        );
+    }
+
+    #[test]
+    fn already_merged_observation_is_not_a_transition() {
+        let observed = ObservedPr {
+            number: 1016,
+            state: PrState::Merged,
+        };
+        assert_eq!(
+            evaluate(
+                &pr(1016, PrState::Merged, None),
+                "2026-08-07 17:06:00",
+                Some(&observed),
+            ),
+            AutoArchiveVerdict::Unverifiable
+        );
+    }
+
+    #[test]
+    fn no_timestamp_and_no_history_is_refused() {
+        assert_eq!(
+            evaluate(
+                &pr(1016, PrState::Merged, None),
+                "2026-08-07 17:06:00",
+                None
+            ),
+            AutoArchiveVerdict::Unverifiable
+        );
+    }
+
+    #[test]
+    fn unparseable_created_at_falls_back_to_transition_only() {
+        assert_eq!(
+            evaluate(
+                &pr(1016, PrState::Merged, Some("2026-08-07T18:30:00Z")),
+                "",
+                None,
+            ),
+            AutoArchiveVerdict::Unverifiable
+        );
+    }
+
+    #[test]
+    fn parses_the_timestamp_shapes_this_codebase_produces() {
+        // SQLite datetime('now') — the workspaces.created_at column default.
+        let sqlite = parse_timestamp(Some("2026-08-07 17:06:00")).unwrap();
+        // RFC 3339 from gh / glab.
+        let rfc = parse_timestamp(Some("2026-08-07T17:06:00Z")).unwrap();
+        assert_eq!(sqlite, rfc);
+
+        // Offset-bearing RFC 3339 normalizes to UTC.
+        assert_eq!(
+            parse_timestamp(Some("2026-08-07T13:06:00-04:00")).unwrap(),
+            rfc
+        );
+
+        // Epoch seconds — ops::workspace::create's in-memory shape.
+        assert_eq!(parse_timestamp(Some("1786122360")).unwrap(), rfc);
+
+        assert!(parse_timestamp(None).is_none());
+        assert!(parse_timestamp(Some("   ")).is_none());
+        assert!(parse_timestamp(Some("not a date")).is_none());
+    }
+
+    /// Pins the contract between the `workspaces.created_at` column default
+    /// and the merge-time guard. If that format ever drifts out of
+    /// [`parse_timestamp`]'s reach, `evaluate` silently degrades to
+    /// transition-only and auto-archive stops firing across restarts — a
+    /// failure that is invisible without this test.
+    #[test]
+    fn persisted_workspace_created_at_is_parseable() {
+        let db = crate::db::test_support::setup_db_with_workspace();
+        let ws = db.list_workspaces().unwrap().pop().unwrap();
+        assert!(
+            parse_timestamp(Some(&ws.created_at)).is_some(),
+            "workspaces.created_at {:?} is not a shape parse_timestamp understands",
+            ws.created_at
+        );
+    }
+}

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -8,5 +8,8 @@
 //! The actual plugin execution happens in `crate::plugin_runtime`; this
 //! module just provides the SCM-specific shapes on top.
 
+pub mod auto_archive;
 pub mod detect;
+#[cfg(test)]
+mod plugin_tests;
 pub mod types;

--- a/src/scm/plugin_tests.rs
+++ b/src/scm/plugin_tests.rs
@@ -1,0 +1,151 @@
+//! Unit tests for the bundled SCM Lua plugins.
+//!
+//! Mirrors `crate::env_provider::plugin_tests`: each plugin's `init.lua` is
+//! loaded into a sandboxed Lua VM and its operations are invoked directly,
+//! with `host.exec` stubbed to return canned `gh` / `glab` JSON. No external
+//! CLI is required.
+//!
+//! Loading the source at all is half the value — before this file, a syntax
+//! error in a bundled SCM plugin compiled fine and only surfaced at runtime
+//! as a plugin-load failure. The rest pins the `merged_at` mapping that
+//! `crate::scm::auto_archive` depends on to tell a workspace's own merge from
+//! one it inherited through a branch-name collision.
+
+use mlua::{Lua, LuaSerdeExt};
+
+use crate::plugin_runtime::host_api::{HostContext, WorkspaceInfo, create_lua_vm};
+use crate::plugin_runtime::manifest::PluginKind;
+use crate::scm::types::{PrState, PullRequest};
+
+const GITHUB_SRC: &str = include_str!("../../plugins/scm-github/init.lua");
+const GITLAB_SRC: &str = include_str!("../../plugins/scm-gitlab/init.lua");
+
+/// Build a VM for an SCM plugin with `host.exec` replaced by a stub that
+/// always returns `stdout` and a zero exit code.
+fn vm_with_stubbed_exec(plugin: &str, cli: &str, stdout: &str) -> Lua {
+    let ctx = HostContext {
+        plugin_name: plugin.to_string(),
+        kind: PluginKind::Scm,
+        allowed_clis: vec![cli.to_string()],
+        workspace_info: WorkspaceInfo {
+            id: "ws-1".into(),
+            name: "test".into(),
+            branch: "doomspork/fix-insights-rendering".into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let lua = create_lua_vm(ctx).expect("create vm");
+    // Long-bracket string so the canned JSON needs no escaping.
+    let stub = format!(
+        r#"
+        host.exec = function(cmd, args)
+            return {{ code = 0, stdout = [==[{stdout}]==], stderr = "" }}
+        end
+        "#
+    );
+    lua.load(&stub).exec().expect("install host.exec stub");
+    lua
+}
+
+/// Invoke `M.<op>(args)` on the plugin source and decode the result as a
+/// list of [`PullRequest`], exactly as `PluginRegistry::call_operation`
+/// would before handing it to the SCM poller.
+fn call_list_prs(plugin: &str, src: &str, cli: &str, stdout: &str) -> Vec<PullRequest> {
+    let lua = vm_with_stubbed_exec(plugin, cli, stdout);
+    let script = format!(
+        r#"
+        local M = (function() {src} end)()
+        return M.list_pull_requests({{ branch = "doomspork/fix-insights-rendering" }})
+        "#
+    );
+    let value: mlua::Value = lua.load(&script).eval().expect("list_pull_requests call");
+    let json: serde_json::Value = lua.from_value(value).expect("lua -> json");
+    serde_json::from_value(json).expect("json -> Vec<PullRequest>")
+}
+
+const GH_PR_LIST: &str = r#"[
+    {"number":1016,"title":"Fix insights","state":"MERGED","url":"https://example.test/1016",
+     "author":{"login":"doomspork"},"headRefName":"doomspork/fix-insights-rendering",
+     "baseRefName":"main","isDraft":false,"statusCheckRollup":[],
+     "mergedAt":"2026-08-05T22:54:34Z"},
+    {"number":1017,"title":"Still open","state":"OPEN","url":"https://example.test/1017",
+     "author":{"login":"doomspork"},"headRefName":"doomspork/other",
+     "baseRefName":"main","isDraft":false,"statusCheckRollup":[],
+     "mergedAt":null}
+]"#;
+
+const GLAB_MR_LIST: &str = r#"[
+    {"iid":1016,"title":"Fix insights","state":"merged","web_url":"https://example.test/1016",
+     "author":{"username":"doomspork"},"source_branch":"doomspork/fix-insights-rendering",
+     "target_branch":"main","draft":false,"merged_at":"2026-08-05T22:54:34Z"},
+    {"iid":1017,"title":"Still open","state":"opened","web_url":"https://example.test/1017",
+     "author":{"username":"doomspork"},"source_branch":"doomspork/other",
+     "target_branch":"main","draft":false,"merged_at":null}
+]"#;
+
+#[test]
+fn github_list_pull_requests_maps_merged_at() {
+    let prs = call_list_prs("scm-github", GITHUB_SRC, "gh", GH_PR_LIST);
+    assert_eq!(prs.len(), 2);
+
+    assert_eq!(prs[0].state, PrState::Merged);
+    assert_eq!(prs[0].merged_at.as_deref(), Some("2026-08-05T22:54:34Z"));
+
+    // An unmerged PR's `mergedAt` is JSON null; the plugin must leave the
+    // key absent so it round-trips to `None` rather than failing to decode.
+    assert_eq!(prs[1].state, PrState::Open);
+    assert_eq!(prs[1].merged_at, None);
+}
+
+#[test]
+fn gitlab_list_pull_requests_maps_merged_at() {
+    let prs = call_list_prs("scm-gitlab", GITLAB_SRC, "glab", GLAB_MR_LIST);
+    assert_eq!(prs.len(), 2);
+
+    assert_eq!(prs[0].state, PrState::Merged);
+    assert_eq!(prs[0].merged_at.as_deref(), Some("2026-08-05T22:54:34Z"));
+
+    assert_eq!(prs[1].state, PrState::Open);
+    assert_eq!(prs[1].merged_at, None);
+}
+
+#[test]
+fn github_get_pull_request_maps_merged_at() {
+    let stdout = r#"{"number":1016,"title":"Fix insights","state":"MERGED",
+        "url":"https://example.test/1016","author":{"login":"doomspork"},
+        "headRefName":"doomspork/fix-insights-rendering","baseRefName":"main",
+        "isDraft":false,"statusCheckRollup":[],"mergedAt":"2026-08-05T22:54:34Z"}"#;
+    let lua = vm_with_stubbed_exec("scm-github", "gh", stdout);
+    let script = format!(
+        r#"
+        local M = (function() {GITHUB_SRC} end)()
+        return M.get_pull_request({{ number = 1016 }})
+        "#
+    );
+    let value: mlua::Value = lua.load(&script).eval().expect("get_pull_request call");
+    let json: serde_json::Value = lua.from_value(value).expect("lua -> json");
+    let pr: PullRequest = serde_json::from_value(json).expect("json -> PullRequest");
+
+    assert_eq!(pr.merged_at.as_deref(), Some("2026-08-05T22:54:34Z"));
+}
+
+/// End-to-end over the seam this change exists to close: a merged PR
+/// resolved for a branch the workspace only just adopted must not archive
+/// it, while the same PR merged after creation must.
+#[test]
+fn merged_at_from_the_github_plugin_drives_the_auto_archive_gate() {
+    use crate::scm::auto_archive::{AutoArchiveVerdict, evaluate};
+
+    let prs = call_list_prs("scm-github", GITHUB_SRC, "gh", GH_PR_LIST);
+    let merged = &prs[0];
+
+    assert_eq!(
+        evaluate(merged, "2026-08-07 17:06:00", None),
+        AutoArchiveVerdict::PrPredatesWorkspace
+    );
+    assert_eq!(
+        evaluate(merged, "2026-08-04 09:00:00", None),
+        AutoArchiveVerdict::Archive
+    );
+}

--- a/src/scm/types.rs
+++ b/src/scm/types.rs
@@ -28,6 +28,14 @@ pub struct PullRequest {
     pub base: String,
     pub draft: bool,
     pub ci_status: Option<CiOverallStatus>,
+    /// When the PR was merged, as reported by the provider (RFC 3339).
+    /// `None` for unmerged PRs, for providers that don't report it, and for
+    /// `scm_status_cache` rows persisted before this field existed — hence
+    /// `serde(default)`. Consumed by `crate::scm::auto_archive` to tell a
+    /// merge that belongs to a workspace from one it inherited through a
+    /// branch-name collision.
+    #[serde(default)]
+    pub merged_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/ui/src/types/plugin.ts
+++ b/src/ui/src/types/plugin.ts
@@ -18,6 +18,10 @@ export interface PullRequest {
   base: string;
   draft: boolean;
   ci_status: "pending" | "success" | "failure" | null;
+  /** RFC 3339 merge time when the provider reports one. Absent on payloads
+   *  from older remote servers and on SCM cache rows written before the
+   *  field existed, so treat it as optional. */
+  merged_at?: string | null;
 }
 
 export interface CiCheck {


### PR DESCRIPTION
### Summary

Auto-archive-on-merge could delete a brand-new workspace seconds after its first prompt, killing the agent mid-turn.

The SCM poller resolves a workspace's PR by **branch name alone** (`gh pr list --state all --head <branch>` — all-state is deliberate so the sidebar badge survives a merge), and `PullRequest` carried **no merge timestamp**. So `state == Merged` was the entire archive test.

That's unsafe because branch names get reused. A workspace's first prompt auto-renames its branch to a Haiku-generated slug, and two similar prompts produce the same slug. Meanwhile `git_delete_branch_on_archive` hard-deletes the workspace row *and* the local branch — the only two things `allocate_workspace_name` and `try_auto_rename` check for collisions — while the remote branch and merged PR survive. The feature was destroying exactly the evidence needed to prevent its own recurrence.

Observed in the wild: workspace `658872ae` was created, received its first and only prompt at `17:07:11Z`, auto-renamed onto `doomspork/fix-insights-rendering`, and at `17:07:35Z` was hard-deleted against PR #1016 — which had merged two days earlier, for a workspace that no longer existed.

Archiving now requires **at least one** of two independent signals:

1. **Merge time** — `merged_at >= workspace.created_at`, so the merge plausibly came from this workspace's own work.
2. **Observed transition** — this process watched the *same PR number* go from open/draft to merged while polling this workspace.

Either alone is sufficient, which preserves the feature in both directions: providers that report no merge timestamp are covered by (2), and merges that land while the app is closed are covered by (1). A PR inherited through a branch-name collision satisfies neither.

```mermaid
flowchart TD
    A[SCM poll returns a PR] --> B{state == Merged?}
    B -- no --> Z[NotMerged — nothing to do]
    B -- yes --> C{merged_at and created_at<br/>both parseable?}
    C -- yes --> D{merged_at >= created_at?}
    D -- yes --> ARCH[Archive]
    D -- no --> E{same PR number seen<br/>non-merged earlier?}
    E -- yes --> ARCH
    E -- no --> F[PrPredatesWorkspace<br/>decline + log once]
    C -- no --> G{same PR number seen<br/>non-merged earlier?}
    G -- yes --> ARCH
    G -- no --> H[Unverifiable<br/>decline + log once]
```

Supporting changes:

- `merged_at` added to `PullRequest` as `#[serde(default)]`, so `scm_status_cache` rows written before this still deserialize.
- Both bundled SCM plugins emit it, assigned **conditionally** so an unmerged PR's JSON `null` leaves the key absent rather than depending on how null decodes through mlua.
- `AppState.pr_last_observed` tracks PR state per **workspace**, not per branch — keying by branch would re-inherit the very history a rename should reset.
- New `src/scm/plugin_tests.rs`. The bundled SCM plugins had **no** test coverage, so a Lua syntax error compiled clean and only surfaced at runtime as a plugin-load failure. Mirrors the existing `env_provider/plugin_tests.rs` harness.

### Complexity Notes

- **The two guards are OR'd, not AND'd.** This is load-bearing. AND-ing them would silently disable auto-archive across app restarts (nothing observed) and for third-party plugins that don't report `mergedAt`. Both are real regressions that wouldn't show up in tests.
- **The PR-number comparison in the transition check matters.** Without it, "PR #900 open on the pre-rename branch" → "PR #1016 merged on the renamed branch" reads as a legitimate transition and the bug survives. Covered by `observation_of_a_different_pr_is_not_a_transition`.
- **`workspaces.created_at` is written by the SQLite column DEFAULT (`datetime('now')`), not by the app** — `ops::workspace::create`'s `now_iso()` epoch-seconds value is silently dropped on insert. `parse_timestamp` handles RFC 3339, SQLite's space-separated UTC, and epoch seconds. If that format ever drifts out of reach, `evaluate` degrades to transition-only and auto-archive quietly stops firing across restarts — an invisible failure, so `persisted_workspace_created_at_is_parseable` pins the contract against a real DB.
- **The prior observation is read before the current one is recorded** (`scm.rs`), otherwise the transition is never visible.
- **Decline logging is rate-limited to first sighting** of a given merged PR, so a workspace parked on an adopted PR doesn't log every 30s tick.
- **Behavior change, called out intentionally:** a workspace created directly on a branch whose PR is already merged is no longer auto-archived on the first poll. That is the bug being fixed, not a regression — but it is a visible difference for anyone who relied on it as a cleanup path.

### Test Steps

1. `cargo test -p claudette scm::` — 50 pass, including 19 new (12 in `auto_archive`, 7 in `plugin_tests`).
2. `cargo test -p claudette -p claudette-server -p claudette-cli --all-features` — 1518 pass.
3. `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` — zero warnings.
4. `./scripts/stage-cli-sidecar.sh --profile debug && RUSTFLAGS="-Dwarnings" cargo test -p claudette-tauri --no-default-features --features devtools,server,voice,alternative-backends --no-run` — clean.
5. `cd src/ui && bunx tsc -b && bun run test && bun run lint:css` — 2937 tests pass, token checks pass.
6. **Manual, the regression path:** with **Settings > General > Archive on merge** on, create a workspace and rename its branch to one with an already-merged PR (`git branch -m doomspork/<merged-branch>` in the worktree). Within ~30s the log writes one `declining auto-archive — merged PR is not this workspace's work` line on target `claudette::scm`, and the workspace survives. Previously it was archived (or deleted) immediately.
7. **Manual, the happy path unchanged:** open a PR from a workspace, merge it on the remote, confirm the workspace is still auto-archived on the next poll and the tray notification fires.

### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)