### PR TITLE
fix(chat): resolve backgrounded Workflow runs from the Rust notification path

### DIFF
--- a/site/src/content/docs/features/workflows.mdx
+++ b/site/src/content/docs/features/workflows.mdx
@@ -30,7 +30,9 @@ The pill disappears when the run ends — whether it completed, failed, or was t
 
 A completed run's tree is stored with the turn, so it renders the same after an app restart, in [forked sessions](/claudette/features/checkpoints-and-forking/), and when history is replayed from disk.
 
-Because a workflow typically finishes long after its turn was saved, Claudette writes the final tree back to that turn when the completion notification arrives.
+Because a workflow typically finishes long after its turn was saved, Claudette writes the final tree back to that turn when the completion notification arrives. That happens whether or not the run's session is the one on screen — you can start a workflow, switch to another workspace, and still find the finished tree waiting when you come back.
+
+A run's last progress update usually predates its final agent transitions, so a workflow that ends while agents are still shown mid-flight has them settled to match: finished for a completed run, stopped for one that ended early. Genuine failures keep their own state and still count toward the card's failure badge.
 
 A workflow runs inside the Claude Code process that started it, so it does not survive that process going away — quitting Claudette, stopping the agent, or resetting the session ends the run. Claudette marks those runs stopped rather than leaving them mid-flight: any still marked running when Claudette starts belongs to a process that is gone, and is resolved at launch. Their cards keep the tree as of the last progress update before the process ended.
 

