### PR TITLE
fix(ci): stop nightly version rewinds that strand updater clients

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -627,8 +627,39 @@ jobs:
           # pipefail`, `-f` would hard-fail the promote whenever `nightly` is
           # legitimately absent, wedging recovery. And not `sort -V`, which
           # orders 0.28.0 BEFORE 0.28.0-dev.3 — the opposite of semver.)
-          LIVE=$(curl -sL "https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/latest.json" \
-                   | jq -r '.version // empty' 2>/dev/null || true)
+          MANIFEST_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/latest.json"
+
+          # Fail CLOSED. An earlier draft swallowed every curl/jq failure into
+          # an empty $LIVE, which disabled the guard exactly when the API is
+          # misbehaving — i.e. when a bad promote is most likely. Only an
+          # explicit 404 means "no live release" (first promote, or recovery
+          # after the release was deleted); transport, non-2xx and parse
+          # failures abort rather than promote blind.
+          LIVE=""
+          LIVE_MANIFEST="${RUNNER_TEMP:-/tmp}/live-nightly-manifest.json"
+          for attempt in 1 2 3; do
+            http=$(curl -sL -o "$LIVE_MANIFEST" -w "%{http_code}" "$MANIFEST_URL" || echo "000")
+            if [ "$http" = "404" ]; then
+              echo "No live nightly manifest (HTTP 404) — first promote or post-recovery; skipping monotonicity check"
+              break
+            fi
+            if [ "$http" = "200" ]; then
+              LIVE=$(jq -r '.version // empty' "$LIVE_MANIFEST" 2>/dev/null || echo "")
+              if [ -n "$LIVE" ]; then
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "::error::live nightly manifest at $MANIFEST_URL is unparseable or has no .version — refusing to promote blind"
+                exit 1
+              fi
+            elif [ "$attempt" -eq 3 ]; then
+              echo "::error::could not read live nightly manifest (HTTP $http) after 3 attempts — refusing to promote blind"
+              exit 1
+            fi
+            echo "Live-manifest read attempt $attempt returned HTTP $http; retrying in 5s"
+            sleep 5
+          done
+
           if [ -n "$LIVE" ]; then
             if [ "$LIVE" = "$VERSION" ]; then
               echo "::warning::republishing identical version $VERSION"
@@ -646,22 +677,34 @@ jobs:
           # stranded as a draft. Verified against the live API: a draft can
           # be PATCHed to tag_name=nightly while a published release still
           # owns that tag (HTTP 200, not 422).
-          STAGING_ID=$(gh release view nightly-staging --repo "$GITHUB_REPOSITORY" --json id --jq '.id')
+          # `--json id` returns the GraphQL node ID (RE_kwDO...), which
+          # `GET/PATCH /repos/{owner}/{repo}/releases/{release_id}` rejects with
+          # a 404. The REST endpoints need the numeric database ID.
+          STAGING_ID=$(gh release view nightly-staging --repo "$GITHUB_REPOSITORY" --json databaseId --jq '.databaseId')
           echo "Promoting staging release id=$STAGING_ID to nightly"
 
           # Delete the live `nightly`, with the same retry the rest of this
           # step uses, then verify it is actually gone. Swallowing this
           # failure is what makes the stale-nightly path silent.
+          # Verify via the Releases LIST endpoint, which includes drafts. A
+          # by-tag lookup cannot see them, so a draft left tagged `nightly` by
+          # a run that retagged but died before un-drafting would be reported
+          # as absent — and the next run would retag onto an already-owned
+          # tag. Counting matches also fails closed: `! gh release view` is
+          # true for rate limits, auth failures and outages, not just 404, so
+          # it would break out of this loop as though the delete had worked.
           for attempt in 1 2 3; do
             gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
-            if ! gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            remaining=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+              --jq '[.[] | select(.tag_name == "nightly")] | length' 2>/dev/null || echo "unknown")
+            if [ "$remaining" = "0" ]; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
-              echo "::error::old nightly release still present after 3 delete attempts; aborting rather than publishing a stale nightly"
+              echo "::error::nightly release still present after 3 delete attempts (remaining=$remaining — \"unknown\" means the query itself failed); aborting rather than risking a stale nightly"
               exit 1
             fi
