### PR TITLE
fix(db): stop "database is locked" errors during archive and bulk cleanup

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
 
 use claudette::agent::history_seeder;
-use claudette::db::Database;
+use claudette::db::{Database, PostDeleteHousekeeping};
 use claudette::fork::{self, ForkInputs};
 use claudette::git;
 use claudette::mcp_supervisor::McpSupervisor;
@@ -1329,6 +1329,9 @@ async fn delete_workspaces_bulk_body(
     let mut cancelled: Vec<String> = Vec::new();
     let mut affected_repos: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut env_cleanup_paths: Vec<String> = Vec::new();
+    // Orphan-blob GC + incremental vacuum owed by the rows deleted below,
+    // accumulated across the batch and paid once after the loop.
+    let mut owed_housekeeping = PostDeleteHousekeeping::default();
 
     let emit_progress = |workspace_id: &str, status: &'static str, error: Option<String>| {
         let Some(req_id) = request_id else {
@@ -1369,10 +1372,13 @@ async fn delete_workspaces_bulk_body(
             .map(|w| w.repository_id.clone())
             .unwrap_or_default();
 
-        // DB delete (in-transaction Archived guard inside).
-        match db.try_delete_archived_workspace_with_summary(id) {
-            Ok(true) => {} // success — fall through to cleanup
-            Ok(false) => {
+        // DB delete (in-transaction Archived guard inside). Housekeeping
+        // (orphan-blob GC + incremental vacuum) is deferred and accumulated
+        // into `owed_housekeeping`, then run once after the loop — see
+        // `try_delete_archived_workspace_deferring_housekeeping`.
+        match db.try_delete_archived_workspace_deferring_housekeeping(id) {
+            Ok(Some(work)) => owed_housekeeping.merge(work), // fall through to cleanup
+            Ok(None) => {
                 let err = "workspace no longer archived".to_string();
                 failed.push(BulkDeleteFailure {
                     id: id.clone(),
@@ -1430,6 +1436,13 @@ async fn delete_workspaces_bulk_body(
         deleted.push(id.clone());
         emit_progress(id, "deleted", None);
     }
+
+    // One orphan-blob GC + incremental vacuum for the whole batch. Run
+    // after the loop (not per row) so the batch takes the write lock once
+    // for housekeeping instead of 2N extra times — the per-row version was
+    // contending with agent/metrics writers throughout the run. Best-effort
+    // and post-commit, so it can't affect any row's reported outcome.
+    db.run_post_delete_housekeeping(owed_housekeeping);
 
     // Env-watcher unregister + env-cache invalidate batched at the
     // end so we acquire the watcher read lock once instead of

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -14,7 +14,7 @@ use crate::model::{
     ChatMessage, CheckpointFile, CompletedTurnData, ConversationCheckpoint, TurnToolActivity,
 };
 
-use super::Database;
+use super::{Database, retry_on_busy};
 
 #[derive(Debug)]
 struct MissingCheckpointBlob {
@@ -320,18 +320,69 @@ impl Database {
         &self,
         workspace_id: &str,
     ) -> Result<usize, rusqlite::Error> {
-        let deleted = self.conn.execute(
-            "DELETE FROM checkpoint_files
-             WHERE checkpoint_id IN (
-                 SELECT id FROM conversation_checkpoints WHERE workspace_id = ?1
-             )",
-            params![workspace_id],
-        )?;
-        // Reclaim blobs the purge just orphaned and drain the freelist. Both
-        // short-circuit when nothing was deleted, so an archive of a
-        // file-less workspace is a cheap no-op.
-        self.gc_orphan_blobs_after_delete(deleted);
-        self.best_effort_incremental_vacuum_after_delete(deleted);
+        let deleted = retry_on_busy(|| {
+            let tx = self.conn.unchecked_transaction()?;
+
+            // Collect the blobs this purge is about to orphan *before* the
+            // referencing rows disappear. Scoping the GC to these shas is
+            // what keeps archive proportional to the workspace instead of
+            // to the database: the blanket
+            // `DELETE FROM checkpoint_blobs WHERE NOT EXISTS (...)` plans as
+            // `SCAN checkpoint_blobs`, and since `bytes BLOB` is stored
+            // inline that scan walks every payload page in the table. On a
+            // multi-GB database that meant every archive held the write lock
+            // for a full sweep of the blob store while agents were streaming
+            // into the same DB — surfacing as "database is locked".
+            let candidate_shas: Vec<String> = {
+                let mut stmt = tx.prepare(
+                    "SELECT DISTINCT blob_sha256 FROM checkpoint_files
+                      WHERE blob_sha256 IS NOT NULL
+                        AND checkpoint_id IN (
+                            SELECT id FROM conversation_checkpoints WHERE workspace_id = ?1
+                        )",
+                )?;
+                let rows = stmt.query_map(params![workspace_id], |r| r.get::<_, String>(0))?;
+                rows.collect::<Result<_, _>>()?
+            };
+
+            let deleted = tx.execute(
+                "DELETE FROM checkpoint_files
+                 WHERE checkpoint_id IN (
+                     SELECT id FROM conversation_checkpoints WHERE workspace_id = ?1
+                 )",
+                params![workspace_id],
+            )?;
+
+            // Drop only those candidates nothing references any more. The
+            // `NOT EXISTS` guard is what preserves blobs still shared with
+            // another workspace (content-addressed storage dedupes identical
+            // bytes across workspaces), and it resolves via
+            // `idx_checkpoint_files_blob_sha256` — one indexed probe per
+            // candidate rather than a table scan.
+            {
+                let mut stmt = tx.prepare(
+                    "DELETE FROM checkpoint_blobs
+                      WHERE sha256 = ?1
+                        AND NOT EXISTS (
+                            SELECT 1 FROM checkpoint_files WHERE blob_sha256 = ?1
+                        )",
+                )?;
+                for sha in &candidate_shas {
+                    stmt.execute(params![sha])?;
+                }
+            }
+
+            tx.commit()?;
+            Ok(deleted)
+        })?;
+
+        // Space reclaim is deliberately NOT unconditional here. Draining the
+        // freelist on every archive spends write-locked page I/O even when
+        // only a handful of pages were freed; gating on an accumulated
+        // freelist amortizes it across archives. Same rationale as the
+        // retroactive #1002 sweep, which skips reclaim entirely and defers to
+        // the shared post-boot pass in `checkpoint_backfill`.
+        self.best_effort_reclaim_freelist_if_worthwhile();
         Ok(deleted)
     }
 
@@ -2073,6 +2124,86 @@ mod tests {
         let w2_files = db.get_checkpoint_files("cp2").unwrap();
         assert_eq!(w2_files.len(), 1);
         assert_eq!(w2_files[0].content.as_deref(), Some(shared.as_slice()));
+    }
+
+    /// The purge's blob GC is scoped to the shas it just orphaned rather than
+    /// scanning the whole blob store (that blanket `NOT EXISTS` delete plans
+    /// as `SCAN checkpoint_blobs`, which on a multi-GB DB held the write lock
+    /// through every inline payload page on every archive). Scoping is only
+    /// safe if it is *exact* — this pins that the purge leaves behind zero
+    /// blobs it orphaned itself, so nothing accumulates.
+    #[test]
+    fn purge_workspace_checkpoint_files_leaves_none_of_its_own_orphans() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        for i in 0..5 {
+            db.insert_checkpoint_files(&[raw_file(
+                &format!("f{i}"),
+                "cp1",
+                &format!("file{i}.bin"),
+                format!("unique-bytes-{i}").as_bytes(),
+            )])
+            .unwrap();
+        }
+        assert_eq!(blob_count(&db), 5);
+
+        db.purge_workspace_checkpoint_files("w1").unwrap();
+
+        let orphans: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM checkpoint_blobs
+                  WHERE NOT EXISTS (
+                      SELECT 1 FROM checkpoint_files WHERE blob_sha256 = checkpoint_blobs.sha256
+                  )",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(orphans, 0, "purge must not leave blobs it orphaned itself");
+        assert_eq!(blob_count(&db), 0);
+    }
+
+    /// Documents the one intentional behavior change from scoping the GC: an
+    /// archive no longer opportunistically sweeps unrelated pre-existing
+    /// orphans. Those are still collected by the blanket
+    /// `gc_orphan_blobs_after_delete` on the delete/prune paths — an archive
+    /// simply stops paying a whole-table scan to do someone else's cleanup.
+    #[test]
+    fn purge_workspace_checkpoint_files_leaves_unrelated_orphans_to_the_delete_paths() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        db.insert_checkpoint_files(&[raw_file("f1", "cp1", "a.bin", b"w1-bytes")])
+            .unwrap();
+
+        // A stray blob no `checkpoint_files` row has ever referenced.
+        db.conn()
+            .execute(
+                "INSERT INTO checkpoint_blobs (sha256, bytes, byte_size, compression)
+                 VALUES ('deadbeef', X'00', 1, 'none')",
+                [],
+            )
+            .unwrap();
+        assert_eq!(blob_count(&db), 2);
+
+        db.purge_workspace_checkpoint_files("w1").unwrap();
+
+        let stray: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM checkpoint_blobs WHERE sha256 = 'deadbeef'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stray, 1, "unrelated orphan is out of this purge's scope");
+        assert_eq!(blob_count(&db), 1, "w1's own blob is still reclaimed");
     }
 
     /// Regression pin for the #1002 retroactive sweep: purging archived

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::time::Duration;
 
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, ErrorCode, TransactionBehavior, params};
 
 use crate::migrations::{MIGRATIONS, Migration};
 
@@ -10,6 +10,66 @@ pub(crate) const SQLITE_AUTO_VACUUM_FULL: i64 = 1;
 pub(crate) const SQLITE_AUTO_VACUUM_INCREMENTAL: i64 = 2;
 const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 const INCREMENTAL_VACUUM_PAGES_AFTER_DELETE: i64 = 4096;
+/// Freelist size (pages) at which [`Database::best_effort_reclaim_freelist_if_worthwhile`]
+/// decides a drain is worth its write-locked page I/O. Matched to the
+/// per-drain chunk size so a reclaim that fires always has a full chunk of
+/// work to do rather than truncating a few tail pages.
+const FREELIST_RECLAIM_THRESHOLD_PAGES: i64 = INCREMENTAL_VACUUM_PAGES_AFTER_DELETE;
+
+/// Total attempts (initial + retries) for [`retry_on_busy`].
+const BUSY_RETRY_ATTEMPTS: u32 = 5;
+/// First backoff step; doubles per retry (20/40/80/160ms ≈ 300ms worst case).
+const BUSY_RETRY_BASE_DELAY: Duration = Duration::from_millis(20);
+
+/// True for the `SQLITE_BUSY` / `SQLITE_LOCKED` families, including the
+/// extended `SQLITE_BUSY_SNAPSHOT` code (its primary code is `SQLITE_BUSY`,
+/// so it maps to [`ErrorCode::DatabaseBusy`]).
+fn is_busy_error(err: &rusqlite::Error) -> bool {
+    matches!(
+        err.sqlite_error_code(),
+        Some(ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
+    )
+}
+
+/// Re-run `op` when SQLite reports the database as busy/locked.
+///
+/// Necessary because `busy_timeout` does **not** cover every contention
+/// case. SQLite skips the busy handler entirely whenever invoking it could
+/// deadlock — most importantly `SQLITE_BUSY_SNAPSHOT`, returned when a
+/// deferred transaction that already took a read snapshot tries to upgrade
+/// to a write after another connection committed. No amount of waiting
+/// clears that: the snapshot is permanently stale and the transaction has
+/// to be rolled back and replayed from the top.
+///
+/// `configure_connection` makes transactions `IMMEDIATE`, which removes the
+/// upgrade path that produces `SQLITE_BUSY_SNAPSHOT`. This retry covers what
+/// remains — two `IMMEDIATE` writers colliding, or a WAL checkpoint holding
+/// the write lock past the busy timeout.
+///
+/// `op` must be self-contained (open its own transaction and commit it), as
+/// it may run several times. Keep post-commit housekeeping outside.
+pub(crate) fn retry_on_busy<T>(
+    mut op: impl FnMut() -> Result<T, rusqlite::Error>,
+) -> Result<T, rusqlite::Error> {
+    let mut attempt: u32 = 0;
+    loop {
+        match op() {
+            Err(e) if is_busy_error(&e) && attempt + 1 < BUSY_RETRY_ATTEMPTS => {
+                let delay = BUSY_RETRY_BASE_DELAY * 2u32.pow(attempt);
+                tracing::debug!(
+                    target: "claudette::db",
+                    attempt = attempt + 1,
+                    delay_ms = delay.as_millis() as u64,
+                    error = %e,
+                    "database busy; retrying transaction"
+                );
+                std::thread::sleep(delay);
+                attempt += 1;
+            }
+            other => return other,
+        }
+    }
+}
 
 mod repository;
 pub use repository::is_duplicate_repository_path_error;
@@ -46,6 +106,32 @@ pub struct Database {
     conn: Connection,
 }
 
+/// Freelist / orphan-blob work owed after a workspace delete has committed.
+///
+/// Modelled as a value so bulk callers can accumulate across a batch and pay
+/// the cost once via [`Database::run_post_delete_housekeeping`], rather than
+/// taking the write lock two extra times per deleted row.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PostDeleteHousekeeping {
+    /// `checkpoint_files` rows that belonged to the deleted workspace.
+    pub file_rows: usize,
+    /// `workspaces` rows actually removed (0 or 1 per delete).
+    pub deleted: usize,
+}
+
+impl PostDeleteHousekeeping {
+    /// Fold another delete's owed work into this one.
+    pub fn merge(&mut self, other: Self) {
+        self.file_rows += other.file_rows;
+        self.deleted += other.deleted;
+    }
+
+    /// True when nothing was deleted and so no housekeeping is owed.
+    pub fn is_empty(&self) -> bool {
+        self.file_rows == 0 && self.deleted == 0
+    }
+}
+
 impl Database {
     /// Open (or create) the SQLite database at `path` and run any
     /// pending migrations. Wrapped in a `claudette::db` span at TRACE
@@ -63,8 +149,8 @@ impl Database {
             })?;
         }
         let is_fresh_file = is_fresh_database_file(path);
-        let conn = Connection::open(path)?;
-        Self::configure_connection(&conn, is_fresh_file)?;
+        let mut conn = Connection::open(path)?;
+        Self::configure_connection(&mut conn, is_fresh_file)?;
         let db = Self { conn };
         db.migrate()?;
         Ok(db)
@@ -72,18 +158,39 @@ impl Database {
 
     #[allow(dead_code)]
     pub fn open_in_memory() -> Result<Self, rusqlite::Error> {
-        let conn = Connection::open_in_memory()?;
-        Self::configure_connection(&conn, true)?;
+        let mut conn = Connection::open_in_memory()?;
+        Self::configure_connection(&mut conn, true)?;
         let db = Self { conn };
         db.migrate()?;
         Ok(db)
     }
 
     fn configure_connection(
-        conn: &Connection,
+        conn: &mut Connection,
         enable_incremental_auto_vacuum_before_schema: bool,
     ) -> Result<(), rusqlite::Error> {
         conn.busy_timeout(SQLITE_BUSY_TIMEOUT)?;
+        // `BEGIN IMMEDIATE` for every `unchecked_transaction()` in the crate.
+        //
+        // rusqlite defaults to `DEFERRED`, which takes no lock at BEGIN. A
+        // transaction that reads before it writes therefore pins a WAL read
+        // snapshot and only tries to become a writer on its first mutation —
+        // and if any other connection committed in that window SQLite fails
+        // it with `SQLITE_BUSY_SNAPSHOT` *without consulting the busy
+        // handler*, because waiting could never resolve it. That made the
+        // 30s `busy_timeout` above inert on every read-then-write path and
+        // surfaced to users as "database is locked" (most visibly in bulk
+        // archived-workspace cleanup, which runs a read-then-write delete per
+        // row while agents stream concurrently).
+        //
+        // IMMEDIATE takes the write lock at BEGIN, so there is no upgrade and
+        // no stale snapshot — and because the lock is acquired up front, the
+        // busy handler *does* apply and `busy_timeout` starts working.
+        //
+        // Safe as a blanket default here: every `unchecked_transaction()` site
+        // in `src/db/` is a write transaction, so none pay a read-serialization
+        // cost. Revisit if a read-only transaction is ever introduced.
+        conn.set_transaction_behavior(TransactionBehavior::Immediate);
         if enable_incremental_auto_vacuum_before_schema {
             conn.execute_batch("PRAGMA auto_vacuum=INCREMENTAL;")?;
         }
@@ -173,6 +280,43 @@ impl Database {
         if rows_deleted > 0 {
             self.best_effort_incremental_vacuum(INCREMENTAL_VACUUM_PAGES_AFTER_DELETE);
         }
+    }
+
+    /// Drain the freelist only once it has grown past
+    /// [`FREELIST_RECLAIM_THRESHOLD_PAGES`].
+    ///
+    /// For paths on a user-interactive critical section (archive), where the
+    /// alternative is paying write-locked vacuum I/O on *every* invocation to
+    /// reclaim a handful of pages. The threshold check is a single
+    /// `PRAGMA freelist_count` read, so the common case costs nothing and the
+    /// drain still happens — just amortized, once the freed pages are worth
+    /// a full chunk.
+    pub(crate) fn best_effort_reclaim_freelist_if_worthwhile(&self) {
+        match self.freelist_page_count() {
+            Ok(pages) if pages >= FREELIST_RECLAIM_THRESHOLD_PAGES => {
+                self.best_effort_incremental_vacuum(INCREMENTAL_VACUUM_PAGES_AFTER_DELETE);
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(
+                    target: "claudette::db",
+                    error = %e,
+                    "freelist probe failed; skipping opportunistic reclaim"
+                );
+            }
+        }
+    }
+
+    /// Perform the orphan-blob GC + incremental vacuum owed by one or more
+    /// committed workspace deletes. Best-effort — both helpers log and
+    /// swallow their own failures, so a housekeeping problem never fails a
+    /// delete the user already saw succeed.
+    pub fn run_post_delete_housekeeping(&self, work: PostDeleteHousekeeping) {
+        if work.is_empty() {
+            return;
+        }
+        self.gc_orphan_blobs_after_delete(work.file_rows);
+        self.best_effort_incremental_vacuum_after_delete(work.file_rows + work.deleted);
     }
 
     /// Drop `checkpoint_blobs` rows that no `checkpoint_files` row references.
@@ -424,6 +568,12 @@ impl Database {
         &self.conn
     }
 
+    /// Test-only: shorten the busy timeout so lock-contention tests fail
+    /// fast instead of blocking for the production [`SQLITE_BUSY_TIMEOUT`].
+    pub(crate) fn set_busy_timeout_for_test(&self, timeout: Duration) {
+        self.conn.busy_timeout(timeout).unwrap();
+    }
+
     /// Test-only: run the migration runner against a caller-supplied slice.
     /// Used to inject synthetic migrations for error-path and ordering tests.
     pub fn migrate_with(&self, migrations: &[Migration]) -> Result<(), rusqlite::Error> {
@@ -464,6 +614,126 @@ fn is_fresh_database_file(path: &Path) -> bool {
 mod tests {
     use super::*;
     use crate::db::test_support::*;
+
+    // --- Write-lock / busy-retry tests ---
+
+    fn busy_error() -> rusqlite::Error {
+        rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+            Some("database is locked".into()),
+        )
+    }
+
+    /// Pins the fix: `unchecked_transaction()` must take the write lock at
+    /// `BEGIN`. Under rusqlite's `DEFERRED` default it would return `Ok`
+    /// here and only try to lock on the first write — the read-then-upgrade
+    /// shape that produced `SQLITE_BUSY_SNAPSHOT`.
+    #[test]
+    fn transactions_take_the_write_lock_at_begin() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let db = Database::open(&path).unwrap();
+        db.set_busy_timeout_for_test(Duration::from_millis(50));
+
+        let blocker = Connection::open(&path).unwrap();
+        blocker.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        let err = db
+            .conn()
+            .unchecked_transaction()
+            .expect_err("BEGIN must acquire the write lock, so this must fail while it is held");
+        assert!(is_busy_error(&err), "expected a busy error, got {err:?}");
+
+        blocker.execute_batch("ROLLBACK").unwrap();
+        db.conn()
+            .unchecked_transaction()
+            .expect("write lock released — BEGIN should succeed again");
+    }
+
+    /// Documents the mechanism the fix removes. A `DEFERRED` transaction
+    /// that reads before it writes pins a WAL snapshot; if another
+    /// connection commits in that window, the upgrade fails with
+    /// `SQLITE_BUSY_SNAPSHOT` *immediately* — SQLite skips the busy handler
+    /// because no amount of waiting can refresh a stale snapshot. That is
+    /// why the 30s `busy_timeout` never protected read-then-write paths,
+    /// and why users saw "database is locked" during bulk cleanup.
+    #[test]
+    fn deferred_read_then_write_upgrade_fails_busy_without_waiting() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let db = Database::open(&path).unwrap();
+        db.conn()
+            .execute_batch("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER);")
+            .unwrap();
+        db.conn()
+            .execute("INSERT INTO t (id, v) VALUES (1, 1)", [])
+            .unwrap();
+
+        let reader = Connection::open(&path).unwrap();
+        // Deliberately generous — and, on this path, entirely inert.
+        reader.busy_timeout(Duration::from_secs(30)).unwrap();
+        let writer = Connection::open(&path).unwrap();
+
+        reader.execute_batch("BEGIN DEFERRED").unwrap();
+        let _: i64 = reader
+            .query_row("SELECT v FROM t WHERE id = 1", [], |r| r.get(0))
+            .unwrap(); // snapshot pinned here
+
+        writer
+            .execute("UPDATE t SET v = 2 WHERE id = 1", [])
+            .unwrap();
+
+        let started = std::time::Instant::now();
+        let err = reader
+            .execute("UPDATE t SET v = 3 WHERE id = 1", [])
+            .expect_err("upgrade after a concurrent commit must fail");
+        assert!(is_busy_error(&err), "expected a busy error, got {err:?}");
+        assert!(
+            err.to_string().contains("locked"),
+            "this is the string users reported; got {err}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "busy handler should have been skipped, not waited out — took {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn retry_on_busy_retries_until_success() {
+        let mut calls: u32 = 0;
+        let result = retry_on_busy(|| {
+            calls += 1;
+            if calls < 3 {
+                Err(busy_error())
+            } else {
+                Ok(calls)
+            }
+        });
+        assert_eq!(result.unwrap(), 3);
+    }
+
+    #[test]
+    fn retry_on_busy_gives_up_after_the_attempt_cap() {
+        let mut calls: u32 = 0;
+        let result = retry_on_busy(|| -> Result<(), rusqlite::Error> {
+            calls += 1;
+            Err(busy_error())
+        });
+        assert!(result.is_err());
+        assert_eq!(calls, BUSY_RETRY_ATTEMPTS);
+    }
+
+    #[test]
+    fn retry_on_busy_does_not_retry_non_busy_errors() {
+        let mut calls: u32 = 0;
+        let result = retry_on_busy(|| -> Result<(), rusqlite::Error> {
+            calls += 1;
+            Err(rusqlite::Error::InvalidQuery)
+        });
+        assert!(result.is_err());
+        assert_eq!(calls, 1, "a non-busy error must not be retried");
+    }
 
     // --- Migration runner tests ---
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -48,6 +48,24 @@ fn is_busy_error(err: &rusqlite::Error) -> bool {
 ///
 /// `op` must be self-contained (open its own transaction and commit it), as
 /// it may run several times. Keep post-commit housekeeping outside.
+///
+/// **Blocking:** the backoff is a synchronous `thread::sleep`, and callers
+/// are async. That is deliberate rather than overlooked. `rusqlite`'s
+/// `Connection` is not `Send`, so the whole `db` layer is synchronous and
+/// called directly from async commands; no DB path in this codebase runs
+/// under `spawn_blocking`. More to the point, `busy_timeout`
+/// ([`SQLITE_BUSY_TIMEOUT`], 30s) already parks the calling thread inside
+/// `sqlite3_step` on these same paths — two orders of magnitude longer than
+/// this helper's ~300ms worst case — so an async backoff here would leave
+/// the dominant blocking untouched. Making that genuinely non-blocking means
+/// moving the DB layer off the async runtime (opening connections inside
+/// each blocking task), which is a separate architectural change.
+///
+/// Note the interaction with `IMMEDIATE`: taking the write lock at `BEGIN`
+/// means a contended write now *waits* on the busy handler where the
+/// previous `DEFERRED` upgrade failed fast with `SQLITE_BUSY_SNAPSHOT`.
+/// Better for users — the operation succeeds instead of erroring — but it
+/// does make the existing 30s wait more reachable.
 pub(crate) fn retry_on_busy<T>(
     mut op: impl FnMut() -> Result<T, rusqlite::Error>,
 ) -> Result<T, rusqlite::Error> {

--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -12,7 +12,7 @@ use rusqlite::{OptionalExtension, params};
 
 use crate::model::{Workspace, WorkspaceStatus};
 
-use super::Database;
+use super::{Database, PostDeleteHousekeeping, retry_on_busy};
 
 pub const WORKSPACE_ORDER_MODE_PREFIX: &str = "workspace_order_mode:";
 
@@ -623,24 +623,52 @@ impl Database {
         &self,
         id: &str,
     ) -> Result<bool, rusqlite::Error> {
-        let tx = self.conn.unchecked_transaction()?;
-        let status: Option<String> = tx
-            .query_row(
-                "SELECT status FROM workspaces WHERE id = ?1",
-                params![id],
-                |row| row.get(0),
-            )
-            .optional()?;
-        if status.as_deref() != Some("archived") {
+        let Some(work) = self.try_delete_archived_workspace_deferring_housekeeping(id)? else {
             return Ok(false);
-        }
-        Self::materialize_workspace_summary_tx(&tx, id)?;
-        let file_rows = self.count_workspace_checkpoint_files(id)?;
-        let deleted = tx.execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
-        tx.commit()?;
-        self.gc_orphan_blobs_after_delete(file_rows);
-        self.best_effort_incremental_vacuum_after_delete(file_rows + deleted);
+        };
+        self.run_post_delete_housekeeping(work);
         Ok(true)
+    }
+
+    /// As [`Self::try_delete_archived_workspace_with_summary`], but returns
+    /// the owed post-delete housekeeping instead of performing it.
+    ///
+    /// Bulk callers accumulate the returned counts and make a single
+    /// [`Database::run_post_delete_housekeeping`] call after the batch. Run
+    /// per row, the orphan-blob GC and incremental vacuum take the write
+    /// lock two extra times *per workspace* — pure contention against the
+    /// concurrent writers (agent streaming, metrics, terminal state) that
+    /// this path is already racing, for housekeeping that coalesces
+    /// perfectly well.
+    ///
+    /// `Ok(None)` means the row was missing or no longer Archived.
+    pub fn try_delete_archived_workspace_deferring_housekeeping(
+        &self,
+        id: &str,
+    ) -> Result<Option<PostDeleteHousekeeping>, rusqlite::Error> {
+        // Retried as a unit: the closure opens and commits its own
+        // transaction, so a busy failure replays the Archived guard as well
+        // as the delete. Replaying the guard is required for correctness —
+        // a `restore_workspace` that lands between attempts must still be
+        // able to veto the delete.
+        retry_on_busy(|| {
+            let tx = self.conn.unchecked_transaction()?;
+            let status: Option<String> = tx
+                .query_row(
+                    "SELECT status FROM workspaces WHERE id = ?1",
+                    params![id],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            if status.as_deref() != Some("archived") {
+                return Ok(None);
+            }
+            Self::materialize_workspace_summary_tx(&tx, id)?;
+            let file_rows = self.count_workspace_checkpoint_files(id)?;
+            let deleted = tx.execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
+            tx.commit()?;
+            Ok(Some(PostDeleteHousekeeping { file_rows, deleted }))
+        })
     }
 
     /// Hard-delete a repository, materializing summaries for all its


### PR DESCRIPTION
### Summary

Users hit `database is locked` during workspace **archive** (and, less often, bulk archived-cleanup). Investigation turned up two independent causes that both surface as that identical rusqlite string.

**1. Every transaction was `DEFERRED`.** rusqlite's default takes no lock at `BEGIN`. A transaction that reads before it writes pins a WAL read snapshot and only attempts the write lock on its first mutation — and if another connection commits in that window, SQLite returns `SQLITE_BUSY_SNAPSHOT` **without invoking the busy handler**, because waiting can never refresh a stale snapshot. The 30s `busy_timeout` at `src/db/mod.rs:86` was therefore inert on every read-then-write path in the codebase.

Fix: `TransactionBehavior::Immediate` in `configure_connection`. The lock is taken at `BEGIN`, so there's no upgrade and no stale snapshot — and because it's acquired up front, the busy handler applies and the existing timeout finally does its job. Audited all 21 `unchecked_transaction()` sites: every one is a write transaction, so none pays a read-serialization cost. Added `retry_on_busy` for the contention IMMEDIATE doesn't remove (two immediate writers colliding, WAL checkpoints).

**2. Archive did work proportional to total database size.** The `#1002` archive-time purge reclaimed blobs with a blanket `DELETE FROM checkpoint_blobs WHERE NOT EXISTS (...)`. Measured against the real schema:

```
before:  SCAN checkpoint_blobs                               <- whole blob store, every archive
after:   SEARCH checkpoint_blobs USING INDEX (sha256=?)      <- one indexed probe per orphan
```

Since `bytes BLOB` is stored inline, that scan walked every payload page in the table. So **every archive held the write lock for a full sweep of the blob store**, scaling with total DB size rather than with the workspace being archived — which is why it got worse exactly as a user's database filled up.

Fix: scope the GC to the shas the purge just orphaned, and gate the incremental vacuum on an accumulated freelist instead of firing on every archive.

```mermaid
flowchart TD
    A[archive workspace] --> B[purge checkpoint_files for workspace]
    B --> C{blob GC}
    C -->|before| D["SCAN checkpoint_blobs<br/>O(total DB size)<br/>write lock held throughout"]
    C -->|after| E["SEARCH by sha256<br/>O(rows purged)<br/>indexed probe per orphan"]
    D --> F{incremental vacuum}
    E --> G{freelist >= 4096 pages?}
    F -->|every archive| H[4096 pages of write-locked I/O]
    G -->|no| I[skip - costs one PRAGMA read]
    G -->|yes| H
```

Also batches bulk-delete housekeeping: orphan GC + incremental vacuum now run once per batch instead of taking the write lock 2N extra times across the loop.

### Complexity Notes

- **The IMMEDIATE change is global** — it applies to all ~490 `Database::open` call sites. It's safe because every transaction in `src/db/` is a write transaction (verified site by site); the code comment records that as the condition to revisit if a read-only transaction is ever introduced. It slightly lengthens how long the write lock is held within a transaction (now covering the leading `SELECT`), which is the correct trade against failing outright.
- **`retry_on_busy` replays the whole transaction, including the `status = 'archived'` guard** — not just the `DELETE`. This is load-bearing: a `restore_workspace` landing between attempts must still be able to veto the delete. Retrying only the write would reintroduce the race the in-transaction guard exists to close.
- **Scoped GC is only safe if it's exact.** If it under-collected, orphans would accumulate silently forever. `purge_workspace_checkpoint_files_leaves_none_of_its_own_orphans` pins that the purge leaves zero blobs it orphaned itself. The pre-existing `..._preserves_cross_workspace_shared_blobs` test is the other guard rail — content-addressed storage dedupes identical bytes across workspaces, so a naive "delete every sha this workspace referenced" would corrupt another workspace's snapshots. It passes unchanged.
- **Intentional behavior change:** an archive no longer opportunistically sweeps *unrelated* pre-existing orphaned blobs. Those are still collected by the blanket `gc_orphan_blobs_after_delete` on the delete/prune paths — an archive just stops paying a whole-table scan to do someone else's cleanup. Pinned by `purge_workspace_checkpoint_files_leaves_unrelated_orphans_to_the_delete_paths`.
- `ops::workspace::delete_workspaces_bulk` was deliberately left untouched — it has no production callers (tests only; GUI and CLI both route through `commands::workspace::delete_workspaces_bulk_inner`) and already inherits the IMMEDIATE + retry fix transitively.

### Test Steps

1. **Verify the regression tests fail without the fix.** Revert just the one line `conn.set_transaction_behavior(TransactionBehavior::Immediate);` in `src/db/mod.rs` and run:
   ```bash
   cargo test -p claudette --lib transactions_take_the_write_lock_at_begin
   ```
   It should fail (under `DEFERRED`, `BEGIN` returns `Ok` while another connection holds the write lock). Restore the line; it passes.

2. **Confirm the mechanism is documented and pinned:**
   ```bash
   cargo test -p claudette --lib deferred_read_then_write_upgrade_fails_busy_without_waiting
   ```
   Reproduces `SQLITE_BUSY_SNAPSHOT` with a 30s busy timeout set, asserting it returns in well under 5s — i.e. the busy handler was skipped, not waited out.

3. **Verify the blob-GC scoping invariants:**
   ```bash
   cargo test -p claudette --lib purge_workspace
   ```
   All four pass, including the pre-existing cross-workspace shared-blob test.

4. **Confirm the query plan improvement yourself:**
   ```bash
   sqlite3 /tmp/plan.db "
   CREATE TABLE checkpoint_blobs (sha256 TEXT PRIMARY KEY, bytes BLOB NOT NULL, byte_size INTEGER NOT NULL, compression TEXT NOT NULL DEFAULT 'none', created_at TEXT);
   CREATE TABLE checkpoint_files (id TEXT PRIMARY KEY, checkpoint_id TEXT, blob_sha256 TEXT);
   CREATE INDEX idx_checkpoint_files_blob_sha256 ON checkpoint_files(blob_sha256);
   EXPLAIN QUERY PLAN DELETE FROM checkpoint_blobs WHERE NOT EXISTS (SELECT 1 FROM checkpoint_files WHERE blob_sha256 = checkpoint_blobs.sha256);
   EXPLAIN QUERY PLAN DELETE FROM checkpoint_blobs WHERE sha256 = ?1 AND NOT EXISTS (SELECT 1 FROM checkpoint_files WHERE blob_sha256 = ?1);
   "
   ```
   First prints `SCAN checkpoint_blobs`; second prints `SEARCH checkpoint_blobs USING INDEX`.

5. **End-to-end in the app** (`./scripts/dev.sh`): with at least one agent actively streaming a response, archive a workspace that has accumulated checkpoint history. It should complete without a `database is locked` error. Then open **Settings → Storage → Clean up** and bulk-delete several archived workspaces; rows should all report deleted rather than failing.

6. **Full gate:**
   ```bash
   cargo test -p claudette -p claudette-server -p claudette-cli --all-features
   RUSTFLAGS="-Dwarnings" cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features
   cargo fmt --all --check
   ```
   1,525 tests pass, clippy clean, fmt clean.

### Notes for reviewers

I have not seen the reporting user's logs, so I can't confirm which of the two causes they were hitting — both print the identical string. After upgrading, `~/.claudette/logs/claudette.<date>.log` will show `"database busy; retrying transaction"` at debug on `claudette::db` if contention still occurs but now recovers. Worth also ruling out literal disk-full, which surfaces as `"database or disk is full"` instead.

**No docs change:** this is a reliability fix with no new setting, flag, command, or user-visible surface, so nothing in `site/src/content/docs/` applies. Flagging explicitly per CLAUDE.md's rule that intentional docs omissions get reviewed rather than assumed.

### Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable) — N/A, see note above