--- a/src-tauri/src/commands/chat/checkpoint.rs
+++ b/src-tauri/src/commands/chat/checkpoint.rs
@@ -299,6 +299,15 @@ pub async fn save_turn_tool_activities(
 /// already been checkpointed. See
 /// [`claudette::db::Database::update_turn_tool_activity_progress`] for why a
 /// targeted update is needed rather than a re-save of the whole turn.
+///
+/// A terminal `agent_status` routes through
+/// [`claudette::db::Database::finish_workflow_activity`] so the caller's tree
+/// is reconciled against it. The webview holds the freshest snapshot (only it
+/// sees the `task_progress` ticks that arrive after the turn was
+/// checkpointed), but that snapshot predates the run's final transitions —
+/// writing it verbatim would put back the stale "48/49" the Rust-side
+/// notification handler had just resolved, since the two writers race.
+/// Reconciling on both paths makes the outcome order-independent.
 #[tauri::command]
 pub async fn update_turn_tool_activity_progress(
     tool_use_id: String,
@@ -307,12 +316,20 @@ pub async fn update_turn_tool_activity_progress(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    db.update_turn_tool_activity_progress(
-        &tool_use_id,
-        workflow_progress_json.as_deref(),
-        agent_status.as_deref(),
-    )
-    .map_err(|e| e.to_string())?;
+    match agent_status.as_deref() {
+        Some(status) if claudette::agent::workflow_progress::is_terminal_task_status(status) => {
+            db.finish_workflow_activity(&tool_use_id, status, workflow_progress_json.as_deref())
+                .map_err(|e| e.to_string())?;
+        }
+        _ => {
+            db.update_turn_tool_activity_progress(
+                &tool_use_id,
+                workflow_progress_json.as_deref(),
+                agent_status.as_deref(),
+            )
+            .map_err(|e| e.to_string())?;
+        }
+    }
     Ok(())
 }
 

--- a/src-tauri/src/commands/chat/checkpoint.rs
+++ b/src-tauri/src/commands/chat/checkpoint.rs
@@ -308,18 +308,34 @@ pub async fn save_turn_tool_activities(
 /// writing it verbatim would put back the stale "48/49" the Rust-side
 /// notification handler had just resolved, since the two writers race.
 /// Reconciling on both paths makes the outcome order-independent.
+///
+/// `chat_session_id` scopes that terminal write to one activity. Forking
+/// copies `tool_use_id` verbatim into the fork's rows (`crate::fork`), so
+/// without it a completion would rewrite the copied history in every fork.
+/// Optional so the command's existing payload stays valid: callers that omit
+/// it fall back to the unscoped update this command has always performed,
+/// rather than silently writing nothing.
 #[tauri::command]
 pub async fn update_turn_tool_activity_progress(
     tool_use_id: String,
     workflow_progress_json: Option<String>,
     agent_status: Option<String>,
+    chat_session_id: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    match agent_status.as_deref() {
-        Some(status) if claudette::agent::workflow_progress::is_terminal_task_status(status) => {
-            db.finish_workflow_activity(&tool_use_id, status, workflow_progress_json.as_deref())
-                .map_err(|e| e.to_string())?;
+    match (agent_status.as_deref(), chat_session_id.as_deref()) {
+        (Some(status), Some(session_id))
+            if claudette::agent::workflow_progress::is_terminal_task_status(status) =>
+        {
+            db.finish_workflow_activity(
+                session_id,
+                Some(&tool_use_id),
+                None,
+                status,
+                workflow_progress_json.as_deref(),
+            )
+            .map_err(|e| e.to_string())?;
         }
         _ => {
             db.update_turn_tool_activity_progress(

--- a/src-tauri/src/commands/chat/send/background_tasks.rs
+++ b/src-tauri/src/commands/chat/send/background_tasks.rs
@@ -11,7 +11,10 @@ use claudette::agent::background::{
     AgentBackgroundTaskEvent, AgentBackgroundTaskEventKind, append_terminal_output_sync,
     parse_bash_start, parse_task_notification, workspace_terminal_output_path,
 };
-use claudette::agent::{AgentEvent, InnerStreamEvent, StartContentBlock, StreamEvent};
+use claudette::agent::workflow_progress::WorkflowActivityStatusEvent;
+use claudette::agent::{
+    AgentEvent, InnerStreamEvent, StartContentBlock, StreamEvent, WorkflowProgressEntry,
+};
 use claudette::chat::{
     BuildAssistantArgs, assistant_usage_fields_from_result, build_assistant_chat_message,
     extract_assistant_text, extract_event_thinking,
@@ -239,11 +242,14 @@ pub(super) fn get_or_create_agent_shell_terminal_tab(
     Some(tab)
 }
 
+/// Whether a background task's status means the task has ended.
+///
+/// Delegates to the shared vocabulary in `claudette::agent::workflow_progress`.
+/// This used to be a local `matches!` that omitted `"error"` while the two
+/// other copies of the set (the frontend's and a SQL literal) included it —
+/// so an `error` notification re-armed the wake instead of resolving the run.
 fn is_terminal_task_status(status: &str) -> bool {
-    matches!(
-        status.to_ascii_lowercase().as_str(),
-        "completed" | "failed" | "stopped" | "killed" | "cancelled" | "canceled"
-    )
+    claudette::agent::workflow_progress::is_terminal_task_status(status)
 }
 
 pub(super) fn is_final_terminal_task_status(status: &str) -> bool {
@@ -598,6 +604,107 @@ impl BackgroundTaskInputTracker {
     }
 }
 
+/// Persist a backgrounded `Workflow` run's terminal outcome and tell the open
+/// UI about it.
+///
+/// This is the fix for the status pill that never cleared. The activity row
+/// used to be written only from the webview's `task_notification` handler, but
+/// for a backgrounded run that notification arrives *after* the launching turn
+/// has ended — and the per-turn `agent-stream` forwarder is torn down at the
+/// turn's `Result` (`claudette::agent::session`), so nothing carried it to the
+/// webview. The write never happened, the row stayed `"running"`, and the pill
+/// came back on every reload, forever.
+///
+/// Doing it here covers all three notification routes at once, since every one
+/// of them funnels through [`apply_task_notification_status`]: the in-turn
+/// stream, the wake loop's terminal break, and the post-wake drain.
+///
+/// Failures are logged and swallowed. A missed write costs a stale pill until
+/// the next boot sweep — it must not take down the wake machinery that reports
+/// the task's result back to the user.
+#[allow(clippy::too_many_arguments)]
+fn resolve_workflow_activity(
+    app: &AppHandle,
+    db: &Database,
+    workspace_id: &str,
+    chat_session_id: &str,
+    task_id: &str,
+    tool_use_id: Option<&str>,
+    status: &str,
+) {
+    // `tool_use_id` is optional on `task_notification`, and nothing in this
+    // repo pins whether the CLI populates it for every workflow. Fall back to
+    // the task id, which the row records from the `task_started` /
+    // `task_progress` events — those carry both, so the join is always
+    // available by the time a run can end.
+    let resolved_id;
+    let tool_use_id = match tool_use_id {
+        Some(id) => id,
+        None => match db.find_workflow_activity_by_task_id(task_id) {
+            Ok(Some(id)) => {
+                resolved_id = id;
+                resolved_id.as_str()
+            }
+            // No match is the ordinary case for background Bash and
+            // backgrounded subagents: they share this notification path but
+            // own no `Workflow` row.
+            Ok(None) => return,
+            Err(err) => {
+                tracing::warn!(
+                    target: "claudette::chat",
+                    task_id,
+                    error = %err,
+                    "failed to resolve workflow activity by task id"
+                );
+                return;
+            }
+        },
+    };
+    let resolution = match db.finish_workflow_activity(tool_use_id, status, None) {
+        Ok(resolution) => resolution,
+        Err(err) => {
+            tracing::warn!(
+                target: "claudette::chat",
+                tool_use_id,
+                status,
+                error = %err,
+                "failed to persist terminal workflow status"
+            );
+            return;
+        }
+    };
+    // Zero rows is the ordinary outcome for every non-Workflow background task
+    // (a background Bash, a backgrounded subagent) — they share this
+    // notification path but own no `Workflow` activity row. Staying quiet
+    // keeps the log signal about workflows only.
+    if resolution.rows_updated == 0 {
+        return;
+    }
+    // Logged at info because this pipeline was previously invisible: a search
+    // of the shipped logs for "workflow" or "task_notification" returned
+    // nothing, which is part of why the wedge went undiagnosed for so long.
+    tracing::info!(
+        target: "claudette::chat",
+        tool_use_id,
+        status,
+        "resolved workflow activity from terminal task notification"
+    );
+    let workflow_progress = resolution
+        .tree_json
+        .as_deref()
+        .and_then(|json| serde_json::from_str::<Vec<WorkflowProgressEntry>>(json).ok());
+    let _ = app.emit(
+        "workflow-activity-status",
+        &WorkflowActivityStatusEvent {
+            workspace_id: workspace_id.to_string(),
+            chat_session_id: chat_session_id.to_string(),
+            tool_use_id: tool_use_id.to_string(),
+            status: status.to_string(),
+            workflow_progress,
+        },
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn apply_task_notification_status(
     app: &AppHandle,
@@ -634,15 +741,26 @@ pub(super) async fn apply_task_notification_status(
         })
     };
     if is_terminal_task_status(status) {
-        let mut agents = app_state.agents.write().await;
-        if let Some(session) = agents.get_mut(chat_session_id) {
-            session.running_background_tasks.remove(task_id);
-            session.background_task_output_paths.remove(task_id);
-            if let Some(tool_use_id) = tool_use_id {
-                session.running_background_tasks.remove(tool_use_id);
-                session.background_task_output_paths.remove(tool_use_id);
+        {
+            let mut agents = app_state.agents.write().await;
+            if let Some(session) = agents.get_mut(chat_session_id) {
+                session.running_background_tasks.remove(task_id);
+                session.background_task_output_paths.remove(task_id);
+                if let Some(tool_use_id) = tool_use_id {
+                    session.running_background_tasks.remove(tool_use_id);
+                    session.background_task_output_paths.remove(tool_use_id);
+                }
             }
         }
+        resolve_workflow_activity(
+            app,
+            &db,
+            workspace_id,
+            chat_session_id,
+            task_id,
+            tool_use_id,
+            status,
+        );
     }
     let _ = db.update_agent_task_terminal_tab_status(
         chat_session_id,
@@ -1138,7 +1256,7 @@ pub(super) fn schedule_background_task_wake(
 mod tests {
     use super::{
         BackgroundTaskCompletion, BackgroundTaskInputTracker,
-        build_background_task_completion_prompt, markdown_code_fence_for,
+        build_background_task_completion_prompt, is_terminal_task_status, markdown_code_fence_for,
         should_arm_wake_for_status, should_defer_persistent_restart_for_state, terminal_text,
     };
     use claudette::agent::{
@@ -1237,6 +1355,27 @@ mod tests {
             !tracker.is_bash_tool_result("cmd-1"),
             "a structured Codex terminal completion must prevent the legacy ToolResult fallback"
         );
+    }
+
+    /// Regression: this module carried its own copy of the terminal-status
+    /// set that omitted `"error"`, while the frontend's copy and the boot
+    /// sweep's SQL literal both included it. An `error` notification therefore
+    /// re-armed the wake instead of resolving the run, and the activity row
+    /// stayed in flight forever. All three now read one shared vocabulary.
+    #[test]
+    fn terminal_task_statuses_match_the_shared_vocabulary() {
+        for status in claudette::agent::workflow_progress::TERMINAL_TASK_STATUSES {
+            assert!(
+                is_terminal_task_status(status),
+                "{status} must be terminal here too"
+            );
+            assert!(
+                !should_arm_wake_for_status(status),
+                "{status} must not re-arm the wake"
+            );
+        }
+        assert!(should_arm_wake_for_status("running"));
+        assert!(should_arm_wake_for_status("starting"));
     }
 
     #[test]

--- a/src-tauri/src/commands/chat/send/background_tasks.rs
+++ b/src-tauri/src/commands/chat/send/background_tasks.rs
@@ -632,39 +632,22 @@ fn resolve_workflow_activity(
     tool_use_id: Option<&str>,
     status: &str,
 ) {
-    // `tool_use_id` is optional on `task_notification`, and nothing in this
-    // repo pins whether the CLI populates it for every workflow. Fall back to
-    // the task id, which the row records from the `task_started` /
-    // `task_progress` events — those carry both, so the join is always
-    // available by the time a run can end.
-    let resolved_id;
-    let tool_use_id = match tool_use_id {
-        Some(id) => id,
-        None => match db.find_workflow_activity_by_task_id(task_id) {
-            Ok(Some(id)) => {
-                resolved_id = id;
-                resolved_id.as_str()
-            }
-            // No match is the ordinary case for background Bash and
-            // backgrounded subagents: they share this notification path but
-            // own no `Workflow` row.
-            Ok(None) => return,
-            Err(err) => {
-                tracing::warn!(
-                    target: "claudette::chat",
-                    task_id,
-                    error = %err,
-                    "failed to resolve workflow activity by task id"
-                );
-                return;
-            }
-        },
-    };
-    let resolution = match db.finish_workflow_activity(tool_use_id, status, None) {
+    // Resolution is session-scoped and falls back from `tool_use_id` (optional
+    // on `task_notification`) to `task_id`, which the row records from the
+    // `task_started` / `task_progress` events — those carry both, so the join
+    // is always available by the time a run can end.
+    let resolution = match db.finish_workflow_activity(
+        chat_session_id,
+        tool_use_id,
+        Some(task_id),
+        status,
+        None,
+    ) {
         Ok(resolution) => resolution,
         Err(err) => {
             tracing::warn!(
                 target: "claudette::chat",
+                task_id,
                 tool_use_id,
                 status,
                 error = %err,
@@ -685,6 +668,7 @@ fn resolve_workflow_activity(
     // nothing, which is part of why the wedge went undiagnosed for so long.
     tracing::info!(
         target: "claudette::chat",
+        task_id,
         tool_use_id,
         status,
         "resolved workflow activity from terminal task notification"
@@ -693,12 +677,17 @@ fn resolve_workflow_activity(
         .tree_json
         .as_deref()
         .and_then(|json| serde_json::from_str::<Vec<WorkflowProgressEntry>>(json).ok());
+    // The resolved id, not the one on the event: a notification may name only
+    // its `task_id`, and the UI keys on the tool use.
+    let Some(resolved_tool_use_id) = resolution.tool_use_id else {
+        return;
+    };
     let _ = app.emit(
         "workflow-activity-status",
         &WorkflowActivityStatusEvent {
             workspace_id: workspace_id.to_string(),
             chat_session_id: chat_session_id.to_string(),
-            tool_use_id: tool_use_id.to_string(),
+            tool_use_id: resolved_tool_use_id,
             status: status.to_string(),
             workflow_progress,
         },

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -9,6 +9,7 @@ mod naming;
 mod process;
 mod session;
 mod types;
+pub mod workflow_progress;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/agent/workflow_progress.rs
+++ b/src/agent/workflow_progress.rs
@@ -1,0 +1,324 @@
+//! Terminal-status vocabulary for background tasks, and reconciliation of a
+//! `Workflow` run's progress tree against that status.
+//!
+//! # Why this module exists
+//!
+//! Two independent facts describe a backgrounded `Workflow`:
+//!
+//! * its **task status** — `running` until a terminal `task_notification`
+//!   arrives, then `completed` / `failed` / `stopped` / …
+//! * its **progress tree** — the `workflow_progress` snapshot the CLI attaches
+//!   to `task_progress` events, from which the UI derives "42 of 49 agents
+//!   done".
+//!
+//! Nothing used to reconcile them, and they are delivered on different
+//! schedules: the tree only accompanies real agent state transitions, while
+//! the status arrives once at the end. A run whose last delivered snapshot
+//! still showed agents in flight therefore kept advertising an unfinished
+//! fraction forever, even after reporting `completed` — the "48/49 that never
+//! goes away" bug. [`reconcile_tree_on_terminal`] closes that by stamping the
+//! stragglers when the run's own status says it is over, which makes the
+//! invariant *finished ⇒ no agent left non-terminal* hold by construction
+//! instead of by hoping the last snapshot landed.
+//!
+//! The terminal-status set lives here too because it had drifted into three
+//! copies — this crate, the Tauri command layer, and a SQL literal — with a
+//! comment asking humans to keep them in sync. They now all read from
+//! [`is_terminal_task_status`] / [`TERMINAL_TASK_STATUSES`].
+
+use serde::Serialize;
+
+use crate::agent::types::WorkflowProgressEntry;
+
+/// Payload of the `workflow-activity-status` Tauri event.
+///
+/// Emitted when a backgrounded `Workflow` run reaches a terminal status, so
+/// the open UI drops its status pill and settles its card without waiting for
+/// a reload. The database write has already happened by the time this is sent
+/// — this event is a live-update convenience, never the source of truth. That
+/// split is deliberate: the store may not have the owning session hydrated
+/// (its transcript was never opened, or the app restarted since), in which
+/// case applying the event is a no-op and the next hydrate reads the correct
+/// row from disk anyway.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkflowActivityStatusEvent {
+    pub workspace_id: String,
+    pub chat_session_id: String,
+    pub tool_use_id: String,
+    /// The run's own terminal status (`completed`, `failed`, …) — not a
+    /// synthesized sentinel, so the card reports what actually happened.
+    pub status: String,
+    /// Reconciled progress tree. `None` when the row carried no readable tree,
+    /// which the consumer must treat as "keep what you have" rather than
+    /// "clear it".
+    pub workflow_progress: Option<Vec<WorkflowProgressEntry>>,
+}
+
+/// Every status value that means a background task has ended.
+///
+/// The Claude CLI declares a closed enum for the notification that ends a run
+/// (`status: z.enum(["completed", "failed", "stopped"])`). `"killed"` comes
+/// from the adjacent `task_updated.patch.status` channel, which Claudette does
+/// not consume yet but which must not be able to reintroduce a wedge if it is
+/// ever wired up. `"error"` / `"cancelled"` / `"canceled"` appear in neither
+/// schema and are tolerated aliases.
+///
+/// The asymmetry that justifies being generous here: a false positive costs a
+/// finished run stopping being advertised, while a false negative is an
+/// indicator that never goes away. The second is the failure this set exists
+/// to prevent.
+///
+/// Kept in sync with `TERMINAL_BACKGROUND_TASK_STATUSES` in
+/// `src/ui/src/types/backgroundTaskStatus.ts`, which the UI needs for rows
+/// loaded straight from the database.
+pub const TERMINAL_TASK_STATUSES: &[&str] = &[
+    "completed",
+    "failed",
+    "stopped",
+    "killed",
+    "error",
+    "cancelled",
+    "canceled",
+];
+
+/// Whether a background task's status means the task itself has ended.
+///
+/// `""` is not terminal: a row checkpointed before its first progress tick has
+/// no status yet and is genuinely still starting.
+pub fn is_terminal_task_status(status: &str) -> bool {
+    let status = status.trim().to_ascii_lowercase();
+    TERMINAL_TASK_STATUSES.contains(&status.as_str())
+}
+
+/// Status recorded for a background task whose owning CLI process went away
+/// without ever reporting an outcome.
+///
+/// Deliberately `"stopped"` rather than a Claudette-specific sentinel: it is a
+/// real value in the CLI's own `task_notification` enum with exactly this
+/// meaning, so a reaped row needs no special-casing at any read site. Mirrored
+/// by `REAPED_BACKGROUND_TASK_STATUS` in
+/// `src/ui/src/types/backgroundTaskStatus.ts`.
+pub const REAPED_TASK_STATUS: &str = "stopped";
+
+/// Agent states that will not change again.
+///
+/// `"stopped"` is included so [`reconcile_tree_on_terminal`] has an honest
+/// value for an agent that never finished on a run that did not complete —
+/// stamping those `"done"` would claim work that never happened, and stamping
+/// them `"error"` would inflate the failure badge for a run the user simply
+/// cancelled. Mirrored by `TERMINAL_AGENT_STATES` in
+/// `src/ui/src/types/workflow.ts`.
+const TERMINAL_AGENT_STATES: &[&str] = &["done", "error", "stopped"];
+
+fn is_terminal_agent_state(state: &str) -> bool {
+    TERMINAL_AGENT_STATES.contains(&state.trim().to_ascii_lowercase().as_str())
+}
+
+/// The state to stamp on agents still in flight when a run reaches `status`.
+///
+/// Only a `completed` run may claim its stragglers finished their work; every
+/// other terminal status means the run ended without them getting there.
+fn straggler_state_for(status: &str) -> &'static str {
+    if status.trim().eq_ignore_ascii_case("completed") {
+        "done"
+    } else {
+        "stopped"
+    }
+}
+
+/// Stamp every non-terminal agent in `entries` as terminal, because the run
+/// that owns them has reported `status`.
+///
+/// No-op unless `status` is terminal, so a `running` tick can never
+/// prematurely close out agents. Agents already in a terminal state keep the
+/// state they reported — a genuine `error` is never rewritten to `done` by a
+/// run that completed despite it.
+///
+/// Returns the number of agents changed, so callers can skip a database write
+/// when there was nothing to fix.
+pub fn reconcile_tree_on_terminal(entries: &mut [WorkflowProgressEntry], status: &str) -> usize {
+    if !is_terminal_task_status(status) {
+        return 0;
+    }
+    let stamped = straggler_state_for(status);
+    let mut changed = 0;
+    for entry in entries.iter_mut() {
+        // Phase headings and entry kinds we don't model carry no state to
+        // reconcile. `Unknown` deliberately stays untouched rather than being
+        // dropped: it round-trips as `{"type":"Unknown"}` either way, and
+        // discarding entries here would silently shrink a tree the UI keys on
+        // by position.
+        let WorkflowProgressEntry::Agent(agent) = entry else {
+            continue;
+        };
+        if is_terminal_agent_state(&agent.state) {
+            continue;
+        }
+        agent.state = stamped.to_string();
+        changed += 1;
+    }
+    changed
+}
+
+/// Apply [`reconcile_tree_on_terminal`] to a serialized tree.
+///
+/// Returns `None` when nothing changed — including when the JSON is
+/// unparseable. A tree we cannot read is one we must not overwrite: the stored
+/// value is the only copy, and replacing it with `[]` would turn a stale
+/// display into a permanently blank one.
+pub fn reconcile_tree_json_on_terminal(tree_json: &str, status: &str) -> Option<String> {
+    if !is_terminal_task_status(status) {
+        return None;
+    }
+    let mut entries: Vec<WorkflowProgressEntry> = serde_json::from_str(tree_json).ok()?;
+    if reconcile_tree_on_terminal(&mut entries, status) == 0 {
+        return None;
+    }
+    serde_json::to_string(&entries).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::types::WorkflowAgentProgress;
+
+    fn agent(index: i64, state: &str) -> WorkflowProgressEntry {
+        WorkflowProgressEntry::Agent(Box::new(WorkflowAgentProgress {
+            index,
+            label: format!("agent-{index}"),
+            state: state.to_string(),
+            ..Default::default()
+        }))
+    }
+
+    fn state_of(entry: &WorkflowProgressEntry) -> &str {
+        match entry {
+            WorkflowProgressEntry::Agent(a) => a.state.as_str(),
+            _ => "",
+        }
+    }
+
+    #[test]
+    fn terminal_status_set_includes_the_alias_the_command_layer_used_to_miss() {
+        // Regression: `background_tasks.rs` had its own copy of this set that
+        // omitted "error", so an `error` notification re-armed the wake and
+        // never resolved the activity. Every copy now delegates here.
+        for status in ["completed", "failed", "stopped", "killed", "error"] {
+            assert!(is_terminal_task_status(status), "{status} must be terminal");
+        }
+        assert!(is_terminal_task_status("Completed"), "case-insensitive");
+        assert!(is_terminal_task_status("  failed  "), "trimmed");
+    }
+
+    #[test]
+    fn in_flight_statuses_are_not_terminal() {
+        for status in ["running", "starting", "paused", "", "  "] {
+            assert!(
+                !is_terminal_task_status(status),
+                "{status:?} must not be terminal"
+            );
+        }
+    }
+
+    #[test]
+    fn completed_run_stamps_stragglers_done() {
+        // The exact shape behind the reported bug: every agent still reads
+        // `progress` in the last snapshot that reached us, so the UI renders
+        // "0/5" for a run that finished.
+        let mut tree = vec![
+            WorkflowProgressEntry::Phase {
+                index: 0,
+                title: "Investigate".to_string(),
+            },
+            agent(1, "progress"),
+            agent(2, "progress"),
+            agent(3, "queued"),
+        ];
+        assert_eq!(reconcile_tree_on_terminal(&mut tree, "completed"), 3);
+        assert_eq!(state_of(&tree[1]), "done");
+        assert_eq!(state_of(&tree[2]), "done");
+        assert_eq!(state_of(&tree[3]), "done");
+        // The phase heading survives — the UI keys its grouping on it.
+        assert!(matches!(tree[0], WorkflowProgressEntry::Phase { .. }));
+    }
+
+    #[test]
+    fn non_completed_terminal_status_stamps_stopped_not_done() {
+        // A cancelled run must not claim its unfinished agents succeeded, and
+        // must not inflate the failure badge either.
+        for status in ["stopped", "killed", "cancelled"] {
+            let mut tree = vec![agent(1, "progress")];
+            assert_eq!(reconcile_tree_on_terminal(&mut tree, status), 1);
+            assert_eq!(state_of(&tree[0]), "stopped", "for status {status}");
+        }
+    }
+
+    #[test]
+    fn already_terminal_agents_keep_their_own_outcome() {
+        // A run can complete with a failed agent (the script filtered it out).
+        // Rewriting that to `done` would erase a real failure from the card.
+        let mut tree = vec![agent(1, "done"), agent(2, "error"), agent(3, "progress")];
+        assert_eq!(reconcile_tree_on_terminal(&mut tree, "completed"), 1);
+        assert_eq!(state_of(&tree[0]), "done");
+        assert_eq!(state_of(&tree[1]), "error");
+        assert_eq!(state_of(&tree[2]), "done");
+    }
+
+    #[test]
+    fn non_terminal_status_is_a_no_op() {
+        // Guards the ordering hazard: reconciliation is driven by the same
+        // notification path that also sees `running` ticks, and closing agents
+        // out on one of those would freeze a live run's card.
+        let mut tree = vec![agent(1, "progress"), agent(2, "queued")];
+        assert_eq!(reconcile_tree_on_terminal(&mut tree, "running"), 0);
+        assert_eq!(state_of(&tree[0]), "progress");
+        assert_eq!(state_of(&tree[1]), "queued");
+    }
+
+    #[test]
+    fn unknown_entries_are_preserved_not_dropped() {
+        let mut tree = vec![
+            WorkflowProgressEntry::Unknown,
+            agent(1, "progress"),
+            WorkflowProgressEntry::Unknown,
+        ];
+        assert_eq!(reconcile_tree_on_terminal(&mut tree, "completed"), 1);
+        assert_eq!(tree.len(), 3);
+        assert!(matches!(tree[0], WorkflowProgressEntry::Unknown));
+        assert!(matches!(tree[2], WorkflowProgressEntry::Unknown));
+    }
+
+    #[test]
+    fn json_helper_returns_none_when_nothing_changes() {
+        let already_done = r#"[{"type":"workflow_agent","index":1,"label":"a","state":"done"}]"#;
+        assert_eq!(
+            reconcile_tree_json_on_terminal(already_done, "completed"),
+            None
+        );
+        assert_eq!(reconcile_tree_json_on_terminal("[]", "completed"), None);
+    }
+
+    #[test]
+    fn json_helper_refuses_to_rewrite_an_unparseable_tree() {
+        // The stored tree is the only copy. Replacing garbage with `[]` would
+        // convert a stale card into a permanently blank one.
+        assert_eq!(
+            reconcile_tree_json_on_terminal("not json", "completed"),
+            None
+        );
+        assert_eq!(
+            reconcile_tree_json_on_terminal(r#"{"not":"an array"}"#, "completed"),
+            None
+        );
+    }
+
+    #[test]
+    fn json_helper_round_trips_a_reconciled_tree() {
+        let json = r#"[{"type":"workflow_phase","index":0,"title":"Investigate"},
+                       {"type":"workflow_agent","index":1,"label":"probe","state":"progress"}]"#;
+        let out = reconcile_tree_json_on_terminal(json, "completed").expect("tree changed");
+        let entries: Vec<WorkflowProgressEntry> = serde_json::from_str(&out).unwrap();
+        assert_eq!(state_of(&entries[1]), "done");
+        assert!(matches!(entries[0], WorkflowProgressEntry::Phase { .. }));
+    }
+}

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -1086,8 +1086,22 @@ impl Database {
         // right outcome for a run that never reported agents and for a tree we
         // could not parse.
         let to_write = reconciled.as_deref().or(incoming_tree_json);
-        let rows_updated =
-            self.update_turn_tool_activity_progress(tool_use_id, to_write, Some(status))?;
+        // Carries the same `tool_name = 'Workflow'` predicate as the SELECT
+        // above rather than delegating to `update_turn_tool_activity_progress`,
+        // which matches on `tool_use_id` alone. There is no unique constraint
+        // on that column, so a duplicate id shared with a non-Workflow row
+        // would otherwise be rewritten too — and the caller may have arrived
+        // here from `find_workflow_activity_by_task_id`, where the id came out
+        // of a lookup rather than straight from the event. Same COALESCE
+        // semantics: `None` leaves the stored column untouched.
+        let rows_updated = self.conn.execute(
+            "UPDATE turn_tool_activities
+                SET workflow_progress_json =
+                        COALESCE(?1, workflow_progress_json),
+                    agent_status = COALESCE(?2, agent_status)
+              WHERE tool_use_id = ?3 AND tool_name = 'Workflow'",
+            params![to_write, status, tool_use_id],
+        )?;
         Ok(WorkflowActivityResolution {
             rows_updated,
             tree_json: Some(to_write.unwrap_or(&stored_tree).to_string()),
@@ -1930,6 +1944,55 @@ mod tests {
                 .unwrap()
                 .rows_updated,
             0
+        );
+    }
+
+    /// `tool_use_id` has no unique index, so the terminal write carries the
+    /// same `tool_name = 'Workflow'` predicate as the read that precedes it.
+    /// Without it a duplicate id shared with another tool's row would be
+    /// rewritten too, contradicting what this method documents about its own
+    /// scope.
+    #[test]
+    fn test_finish_workflow_activity_update_is_scoped_to_workflow_rows() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+
+        let mut wf = make_tool_activity("a1", "cp1", "Workflow", 0);
+        wf.agent_status = Some("running".into());
+        // Same `tool_use_id`, different tool. Contrived — ids from the API are
+        // unique in practice — but nothing in the schema prevents it, and the
+        // write must not depend on that holding.
+        let mut collided = make_tool_activity("a2", "cp1", "Bash", 1);
+        collided.tool_use_id = "tu_a1".into();
+        collided.agent_status = Some("running".into());
+        db.insert_turn_tool_activities(&[wf, collided]).unwrap();
+
+        let resolution = db
+            .finish_workflow_activity("tu_a1", "completed", None)
+            .unwrap();
+        assert_eq!(
+            resolution.rows_updated, 1,
+            "only the Workflow row is written"
+        );
+
+        let turns = db.list_completed_turns("w1").unwrap();
+        let by_tool = |tool: &str| {
+            turns[0]
+                .activities
+                .iter()
+                .find(|a| a.tool_name == tool)
+                .unwrap()
+                .agent_status
+                .clone()
+        };
+        assert_eq!(by_tool("Workflow").as_deref(), Some("completed"));
+        assert_eq!(
+            by_tool("Bash").as_deref(),
+            Some("running"),
+            "the colliding non-Workflow row must be left alone"
         );
     }
 

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -26,6 +26,10 @@ pub struct WorkflowActivityResolution {
     /// `None` when no row matched. Callers forward this to the UI so a live
     /// card stops contradicting the status it just received.
     pub tree_json: Option<String>,
+    /// The resolved row's `tool_use_id`. `None` when no row matched. Callers
+    /// forward this rather than echoing the id they passed in: a notification
+    /// may identify its run only by `task_id`, and the UI keys on the tool use.
+    pub tool_use_id: Option<String>,
 }
 
 #[derive(Debug)]
@@ -1008,8 +1012,12 @@ impl Database {
     /// pill that had otherwise cleared. See
     /// [`crate::agent::workflow_progress::reconcile_tree_on_terminal`].
     ///
-    /// Scoped to `tool_name = 'Workflow'` so a `task_id` collision with some
-    /// other tool's activity cannot rewrite it.
+    /// Identified by `tool_use_id` within `chat_session_id`, falling back to
+    /// `task_id`. Both ids are copied verbatim into a fork's own rows
+    /// (`crate::fork`), so neither identifies a single activity on its own —
+    /// without the session scope, completing a run in one session would
+    /// rewrite the copied history in every fork of it, and `rows_updated` and
+    /// the returned tree would stop describing one activity.
     ///
     /// Pass `incoming_tree_json` when the caller holds a fresher snapshot than
     /// the row does — the webview does, since only it sees the `task_progress`
@@ -1022,33 +1030,60 @@ impl Database {
     /// later from its own handler. Whichever lands last still leaves a
     /// reconciled tree, so the stale fraction cannot come back.
     ///
-    /// A row whose turn was never checkpointed matches nothing, which reports
-    /// [`WorkflowActivityResolution::rows_updated`] `== 0` rather than
+    /// A run whose turn was never checkpointed resolves to no row, which
+    /// reports [`WorkflowActivityResolution::rows_updated`] `== 0` rather than
     /// erroring — that is the normal outcome for a run stopped before its
     /// first checkpoint, and there is no row to resurrect a pill from either.
-    /// The `tool_use_id` of the `Workflow` activity a background task belongs
-    /// to, found by the task id the CLI assigned it.
+    /// The row id of the `Workflow` activity a background task belongs to,
+    /// within one chat session.
     ///
-    /// The fallback for a `task_notification` that identifies its task but not
-    /// the originating tool use — `tool_use_id` is optional on that event, and
-    /// nothing in this repo pins whether the CLI populates it for every
-    /// workflow. `agent_task_id` is recorded on the row from the
-    /// `task_started` / `task_progress` events, which do carry both, so the
-    /// join is always available by the time a run can end.
+    /// Session scope is load-bearing, not defensive. Forking copies both
+    /// `tool_use_id` and `agent_task_id` verbatim into the fork's own rows
+    /// (`crate::fork`), so neither id identifies a single activity across the
+    /// database — a global lookup can hand back a fork's copy for a completion
+    /// that belongs to the source session, and the tree read off that row then
+    /// gets written and broadcast as if it were the live run's.
     ///
-    /// Newest row wins. Task ids are effectively unique, but a resumed or
-    /// forked session can duplicate one, and the most recent row is the live
-    /// one in that case.
+    /// Returns the row's primary key rather than its `tool_use_id`, so the
+    /// caller's write can target exactly the activity that was resolved.
+    ///
+    /// `task_id` is the fallback identifier for a `task_notification` that
+    /// names its task but not the originating tool use — `tool_use_id` is
+    /// optional on that event, and nothing in this repo pins whether the CLI
+    /// populates it for every workflow. `agent_task_id` is recorded from the
+    /// `task_started` / `task_progress` events, which carry both, so the join
+    /// is always available by the time a run can end.
+    ///
+    /// Newest row wins within the session: a resumed session can re-emit an
+    /// id, and the most recent row is the live one.
     pub fn find_workflow_activity_by_task_id(
         &self,
+        chat_session_id: &str,
         task_id: &str,
+    ) -> Result<Option<String>, rusqlite::Error> {
+        self.find_workflow_activity_row(chat_session_id, "agent_task_id", task_id)
+    }
+
+    /// Session-scoped row lookup shared by the `tool_use_id` and
+    /// `agent_task_id` paths. `column` is a literal chosen by the two callers
+    /// below, never caller input.
+    fn find_workflow_activity_row(
+        &self,
+        chat_session_id: &str,
+        column: &str,
+        value: &str,
     ) -> Result<Option<String>, rusqlite::Error> {
         self.conn
             .query_row(
-                "SELECT tool_use_id FROM turn_tool_activities
-                  WHERE tool_name = 'Workflow' AND agent_task_id = ?1
-                  ORDER BY rowid DESC LIMIT 1",
-                params![task_id],
+                &format!(
+                    "SELECT ta.id FROM turn_tool_activities ta
+                       JOIN conversation_checkpoints cp ON cp.id = ta.checkpoint_id
+                      WHERE ta.tool_name = 'Workflow'
+                        AND ta.{column} = ?1
+                        AND cp.chat_session_id = ?2
+                      ORDER BY ta.rowid DESC LIMIT 1"
+                ),
+                params![value, chat_session_id],
                 |row| row.get(0),
             )
             .optional()
@@ -1056,23 +1091,61 @@ impl Database {
 
     pub fn finish_workflow_activity(
         &self,
-        tool_use_id: &str,
+        chat_session_id: &str,
+        tool_use_id: Option<&str>,
+        task_id: Option<&str>,
         status: &str,
         incoming_tree_json: Option<&str>,
     ) -> Result<WorkflowActivityResolution, rusqlite::Error> {
-        let stored_tree: Option<String> = self
-            .conn
-            .query_row(
-                "SELECT workflow_progress_json FROM turn_tool_activities
-                  WHERE tool_use_id = ?1 AND tool_name = 'Workflow'",
-                params![tool_use_id],
-                |row| row.get(0),
-            )
-            .optional()?;
-        let Some(stored_tree) = stored_tree else {
+        let mut row_id = match tool_use_id {
+            Some(id) => self.find_workflow_activity_row(chat_session_id, "tool_use_id", id)?,
+            None => None,
+        };
+        if row_id.is_none()
+            && let Some(task_id) = task_id
+        {
+            row_id = self.find_workflow_activity_by_task_id(chat_session_id, task_id)?;
+        }
+        let Some(row_id) = row_id else {
             return Ok(WorkflowActivityResolution {
                 rows_updated: 0,
                 tree_json: None,
+                tool_use_id: None,
+            });
+        };
+        self.finish_workflow_activity_row(&row_id, status, incoming_tree_json)
+    }
+
+    /// [`Database::finish_workflow_activity`] against an already-resolved row.
+    ///
+    /// Targets the activity's primary key, which is the only identifier that
+    /// names exactly one row: `tool_use_id` and `agent_task_id` are both
+    /// duplicated across forks, and `tool_use_id` additionally has no unique
+    /// index, so a value shared with another tool's row would be caught by a
+    /// looser predicate.
+    ///
+    /// Used directly by the boot sweep, which already holds the ids of the
+    /// rows it selected and has no session to scope by.
+    pub fn finish_workflow_activity_row(
+        &self,
+        activity_id: &str,
+        status: &str,
+        incoming_tree_json: Option<&str>,
+    ) -> Result<WorkflowActivityResolution, rusqlite::Error> {
+        let row: Option<(String, String)> = self
+            .conn
+            .query_row(
+                "SELECT workflow_progress_json, tool_use_id FROM turn_tool_activities
+                  WHERE id = ?1 AND tool_name = 'Workflow'",
+                params![activity_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        let Some((stored_tree, tool_use_id)) = row else {
+            return Ok(WorkflowActivityResolution {
+                rows_updated: 0,
+                tree_json: None,
+                tool_use_id: None,
             });
         };
         let effective_tree = incoming_tree_json.unwrap_or(&stored_tree);
@@ -1086,25 +1159,22 @@ impl Database {
         // right outcome for a run that never reported agents and for a tree we
         // could not parse.
         let to_write = reconciled.as_deref().or(incoming_tree_json);
-        // Carries the same `tool_name = 'Workflow'` predicate as the SELECT
-        // above rather than delegating to `update_turn_tool_activity_progress`,
-        // which matches on `tool_use_id` alone. There is no unique constraint
-        // on that column, so a duplicate id shared with a non-Workflow row
-        // would otherwise be rewritten too — and the caller may have arrived
-        // here from `find_workflow_activity_by_task_id`, where the id came out
-        // of a lookup rather than straight from the event. Same COALESCE
+        // Keyed on the primary key rather than delegating to
+        // `update_turn_tool_activity_progress`, which matches on `tool_use_id`
+        // alone and would fan the write out across forks. Same COALESCE
         // semantics: `None` leaves the stored column untouched.
         let rows_updated = self.conn.execute(
             "UPDATE turn_tool_activities
                 SET workflow_progress_json =
                         COALESCE(?1, workflow_progress_json),
                     agent_status = COALESCE(?2, agent_status)
-              WHERE tool_use_id = ?3 AND tool_name = 'Workflow'",
-            params![to_write, status, tool_use_id],
+              WHERE id = ?3 AND tool_name = 'Workflow'",
+            params![to_write, status, activity_id],
         )?;
         Ok(WorkflowActivityResolution {
             rows_updated,
             tree_json: Some(to_write.unwrap_or(&stored_tree).to_string()),
+            tool_use_id: Some(tool_use_id),
         })
     }
 
@@ -1148,7 +1218,7 @@ impl Database {
             .collect::<Vec<_>>()
             .join(", ");
         let sql = format!(
-            "SELECT tool_use_id FROM turn_tool_activities
+            "SELECT id FROM turn_tool_activities
               WHERE tool_name = 'Workflow'
                 AND (agent_status IS NULL
                      OR LOWER(TRIM(agent_status)) NOT IN ({placeholders}))"
@@ -1165,9 +1235,9 @@ impl Database {
         // pill cleared but the replayed card still reading "0/5" — a run
         // relabelled as ended while its own tree insisted it was mid-flight.
         let mut resolved = 0;
-        for tool_use_id in orphaned {
+        for activity_id in orphaned {
             resolved += self
-                .finish_workflow_activity(&tool_use_id, REAPED_TASK_STATUS, None)?
+                .finish_workflow_activity_row(&activity_id, REAPED_TASK_STATUS, None)?
                 .rows_updated;
         }
         Ok(resolved)
@@ -1367,6 +1437,13 @@ mod tests {
 
     /// Build a `ConversationCheckpoint` anchored to the workspace's default
     /// active session.
+    /// The chat session every `make_checkpoint` in these tests hangs off.
+    fn session_of(db: &Database, ws_id: &str) -> String {
+        db.default_session_id_for_workspace(ws_id)
+            .unwrap()
+            .expect("workspace must have a default session for tests")
+    }
+
     fn make_checkpoint(
         db: &Database,
         id: &str,
@@ -1837,7 +1914,13 @@ mod tests {
         db.insert_turn_tool_activities(&[activity]).unwrap();
 
         let resolution = db
-            .finish_workflow_activity("tu_a1", "completed", None)
+            .finish_workflow_activity(
+                &session_of(&db, "w1"),
+                Some("tu_a1"),
+                None,
+                "completed",
+                None,
+            )
             .unwrap();
         assert_eq!(resolution.rows_updated, 1);
 
@@ -1875,16 +1958,30 @@ mod tests {
         bash.agent_task_id = Some("task_bash".into());
         db.insert_turn_tool_activities(&[wf, bash]).unwrap();
 
+        let session = session_of(&db, "w1");
         assert_eq!(
-            db.find_workflow_activity_by_task_id("w2lwlmfps").unwrap(),
-            Some("tu_a1".to_string())
+            db.find_workflow_activity_by_task_id(&session, "w2lwlmfps")
+                .unwrap(),
+            Some("a1".to_string()),
+            "resolves to the activity row id"
         );
         assert_eq!(
-            db.find_workflow_activity_by_task_id("task_bash").unwrap(),
+            db.find_workflow_activity_by_task_id(&session, "task_bash")
+                .unwrap(),
             None,
             "non-Workflow rows are out of scope"
         );
-        assert_eq!(db.find_workflow_activity_by_task_id("nope").unwrap(), None);
+        assert_eq!(
+            db.find_workflow_activity_by_task_id(&session, "nope")
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            db.find_workflow_activity_by_task_id("some-other-session", "w2lwlmfps")
+                .unwrap(),
+            None,
+            "another session's completion must not resolve this row"
+        );
     }
 
     /// A run that ends without ever reporting agents still has to resolve its
@@ -1901,9 +1998,15 @@ mod tests {
         db.insert_turn_tool_activities(&[activity]).unwrap();
 
         assert_eq!(
-            db.finish_workflow_activity("tu_a1", "failed", None)
-                .unwrap()
-                .rows_updated,
+            db.finish_workflow_activity(
+                &session_of(&db, "w1"),
+                Some("tu_a1"),
+                None,
+                "failed",
+                None
+            )
+            .unwrap()
+            .rows_updated,
             1
         );
         let turns = db.list_completed_turns("w1").unwrap();
@@ -1929,7 +2032,13 @@ mod tests {
         db.insert_turn_tool_activities(&[bash]).unwrap();
 
         let resolution = db
-            .finish_workflow_activity("tu_a1", "completed", None)
+            .finish_workflow_activity(
+                &session_of(&db, "w1"),
+                Some("tu_a1"),
+                None,
+                "completed",
+                None,
+            )
             .unwrap();
         assert_eq!(resolution.rows_updated, 0, "Bash row is out of scope");
         assert_eq!(resolution.tree_json, None);
@@ -1940,9 +2049,15 @@ mod tests {
         );
 
         assert_eq!(
-            db.finish_workflow_activity("tu_missing", "completed", None)
-                .unwrap()
-                .rows_updated,
+            db.finish_workflow_activity(
+                &session_of(&db, "w1"),
+                Some("tu_missing"),
+                None,
+                "completed",
+                None
+            )
+            .unwrap()
+            .rows_updated,
             0
         );
     }
@@ -1971,7 +2086,13 @@ mod tests {
         db.insert_turn_tool_activities(&[wf, collided]).unwrap();
 
         let resolution = db
-            .finish_workflow_activity("tu_a1", "completed", None)
+            .finish_workflow_activity(
+                &session_of(&db, "w1"),
+                Some("tu_a1"),
+                None,
+                "completed",
+                None,
+            )
             .unwrap();
         assert_eq!(
             resolution.rows_updated, 1,
@@ -1993,6 +2114,102 @@ mod tests {
             by_tool("Bash").as_deref(),
             Some("running"),
             "the colliding non-Workflow row must be left alone"
+        );
+    }
+
+    /// Forking copies `tool_use_id` and `agent_task_id` verbatim into the
+    /// fork's own rows (`crate::fork`), so neither id names a single activity.
+    /// A completion in one session must resolve that session's row and leave
+    /// the fork's copied history alone — otherwise `rows_updated` and the
+    /// returned tree stop describing one activity, and the tree broadcast to
+    /// the UI can come off the wrong row entirely.
+    #[test]
+    fn test_finish_workflow_activity_is_scoped_to_the_owning_session() {
+        let db = setup_db_with_workspace();
+        let source_session = session_of(&db, "w1");
+        let fork_session = db.create_chat_session("w1").unwrap().id;
+
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        // The fork's checkpoint, hanging off its own session.
+        let mut fork_cp = make_checkpoint(&db, "cp2", "w1", "m1", 1);
+        fork_cp.chat_session_id = fork_session.clone();
+        db.insert_checkpoint(&fork_cp).unwrap();
+
+        let mut source = make_tool_activity("a1", "cp1", "Workflow", 0);
+        source.agent_task_id = Some("w2lwlmfps".into());
+        source.agent_status = Some("running".into());
+        // What `fork::copy_checkpoints` produces: a new row id, the same
+        // `tool_use_id` and `agent_task_id`.
+        let mut forked = make_tool_activity("a2", "cp2", "Workflow", 0);
+        forked.tool_use_id = "tu_a1".into();
+        forked.agent_task_id = Some("w2lwlmfps".into());
+        forked.agent_status = Some("running".into());
+        db.insert_turn_tool_activities(&[source, forked]).unwrap();
+
+        let resolution = db
+            .finish_workflow_activity(&source_session, Some("tu_a1"), None, "completed", None)
+            .unwrap();
+        assert_eq!(resolution.rows_updated, 1, "exactly one activity");
+        assert_eq!(resolution.tool_use_id.as_deref(), Some("tu_a1"));
+
+        let status_of = |id: &str| {
+            db.list_completed_turns("w1")
+                .unwrap()
+                .iter()
+                .flat_map(|t| t.activities.clone())
+                .find(|a| a.id == id)
+                .unwrap()
+                .agent_status
+                .clone()
+        };
+        assert_eq!(status_of("a1").as_deref(), Some("completed"));
+        assert_eq!(
+            status_of("a2").as_deref(),
+            Some("running"),
+            "the fork's copied history must be left alone"
+        );
+    }
+
+    /// The `task_id` fallback runs when a notification names its task but not
+    /// the originating tool use, and must be session-scoped for the same
+    /// reason.
+    #[test]
+    fn test_finish_workflow_activity_falls_back_to_task_id_within_the_session() {
+        let db = setup_db_with_workspace();
+        let session = session_of(&db, "w1");
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        let mut wf = make_tool_activity("a1", "cp1", "Workflow", 0);
+        wf.agent_task_id = Some("w2lwlmfps".into());
+        wf.agent_status = Some("running".into());
+        db.insert_turn_tool_activities(&[wf]).unwrap();
+
+        let resolution = db
+            .finish_workflow_activity(&session, None, Some("w2lwlmfps"), "completed", None)
+            .unwrap();
+        assert_eq!(resolution.rows_updated, 1);
+        // The caller forwards this to the UI, which keys on the tool use — so
+        // it has to be the resolved id, not the one the notification carried.
+        assert_eq!(resolution.tool_use_id.as_deref(), Some("tu_a1"));
+
+        // A completion for a task belonging to some other session resolves
+        // nothing here.
+        assert_eq!(
+            db.finish_workflow_activity(
+                "other-session",
+                None,
+                Some("w2lwlmfps"),
+                "completed",
+                None
+            )
+            .unwrap()
+            .rows_updated,
+            0
         );
     }
 

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -16,6 +16,18 @@ use crate::model::{
 
 use super::{Database, retry_on_busy};
 
+/// Outcome of [`Database::finish_workflow_activity`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowActivityResolution {
+    /// Rows the UPDATE touched. `0` means the activity was never checkpointed.
+    pub rows_updated: usize,
+    /// The row's progress tree after the write — reconciled when the terminal
+    /// status closed out stragglers, otherwise the stored value verbatim.
+    /// `None` when no row matched. Callers forward this to the UI so a live
+    /// card stops contradicting the status it just received.
+    pub tree_json: Option<String>,
+}
+
 #[derive(Debug)]
 struct MissingCheckpointBlob {
     sha: String,
@@ -975,6 +987,113 @@ impl Database {
         )
     }
 
+    /// Record a background `Workflow` run's terminal outcome on its activity
+    /// row, reconciling the stored progress tree against it.
+    ///
+    /// This is the durable half of the fix for the status pill that never
+    /// cleared. The row used to be written only by the webview, from the
+    /// stream handler for a `task_notification` — but that notification
+    /// arrives *between* turns for a backgrounded run, and the `agent-stream`
+    /// feed the webview listens on is torn down at each turn's `Result`
+    /// (`src/agent/session.rs`). Nothing forwarded it, so the write never
+    /// happened and the row sat at `"running"` forever. Persisting from the
+    /// Rust side, where the notification actually lands, makes the outcome
+    /// independent of whether a webview was listening or the transcript
+    /// happened to be hydrated.
+    ///
+    /// The tree is reconciled in the same statement because status alone is
+    /// not enough: the card and pill derive their fraction purely from the
+    /// tree, and the last snapshot that reached us usually predates the run's
+    /// final transitions. Left alone it would keep reading "48/49" behind a
+    /// pill that had otherwise cleared. See
+    /// [`crate::agent::workflow_progress::reconcile_tree_on_terminal`].
+    ///
+    /// Scoped to `tool_name = 'Workflow'` so a `task_id` collision with some
+    /// other tool's activity cannot rewrite it.
+    ///
+    /// Pass `incoming_tree_json` when the caller holds a fresher snapshot than
+    /// the row does — the webview does, since only it sees the `task_progress`
+    /// ticks that arrive after the launching turn was checkpointed. Passing
+    /// `None` reconciles whatever is already stored.
+    ///
+    /// Reconciling on *every* terminal write, not just the first, is what
+    /// makes this safe against write ordering: Rust persists from the
+    /// notification path and the webview may persist the same run moments
+    /// later from its own handler. Whichever lands last still leaves a
+    /// reconciled tree, so the stale fraction cannot come back.
+    ///
+    /// A row whose turn was never checkpointed matches nothing, which reports
+    /// [`WorkflowActivityResolution::rows_updated`] `== 0` rather than
+    /// erroring — that is the normal outcome for a run stopped before its
+    /// first checkpoint, and there is no row to resurrect a pill from either.
+    /// The `tool_use_id` of the `Workflow` activity a background task belongs
+    /// to, found by the task id the CLI assigned it.
+    ///
+    /// The fallback for a `task_notification` that identifies its task but not
+    /// the originating tool use — `tool_use_id` is optional on that event, and
+    /// nothing in this repo pins whether the CLI populates it for every
+    /// workflow. `agent_task_id` is recorded on the row from the
+    /// `task_started` / `task_progress` events, which do carry both, so the
+    /// join is always available by the time a run can end.
+    ///
+    /// Newest row wins. Task ids are effectively unique, but a resumed or
+    /// forked session can duplicate one, and the most recent row is the live
+    /// one in that case.
+    pub fn find_workflow_activity_by_task_id(
+        &self,
+        task_id: &str,
+    ) -> Result<Option<String>, rusqlite::Error> {
+        self.conn
+            .query_row(
+                "SELECT tool_use_id FROM turn_tool_activities
+                  WHERE tool_name = 'Workflow' AND agent_task_id = ?1
+                  ORDER BY rowid DESC LIMIT 1",
+                params![task_id],
+                |row| row.get(0),
+            )
+            .optional()
+    }
+
+    pub fn finish_workflow_activity(
+        &self,
+        tool_use_id: &str,
+        status: &str,
+        incoming_tree_json: Option<&str>,
+    ) -> Result<WorkflowActivityResolution, rusqlite::Error> {
+        let stored_tree: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT workflow_progress_json FROM turn_tool_activities
+                  WHERE tool_use_id = ?1 AND tool_name = 'Workflow'",
+                params![tool_use_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let Some(stored_tree) = stored_tree else {
+            return Ok(WorkflowActivityResolution {
+                rows_updated: 0,
+                tree_json: None,
+            });
+        };
+        let effective_tree = incoming_tree_json.unwrap_or(&stored_tree);
+        let reconciled = crate::agent::workflow_progress::reconcile_tree_json_on_terminal(
+            effective_tree,
+            status,
+        );
+        // Write the reconciled tree when reconciliation changed something,
+        // else the caller's own tree when it supplied one, else nothing —
+        // `None` leaves the stored value untouched via COALESCE, which is the
+        // right outcome for a run that never reported agents and for a tree we
+        // could not parse.
+        let to_write = reconciled.as_deref().or(incoming_tree_json);
+        let rows_updated =
+            self.update_turn_tool_activity_progress(tool_use_id, to_write, Some(status))?;
+        Ok(WorkflowActivityResolution {
+            rows_updated,
+            tree_json: Some(to_write.unwrap_or(&stored_tree).to_string()),
+        })
+    }
+
     /// Resolve `Workflow` activities left mid-run by a previous app session.
     ///
     /// A workflow's background task lives inside the Claude CLI process, so
@@ -1003,21 +1122,41 @@ impl Database {
     ///
     /// Returns the number of rows resolved.
     pub fn resolve_orphaned_workflow_activities(&self) -> Result<usize, rusqlite::Error> {
-        // Keep the terminal set in sync with `isTerminalBackgroundTaskStatus`
-        // in `src/ui/src/types/backgroundTaskStatus.ts`, which is where the
-        // vocabulary is documented. `"stopped"` is the CLI's own value for a
-        // task that ended without completing, so a resolved row needs no
-        // special-casing on the read side.
-        self.conn.execute(
-            "UPDATE turn_tool_activities
-                SET agent_status = 'stopped'
+        use crate::agent::workflow_progress::{REAPED_TASK_STATUS, TERMINAL_TASK_STATUSES};
+
+        // The terminal vocabulary is bound from the shared constant rather
+        // than spelled out as a SQL literal. It used to be a third hand-
+        // maintained copy behind a "keep this in sync" comment, and the last
+        // time these copies drifted (`"stopped"` missing from two of them) a
+        // terminated run pinned its pill forever — the bug this function
+        // exists to clean up after.
+        let placeholders = std::iter::repeat_n("?", TERMINAL_TASK_STATUSES.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT tool_use_id FROM turn_tool_activities
               WHERE tool_name = 'Workflow'
                 AND (agent_status IS NULL
-                     OR LOWER(agent_status) NOT IN
-                        ('completed', 'failed', 'stopped', 'killed',
-                         'error', 'cancelled', 'canceled'))",
-            [],
-        )
+                     OR LOWER(TRIM(agent_status)) NOT IN ({placeholders}))"
+        );
+        let orphaned: Vec<String> = {
+            let mut stmt = self.conn.prepare(&sql)?;
+            let rows =
+                stmt.query_map(params_from_iter(TERMINAL_TASK_STATUSES), |row| row.get(0))?;
+            rows.collect::<Result<_, _>>()?
+        };
+
+        // Resolved one row at a time rather than with a bulk UPDATE so each
+        // one's progress tree is reconciled too. A status-only sweep left the
+        // pill cleared but the replayed card still reading "0/5" — a run
+        // relabelled as ended while its own tree insisted it was mid-flight.
+        let mut resolved = 0;
+        for tool_use_id in orphaned {
+            resolved += self
+                .finish_workflow_activity(&tool_use_id, REAPED_TASK_STATUS, None)?
+                .rows_updated;
+        }
+        Ok(resolved)
     }
 
     /// Load all completed turns for a workspace: checkpoints joined with their
@@ -1659,6 +1798,171 @@ mod tests {
 
         // Idempotent: a second boot has nothing left to do.
         assert_eq!(db.resolve_orphaned_workflow_activities().unwrap(), 0);
+    }
+
+    /// The bug this whole path exists for: a run reports `completed` while the
+    /// last progress snapshot that reached us still shows every agent in
+    /// flight. Status alone is not enough — the pill clears but the card keeps
+    /// reading "0/5" — so the tree has to be reconciled in the same write.
+    #[test]
+    fn test_finish_workflow_activity_reconciles_a_stale_tree() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+
+        let mut activity = make_tool_activity("a1", "cp1", "Workflow", 0);
+        activity.agent_status = Some("running".into());
+        activity.workflow_progress_json = r#"[
+            {"type":"workflow_phase","index":0,"title":"Investigate"},
+            {"type":"workflow_agent","index":1,"label":"probe-a","state":"progress"},
+            {"type":"workflow_agent","index":2,"label":"probe-b","state":"done"}
+        ]"#
+        .into();
+        db.insert_turn_tool_activities(&[activity]).unwrap();
+
+        let resolution = db
+            .finish_workflow_activity("tu_a1", "completed", None)
+            .unwrap();
+        assert_eq!(resolution.rows_updated, 1);
+
+        let turns = db.list_completed_turns("w1").unwrap();
+        let stored = &turns[0].activities[0];
+        assert_eq!(stored.agent_status.as_deref(), Some("completed"));
+        let tree: Vec<crate::agent::WorkflowProgressEntry> =
+            serde_json::from_str(&stored.workflow_progress_json).unwrap();
+        let states: Vec<&str> = tree
+            .iter()
+            .filter_map(|e| match e {
+                crate::agent::WorkflowProgressEntry::Agent(a) => Some(a.state.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(states, vec!["done", "done"], "stragglers closed out");
+        // The caller forwards this to the UI so a live card settles too.
+        assert!(resolution.tree_json.is_some());
+    }
+
+    /// The `tool_use_id` fallback path: a terminal notification that names its
+    /// task but not the tool use it came from must still resolve the run.
+    #[test]
+    fn test_find_workflow_activity_by_task_id() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        let mut wf = make_tool_activity("a1", "cp1", "Workflow", 0);
+        wf.agent_task_id = Some("w2lwlmfps".into());
+        wf.agent_status = Some("running".into());
+        // A background Bash sharing the notification path must not be matched.
+        let mut bash = make_tool_activity("a2", "cp1", "Bash", 1);
+        bash.agent_task_id = Some("task_bash".into());
+        db.insert_turn_tool_activities(&[wf, bash]).unwrap();
+
+        assert_eq!(
+            db.find_workflow_activity_by_task_id("w2lwlmfps").unwrap(),
+            Some("tu_a1".to_string())
+        );
+        assert_eq!(
+            db.find_workflow_activity_by_task_id("task_bash").unwrap(),
+            None,
+            "non-Workflow rows are out of scope"
+        );
+        assert_eq!(db.find_workflow_activity_by_task_id("nope").unwrap(), None);
+    }
+
+    /// A run that ends without ever reporting agents still has to resolve its
+    /// status, and passing no tree must not blank the column.
+    #[test]
+    fn test_finish_workflow_activity_without_a_tree_still_records_status() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        let mut activity = make_tool_activity("a1", "cp1", "Workflow", 0);
+        activity.agent_status = Some("running".into());
+        db.insert_turn_tool_activities(&[activity]).unwrap();
+
+        assert_eq!(
+            db.finish_workflow_activity("tu_a1", "failed", None)
+                .unwrap()
+                .rows_updated,
+            1
+        );
+        let turns = db.list_completed_turns("w1").unwrap();
+        assert_eq!(
+            turns[0].activities[0].agent_status.as_deref(),
+            Some("failed")
+        );
+        assert_eq!(turns[0].activities[0].workflow_progress_json, "[]");
+    }
+
+    /// Background Bash and backgrounded subagents share the notification path
+    /// that calls this, but own no `Workflow` row. They must not be rewritten,
+    /// and an unmatched id is not an error.
+    #[test]
+    fn test_finish_workflow_activity_ignores_other_tools_and_missing_rows() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        let mut bash = make_tool_activity("a1", "cp1", "Bash", 0);
+        bash.agent_status = Some("running".into());
+        db.insert_turn_tool_activities(&[bash]).unwrap();
+
+        let resolution = db
+            .finish_workflow_activity("tu_a1", "completed", None)
+            .unwrap();
+        assert_eq!(resolution.rows_updated, 0, "Bash row is out of scope");
+        assert_eq!(resolution.tree_json, None);
+        let turns = db.list_completed_turns("w1").unwrap();
+        assert_eq!(
+            turns[0].activities[0].agent_status.as_deref(),
+            Some("running")
+        );
+
+        assert_eq!(
+            db.finish_workflow_activity("tu_missing", "completed", None)
+                .unwrap()
+                .rows_updated,
+            0
+        );
+    }
+
+    /// The boot sweep relabels a wedged run as `stopped`; without reconciling
+    /// the tree it would leave a card insisting the run is mid-flight while
+    /// its own status says it ended.
+    #[test]
+    fn test_resolve_orphaned_workflow_activities_reconciles_trees() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        let mut wedged = make_tool_activity("a1", "cp1", "Workflow", 0);
+        wedged.agent_status = Some("running".into());
+        wedged.workflow_progress_json =
+            r#"[{"type":"workflow_agent","index":1,"label":"probe","state":"progress"}]"#.into();
+        db.insert_turn_tool_activities(&[wedged]).unwrap();
+
+        assert_eq!(db.resolve_orphaned_workflow_activities().unwrap(), 1);
+
+        let turns = db.list_completed_turns("w1").unwrap();
+        let stored = &turns[0].activities[0];
+        assert_eq!(stored.agent_status.as_deref(), Some("stopped"));
+        let tree: Vec<crate::agent::WorkflowProgressEntry> =
+            serde_json::from_str(&stored.workflow_progress_json).unwrap();
+        match &tree[0] {
+            crate::agent::WorkflowProgressEntry::Agent(a) => assert_eq!(
+                a.state, "stopped",
+                "a reaped run must not claim its agents finished"
+            ),
+            other => panic!("expected an agent entry, got {other:?}"),
+        }
     }
 
     /// An unknown `tool_use_id` is normal (the turn may never have been

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -991,49 +991,6 @@ impl Database {
         )
     }
 
-    /// Record a background `Workflow` run's terminal outcome on its activity
-    /// row, reconciling the stored progress tree against it.
-    ///
-    /// This is the durable half of the fix for the status pill that never
-    /// cleared. The row used to be written only by the webview, from the
-    /// stream handler for a `task_notification` — but that notification
-    /// arrives *between* turns for a backgrounded run, and the `agent-stream`
-    /// feed the webview listens on is torn down at each turn's `Result`
-    /// (`src/agent/session.rs`). Nothing forwarded it, so the write never
-    /// happened and the row sat at `"running"` forever. Persisting from the
-    /// Rust side, where the notification actually lands, makes the outcome
-    /// independent of whether a webview was listening or the transcript
-    /// happened to be hydrated.
-    ///
-    /// The tree is reconciled in the same statement because status alone is
-    /// not enough: the card and pill derive their fraction purely from the
-    /// tree, and the last snapshot that reached us usually predates the run's
-    /// final transitions. Left alone it would keep reading "48/49" behind a
-    /// pill that had otherwise cleared. See
-    /// [`crate::agent::workflow_progress::reconcile_tree_on_terminal`].
-    ///
-    /// Identified by `tool_use_id` within `chat_session_id`, falling back to
-    /// `task_id`. Both ids are copied verbatim into a fork's own rows
-    /// (`crate::fork`), so neither identifies a single activity on its own —
-    /// without the session scope, completing a run in one session would
-    /// rewrite the copied history in every fork of it, and `rows_updated` and
-    /// the returned tree would stop describing one activity.
-    ///
-    /// Pass `incoming_tree_json` when the caller holds a fresher snapshot than
-    /// the row does — the webview does, since only it sees the `task_progress`
-    /// ticks that arrive after the launching turn was checkpointed. Passing
-    /// `None` reconciles whatever is already stored.
-    ///
-    /// Reconciling on *every* terminal write, not just the first, is what
-    /// makes this safe against write ordering: Rust persists from the
-    /// notification path and the webview may persist the same run moments
-    /// later from its own handler. Whichever lands last still leaves a
-    /// reconciled tree, so the stale fraction cannot come back.
-    ///
-    /// A run whose turn was never checkpointed resolves to no row, which
-    /// reports [`WorkflowActivityResolution::rows_updated`] `== 0` rather than
-    /// erroring — that is the normal outcome for a run stopped before its
-    /// first checkpoint, and there is no row to resurrect a pill from either.
     /// The row id of the `Workflow` activity a background task belongs to,
     /// within one chat session.
     ///
@@ -1089,6 +1046,49 @@ impl Database {
             .optional()
     }
 
+    /// Record a background `Workflow` run's terminal outcome on its activity
+    /// row, reconciling the stored progress tree against it.
+    ///
+    /// This is the durable half of the fix for the status pill that never
+    /// cleared. The row used to be written only by the webview, from the
+    /// stream handler for a `task_notification` — but that notification
+    /// arrives *between* turns for a backgrounded run, and the `agent-stream`
+    /// feed the webview listens on is torn down at each turn's `Result`
+    /// (`src/agent/session.rs`). Nothing forwarded it, so the write never
+    /// happened and the row sat at `"running"` forever. Persisting from the
+    /// Rust side, where the notification actually lands, makes the outcome
+    /// independent of whether a webview was listening or the transcript
+    /// happened to be hydrated.
+    ///
+    /// The tree is reconciled in the same statement because status alone is
+    /// not enough: the card and pill derive their fraction purely from the
+    /// tree, and the last snapshot that reached us usually predates the run's
+    /// final transitions. Left alone it would keep reading "48/49" behind a
+    /// pill that had otherwise cleared. See
+    /// [`crate::agent::workflow_progress::reconcile_tree_on_terminal`].
+    ///
+    /// Identified by `tool_use_id` within `chat_session_id`, falling back to
+    /// `task_id`. Both ids are copied verbatim into a fork's own rows
+    /// (`crate::fork`), so neither identifies a single activity on its own —
+    /// without the session scope, completing a run in one session would
+    /// rewrite the copied history in every fork of it, and `rows_updated` and
+    /// the returned tree would stop describing one activity.
+    ///
+    /// Pass `incoming_tree_json` when the caller holds a fresher snapshot than
+    /// the row does — the webview does, since only it sees the `task_progress`
+    /// ticks that arrive after the launching turn was checkpointed. Passing
+    /// `None` reconciles whatever is already stored.
+    ///
+    /// Reconciling on *every* terminal write, not just the first, is what
+    /// makes this safe against write ordering: Rust persists from the
+    /// notification path and the webview may persist the same run moments
+    /// later from its own handler. Whichever lands last still leaves a
+    /// reconciled tree, so the stale fraction cannot come back.
+    ///
+    /// A run whose turn was never checkpointed resolves to no row, which
+    /// reports [`WorkflowActivityResolution::rows_updated`] `== 0` rather than
+    /// erroring — that is the normal outcome for a run stopped before its
+    /// first checkpoint, and there is no row to resurrect a pill from either.
     pub fn finish_workflow_activity(
         &self,
         chat_session_id: &str,
@@ -1148,16 +1148,25 @@ impl Database {
                 tool_use_id: None,
             });
         };
+        // Screened before use, because `reconcile_tree_json_on_terminal`
+        // returns `None` both for "already consistent" and "could not parse".
+        // Falling back to an unscreened `incoming_tree_json` on that shared
+        // `None` would write the caller's garbage straight over a readable
+        // stored tree — the one case the reconciler explicitly refuses to
+        // handle, undone by its own caller.
+        let incoming_tree_json = incoming_tree_json.filter(|json| {
+            serde_json::from_str::<Vec<crate::agent::WorkflowProgressEntry>>(json).is_ok()
+        });
         let effective_tree = incoming_tree_json.unwrap_or(&stored_tree);
         let reconciled = crate::agent::workflow_progress::reconcile_tree_json_on_terminal(
             effective_tree,
             status,
         );
         // Write the reconciled tree when reconciliation changed something,
-        // else the caller's own tree when it supplied one, else nothing —
-        // `None` leaves the stored value untouched via COALESCE, which is the
-        // right outcome for a run that never reported agents and for a tree we
-        // could not parse.
+        // else the caller's own (screened) tree when it supplied one, else
+        // nothing — `None` leaves the stored value untouched via COALESCE,
+        // which is the right outcome for a run that never reported agents and
+        // for a tree we could not parse.
         let to_write = reconciled.as_deref().or(incoming_tree_json);
         // Keyed on the primary key rather than delegating to
         // `update_turn_tool_activity_progress`, which matches on `tool_use_id`
@@ -2211,6 +2220,50 @@ mod tests {
             .rows_updated,
             0
         );
+    }
+
+    /// `reconcile_tree_json_on_terminal` returns `None` both for "already
+    /// consistent" and "could not parse", so an unscreened fallback to the
+    /// caller's tree on that shared `None` would write garbage over a
+    /// readable stored tree — undoing the one case the reconciler explicitly
+    /// refuses to handle.
+    #[test]
+    fn test_finish_workflow_activity_rejects_a_malformed_incoming_tree() {
+        let db = setup_db_with_workspace();
+        let session = session_of(&db, "w1");
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        let good = r#"[{"type":"workflow_agent","index":1,"label":"probe","state":"progress"}]"#;
+        let mut activity = make_tool_activity("a1", "cp1", "Workflow", 0);
+        activity.agent_status = Some("running".into());
+        activity.workflow_progress_json = good.into();
+        db.insert_turn_tool_activities(&[activity]).unwrap();
+
+        let resolution = db
+            .finish_workflow_activity(
+                &session,
+                Some("tu_a1"),
+                None,
+                "completed",
+                Some("{ not a tree"),
+            )
+            .unwrap();
+        assert_eq!(resolution.rows_updated, 1, "the status still lands");
+
+        let turns = db.list_completed_turns("w1").unwrap();
+        let stored = &turns[0].activities[0];
+        assert_eq!(stored.agent_status.as_deref(), Some("completed"));
+        // The stored tree was readable, so it is reconciled — never replaced
+        // by the caller's garbage.
+        let tree: Vec<crate::agent::WorkflowProgressEntry> =
+            serde_json::from_str(&stored.workflow_progress_json)
+                .expect("stored tree must still parse");
+        match &tree[0] {
+            crate::agent::WorkflowProgressEntry::Agent(a) => assert_eq!(a.state, "done"),
+            other => panic!("expected an agent entry, got {other:?}"),
+        }
     }
 
     /// The boot sweep relabels a wedged run as `stopped`; without reconciling

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -106,6 +106,7 @@ pub use terminal::CLAUDETTE_TERMINAL_TITLE;
 mod remote;
 
 mod checkpoint;
+pub use checkpoint::WorkflowActivityResolution;
 pub(crate) use checkpoint::sha256_hex;
 
 mod chat;

--- a/src/ui/src/components/chat/WorkflowCard.tsx
+++ b/src/ui/src/components/chat/WorkflowCard.tsx
@@ -47,6 +47,11 @@ function stateIcon(state: string): string {
       return "✕";
     case "progress":
       return "◐";
+    case "stopped":
+      // Reconciled straggler: the run ended before this agent did. Distinct
+      // from "queued" so a cancelled run doesn't read as one that never
+      // started, and from "error" so it doesn't read as a failure.
+      return "–";
     default:
       // Covers "queued" and any state we don't recognize — both mean
       // "hasn't produced anything yet" as far as the reader is concerned.
@@ -62,6 +67,8 @@ function stateClass(state: string): string {
       return styles.stateError;
     case "progress":
       return styles.stateProgress;
+    // "stopped" shares the muted treatment with "queued": neither produced
+    // a result, and neither is a failure worth colouring.
     default:
       return styles.stateQueued;
   }

--- a/src/ui/src/components/layout/AppLayout.terminal.test.tsx
+++ b/src/ui/src/components/layout/AppLayout.terminal.test.tsx
@@ -43,6 +43,9 @@ vi.mock("./ResizeHandle", () => ({ ResizeHandle: () => <div /> }));
 vi.mock("./Toast", () => ({ ToastContainer: () => <div /> }));
 vi.mock("../shared/AppTooltip", () => ({ AppTooltip: () => <div /> }));
 vi.mock("../../hooks/useAgentStream", () => ({ useAgentStream: vi.fn() }));
+vi.mock("../../hooks/useWorkflowActivityStatus", () => ({
+  useWorkflowActivityStatus: vi.fn(),
+}));
 vi.mock("../../hooks/useKeyboardShortcuts", () => ({ useKeyboardShortcuts: vi.fn() }));
 vi.mock("../../hooks/useBranchRefresh", () => ({ useBranchRefresh: vi.fn() }));
 vi.mock("../../hooks/useAutoUpdater", () => ({ useAutoUpdater: vi.fn() }));

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -18,6 +18,7 @@ import { ResizeHandle } from "./ResizeHandle";
 import { ToastContainer } from "./Toast";
 import { AppTooltip } from "../shared/AppTooltip";
 import { useAgentStream } from "../../hooks/useAgentStream";
+import { useWorkflowActivityStatus } from "../../hooks/useWorkflowActivityStatus";
 import { useKeyboardShortcuts } from "../../hooks/useKeyboardShortcuts";
 import { useBranchRefresh } from "../../hooks/useBranchRefresh";
 import { useAutoUpdater } from "../../hooks/useAutoUpdater";
@@ -44,6 +45,7 @@ export function AppLayout() {
   const commandPaletteOpen = useAppStore((s) => s.commandPaletteOpen);
 
   useAgentStream();
+  useWorkflowActivityStatus();
   useKeyboardShortcuts();
   useBranchRefresh();
   useAutoUpdater();

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -4,6 +4,7 @@ import { useAppStore } from "../stores/useAppStore";
 import { findToolActivity } from "../stores/findToolActivity";
 import { collectInFlightWorkflows } from "../stores/inFlightWorkflows";
 import { REAPED_BACKGROUND_TASK_STATUS } from "../types/backgroundTaskStatus";
+import { reconcileAgentStatesOnTerminal } from "../types/workflow";
 import {
   loadChatHistory,
   saveTurnToolActivities,
@@ -102,15 +103,27 @@ function reapInFlightWorkflows(
     toolUseIds: orphaned.map((a) => a.toolUseId),
   });
   for (const activity of orphaned) {
+    // Reconcile the live tree, not just the status. A status-only update
+    // leaves the open card counting agents that stopped when the process
+    // did — an unfinished fraction behind a run the same write just marked
+    // ended, until the next reload disagrees with it.
+    const reconciled = activity.workflowProgress?.length
+      ? reconcileAgentStatesOnTerminal(
+          activity.workflowProgress,
+          REAPED_BACKGROUND_TASK_STATUS,
+        )
+      : null;
     updateToolActivity(sessionId, activity.toolUseId, {
       agentStatus: REAPED_BACKGROUND_TASK_STATUS,
+      ...(reconciled ? { workflowProgress: reconciled } : {}),
     });
-    // `null` for the tree: whatever the last `task_progress` tick left in
-    // the store is already the stored value, and both columns COALESCE, so
-    // a status-only write can't blank a good tree.
+    // The store's tree is the freshest one anywhere — it holds every
+    // `task_progress` tick since the launching turn was checkpointed, which
+    // the row does not. Send it when we have one; `null` otherwise, where
+    // both columns COALESCE so a status-only write can't blank a good tree.
     void updateTurnToolActivityProgress(
       activity.toolUseId,
-      null,
+      reconciled ? JSON.stringify(reconciled) : null,
       REAPED_BACKGROUND_TASK_STATUS,
       sessionId,
     ).catch((err) => {

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -112,6 +112,7 @@ function reapInFlightWorkflows(
       activity.toolUseId,
       null,
       REAPED_BACKGROUND_TASK_STATUS,
+      sessionId,
     ).catch((err) => {
       debugChat("stream", "persist reaped workflow status failed", {
         toolUseId: activity.toolUseId,
@@ -459,6 +460,7 @@ export function useAgentStream() {
                       ? JSON.stringify(activity.workflowProgress)
                       : null,
                     activity.agentStatus ?? null,
+                    sessionId,
                   ).catch((err) => {
                     debugChat("stream", "persist workflow progress failed", {
                       toolUseId: streamEvent.tool_use_id,

--- a/src/ui/src/hooks/useAgentStream.workflowReap.test.tsx
+++ b/src/ui/src/hooks/useAgentStream.workflowReap.test.tsx
@@ -197,7 +197,9 @@ describe("useAgentStream — reaping orphaned workflows on ProcessExited", () =>
     await fireProcessExited();
 
     expect(persistSpy).toHaveBeenCalledTimes(1);
-    expect(persistSpy).toHaveBeenCalledWith(WF_ID, null, "stopped");
+    // The session id scopes the write: forking copies `tool_use_id` into the
+    // fork's own rows, so an unscoped update would reach every fork's copy.
+    expect(persistSpy).toHaveBeenCalledWith(WF_ID, null, "stopped", SESSION_ID);
   });
 
   // A run checkpointed before its first `task_progress` tick has no status

--- a/src/ui/src/hooks/useAgentStream.workflowReap.test.tsx
+++ b/src/ui/src/hooks/useAgentStream.workflowReap.test.tsx
@@ -64,7 +64,10 @@ import {
   type ToolActivity,
 } from "../stores/useAppStore";
 import { findToolActivity } from "../stores/findToolActivity";
-import type { WorkflowProgressEntry } from "../types/workflow";
+import {
+  summarizeWorkflowProgress,
+  type WorkflowProgressEntry,
+} from "../types/workflow";
 
 const WS_ID = "ws-1";
 const SESSION_ID = "session-1";
@@ -186,8 +189,9 @@ describe("useAgentStream — reaping orphaned workflows on ProcessExited", () =>
 
   // Persisted as well as applied in-store: the store copy dies with the
   // session view, and it is the stale DB row that resurrects the pill on
-  // the next load. `null` for the tree so the COALESCE keeps whatever the
-  // last progress tick stored.
+  // the next load. The store's tree goes with it — it holds every
+  // `task_progress` tick since the launching turn was checkpointed, which
+  // the row does not.
   it("persists the resolved status so a reload cannot resurrect the pill", async () => {
     useAppStore.setState({
       completedTurns: { [SESSION_ID]: [turn("turn-1", [workflowActivity()])] },
@@ -199,6 +203,53 @@ describe("useAgentStream — reaping orphaned workflows on ProcessExited", () =>
     expect(persistSpy).toHaveBeenCalledTimes(1);
     // The session id scopes the write: forking copies `tool_use_id` into the
     // fork's own rows, so an unscoped update would reach every fork's copy.
+    const [toolUseId, treeJson, status, sessionId] = persistSpy.mock.calls[0];
+    expect(toolUseId).toBe(WF_ID);
+    expect(status).toBe("stopped");
+    expect(sessionId).toBe(SESSION_ID);
+    // Reconciled on the way out: the reaped run's in-flight agents are
+    // stamped, so the persisted tree can't contradict the status beside it.
+    expect(JSON.parse(treeJson as string)).toEqual([
+      TREE[0],
+      { ...TREE[1], state: "stopped" },
+    ]);
+  });
+
+  // The open card has to settle too. A status-only update left it counting
+  // agents that stopped when the process did — an unfinished fraction behind
+  // a run the same write had just marked ended.
+  it("reconciles the live tree so the open card stops counting", async () => {
+    useAppStore.setState({
+      completedTurns: { [SESSION_ID]: [turn("turn-1", [workflowActivity()])] },
+    });
+    await mountHook();
+
+    await fireProcessExited();
+
+    const tree = findToolActivity(useAppStore.getState(), SESSION_ID, WF_ID)
+      ?.workflowProgress;
+    expect(summarizeWorkflowProgress(tree)).toMatchObject({
+      doneCount: 1,
+      totalCount: 1,
+      running: false,
+      errorCount: 0,
+    });
+  });
+
+  // Nothing to reconcile must not turn into a tree write: `null` lets the
+  // COALESCE keep whatever the last progress tick stored.
+  it("sends no tree when the reaped run never reported agents", async () => {
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION_ID]: [
+          turn("turn-1", [workflowActivity({ workflowProgress: [] })]),
+        ],
+      },
+    });
+    await mountHook();
+
+    await fireProcessExited();
+
     expect(persistSpy).toHaveBeenCalledWith(WF_ID, null, "stopped", SESSION_ID);
   });
 

--- a/src/ui/src/hooks/useWorkflowActivityStatus.test.tsx
+++ b/src/ui/src/hooks/useWorkflowActivityStatus.test.tsx
@@ -215,6 +215,73 @@ describe("useWorkflowActivityStatus", () => {
     expect(summary.errorCount).toBe(0);
   });
 
+  it("reconciles the live tree instead of taking the payload's older one", async () => {
+    // Rust reconciles the *checkpointed* row, which is a snapshot from seconds
+    // after launch — commonly `[]`, since a workflow's tool_result lands within
+    // a second of the turn being saved. Every tick since went only to this
+    // store. Taking the payload verbatim would blank a rich card, and
+    // `useAgentStream`'s handler for the same notification would then persist
+    // the downgraded copy back to the row.
+    useAppStore.setState({
+      completedTurns: { [SESSION_ID]: [turn("t1", [workflowActivity()])] },
+    });
+    await mountHook();
+
+    await fireStatus({ status: "completed", workflow_progress: [] });
+
+    const tree = activityNow()?.workflowProgress;
+    expect(tree).toHaveLength(STALE_TREE.length);
+    const summary = summarizeWorkflowProgress(tree);
+    expect(summary.totalCount).toBe(5);
+    expect(summary.doneCount).toBe(5);
+    expect(summary.running).toBe(false);
+  });
+
+  it("preserves per-agent detail the payload's snapshot would have dropped", async () => {
+    // The live tree carries tokens / tool counts / labels accumulated over the
+    // run. Rust's checkpoint snapshot has none of it.
+    const rich = STALE_TREE.map((entry) =>
+      entry.type === "workflow_agent"
+        ? { ...entry, tokens: 1234, toolCalls: 7 }
+        : entry,
+    );
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION_ID]: [turn("t1", [workflowActivity({ workflowProgress: rich })])],
+      },
+    });
+    await mountHook();
+
+    await fireStatus({ status: "completed", workflow_progress: RECONCILED_TREE });
+
+    const summary = summarizeWorkflowProgress(activityNow()?.workflowProgress);
+    expect(summary.totalTokens).toBe(5 * 1234);
+    expect(summary.totalToolCalls).toBe(5 * 7);
+    expect(summary.doneCount).toBe(5);
+  });
+
+  it("falls back to the payload's tree when this window never saw the run", async () => {
+    // A session hydrated from disk after the launching turn was saved has the
+    // checkpoint's empty tree; the payload is the only tree available.
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION_ID]: [turn("t1", [workflowActivity({ workflowProgress: [] })])],
+      },
+    });
+    await mountHook();
+
+    await fireStatus({
+      status: "completed",
+      workflow_progress: RECONCILED_TREE,
+    });
+
+    expect(summarizeWorkflowProgress(activityNow()?.workflowProgress)).toMatchObject({
+      doneCount: 5,
+      totalCount: 5,
+      running: false,
+    });
+  });
+
   it("resolves a run that is still in the live lane", async () => {
     // The other ordering: the notification arrives while the launching turn
     // is somehow still open.
@@ -229,10 +296,10 @@ describe("useWorkflowActivityStatus", () => {
     expect(pillWouldRender()).toBe(false);
   });
 
-  it("keeps the existing tree when the payload carries none", async () => {
-    // `null` means "the row had no readable tree", which must not be
-    // confused with "the tree is empty" — blanking it would turn a stale
-    // card into a permanently empty one.
+  it("reconciles the live tree when the payload carries none", async () => {
+    // `null` means "the row had no readable tree", which must not be confused
+    // with "the tree is empty" — blanking it would turn a stale card into a
+    // permanently empty one. The live tree still gets closed out.
     useAppStore.setState({
       completedTurns: { [SESSION_ID]: [turn("t1", [workflowActivity()])] },
     });
@@ -240,15 +307,32 @@ describe("useWorkflowActivityStatus", () => {
 
     await fireStatus({ status: "completed", workflow_progress: null });
 
-    expect(activityNow()?.workflowProgress).toEqual(STALE_TREE);
+    expect(activityNow()?.workflowProgress).toHaveLength(STALE_TREE.length);
+    expect(summarizeWorkflowProgress(activityNow()?.workflowProgress).doneCount).toBe(5);
     expect(activityNow()?.agentStatus).toBe("completed");
   });
 
-  it("drops a malformed tree but still applies the status", async () => {
-    // Degrade to "status applied, tree unchanged" rather than writing
+  it("leaves the tree untouched when there is nothing anywhere to reconcile", async () => {
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION_ID]: [turn("t1", [workflowActivity({ workflowProgress: undefined })])],
+      },
+    });
+    await mountHook();
+
+    await fireStatus({ status: "completed", workflow_progress: null });
+
+    expect(activityNow()?.workflowProgress).toBeUndefined();
+    expect(activityNow()?.agentStatus).toBe("completed");
+  });
+
+  it("drops a malformed payload tree but still applies the status", async () => {
+    // Degrade to "status applied, live tree reconciled" rather than writing
     // garbage the summarizer would then have to defend against.
     useAppStore.setState({
-      completedTurns: { [SESSION_ID]: [turn("t1", [workflowActivity()])] },
+      completedTurns: {
+        [SESSION_ID]: [turn("t1", [workflowActivity({ workflowProgress: undefined })])],
+      },
     });
     await mountHook();
 
@@ -257,7 +341,7 @@ describe("useWorkflowActivityStatus", () => {
       workflow_progress: [{ type: "workflow_agent", index: 1 }],
     });
 
-    expect(activityNow()?.workflowProgress).toEqual(STALE_TREE);
+    expect(activityNow()?.workflowProgress).toBeUndefined();
     expect(activityNow()?.agentStatus).toBe("completed");
   });
 

--- a/src/ui/src/hooks/useWorkflowActivityStatus.test.tsx
+++ b/src/ui/src/hooks/useWorkflowActivityStatus.test.tsx
@@ -39,6 +39,15 @@ vi.mock("@tauri-apps/api/event", () => ({
   },
 }));
 
+const persistSpy = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../services/tauri", async () => {
+  const actual = await vi.importActual<typeof import("../services/tauri")>(
+    "../services/tauri",
+  );
+  return { ...actual, updateTurnToolActivityProgress: persistSpy };
+});
+
 import { useWorkflowActivityStatus } from "./useWorkflowActivityStatus";
 import {
   useAppStore,
@@ -158,6 +167,7 @@ function pillWouldRender(): boolean {
 
 beforeEach(() => {
   registeredHandlers.clear();
+  persistSpy.mockClear();
   useAppStore.setState({ toolActivities: {}, completedTurns: {} });
 });
 
@@ -356,6 +366,65 @@ describe("useWorkflowActivityStatus", () => {
 
     expect(useAppStore.getState().toolActivities[SESSION_ID]).toBeUndefined();
     expect(useAppStore.getState().completedTurns[SESSION_ID]).toBeUndefined();
+  });
+
+  it("persists the live tree it kept, so a reload cannot rewind the card", async () => {
+    // On the background-wake path this event is the ONLY webview
+    // notification for the run: the wake loop consumes the
+    // `task_notification` without forwarding it, so `useAgentStream`'s
+    // persistence handler never fires. Rust wrote the status and its own
+    // checkpoint-era tree (often `[]`), so without this the card looks right
+    // all session and regresses on the next reload.
+    useAppStore.setState({
+      completedTurns: { [SESSION_ID]: [turn("t1", [workflowActivity()])] },
+    });
+    await mountHook();
+
+    await fireStatus({ status: "completed", workflow_progress: [] });
+
+    expect(persistSpy).toHaveBeenCalledTimes(1);
+    const [toolUseId, treeJson, status, sessionId] = persistSpy.mock.calls[0];
+    expect(toolUseId).toBe(WF_ID);
+    expect(status).toBe("completed");
+    expect(sessionId).toBe(SESSION_ID);
+    expect(summarizeWorkflowProgress(JSON.parse(treeJson as string))).toMatchObject({
+      doneCount: 5,
+      totalCount: 5,
+      running: false,
+    });
+  });
+
+  it("does not write back a tree that came from the payload", async () => {
+    // That tree is already exactly what Rust wrote; echoing it is a pointless
+    // round-trip through the command.
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION_ID]: [turn("t1", [workflowActivity({ workflowProgress: [] })])],
+      },
+    });
+    await mountHook();
+
+    await fireStatus({
+      status: "completed",
+      workflow_progress: RECONCILED_TREE,
+    });
+
+    expect(persistSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not write back when there is no tree anywhere", async () => {
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION_ID]: [
+          turn("t1", [workflowActivity({ workflowProgress: undefined })]),
+        ],
+      },
+    });
+    await mountHook();
+
+    await fireStatus({ status: "completed", workflow_progress: null });
+
+    expect(persistSpy).not.toHaveBeenCalled();
   });
 
   it("ignores a payload with no session or tool id", async () => {

--- a/src/ui/src/hooks/useWorkflowActivityStatus.test.tsx
+++ b/src/ui/src/hooks/useWorkflowActivityStatus.test.tsx
@@ -1,0 +1,288 @@
+// @vitest-environment happy-dom
+
+/**
+ * Regression tests for the status pill that never went away.
+ *
+ * A backgrounded `Workflow` outlives the turn that launched it, and the
+ * `agent-stream` feed the webview listens on is torn down at every turn's
+ * `Result` (`src/agent/session.rs`). The run's terminal `task_notification`
+ * therefore arrived when no per-turn forwarder was attached — nothing carried
+ * it to the webview, `agentStatus` stayed `"running"`, and because that status
+ * is persisted the pill came back on every reload, forever. The counts froze
+ * with it: the tree's last delivered snapshot still showed agents in flight,
+ * so a finished run kept advertising "0/5" or "48/49".
+ *
+ * The fix persists and reconciles on the Rust side, where the notification
+ * actually lands, then emits `workflow-activity-status` purely so an open
+ * window settles without a reload. These tests pin the consumer half: the
+ * event must resolve a run whose turn was finalized long ago, and it must
+ * never be able to make things worse when the payload is partial.
+ */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type HandlerRecord = (event: { payload: unknown }) => void;
+const registeredHandlers = new Map<string, HandlerRecord[]>();
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (eventName: string, handler: HandlerRecord) => {
+    const list = registeredHandlers.get(eventName) ?? [];
+    list.push(handler);
+    registeredHandlers.set(eventName, list);
+    return Promise.resolve(() => {
+      const after =
+        registeredHandlers.get(eventName)?.filter((h) => h !== handler) ?? [];
+      registeredHandlers.set(eventName, after);
+    });
+  },
+}));
+
+import { useWorkflowActivityStatus } from "./useWorkflowActivityStatus";
+import {
+  useAppStore,
+  type CompletedTurn,
+  type ToolActivity,
+} from "../stores/useAppStore";
+import { findToolActivity } from "../stores/findToolActivity";
+import { collectInFlightWorkflows } from "../stores/inFlightWorkflows";
+import {
+  summarizeWorkflowProgress,
+  type WorkflowProgressEntry,
+} from "../types/workflow";
+
+const WS_ID = "ws-1";
+const SESSION_ID = "session-1";
+const WF_ID = "toolu_wf1";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function mountHook(): Promise<void> {
+  function Probe() {
+    useWorkflowActivityStatus();
+    return null;
+  }
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(<Probe />);
+  });
+}
+
+async function fireStatus(
+  payload: Partial<{
+    workspace_id: string;
+    chat_session_id: string;
+    tool_use_id: string;
+    status: string;
+    workflow_progress: unknown;
+  }>,
+): Promise<void> {
+  const handlers = registeredHandlers.get("workflow-activity-status") ?? [];
+  expect(handlers.length).toBeGreaterThan(0);
+  await act(async () => {
+    for (const handler of handlers) {
+      handler({
+        payload: {
+          workspace_id: WS_ID,
+          chat_session_id: SESSION_ID,
+          tool_use_id: WF_ID,
+          status: "completed",
+          workflow_progress: null,
+          ...payload,
+        },
+      });
+    }
+  });
+}
+
+/** The wedged shape from the field: five agents, none of them terminal. */
+const STALE_TREE: WorkflowProgressEntry[] = [
+  { type: "workflow_phase", index: 0, title: "Investigate" },
+  ...[1, 2, 3, 4, 5].map<WorkflowProgressEntry>((index) => ({
+    type: "workflow_agent",
+    index,
+    label: `probe-${index}`,
+    state: "progress",
+    phaseTitle: "Investigate",
+  })),
+];
+
+/** What Rust sends back after reconciling it against `completed`. */
+const RECONCILED_TREE: WorkflowProgressEntry[] = STALE_TREE.map((entry) =>
+  entry.type === "workflow_agent" ? { ...entry, state: "done" } : entry,
+);
+
+function workflowActivity(overrides: Partial<ToolActivity> = {}): ToolActivity {
+  return {
+    toolUseId: WF_ID,
+    toolName: "Workflow",
+    inputJson: JSON.stringify({ script: "export const meta = {}" }),
+    resultText: "Workflow launched in background. Task ID: w2lwlmfps",
+    collapsed: false,
+    summary: "nightly-publish-investigation",
+    agentStatus: "running",
+    workflowProgress: STALE_TREE,
+    ...overrides,
+  };
+}
+
+function turn(id: string, activities: ToolActivity[]): CompletedTurn {
+  return {
+    id,
+    activities,
+    messageCount: 1,
+    collapsed: true,
+    afterMessageIndex: 1,
+  };
+}
+
+function activityNow(): ToolActivity | undefined {
+  return findToolActivity(useAppStore.getState(), SESSION_ID, WF_ID);
+}
+
+function pillWouldRender(): boolean {
+  const state = useAppStore.getState();
+  return (
+    collectInFlightWorkflows(
+      state.toolActivities[SESSION_ID] ?? [],
+      state.completedTurns[SESSION_ID] ?? [],
+    ).length > 0
+  );
+}
+
+beforeEach(() => {
+  registeredHandlers.clear();
+  useAppStore.setState({ toolActivities: {}, completedTurns: {} });
+});
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
+describe("useWorkflowActivityStatus", () => {
+  it("clears the pill for a run whose launching turn was finalized long ago", async () => {
+    // The normal case, not an edge one: a workflow's launching turn ends
+    // seconds after launch, so by the time the run finishes its activity has
+    // migrated out of the live lane into `completedTurns`.
+    useAppStore.setState({
+      completedTurns: { [SESSION_ID]: [turn("t1", [workflowActivity()])] },
+    });
+    await mountHook();
+    expect(pillWouldRender()).toBe(true);
+
+    await fireStatus({ status: "completed" });
+
+    expect(activityNow()?.agentStatus).toBe("completed");
+    expect(pillWouldRender()).toBe(false);
+  });
+
+  it("applies the reconciled tree so the count stops reading 0/5", async () => {
+    // Status alone is not enough. The card and pill derive their fraction
+    // purely from the tree, so a finished run whose last snapshot showed
+    // agents in flight kept advertising an unfinished fraction.
+    useAppStore.setState({
+      completedTurns: { [SESSION_ID]: [turn("t1", [workflowActivity()])] },
+    });
+    await mountHook();
+    expect(summarizeWorkflowProgress(STALE_TREE)).toMatchObject({
+      doneCount: 0,
+      totalCount: 5,
+      running: true,
+    });
+
+    await fireStatus({
+      status: "completed",
+      workflow_progress: RECONCILED_TREE,
+    });
+
+    const summary = summarizeWorkflowProgress(activityNow()?.workflowProgress);
+    expect(summary.doneCount).toBe(5);
+    expect(summary.totalCount).toBe(5);
+    expect(summary.running).toBe(false);
+    expect(summary.errorCount).toBe(0);
+  });
+
+  it("resolves a run that is still in the live lane", async () => {
+    // The other ordering: the notification arrives while the launching turn
+    // is somehow still open.
+    useAppStore.setState({
+      toolActivities: { [SESSION_ID]: [workflowActivity()] },
+    });
+    await mountHook();
+
+    await fireStatus({ status: "failed" });
+
+    expect(activityNow()?.agentStatus).toBe("failed");
+    expect(pillWouldRender()).toBe(false);
+  });
+
+  it("keeps the existing tree when the payload carries none", async () => {
+    // `null` means "the row had no readable tree", which must not be
+    // confused with "the tree is empty" — blanking it would turn a stale
+    // card into a permanently empty one.
+    useAppStore.setState({
+      completedTurns: { [SESSION_ID]: [turn("t1", [workflowActivity()])] },
+    });
+    await mountHook();
+
+    await fireStatus({ status: "completed", workflow_progress: null });
+
+    expect(activityNow()?.workflowProgress).toEqual(STALE_TREE);
+    expect(activityNow()?.agentStatus).toBe("completed");
+  });
+
+  it("drops a malformed tree but still applies the status", async () => {
+    // Degrade to "status applied, tree unchanged" rather than writing
+    // garbage the summarizer would then have to defend against.
+    useAppStore.setState({
+      completedTurns: { [SESSION_ID]: [turn("t1", [workflowActivity()])] },
+    });
+    await mountHook();
+
+    await fireStatus({
+      status: "completed",
+      workflow_progress: [{ type: "workflow_agent", index: 1 }],
+    });
+
+    expect(activityNow()?.workflowProgress).toEqual(STALE_TREE);
+    expect(activityNow()?.agentStatus).toBe("completed");
+  });
+
+  it("is a no-op for a session whose transcript was never hydrated", async () => {
+    // Persistence deliberately does not depend on this event: Rust has
+    // already written the row. Applying it here must not throw or invent
+    // store entries for a session the user never opened — the next hydrate
+    // reads the correct row from disk.
+    await mountHook();
+
+    await expect(fireStatus({ status: "completed" })).resolves.toBeUndefined();
+
+    expect(useAppStore.getState().toolActivities[SESSION_ID]).toBeUndefined();
+    expect(useAppStore.getState().completedTurns[SESSION_ID]).toBeUndefined();
+  });
+
+  it("ignores a payload with no session or tool id", async () => {
+    useAppStore.setState({
+      completedTurns: { [SESSION_ID]: [turn("t1", [workflowActivity()])] },
+    });
+    await mountHook();
+
+    await fireStatus({ chat_session_id: "", status: "completed" });
+    await fireStatus({ tool_use_id: "", status: "completed" });
+
+    expect(activityNow()?.agentStatus).toBe("running");
+  });
+});

--- a/src/ui/src/hooks/useWorkflowActivityStatus.ts
+++ b/src/ui/src/hooks/useWorkflowActivityStatus.ts
@@ -1,8 +1,10 @@
 import { useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "../stores/useAppStore";
+import { findToolActivity } from "../stores/findToolActivity";
 import {
   isWorkflowProgressEntry,
+  reconcileAgentStatesOnTerminal,
   type WorkflowProgressEntry,
 } from "../types/workflow";
 import { debugChat } from "../utils/chatDebug";
@@ -64,11 +66,32 @@ export function useWorkflowActivityStatus() {
         // Validate at the boundary and only on the happy path. A malformed
         // tree is dropped rather than written, so a bad payload degrades to
         // "status applied, tree unchanged" instead of blanking a good card.
-        if (
+        const incoming =
           Array.isArray(workflow_progress) &&
           workflow_progress.every(isWorkflowProgressEntry)
-        ) {
-          updates.workflowProgress = workflow_progress;
+            ? workflow_progress
+            : null;
+
+        // The live tree wins over the one in the payload. Rust reconciled the
+        // *checkpointed* row, which is a snapshot from seconds after launch and
+        // is frequently `[]` — a workflow's `tool_result` lands within a second
+        // of the turn being saved, while every `task_progress` tick since has
+        // gone only to this store. Taking the payload's tree verbatim would
+        // blank or rewind a rich card, and `useAgentStream`'s handler for the
+        // same notification would then persist the downgraded copy back to the
+        // row. Reconcile the live tree locally instead; fall back to the
+        // payload's when this window never saw the run's ticks.
+        const live = findToolActivity(
+          useAppStore.getState(),
+          chat_session_id,
+          tool_use_id,
+        )?.workflowProgress;
+        const base = live && live.length > 0 ? live : incoming;
+        if (base) {
+          updates.workflowProgress = reconcileAgentStatesOnTerminal(
+            base,
+            status,
+          );
         }
         debugChat("stream", "workflow activity resolved", {
           sessionId: chat_session_id,

--- a/src/ui/src/hooks/useWorkflowActivityStatus.ts
+++ b/src/ui/src/hooks/useWorkflowActivityStatus.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "../stores/useAppStore";
 import { findToolActivity } from "../stores/findToolActivity";
+import { updateTurnToolActivityProgress } from "../services/tauri";
 import {
   isWorkflowProgressEntry,
   reconcileAgentStatesOnTerminal,
@@ -100,6 +101,31 @@ export function useWorkflowActivityStatus() {
           agents: updates.workflowProgress?.length ?? null,
         });
         updateToolActivity(chat_session_id, tool_use_id, updates);
+
+        // Write the live tree back when it is the one that survived above.
+        // Rust has already recorded the terminal status, so the pill is
+        // safe either way — but on the background-wake path this event is
+        // the *only* webview notification for the run: the wake loop
+        // consumes the `task_notification` without forwarding it, so
+        // `useAgentStream`'s persistence handler never fires. Without this
+        // the row keeps Rust's checkpoint-era tree (often `[]`), and a card
+        // that looked right all session regresses on the next reload.
+        //
+        // Skipped when the payload's tree is the one we used: that is
+        // already exactly what Rust wrote.
+        if (live && live.length > 0 && updates.workflowProgress) {
+          void updateTurnToolActivityProgress(
+            tool_use_id,
+            JSON.stringify(updates.workflowProgress),
+            status,
+            chat_session_id,
+          ).catch((err) => {
+            debugChat("stream", "persist resolved workflow tree failed", {
+              toolUseId: tool_use_id,
+              error: String(err),
+            });
+          });
+        }
       },
     );
 

--- a/src/ui/src/hooks/useWorkflowActivityStatus.ts
+++ b/src/ui/src/hooks/useWorkflowActivityStatus.ts
@@ -1,0 +1,88 @@
+import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { useAppStore } from "../stores/useAppStore";
+import {
+  isWorkflowProgressEntry,
+  type WorkflowProgressEntry,
+} from "../types/workflow";
+import { debugChat } from "../utils/chatDebug";
+
+/** Payload of the `workflow-activity-status` Tauri event. Mirrors
+ *  `WorkflowActivityStatusEvent` in `src/agent/workflow_progress.rs`. */
+export interface WorkflowActivityStatusPayload {
+  workspace_id: string;
+  chat_session_id: string;
+  tool_use_id: string;
+  status: string;
+  /** Reconciled tree. `null` means "keep what you have" — the row carried
+   *  no readable tree, which must not be confused with "the tree is empty". */
+  workflow_progress: WorkflowProgressEntry[] | null;
+}
+
+/**
+ * Settle a backgrounded `Workflow` run in the live store when Rust reports it
+ * has ended.
+ *
+ * Why this exists as its own channel rather than riding `agent-stream`: the
+ * `agent-stream` feed is torn down at every turn's `Result`
+ * (`src/agent/session.rs`), and a backgrounded workflow routinely finishes
+ * long after the turn that launched it. Its terminal `task_notification`
+ * therefore arrives when no per-turn forwarder is attached, so the webview
+ * never saw it — the run's status stayed `"running"` and the pill above the
+ * composer never went away.
+ *
+ * **This is not the source of truth.** Rust has already written the terminal
+ * status and the reconciled tree to `turn_tool_activities` by the time this
+ * event is sent. Applying it here only spares the user a reload; if the
+ * owning session isn't hydrated in the store, `updateToolActivity` no-ops and
+ * the next hydrate reads the correct row from disk. That ordering is
+ * deliberate — persistence must not depend on the webview being awake,
+ * which is exactly the coupling that produced the bug.
+ *
+ * Mounted once, next to `useAgentStream`, so it covers every session rather
+ * than only the visible one.
+ */
+export function useWorkflowActivityStatus() {
+  const updateToolActivity = useAppStore((s) => s.updateToolActivity);
+
+  useEffect(() => {
+    // Same StrictMode guard as `useAgentStream`: the async unlisten() can't
+    // block React's synchronous remount, so a stale listener may briefly
+    // coexist with the new one.
+    let active = true;
+    const unlisten = listen<WorkflowActivityStatusPayload>(
+      "workflow-activity-status",
+      (event) => {
+        if (!active) return;
+        const { chat_session_id, tool_use_id, status, workflow_progress } =
+          event.payload;
+        if (!chat_session_id || !tool_use_id) return;
+
+        const updates: Parameters<typeof updateToolActivity>[2] = {
+          agentStatus: status,
+        };
+        // Validate at the boundary and only on the happy path. A malformed
+        // tree is dropped rather than written, so a bad payload degrades to
+        // "status applied, tree unchanged" instead of blanking a good card.
+        if (
+          Array.isArray(workflow_progress) &&
+          workflow_progress.every(isWorkflowProgressEntry)
+        ) {
+          updates.workflowProgress = workflow_progress;
+        }
+        debugChat("stream", "workflow activity resolved", {
+          sessionId: chat_session_id,
+          toolUseId: tool_use_id,
+          status,
+          agents: updates.workflowProgress?.length ?? null,
+        });
+        updateToolActivity(chat_session_id, tool_use_id, updates);
+      },
+    );
+
+    return () => {
+      active = false;
+      void unlisten.then((fn) => fn());
+    };
+  }, [updateToolActivity]);
+}

--- a/src/ui/src/services/tauri/checkpoints.ts
+++ b/src/ui/src/services/tauri/checkpoints.ts
@@ -53,16 +53,22 @@ export function saveTurnToolActivities(
  *  Both fields are optional and COALESCE against the stored row: pass
  *  `null` for either to leave it untouched. A run that ends without ever
  *  reporting agents still needs its status resolved, and must not blank
- *  the tree on the way. */
+ *  the tree on the way.
+ *
+ *  `chatSessionId` scopes a terminal write to one activity. Forking copies
+ *  `tool_use_id` verbatim into the fork's rows, so an unscoped write would
+ *  rewrite the copied history in every fork of the session. */
 export function updateTurnToolActivityProgress(
   toolUseId: string,
   workflowProgressJson: string | null,
   agentStatus: string | null,
+  chatSessionId: string,
 ): Promise<void> {
   return invoke("update_turn_tool_activity_progress", {
     toolUseId,
     workflowProgressJson,
     agentStatus,
+    chatSessionId,
   });
 }
 

--- a/src/ui/src/types/workflow.test.ts
+++ b/src/ui/src/types/workflow.test.ts
@@ -300,6 +300,26 @@ describe("isAgentTerminal", () => {
     expect(isAgentTerminal(agent(1, "error"))).toBe(true);
   });
 
+  // Stamped by `reconcile_tree_on_terminal` on a run that ended without
+  // completing. If this did not read as terminal, reconciliation could not
+  // close out the stragglers and the pill would keep advertising an
+  // unfinished fraction for a run that is over — the bug it exists to fix.
+  it("treats a reconciled stopped agent as terminal", () => {
+    expect(isAgentTerminal(agent(1, "stopped"))).toBe(true);
+  });
+
+  // "stopped" is deliberately not "error": a cancelled run must not light
+  // up the card's failure badge.
+  it("does not count a stopped agent as a failure", () => {
+    const summary = summarizeWorkflowProgress([
+      agent(1, "stopped"),
+      agent(2, "done"),
+    ]);
+    expect(summary.doneCount).toBe(2);
+    expect(summary.errorCount).toBe(0);
+    expect(summary.running).toBe(false);
+  });
+
   // A state we've never seen must read as "still going", so a run can't
   // report itself finished on the strength of a value we don't understand.
   it("treats queued, progress, and unrecognized states as in-flight", () => {

--- a/src/ui/src/types/workflow.test.ts
+++ b/src/ui/src/types/workflow.test.ts
@@ -5,6 +5,7 @@ import {
   phaseTitleOf,
   readOptionalNumber,
   readOptionalString,
+  reconcileAgentStatesOnTerminal,
   summarizeWorkflowProgress,
   type WorkflowAgentEntry,
   type WorkflowProgressEntry,
@@ -327,5 +328,65 @@ describe("isAgentTerminal", () => {
     expect(isAgentTerminal(agent(1, "progress"))).toBe(false);
     expect(isAgentTerminal(agent(1, "some_future_state"))).toBe(false);
     expect(isAgentTerminal(agent(1, ""))).toBe(false);
+  });
+});
+
+describe("reconcileAgentStatesOnTerminal", () => {
+  // The TS mirror of `reconcile_tree_on_terminal`. It exists because the live
+  // store tree is fresher than the one Rust reconciled off the checkpointed
+  // row, so the hook reconciles locally rather than accepting the older copy.
+  it("stamps stragglers done on a completed run", () => {
+    const out = reconcileAgentStatesOnTerminal(
+      [phase(0, "Investigate"), agent(1, "progress"), agent(2, "queued")],
+      "completed",
+    );
+    expect(summarizeWorkflowProgress(out)).toMatchObject({
+      doneCount: 2,
+      totalCount: 2,
+      running: false,
+      errorCount: 0,
+    });
+    expect(out[0].type).toBe("workflow_phase");
+  });
+
+  it("stamps stopped, not done, when the run did not complete", () => {
+    for (const status of ["stopped", "failed", "killed", "cancelled"]) {
+      const out = reconcileAgentStatesOnTerminal([agent(1, "progress")], status);
+      expect((out[0] as { state: string }).state).toBe("stopped");
+    }
+  });
+
+  it("never rewrites an agent's own terminal outcome", () => {
+    const out = reconcileAgentStatesOnTerminal(
+      [agent(1, "error"), agent(2, "done"), agent(3, "progress")],
+      "completed",
+    );
+    expect(out.map((e) => (e as { state: string }).state)).toEqual([
+      "error",
+      "done",
+      "done",
+    ]);
+    expect(summarizeWorkflowProgress(out).errorCount).toBe(1);
+  });
+
+  it("is a no-op on a non-terminal status", () => {
+    const input = [agent(1, "progress")];
+    expect(reconcileAgentStatesOnTerminal(input, "running")).toBe(input);
+  });
+
+  // Identity is the render bail-out: returning a fresh array every tick would
+  // re-render every card behind a memo that compares by reference.
+  it("returns the same array when nothing needs stamping", () => {
+    const input = [agent(1, "done"), phase(0, "Investigate")];
+    expect(reconcileAgentStatesOnTerminal(input, "completed")).toBe(input);
+  });
+
+  it("matches the Rust straggler vocabulary for every terminal status", () => {
+    // Guards the mirror: a status Rust treats as terminal but this does not
+    // would leave the fraction frozen on exactly the path the fix targets.
+    for (const status of ["completed", "failed", "stopped", "killed", "error", "cancelled", "canceled"]) {
+      const out = reconcileAgentStatesOnTerminal([agent(1, "progress")], status);
+      expect(summarizeWorkflowProgress(out).running).toBe(false);
+    }
   });
 });

--- a/src/ui/src/types/workflow.ts
+++ b/src/ui/src/types/workflow.ts
@@ -138,8 +138,16 @@ export function isWorkflowAgent(
 /** Terminal states — an agent in one of these will not change again.
  *  Anything else (including a state we've never seen) counts as in-flight,
  *  so an unrecognized value degrades to "still running" rather than
- *  silently reporting a run as finished. */
-const TERMINAL_AGENT_STATES = new Set(["done", "error"]);
+ *  silently reporting a run as finished.
+ *
+ *  `"done"` and `"error"` are the CLI's own values. `"stopped"` is ours:
+ *  when a run reports a terminal status while its last progress snapshot
+ *  still showed agents in flight, Rust stamps the stragglers so the tree
+ *  can't keep advertising an unfinished fraction for a finished run — see
+ *  `reconcile_tree_on_terminal` in `src/agent/workflow_progress.rs`. It is
+ *  used only when the run did *not* complete, so it stays out of
+ *  `errorCount` and never inflates the failure badge. */
+const TERMINAL_AGENT_STATES = new Set(["done", "error", "stopped"]);
 
 export function isAgentTerminal(agent: WorkflowAgentEntry): boolean {
   return TERMINAL_AGENT_STATES.has(agent.state);

--- a/src/ui/src/types/workflow.ts
+++ b/src/ui/src/types/workflow.ts
@@ -1,3 +1,5 @@
+import { isTerminalBackgroundTaskStatus } from "./backgroundTaskStatus";
+
 /** The phase/agent tree Claude Code's `Workflow` tool reports on
  *  `subtype: "task_progress"` stream events.
  *
@@ -151,6 +153,44 @@ const TERMINAL_AGENT_STATES = new Set(["done", "error", "stopped"]);
 
 export function isAgentTerminal(agent: WorkflowAgentEntry): boolean {
   return TERMINAL_AGENT_STATES.has(agent.state);
+}
+
+/**
+ * Close out agents still in flight on a run that has reported a terminal
+ * status.
+ *
+ * The TypeScript mirror of `reconcile_tree_on_terminal` in
+ * `src/agent/workflow_progress.rs`, and the reason the duplication is worth
+ * it: the store's tree is usually *fresher* than the one Rust reconciled. Rust
+ * reads the checkpointed row, which is a snapshot from seconds after launch —
+ * often literally `[]`, since a workflow's `tool_result` lands within a second
+ * of the turn being saved. The webview meanwhile has every `task_progress`
+ * tick delivered since. Applying Rust's tree verbatim would replace a rich
+ * live tree with that older snapshot, and the `agent-stream` handler would
+ * then persist the downgraded copy back to the row.
+ *
+ * So the live tree wins, and this reconciles it locally instead. `null` /
+ * empty falls back to whatever Rust sent, which is the only tree available
+ * when the run's ticks never reached this window.
+ *
+ * Returns the input array unchanged when nothing needs stamping, so React can
+ * bail out of a re-render on identity.
+ */
+export function reconcileAgentStatesOnTerminal(
+  entries: WorkflowProgressEntry[],
+  status: string,
+): WorkflowProgressEntry[] {
+  if (!isTerminalBackgroundTaskStatus(status)) return entries;
+  // Only a completed run may claim its stragglers finished their work; any
+  // other terminal status means the run ended without them getting there.
+  const stamped = status.trim().toLowerCase() === "completed" ? "done" : "stopped";
+  let changed = false;
+  const next = entries.map((entry) => {
+    if (!isWorkflowAgent(entry) || isAgentTerminal(entry)) return entry;
+    changed = true;
+    return { ...entry, state: stamped };
+  });
+  return changed ? next : entries;
 }
 
 /**


### PR DESCRIPTION
### Summary

The Workflow status pill above the composer never went away, and its fraction froze part-way (`0/5`, `48/49`) even for runs that demonstrably completed.

**Root cause: `agent-stream` is turn-scoped.** The per-turn broadcast→mpsc forwarder breaks on the first `Result` (`src/agent/session.rs:301-310`), which closes the only loop that emits `agent-stream` (`send.rs`). A backgrounded `Workflow` returns "launched in background" within a second, so its terminal `task_notification` arrives long after that forwarder is gone. The only remaining subscriber is the wake loop (`background_tasks.rs:844-925`), which consumes the notification and emits nothing.

Since `turn_tool_activities.agent_status` was written **only** from the webview's `task_notification` handler, the write never happened. The row stayed `"running"` forever — and because it is persisted, the pill returned on every reload.

Measured across the 8 post-feature `Workflow` rows in a production DB, the split is clean:

| outcome | tree age vs. its own checkpoint |
|---|---|
| `completed` (3) | run finished **9–18 min before** the launching turn ended |
| `running` (5) | launching turn ended **0–9 s after** launch |

The happy path only ever worked when the user happened to still be in the launching turn.

```mermaid
sequenceDiagram
    participant CLI as Claude CLI
    participant Fwd as per-turn forwarder
    participant Wake as wake loop
    participant DB
    participant UI as webview

    CLI->>Fwd: task_progress (tree)
    Fwd->>UI: agent-stream
    CLI->>Fwd: Result
    Note over Fwd: breaks — feed torn down
    CLI-->>Wake: task_progress ×N (dropped)
    CLI->>Wake: task_notification (completed)
    rect rgb(220,245,220)
    Note over Wake,DB: NEW: persist + reconcile here
    Wake->>DB: finish_workflow_activity
    Wake->>UI: workflow-activity-status
    end
```

**Persist from `apply_task_notification_status` instead**, where the notification actually lands. Every notification route funnels through it — the in-turn stream, the wake loop's terminal break, and the post-wake drain — so one call site closes all three. It no longer depends on a webview being awake or a transcript being hydrated. A `task_id` fallback (`find_workflow_activity_by_task_id`) resolves the row when the notification omits `tool_use_id`.

**Status alone was not enough.** Counts derive purely from the progress tree, whose last delivered snapshot predates the run's final transitions. New `src/agent/workflow_progress.rs` stamps non-terminal agents when the run reports a terminal status — `done` for a completed run, `stopped` otherwise, so a cancelled run neither claims work it didn't do nor inflates the failure badge.

Also collapses the terminal-status vocabulary from **three drifting copies** into one. The command layer's copy was missing `"error"`, so an `error` notification re-armed the wake instead of resolving the run.

### Complexity Notes

- **Write ordering is the subtle part.** The webview still persists on its own handler for the in-turn case, and it holds a *fresher* tree than the DB (only it sees the ticks after checkpoint) — but a fresher tree is still stale relative to the run's final transitions. Writing it verbatim after the Rust write would put `48/49` straight back. Rather than pick a winner, both writers go through the same reconciliation: `finish_workflow_activity` reconciles on **every** terminal write, not just the first, so it is idempotent and converges under either order. The webview reaches it via the Tauri command wrapper (`commands/chat/checkpoint.rs`).
- **`"stopped"` is a new agent state** added to `TERMINAL_AGENT_STATES` on both sides. It is ours, not the CLI's — deliberately distinct from `"error"` so it stays out of `errorCount`, and from `"queued"` so a cancelled run doesn't read as one that never started. `WorkflowCard` renders it with a distinct glyph and the muted treatment.
- **`reconcile_tree_json_on_terminal` returns `None` on unparseable JSON** rather than rewriting. The stored tree is the only copy; replacing garbage with `[]` would turn a stale card into a permanently blank one.
- **`resolve_orphaned_workflow_activities` changed from a bulk UPDATE to a per-row loop** so each swept row's tree is reconciled too. Slightly more queries at boot, bounded by the number of wedged rows.
- **The new `workflow-activity-status` event is explicitly not the source of truth** — Rust has already written the row by the time it is emitted. If the owning session isn't hydrated, applying it is a no-op and the next hydrate reads the correct row from disk. That ordering is the point: persistence must not depend on the webview being awake, which is exactly the coupling that caused the bug.
- **`turn_tool_activities` now has two writers.** No migration; both columns already exist and `update_turn_tool_activity_progress` keeps its `COALESCE` semantics.

### Test Steps

1. `cargo test -p claudette -p claudette-server -p claudette-cli --all-features` — 13 new Rust tests, notably `completed_run_stamps_stragglers_done`, `non_completed_terminal_status_stamps_stopped_not_done`, `test_finish_workflow_activity_reconciles_a_stale_tree`, `test_resolve_orphaned_workflow_activities_reconciles_trees`, `test_find_workflow_activity_by_task_id`.
2. `cargo test -p claudette-tauri --no-default-features --features devtools,server,alternative-backends background_tasks` — `terminal_task_statuses_match_the_shared_vocabulary` pins the `"error"` drift by iterating the shared constant rather than restating it.
3. `cd src/ui && bun run test` — 9 new frontend tests. `useWorkflowActivityStatus.test.tsx` covers the wedged shape end to end: a run whose turn was finalized long ago, the reconciled tree landing, a `null` tree leaving the existing one alone, a malformed tree dropped while the status still applies, and a no-op for an unhydrated session.
4. `cd src/ui && bunx tsc -b && bun run lint:css`
5. **Manual:** launch a workflow (`Workflow` tool, backgrounded), then immediately switch to a different workspace so the launching turn ends while the run continues. When it finishes, the pill must disappear and the card must show every agent settled — not a frozen `N-1/N`. Reload the app and confirm the card still reads complete rather than reverting.
6. **Manual (recovery):** any historical rows wedged at `running` are swept at next launch, now with reconciled trees, so their cards no longer contradict their own status.

### Notes for the reviewer

`~/.claudette/logs/*.log` previously contained **zero** occurrences of `workflow`, `task_progress`, or `task_notification` — this pipeline was entirely invisible, which is part of why the wedge went undiagnosed. A single `tracing::info!` now fires per resolved run.

This does not implement the larger refactor (a session-lifetime observer task owning `WorkflowRun` state in Rust, deleting ~190 lines from `useAgentStream.ts` / `chatSlice.ts`). That remains available as a follow-up; this PR is the targeted fix plus the invariant that makes the counts honest.

### Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