-            echo "Delete attempt $attempt left nightly present; retrying in 5s"
+            echo "Delete attempt $attempt left remaining=$remaining; retrying in 5s"
             sleep 5
           done
 
@@ -727,7 +770,6 @@ jobs:
           # is reachable by clients that don't carry a GitHub auth
           # token. A short CDN propagation lag after the un-draft is
           # normal; retry a few times before failing.
-          MANIFEST_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/latest.json"
           for attempt in 1 2 3 4 5; do
             # `set -e` is active for this step; `var=$(failing-cmd)`
             # exits the script on transient curl failures (DNS, TLS,

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,11 +46,27 @@ jobs:
           NEXT_MINOR="${MAJ}.$((MIN + 1)).0"
 
           LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
-          if [ -n "$LAST_TAG" ]; then
-            COMMITS=$(git rev-list --count "${LAST_TAG}..HEAD")
-          else
-            COMMITS=$(git rev-list --count HEAD)
-          fi
+
+          # Total commit count on HEAD — strictly increasing across tags.
+          # Counting from LAST_TAG rewinds the counter whenever a release
+          # tag lands. semver reads a rewind as a DOWNGRADE, so
+          # tauri-plugin-updater (which gates on `release.version >
+          # current_version`, and we set no version_comparator) silently
+          # reports "up to date" and strands nightly users on their
+          # installed build. It rewound two ways:
+          #
+          #   1. The nightly for a release commit races the tag: the run
+          #      fires on the push, before release-please creates the tag,
+          #      so `git describe` finds the PREVIOUS tag and inflates the
+          #      count (ac716c73 -> dev.4). The next build counts from the
+          #      new tag and drops to dev.1.
+          #   2. A patch release leaves NEXT_MINOR unchanged (still 0.28.0)
+          #      while resetting the count (v0.27.1 sent dev.3 -> dev.0).
+          #
+          # Observed: a client on 0.28.0-dev.4.gac716c7 (2026-07-27) was
+          # refused all 7 subsequent nightlies over 25 days.
+          # LAST_TAG is still used below for the release-notes compare link.
+          COMMITS=$(git rev-list --count HEAD)
 
           SHORT=$(git rev-parse --short=7 HEAD)
           VERSION="${NEXT_MINOR}-dev.${COMMITS}.g${SHORT}"
@@ -602,7 +618,52 @@ jobs:
             sleep "$backoff"
           done
 
-          gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+          # Monotonicity guard. tauri-plugin-updater gates on
+          # `release.version > current_version` using plain semver and we set
+          # no version_comparator, so publishing a version that sorts BELOW
+          # the live one silently strands every client already on the newer
+          # build — they are told "up to date" indefinitely. Refuse rather
+          # than demote. (Deliberately not `curl -sfL`: with `set -euo
+          # pipefail`, `-f` would hard-fail the promote whenever `nightly` is
+          # legitimately absent, wedging recovery. And not `sort -V`, which
+          # orders 0.28.0 BEFORE 0.28.0-dev.3 — the opposite of semver.)
+          LIVE=$(curl -sL "https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/latest.json" \
+                   | jq -r '.version // empty' 2>/dev/null || true)
+          if [ -n "$LIVE" ]; then
+            if [ "$LIVE" = "$VERSION" ]; then
+              echo "::warning::republishing identical version $VERSION"
+            elif ! python3 -c 'import sys; k=lambda v:(lambda b,p:([int(x) for x in b.split(".")],(1,[]) if not p else (0,[(0,int(i),"") if i.isdigit() else (1,0,i) for i in p.split(".")])))(*v.split("-",1) if "-" in v else (v,"")); sys.exit(0 if k(sys.argv[1])>k(sys.argv[2]) else 1)' "$VERSION" "$LIVE"; then
+              echo "::error::new version $VERSION sorts at or below live nightly $LIVE — refusing to demote"
+              exit 1
+            fi
+          fi
+
+          # Capture the staging release by ID before the retag. Stages 2/3
+          # must not resolve `nightly` by tag: GitHub's get-release-by-tag
+          # endpoint does not return drafts, so if the delete below silently
+          # no-ops, a by-tag lookup resolves to the OLD published release,
+          # reports draft=false, and the job goes green with the new build
+          # stranded as a draft. Verified against the live API: a draft can
+          # be PATCHed to tag_name=nightly while a published release still
+          # owns that tag (HTTP 200, not 422).
+          STAGING_ID=$(gh release view nightly-staging --repo "$GITHUB_REPOSITORY" --json id --jq '.id')
+          echo "Promoting staging release id=$STAGING_ID to nightly"
+
+          # Delete the live `nightly`, with the same retry the rest of this
+          # step uses, then verify it is actually gone. Swallowing this
+          # failure is what makes the stale-nightly path silent.
+          for attempt in 1 2 3; do
+            gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+            if ! gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::old nightly release still present after 3 delete attempts; aborting rather than publishing a stale nightly"
+              exit 1
+            fi
+            echo "Delete attempt $attempt left nightly present; retrying in 5s"
+            sleep 5
+          done
 
           # Promotion runs in three explicitly-verified stages because
           # combining the tag rename and the draft flip in a single
@@ -634,14 +695,16 @@ jobs:
           done
 
           # Stage 2: un-draft the (now-renamed) release as a separate
-          # PATCH so the API can't drop the flip on the floor. Verify
-          # the post-state via `gh api releases/tags/nightly` rather
-          # than trusting `gh release edit`'s exit code — it has been
-          # observed to print the release URL and return 0 while
-          # `draft` stayed `true`.
+          # PATCH so the API can't drop the flip on the floor. Both the
+          # PATCH and the verification address the release by ID, never
+          # by tag — a by-tag lookup cannot see drafts and would happily
+          # verify a stale published release instead. Verify the
+          # post-state rather than trusting the call's exit code — it has
+          # been observed to return 0 while `draft` stayed `true`.
           for attempt in 1 2 3; do
-            gh release edit nightly --repo "$GITHUB_REPOSITORY" --draft=false || true
-            draft_state=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${STAGING_ID}" \
+              -F draft=false >/dev/null 2>&1 || true
+            draft_state=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${STAGING_ID}" \
               --jq '.draft' 2>/dev/null || echo "unknown")
             if [ "$draft_state" = "false" ]; then
               echo "nightly release is now draft=false"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -629,36 +629,57 @@ jobs:
           # orders 0.28.0 BEFORE 0.28.0-dev.3 — the opposite of semver.)
           MANIFEST_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/latest.json"
 
-          # Fail CLOSED. An earlier draft swallowed every curl/jq failure into
-          # an empty $LIVE, which disabled the guard exactly when the API is
-          # misbehaving — i.e. when a bad promote is most likely. Only an
-          # explicit 404 means "no live release" (first promote, or recovery
-          # after the release was deleted); transport, non-2xx and parse
-          # failures abort rather than promote blind.
+          # Enumerate releases tagged `nightly` from the LIST endpoint. This is
+          # the authoritative existence check on two counts: it includes drafts
+          # (a by-tag lookup does not), and it is not confounded by the asset
+          # layer — a published release can exist with a missing or deleted
+          # latest.json, and the CDN can 404 transiently, so an asset 404 must
+          # never be read as "no release".
+          #
+          # `--slurp` is required: `--paginate` runs a `--jq` filter once PER
+          # PAGE, so past 100 releases the result would be "1\n0" and never
+          # compare equal to "0", aborting every promote. gh (2.97.0) rejects
+          # `--slurp` combined with `--jq`, hence the pipe to standalone jq.
+          list_nightly_releases() {
+            gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate --slurp \
+              | jq -c '[.[][] | select(.tag_name == "nightly") | {id, draft}]'
+          }
+
+          NIGHTLY_JSON=$(list_nightly_releases 2>/dev/null || echo "")
+          if [ -z "$NIGHTLY_JSON" ]; then
+            echo "::error::could not enumerate releases tagged nightly — refusing to promote blind"
+            exit 1
+          fi
+          NIGHTLY_PUBLISHED=$(printf '%s' "$NIGHTLY_JSON" | jq '[.[] | select(.draft == false)] | length')
+          echo "Releases tagged nightly: $NIGHTLY_JSON (published: $NIGHTLY_PUBLISHED)"
+
+          # Monotonicity guard, gated on a PUBLISHED nightly existing. Only a
+          # published release is reachable by updater clients, so only it can
+          # be demoted. Gating on drafts too would deadlock the recovery path:
+          # a draft left tagged `nightly` by a run that died between stage 1
+          # and stage 2 has no anonymously-downloadable manifest, so the fetch
+          # below would fail closed on every subsequent run.
           LIVE=""
-          LIVE_MANIFEST="${RUNNER_TEMP:-/tmp}/live-nightly-manifest.json"
-          for attempt in 1 2 3; do
-            http=$(curl -sL -o "$LIVE_MANIFEST" -w "%{http_code}" "$MANIFEST_URL" || echo "000")
-            if [ "$http" = "404" ]; then
-              echo "No live nightly manifest (HTTP 404) — first promote or post-recovery; skipping monotonicity check"
-              break
-            fi
-            if [ "$http" = "200" ]; then
-              LIVE=$(jq -r '.version // empty' "$LIVE_MANIFEST" 2>/dev/null || echo "")
-              if [ -n "$LIVE" ]; then
-                break
+          if [ "$NIGHTLY_PUBLISHED" != "0" ]; then
+            LIVE_MANIFEST="${RUNNER_TEMP:-/tmp}/live-nightly-manifest.json"
+            for attempt in 1 2 3; do
+              http=$(curl -sL -o "$LIVE_MANIFEST" -w "%{http_code}" "$MANIFEST_URL" || echo "000")
+              if [ "$http" = "200" ]; then
+                LIVE=$(jq -r '.version // empty' "$LIVE_MANIFEST" 2>/dev/null || echo "")
+                if [ -n "$LIVE" ]; then
+                  break
+                fi
               fi
               if [ "$attempt" -eq 3 ]; then
-                echo "::error::live nightly manifest at $MANIFEST_URL is unparseable or has no .version — refusing to promote blind"
+                echo "::error::a published nightly release exists but its manifest could not be read (last HTTP $http) — refusing to promote blind over a live release"
                 exit 1
               fi
-            elif [ "$attempt" -eq 3 ]; then
-              echo "::error::could not read live nightly manifest (HTTP $http) after 3 attempts — refusing to promote blind"
-              exit 1
-            fi
-            echo "Live-manifest read attempt $attempt returned HTTP $http; retrying in 5s"
-            sleep 5
-          done
+              echo "Live-manifest read attempt $attempt returned HTTP $http; retrying in 5s"
+              sleep 5
+            done
+          else
+            echo "No published nightly release — first promote or post-recovery; skipping monotonicity check"
+          fi
 
           if [ -n "$LIVE" ]; then
             if [ "$LIVE" = "$VERSION" ]; then
@@ -669,42 +690,43 @@ jobs:
             fi
           fi
 
-          # Capture the staging release by ID before the retag. Stages 2/3
-          # must not resolve `nightly` by tag: GitHub's get-release-by-tag
-          # endpoint does not return drafts, so if the delete below silently
-          # no-ops, a by-tag lookup resolves to the OLD published release,
-          # reports draft=false, and the job goes green with the new build
-          # stranded as a draft. Verified against the live API: a draft can
-          # be PATCHed to tag_name=nightly while a published release still
-          # owns that tag (HTTP 200, not 422).
+          # Capture the staging release before the retag. Stages 2/3 must not
+          # resolve `nightly` by tag: GitHub's get-release-by-tag endpoint does
+          # not return drafts, so a by-tag lookup can silently resolve to the
+          # OLD published release, report draft=false, and let the job go green
+          # with the new build stranded as a draft. Verified against the live
+          # API: a draft can be PATCHed to tag_name=nightly while a published
+          # release still owns that tag (HTTP 200, not 422).
+          #
           # `--json id` returns the GraphQL node ID (RE_kwDO...), which
-          # `GET/PATCH /repos/{owner}/{repo}/releases/{release_id}` rejects with
-          # a 404. The REST endpoints need the numeric database ID.
+          # GET/PATCH /repos/{owner}/{repo}/releases/{release_id} rejects with a
+          # 404. The REST endpoints need the numeric database ID.
           STAGING_ID=$(gh release view nightly-staging --repo "$GITHUB_REPOSITORY" --json databaseId --jq '.databaseId')
           echo "Promoting staging release id=$STAGING_ID to nightly"
 
-          # Delete the live `nightly`, with the same retry the rest of this
-          # step uses, then verify it is actually gone. Swallowing this
-          # failure is what makes the stale-nightly path silent.
-          # Verify via the Releases LIST endpoint, which includes drafts. A
-          # by-tag lookup cannot see them, so a draft left tagged `nightly` by
-          # a run that retagged but died before un-drafting would be reported
-          # as absent — and the next run would retag onto an already-owned
-          # tag. Counting matches also fails closed: `! gh release view` is
-          # true for rate limits, auth failures and outages, not just 404, so
-          # it would break out of this loop as though the delete had worked.
+          # Delete every release tagged `nightly` BY ID, then the tag ref.
+          # `gh release delete nightly` resolves by tag and cannot remove a
+          # draft that a prior run left tagged `nightly`; that draft would then
+          # be undeletable while still being visible to the post-condition
+          # below, so every subsequent run would abort here and nightly would
+          # stay unpublished until someone cleaned up by hand.
           for attempt in 1 2 3; do
-            gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
-            remaining=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
-              --jq '[.[] | select(.tag_name == "nightly")] | length' 2>/dev/null || echo "unknown")
-            if [ "$remaining" = "0" ]; then
+            for rid in $(printf '%s' "$NIGHTLY_JSON" | jq -r '.[].id'); do
+              gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/${rid}" >/dev/null 2>&1 || true
+            done
+            # The by-ID delete has no `--cleanup-tag` equivalent, so drop the
+            # tag ref separately. Absent ref => 422, which is benign here.
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly" >/dev/null 2>&1 || true
+
+            NIGHTLY_JSON=$(list_nightly_releases 2>/dev/null || echo "")
+            if [ -n "$NIGHTLY_JSON" ] && [ "$(printf '%s' "$NIGHTLY_JSON" | jq 'length')" = "0" ]; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
-              echo "::error::nightly release still present after 3 delete attempts (remaining=$remaining — \"unknown\" means the query itself failed); aborting rather than risking a stale nightly"
+              echo "::error::releases tagged nightly still present after 3 delete attempts (${NIGHTLY_JSON:-enumeration failed}); aborting rather than risking a stale nightly"
               exit 1
             fi
-            echo "Delete attempt $attempt left remaining=$remaining; retrying in 5s"
+            echo "Delete attempt $attempt left ${NIGHTLY_JSON:-enumeration failed}; retrying in 5s"
             sleep 5
           done
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -715,18 +715,42 @@ jobs:
               gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/${rid}" >/dev/null 2>&1 || true
             done
             # The by-ID delete has no `--cleanup-tag` equivalent, so drop the
-            # tag ref separately. Absent ref => 422, which is benign here.
-            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly" >/dev/null 2>&1 || true
+            # tag ref separately. Only the documented absent-ref response is
+            # benign — swallowing a 5xx/403 here would leave the OLD ref in
+            # place while the release list reads empty, letting stage 1 retag
+            # against a stale ref.
+            if ref_err=$(gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly" 2>&1 >/dev/null); then
+              :
+            else
+              case "$ref_err" in
+                *"Reference does not exist"*|*"Not Found"*) ;;
+                *) echo "Tag-ref delete attempt $attempt did not succeed: $ref_err" ;;
+              esac
+            fi
 
+            # Post-condition: BOTH the release objects and the git ref must be
+            # gone. Checking only the release list would let a surviving ref
+            # through. `ref_state` distinguishes a real 404 from a transport
+            # error so an outage cannot masquerade as "already deleted".
             NIGHTLY_JSON=$(list_nightly_releases 2>/dev/null || echo "")
-            if [ -n "$NIGHTLY_JSON" ] && [ "$(printf '%s' "$NIGHTLY_JSON" | jq 'length')" = "0" ]; then
+            if ref_out=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly" 2>&1 >/dev/null); then
+              ref_state="present"
+            else
+              case "$ref_out" in
+                *"Not Found"*) ref_state="absent" ;;
+                *) ref_state="unknown" ;;
+              esac
+            fi
+            if [ -n "$NIGHTLY_JSON" ] \
+               && [ "$(printf '%s' "$NIGHTLY_JSON" | jq 'length')" = "0" ] \
+               && [ "$ref_state" = "absent" ]; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
-              echo "::error::releases tagged nightly still present after 3 delete attempts (${NIGHTLY_JSON:-enumeration failed}); aborting rather than risking a stale nightly"
+              echo "::error::nightly not fully removed after 3 delete attempts (releases=${NIGHTLY_JSON:-enumeration failed}, tag ref=$ref_state); aborting rather than retagging against a stale ref"
               exit 1
             fi
-            echo "Delete attempt $attempt left ${NIGHTLY_JSON:-enumeration failed}; retrying in 5s"
+            echo "Delete attempt $attempt left releases=${NIGHTLY_JSON:-enumeration failed}, tag ref=$ref_state; retrying in 5s"
             sleep 5
           done
 


### PR DESCRIPTION
### Summary

Nightly builds have been publishing successfully, but a large share of nightly users could not receive them. The nightly version counter **rewound** whenever a release tag landed, and semver reads a rewind as a downgrade. `tauri-plugin-updater` gates on `release.version > current_version` and we set no `version_comparator`, so a client on the higher pre-rewind build is told "up to date" indefinitely.

It rewound two ways:

1. **The release commit's nightly races the tag.** The run fires on the push, *before* release-please creates the tag, so `git describe` finds the previous tag and inflates the count. `ac716c73` (the `v0.27.0` release commit) built as `0.28.0-dev.4`; the next build counted from the new `v0.27.0` tag and dropped to `dev.1`.
2. **A patch release leaves the base version unchanged** while resetting the count — `v0.27.1` sent `dev.3` → `dev.0`.

Observed impact: a client on `0.28.0-dev.4.gac716c7` (2026-07-27) was refused **all 7 subsequent nightlies over 25 days**. This has recurred at every patch tag (`v0.5.1`, `v0.5.2`, `v0.5.3`, `v0.13.1`, `v0.20.1`, `v0.27.1`).

```mermaid
gantt
    title Published nightly versions vs a client stuck on dev.4
    dateFormat YYYY-MM-DD
    axisFormat %m-%d
    section Installed
    dev.4.gac716c7 (v0.27.0 release commit) :milestone, 2026-07-27, 0d
    section Published (all refused)
    dev.1.g8c22db7 :2026-07-28, 1d
    dev.2.g285ba41 :2026-07-30, 1d
    dev.3.g0db5c4e :2026-08-05, 1d
    dev.0.g0e108de (v0.27.1 rewind) :2026-08-06, 1d
    dev.1.g2fe88ea :2026-08-07, 1d
    dev.2.g422abc2 :2026-08-11, 1d
    dev.3.gf6f6978 :2026-08-18, 1d
```

**Fix:** use the total commit count on `HEAD`, which is monotonic across tags, plus a promote-time guard that refuses to publish a version sorting at or below the live one.

This PR also closes a silent **succeed-but-not-publish** path in the promote. The delete of the live `nightly` discarded both stderr and exit code with no post-condition check. If it no-opped, stage 1 retagged the draft while the old release survived, and stages 2/3 resolved `nightly` **by tag** — GitHub's get-release-by-tag endpoint does not return drafts, so they verified the *stale* published release, the smoke test passed against the *stale* manifest, and the job exited green with the new build stranded as a draft. The promote now captures the staging release ID before the retag and drives the un-draft and its verification by ID, and the delete gained the same retry plus a post-condition check.

### Complexity Notes

- **An identical version warns and republishes rather than refusing.** That is deliberate: re-running a workflow run is this repo's actual recovery procedure for a failed promote (used on 2026-08-11 → 08-14 after a runner TLS failure), and refusing on equality would break it. The guard's job is to block a *demote*, not to enforce strict inequality. An earlier revision of this PR description incorrectly listed equality as `REFUSE`.
- **The guard deliberately avoids two idiomatic-looking constructs.** `curl -sfL` is wrong here: under `set -euo pipefail`, `-f` would hard-fail the promote whenever `nightly` is legitimately absent, wedging recovery. `sort -V` is wrong as a semver comparator: `printf '0.28.0\n0.28.0-dev.3\n' | sort -V` orders the release *before* the prerelease, the opposite of semver. The inline Python comparator handles prerelease precedence correctly, including "a version with no prerelease outranks one with."
- **The by-tag → by-ID change is the subtle part.** The previous verification *looked* rigorous — it re-read the release and asserted `.draft == false` — but provably could not fail, because it queried an endpoint that cannot see the draft it was meant to check. Confirmed against the live GitHub API that a draft **can** be PATCHed to `tag_name=nightly` while a published release still owns that tag (HTTP 200, not 422), after which both `gh release view nightly` and `gh api .../releases/tags/nightly` resolve to the old published release.
- **The delete-verify loop tolerates read-after-delete lag** via 3 attempts with 5s sleeps; a repeated delete of an already-gone release is a harmless 404 absorbed by `|| true`.
- **Historical versions are not reproducible from history.** Recomputing `ac716c73` today yields `dev.0`, because `v0.27.0` now exists at that commit. The `dev.4` only reproduces by reconstructing what `git describe` saw at build time.
- No Rust or TypeScript changed — the diff is one workflow file.

### Test Steps

1. **Confirm the bug exists on `main`.** Recompute the published series with the old formula:
   ```bash
   git rev-list --count v0.26.0..ac716c73   # => 4, matching the stranded 0.28.0-dev.4.gac716c7
   ```
2. **Confirm the new formula is monotonic** across the same commits:
   ```bash
   for c in ac716c73 8c22db7c 285ba41e 0db5c4e7 0e108dec 2fe88ea6 422abc28 f6f69787; do
     echo "$c -> $(git rev-list --count $c)"
   done   # => 774 775 776 777 778 779 780 781, strictly increasing
   ```
3. **Exercise the guard's comparator** (the exact expression the workflow runs) and check all five cases:
   ```
   0.28.0-dev.0.g0e108de   vs 0.28.0-dev.3.g0db5c4e   -> REFUSE   (the 08-07 regression)
   0.28.0-dev.782.gabc1234 vs 0.28.0-dev.3.gf6f6978   -> PUBLISH
   0.28.0-dev.3.gf6f6978   vs 0.28.0-dev.3.gf6f6978   -> WARN, then republish (idempotent re-run)
   0.28.0                  vs 0.28.0-dev.999.gabc1234 -> PUBLISH  (release outranks prerelease)
   0.29.0-dev.1.gaaaaaaa   vs 0.28.0-dev.999.gbbbbbbb -> PUBLISH
   ```
4. **Lint the workflow:** `actionlint .github/workflows/nightly.yml` — one `SC2129` style finding, byte-identical to `main` (pre-existing, not introduced here).
5. **After merge**, confirm the nightly run publishes `0.28.0-dev.782.g<sha>` (or higher) and that `curl -sL https://github.com/utensils/claudette/releases/download/nightly/latest.json | jq -r .version` reports it.
6. **Confirm the promote still works end-to-end:** the run's `Publish Nightly` job should log `Promoting staging release id=<n> to nightly`, then `nightly release is now draft=false`, then a `HTTP 200` smoke result. Verify `gh release view nightly` shows `draft: false` with a full asset set and all 12 platform keys in `latest.json`.
7. **Stranded clients recover:** an app on `0.28.0-dev.4.gac716c7` should be offered the update on its next check (Settings → General → Check for updates).

### Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)

<sub>Note: no automated test covers `compute-version` — the formula lives in inline workflow shell. The comparator was verified manually (step 3). A follow-up could extract both into `scripts/` with unit tests.</sub>
